### PR TITLE
Fix short ID routing for polls

### DIFF
--- a/app/p/[shortId]/page.tsx
+++ b/app/p/[shortId]/page.tsx
@@ -43,11 +43,13 @@ function PollContent() {
             pollData = await apiGetPollByShortId(pollId);
           }
         } catch {
-          // If UUID lookup fails, try short_id
-          try {
-            pollData = await apiGetPollByShortId(pollId);
-          } catch {
-            pollData = null;
+          // If lookup fails, only try short_id fallback if it doesn't look like a UUID
+          if (!(pollId.length > 10 && pollId.includes('-'))) {
+            try {
+              pollData = await apiGetPollByShortId(pollId);
+            } catch {
+              pollData = null;
+            }
           }
         }
         // Grant access to this poll

--- a/components/FollowUpHeader.tsx
+++ b/components/FollowUpHeader.tsx
@@ -13,6 +13,7 @@ interface FollowUpHeaderProps {
 export default function FollowUpHeader({ followUpToPollId, onRemove }: FollowUpHeaderProps) {
   const router = useRouter();
   const [originalPollTitle, setOriginalPollTitle] = useState<string | null>(null);
+  const [originalPollShortId, setOriginalPollShortId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
@@ -29,6 +30,7 @@ export default function FollowUpHeader({ followUpToPollId, onRemove }: FollowUpH
       try {
         const data = await apiGetPollById(followUpToPollId);
         setOriginalPollTitle(data.title);
+        if (data.short_id) setOriginalPollShortId(data.short_id);
       } catch (err) {
         console.error('Error fetching original poll:', err);
         setError(true);
@@ -117,7 +119,7 @@ export default function FollowUpHeader({ followUpToPollId, onRemove }: FollowUpH
         <div className="text-sm text-blue-900 dark:text-blue-100 mb-1 flex items-center justify-center flex-wrap gap-x-1">
           <span>Follow up to</span>
           <button
-            onClick={() => router.push(`/p/${followUpToPollId}`)}
+            onClick={() => router.push(`/p/${originalPollShortId || followUpToPollId}`)}
             className="inline-flex items-center px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/50 hover:bg-blue-200 dark:hover:bg-blue-800/70 rounded text-sm font-medium text-blue-800 dark:text-blue-200 transition-colors relative overflow-hidden whitespace-nowrap min-w-0 max-w-[180px]"
             title={originalPollTitle}
           >

--- a/components/ForkHeader.tsx
+++ b/components/ForkHeader.tsx
@@ -13,6 +13,7 @@ interface ForkHeaderProps {
 export default function ForkHeader({ forkOfPollId, onRemove }: ForkHeaderProps) {
   const router = useRouter();
   const [originalPollTitle, setOriginalPollTitle] = useState<string | null>(null);
+  const [originalPollShortId, setOriginalPollShortId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
@@ -29,6 +30,7 @@ export default function ForkHeader({ forkOfPollId, onRemove }: ForkHeaderProps) 
       try {
         const data = await apiGetPollById(forkOfPollId);
         setOriginalPollTitle(data.title);
+        if (data.short_id) setOriginalPollShortId(data.short_id);
       } catch (err) {
         console.error('Error fetching original poll:', err);
         setError(true);
@@ -117,7 +119,7 @@ export default function ForkHeader({ forkOfPollId, onRemove }: ForkHeaderProps) 
         <div className="text-sm text-green-900 dark:text-green-100 mb-1 flex items-center justify-center flex-wrap gap-x-1">
           <span>Fork of</span>
           <button
-            onClick={() => router.push(`/p/${forkOfPollId}`)}
+            onClick={() => router.push(`/p/${originalPollShortId || forkOfPollId}`)}
             className="inline-flex items-center px-1.5 py-0.5 bg-green-100 dark:bg-green-900/50 hover:bg-green-200 dark:hover:bg-green-800/70 rounded text-sm font-medium text-green-800 dark:text-green-200 transition-colors relative overflow-hidden whitespace-nowrap min-w-0 max-w-[180px]"
             title={originalPollTitle}
           >

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -238,7 +238,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                 if (!isScrolling.current && !isLongPress.current) {
                   setNavigatingPollId(poll.id); // Show loading state
                   setPressedPollId(null); // Clear pressed state
-                  router.push(`/p/${poll.id}`);
+                  router.push(`/p/${poll.short_id || poll.id}`);
                 } else {
                   // Reset states if not navigating
                   setPressedPollId(null); // Clear pressed state
@@ -282,7 +282,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       <div
                         onClick={() => {
                           setNavigatingPollId(poll.id);
-                          router.push(`/p/${poll.id}`);
+                          router.push(`/p/${poll.short_id || poll.id}`);
                         }}
                         onTouchStart={handleTouchStart}
                         onTouchEnd={handleTouchEnd}
@@ -368,7 +368,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                   if (!isScrolling.current && !isLongPress.current) {
                     setNavigatingPollId(poll.id); // Show loading state
                     setPressedPollId(null); // Clear pressed state
-                    router.push(`/p/${poll.id}`);
+                    router.push(`/p/${poll.short_id || poll.id}`);
                   } else {
                     // Reset states if not navigating
                     setPressedPollId(null); // Clear pressed state
@@ -406,7 +406,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       <div
                         onClick={() => {
                           setNavigatingPollId(poll.id);
-                          router.push(`/p/${poll.id}`);
+                          router.push(`/p/${poll.short_id || poll.id}`);
                         }}
                         onTouchStart={handleTouchStart}
                         onTouchEnd={handleTouchEnd}

--- a/database/migrations/065_fix_sequential_id_default_up.sql
+++ b/database/migrations/065_fix_sequential_id_default_up.sql
@@ -1,0 +1,27 @@
+-- Migration: 065_fix_sequential_id_default
+-- Fix: sequential_id column has no default, so short_id is never generated on new polls.
+-- Re-link the existing polls_sequential_id_seq sequence to the column.
+
+ALTER TABLE polls
+    ALTER COLUMN sequential_id SET DEFAULT nextval('polls_sequential_id_seq');
+
+ALTER SEQUENCE polls_sequential_id_seq OWNED BY polls.sequential_id;
+
+-- Backfill any polls missing sequential_id / short_id
+DO $$
+DECLARE
+    r RECORD;
+    next_seq INTEGER;
+BEGIN
+    FOR r IN
+        SELECT id FROM polls
+        WHERE sequential_id IS NULL
+        ORDER BY created_at
+    LOOP
+        next_seq := nextval('polls_sequential_id_seq');
+        UPDATE polls
+           SET sequential_id = next_seq,
+               short_id = encode_base62(next_seq)
+         WHERE id = r.id;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
- Fix PollList, FollowUpHeader, and ForkHeader to navigate using `short_id` instead of full UUID
- Fix `page.tsx` fallback logic to not send UUIDs to the short-id endpoint
- Add migration 065 to re-link `polls_sequential_id_seq` to the `sequential_id` column (was unlinked, causing new polls to get NULL short_id)
- Backfill short_id for existing polls that were missing it

## Test plan
- [x] Verified new polls get short_id assigned (migration applied to prod DB)
- [x] Verified navigation from home page uses short ID (`GET /p/Y/` in dev logs)
- [x] ESLint passes

https://claude.ai/code/session_011pvWfbWAH5RaJQ85pe9Unw