### PR TITLE
Use native pull-to-refresh; custom only for iOS PWA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -800,6 +800,16 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 
 **Time-saving tip**: Don't guess at the problem. Add logging, get the exact error, then fix the specific constraint.
 
+### PWA / Pull-to-Refresh
+
+- **Native pull-to-refresh works everywhere except iOS PWA standalone mode.** Apple explicitly disables it. Don't use `overscroll-behavior: contain` globally — that blocks the native gesture on all platforms. Only use a custom touch-based pull-to-refresh for iOS PWA (detect with `navigator.standalone` or `matchMedia('(display-mode: standalone)')` + iOS UA check).
+- **Don't put `pullDistance` in a useEffect dependency array** when using touch-based pull-to-refresh. The state updates on every pixel of movement, causing event listener thrashing (detach + reattach 3 listeners 60+ times/sec). Use a local `let` variable inside the effect for the threshold check, and only use React state for rendering the indicator.
+
+### Dev Server Pitfalls
+
+- **`npm run dev` spawns a process chain** (`npm` -> `next` -> `node`). Killing the parent PID doesn't reliably kill child processes holding the TCP port. After PID-based kill, always `fuser -k <port>/tcp` to clean up orphaned children — otherwise the next start gets `EADDRINUSE`.
+- **Dev server shows stale commit info** when the restart fails silently. The old process keeps serving pages. Always check `dev-server-manager.sh list` for `[STOPPED]` status after a push if the commit info doesn't update.
+
 ### API Development Pitfalls
 
 - **Catch-all fallthrough in `get_results()`**: When adding new poll types, `server/routers/polls.py` has a catch-all return at the bottom returning `yes_count=None`. Any poll type without an explicit handler silently falls through and the frontend interprets `None` as `0`. Always add an explicit handler for each poll type.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,10 @@ The sections below contain mandatory rules. Follow them exactly.
 - Client-side console output is captured by the CommitInfo Logs tab (click page header to open).
 - **Keep droplet setup docs current**: When you change anything about the droplet infrastructure (Caddy config, Docker Compose, systemd services, provisioning steps, new services, port changes, etc.), update **both** `docs/droplet-setup.md` and `scripts/provision-droplet.sh` to reflect the change. These files must always describe how to reproduce the current droplet from scratch.
 - **Never bold URLs**: Do not wrap URLs in `**bold**` markers. The asterisks get rendered literally in the terminal and break the link. Write URLs as plain text.
+- **PR workflow**: When asked to open a PR, always do these steps first:
+  1. **Run `/simplify`** to clean up any code quality issues, redundancy, or missed improvements.
+  2. **Update CLAUDE.md** with any lessons learned, new patterns, pitfalls discovered, or infrastructure changes from the current work. Keep the knowledge base growing.
+  3. Then create the PR.
 
 ### Python Tooling: uv (Mandatory)
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -75,7 +75,6 @@ body {
   /* Ensure proper touch scrolling within the scrollable areas */
   .safari-scroll-container {
     -webkit-overflow-scrolling: touch;
-    overscroll-behavior: contain;
   }
 }
 

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -264,9 +264,12 @@ export default function Template({ children }: AppTemplateProps) {
     };
   }, []);
 
-  // Pull-to-refresh functionality
+  // Pull-to-refresh functionality — only for iOS PWA standalone mode
+  // (Native pull-to-refresh works in browsers and Android PWA, but Apple
+  // explicitly disables it in iOS standalone/fullscreen PWA mode.)
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (!isIOSPWA) return;
 
     let startY = 0;
     let currentY = 0;
@@ -298,7 +301,7 @@ export default function Template({ children }: AppTemplateProps) {
 
     const handleTouchEnd = () => {
       if (isDragging && pullDistance > 60) {
-        // Trigger page reload for all pages
+        // Trigger page reload
         window.location.reload();
       }
 
@@ -308,7 +311,6 @@ export default function Template({ children }: AppTemplateProps) {
       setPullDistance(0);
     };
 
-    // Add to document body to capture all touch events
     document.body.addEventListener('touchstart', handleTouchStart, { passive: false });
     document.body.addEventListener('touchmove', handleTouchMove, { passive: false });
     document.body.addEventListener('touchend', handleTouchEnd, { passive: true });
@@ -318,7 +320,7 @@ export default function Template({ children }: AppTemplateProps) {
       document.body.removeEventListener('touchmove', handleTouchMove);
       document.body.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [pullDistance]);
+  }, [pullDistance, isIOSPWA]);
 
   const isPollPage = pathname.startsWith('/p/');
   const isCreatePollPage = pathname === '/create-poll' || pathname === '/create-poll/';
@@ -326,8 +328,8 @@ export default function Template({ children }: AppTemplateProps) {
 
   return (
     <>
-      {/* Pull-to-refresh indicator */}
-      {isPulling && (
+      {/* Pull-to-refresh indicator (iOS PWA only) */}
+      {isIOSPWA && isPulling && (
         <div
           className="fixed top-0 left-0 right-0 z-50 flex justify-center items-center transition-all duration-200"
           style={{

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -272,9 +272,9 @@ export default function Template({ children }: AppTemplateProps) {
     if (!isIOSPWA) return;
 
     let startY = 0;
-    let currentY = 0;
     let isAtTop = true;
     let isDragging = false;
+    let currentPullDistance = 0;
 
     const handleTouchStart = (e: TouchEvent) => {
       startY = e.touches[0].clientY;
@@ -285,28 +285,24 @@ export default function Template({ children }: AppTemplateProps) {
     const handleTouchMove = (e: TouchEvent) => {
       if (!isAtTop) return;
 
-      currentY = e.touches[0].clientY;
-      const deltaY = currentY - startY;
+      const deltaY = e.touches[0].clientY - startY;
 
       if (deltaY > 10) {
-        // Pulling down from top
         isDragging = true;
+        currentPullDistance = deltaY;
         setPullDistance(deltaY);
         setIsPulling(deltaY > 60);
-
-        // Prevent default scrolling when pulling
         e.preventDefault();
       }
     };
 
     const handleTouchEnd = () => {
-      if (isDragging && pullDistance > 60) {
-        // Trigger page reload
+      if (isDragging && currentPullDistance > 60) {
         window.location.reload();
       }
 
-      // Reset state
       isDragging = false;
+      currentPullDistance = 0;
       setIsPulling(false);
       setPullDistance(0);
     };
@@ -320,7 +316,7 @@ export default function Template({ children }: AppTemplateProps) {
       document.body.removeEventListener('touchmove', handleTouchMove);
       document.body.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [pullDistance, isIOSPWA]);
+  }, [isIOSPWA]);
 
   const isPollPage = pathname.startsWith('/p/');
   const isCreatePollPage = pathname === '/create-poll' || pathname === '/create-poll/';

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -104,12 +104,8 @@ stop_nextjs() {
   local slug="$1"
   local dir="${DEV_DIR}/${slug}"
   local pid_file="${dir}/.nextjs.pid"
-  local port=""
-
-  # Read assigned port from metadata so we can clean it up
-  if [ -f "${dir}/.dev-meta.json" ]; then
-    port=$(python3 -c "import json; print(json.load(open('${dir}/.dev-meta.json'))['port'])" 2>/dev/null || echo "")
-  fi
+  local port
+  port=$(get_dev_port "$slug")
 
   if [ -f "$pid_file" ]; then
     local pid

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -97,11 +97,19 @@ get_dev_port() {
 }
 
 # Stop the Next.js process for a dev server
-# next dev spawns child processes, so we kill the entire process group
+# npm run dev spawns child processes (npm -> next -> node), so killing the
+# parent PID alone may leave orphaned children holding the port open.
+# We kill by PID first, then ensure nothing is left on the port.
 stop_nextjs() {
   local slug="$1"
   local dir="${DEV_DIR}/${slug}"
   local pid_file="${dir}/.nextjs.pid"
+  local port=""
+
+  # Read assigned port from metadata so we can clean it up
+  if [ -f "${dir}/.dev-meta.json" ]; then
+    port=$(python3 -c "import json; print(json.load(open('${dir}/.dev-meta.json'))['port'])" 2>/dev/null || echo "")
+  fi
 
   if [ -f "$pid_file" ]; then
     local pid
@@ -123,6 +131,18 @@ stop_nextjs() {
       fi
     fi
     rm -f "$pid_file"
+  fi
+
+  # Kill any orphaned processes still holding the port (child node processes
+  # that survived the parent kill)
+  if [ -n "$port" ]; then
+    local port_pids
+    port_pids=$(fuser "${port}/tcp" 2>/dev/null || true)
+    if [ -n "$port_pids" ]; then
+      log "Killing orphaned processes on port $port: $port_pids"
+      fuser -k "${port}/tcp" 2>/dev/null || true
+      sleep 1
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary
- Remove `overscroll-behavior: contain` so browsers use their native pull-to-refresh gesture (more reliable than custom touch handling)
- Keep custom pull-to-refresh only for iOS PWA standalone mode, where Apple explicitly disables the native gesture
- Fix dev server restart bug: `npm run dev` child processes were orphaning on the port, causing `EADDRINUSE` on restart. Now `fuser -k` cleans up after PID-based kill
- Fix listener thrashing: pull distance state was in useEffect deps, causing 180+ listener attach/detach ops per second during a pull gesture

## Test plan
- [ ] Pull down on page in mobile browser — native pull-to-refresh should work
- [ ] Test in iOS PWA standalone mode — custom pull-to-refresh indicator should appear
- [ ] Push a commit and verify dev server restarts cleanly (no stale commit info)

https://claude.ai/code/session_01Dh8FECxSANU8Yv1PW1qV1w