### PR TITLE
Fix iOS PWA pull-to-refresh and safe area positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ You do NOT need SSH — all server management goes through `scripts/remote.sh`.
 - Every push to GitHub auto-updates your dev server via webhook
 - Uses `next dev` (hot reload) — file changes apply in seconds, no full rebuild
 - Restarts if `package-lock.json` changes (new dependencies) or commit SHA changes (to refresh env vars)
+- **After pushing, wait for the dev server to be ready before telling the user.** The server takes ~45-60 seconds to restart. Poll with `bash scripts/remote.sh "curl -s -o /dev/null -w '%{http_code}' http://localhost:<port>"` until it returns 200, then notify the user.
 - URL is based on your `GIT_AUTHOR_EMAIL`: `<email-slug>.dev.whoeverwants.com`
   - Example: `sam@example.com` → `https://sam-at-example-com.dev.whoeverwants.com`
 - URL stays the same regardless of branch — bookmark it
@@ -803,7 +804,15 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 ### PWA / Pull-to-Refresh
 
 - **Native pull-to-refresh works everywhere except iOS PWA standalone mode.** Apple explicitly disables it. Don't use `overscroll-behavior: contain` globally — that blocks the native gesture on all platforms. Only use a custom touch-based pull-to-refresh for iOS PWA (detect with `navigator.standalone` or `matchMedia('(display-mode: standalone)')` + iOS UA check).
-- **Don't put `pullDistance` in a useEffect dependency array** when using touch-based pull-to-refresh. The state updates on every pixel of movement, causing event listener thrashing (detach + reattach 3 listeners 60+ times/sec). Use a local `let` variable inside the effect for the threshold check, and only use React state for rendering the indicator.
+- **Don't use React state for per-pixel touch tracking.** `setState` on every touchmove causes 60+ re-renders/sec. Instead, use refs + direct DOM manipulation (`element.style.transform`, `element.style.opacity`, `classList.toggle`) for drag visuals, and only use React state for mount/unmount (e.g., `setPullActive(true)` to mount the indicator once).
+- **Coalesce requestAnimationFrame calls.** On 120Hz displays, touchmove fires faster than rAF. Use a `rAFPending` flag to skip redundant frames and read the latest value at callback time (not call time).
+- **Touch listeners must go on the scroll container, not document.body.** `e.preventDefault()` on body touchmove doesn't suppress a child scroll container's native overscroll bounce. Attach listeners to the scrollable element directly.
+
+### iOS PWA Safe Area Positioning
+
+- **`position: fixed; top: 0` goes behind the notch** in iOS PWA with `viewport-fit: cover` and `black-translucent` status bar. All fixed header elements must use `calc(env(safe-area-inset-top, 0px) + offset)`.
+- **The `<html>` element has `padding: env(safe-area-inset-top) ...`** in globals.css, which pushes `<body>` content below the safe area. Elements inside the `ResponsiveScaling` container have their `position: fixed` coordinates relative to the container (because `transform` creates a new containing block), so `top: 0` inside the scaling container is *not* the screen top — it's already below the safe area.
+- **To position at the true screen edge**, render via a portal to `document.body` (outside the scaling container). From there, `fixed top: 0` = the safe area boundary (notch bottom), not the physical screen top.
 
 ### Dev Server Pitfalls
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -32,8 +32,6 @@ function CreatePollContent() {
   const [forkOf, setForkOf] = useState<string | null>(null);
   const [voteFromNomination, setVoteFromNomination] = useState<string | null>(null);
 
-  debugLog.logObject('Create poll page loaded with params', { followUpTo: followUpToParam, forkOf: forkOfParam, duplicateOf: duplicateOfParam, voteFromNomination: voteFromNominationParam }, 'CreatePoll');
-  
   const [title, setTitle] = useState("");
   const [pollType, setPollType] = useState<'poll' | 'nomination' | 'participation'>('nomination');
   const [options, setOptions] = useState<string[]>(['']);
@@ -278,6 +276,7 @@ function CreatePollContent() {
 
   // Initialize state from URL params
   useEffect(() => {
+    debugLog.logObject('Create poll page loaded with params', { followUpTo: followUpToParam, forkOf: forkOfParam, duplicateOf: duplicateOfParam, voteFromNomination: voteFromNominationParam }, 'CreatePoll');
     if (followUpToParam) setFollowUpTo(followUpToParam);
     if (forkOfParam) setForkOf(forkOfParam);
     if (duplicateOfParam) setDuplicateOf(duplicateOfParam);

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -384,7 +384,7 @@ export default function Template({ children }: AppTemplateProps) {
           <div
             className="fixed left-0 right-0 z-50 flex justify-center pointer-events-none"
             style={{
-              top: 'calc(env(safe-area-inset-top, 0px) + 1px)',
+              top: '1px',
               opacity,
               transition: isAnimatingBack ? 'opacity 0.3s ease' : 'none',
             }}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -382,7 +382,7 @@ export default function Template({ children }: AppTemplateProps) {
           <div
             className="fixed left-0 right-0 z-[9999] flex justify-center pointer-events-none"
             style={{
-              top: '1px',
+              top: 'calc(env(safe-area-inset-top, 0px) + 2px)',
               opacity,
               transition: isAnimatingBack ? 'opacity 0.3s ease' : 'none',
             }}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -27,8 +27,9 @@ export default function Template({ children }: AppTemplateProps) {
   const isInBounceRef = useRef(false);
 
   // Pull-to-refresh state
-  const [isPulling, setIsPulling] = useState(false);
-  const [pullDistance, setPullDistance] = useState(0);
+  const [pullDistance, setPullDistance] = useState(0);  // raw touch delta (drives visuals)
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isAnimatingBack, setIsAnimatingBack] = useState(false); // CSS transition active
   
   // Check if referrer is from a different domain or if this is a new tab/external entry
   // Also determine if back button should show home icon instead
@@ -269,6 +270,10 @@ export default function Template({ children }: AppTemplateProps) {
   // explicitly disables it in iOS standalone/fullscreen PWA mode.)
   // Touch listeners must be on the scroll container (not document.body) so that
   // e.preventDefault() actually suppresses the container's native overscroll bounce.
+  //
+  // Mimics Safari's native pull-to-refresh: the whole page translates down with
+  // a damped drag, a circular progress arc shows how close you are to the
+  // threshold, and dragging back up cancels the gesture.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (!isIOSPWA) return;
@@ -279,39 +284,62 @@ export default function Template({ children }: AppTemplateProps) {
     // Suppress native rubber-band overscroll so our custom handler takes over
     scrollContainer.style.overscrollBehaviorY = 'none';
 
+    const THRESHOLD = 80; // px of raw touch movement to trigger refresh
+    const MAX_PULL = 140; // visual cap (raw touch px)
+
     let startY = 0;
     let isAtTop = true;
     let isDragging = false;
     let currentPullDistance = 0;
 
     const handleTouchStart = (e: TouchEvent) => {
+      if (isRefreshing) return;
       startY = e.touches[0].clientY;
       isAtTop = scrollContainer.scrollTop <= 5;
     };
 
     const handleTouchMove = (e: TouchEvent) => {
-      if (!isAtTop) return;
+      if (isRefreshing || !isAtTop) return;
 
-      const deltaY = e.touches[0].clientY - startY;
+      const rawDelta = e.touches[0].clientY - startY;
 
-      if (deltaY > 10) {
+      if (rawDelta > 10) {
         isDragging = true;
-        currentPullDistance = deltaY;
-        setPullDistance(deltaY);
-        setIsPulling(deltaY > 60);
+        // Clamp so the indicator doesn't fly off screen
+        currentPullDistance = Math.min(rawDelta, MAX_PULL);
+        setPullDistance(currentPullDistance);
         e.preventDefault();
+      } else if (isDragging && rawDelta <= 10) {
+        // User dragged back up past the start — cancel
+        isDragging = false;
+        currentPullDistance = 0;
+        setPullDistance(0);
       }
     };
 
     const handleTouchEnd = () => {
-      if (isDragging && currentPullDistance > 60) {
-        window.location.reload();
+      if (isRefreshing) return;
+
+      if (isDragging && currentPullDistance >= THRESHOLD) {
+        // Show refreshing state, then reload
+        setIsRefreshing(true);
+        setPullDistance(THRESHOLD);
+        setTimeout(() => window.location.reload(), 400);
+      } else if (isDragging) {
+        // Animate back: enable CSS transition, then set distance to 0 after the
+        // browser has painted the current pulled-down position with transition enabled.
+        setIsAnimatingBack(true);
+        // Double-rAF ensures the transition property is painted before we change the value
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            setPullDistance(0);
+            setTimeout(() => setIsAnimatingBack(false), 300);
+          });
+        });
       }
 
       isDragging = false;
       currentPullDistance = 0;
-      setIsPulling(false);
-      setPullDistance(0);
     };
 
     scrollContainer.addEventListener('touchstart', handleTouchStart, { passive: true });
@@ -324,7 +352,10 @@ export default function Template({ children }: AppTemplateProps) {
       scrollContainer.removeEventListener('touchend', handleTouchEnd);
       scrollContainer.style.overscrollBehaviorY = '';
     };
-  }, [isIOSPWA]);
+  }, [isIOSPWA, isRefreshing]);
+
+  // Damped visual offset for pull-to-refresh: diminishing returns like rubber band
+  const pullDamped = pullDistance > 0 ? pullDistance * 0.5 : 0;
 
   const isPollPage = pathname.startsWith('/p/');
   const isCreatePollPage = pathname === '/create-poll' || pathname === '/create-poll/';
@@ -332,34 +363,57 @@ export default function Template({ children }: AppTemplateProps) {
 
   return (
     <>
-      {/* Pull-to-refresh indicator (iOS PWA only) */}
-      {isIOSPWA && isPulling && (
-        <div
-          className="fixed top-0 left-0 right-0 z-50 flex justify-center items-center transition-all duration-200"
-          style={{
-            transform: `translateY(${Math.min(pullDistance - 60, 40)}px)`,
-            opacity: pullDistance > 30 ? 1 : pullDistance / 30
-          }}
-        >
-          <div className="bg-white dark:bg-gray-800 rounded-full shadow-lg p-2 mt-4">
-            <svg
-              className={`w-6 h-6 text-blue-600 dark:text-blue-400 ${
-                pullDistance > 60 ? 'animate-spin' : ''
-              }`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
+      {/* Pull-to-refresh indicator (iOS PWA only) — circular progress arc like Safari */}
+      {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && (() => {
+        const THRESHOLD = 80;
+        // Progress 0→1 based on how close to threshold
+        const progress = Math.min(pullDistance / THRESHOLD, 1);
+        const pastThreshold = pullDistance >= THRESHOLD;
+        // SVG arc: radius 10, circumference ≈ 62.8
+        const circumference = 2 * Math.PI * 10;
+        const arcLength = progress * circumference;
+
+        return (
+          <div
+            className="fixed left-0 right-0 z-50 flex justify-center pointer-events-none"
+            style={{
+              top: `calc(env(safe-area-inset-top, 0px) + ${pullDamped - 20}px)`,
+              transition: isAnimatingBack ? 'top 0.3s ease, opacity 0.3s ease' : 'none',
+              opacity: isAnimatingBack ? 0 : 1,
+            }}
+          >
+            <div className="bg-white dark:bg-gray-800 rounded-full shadow-lg p-2">
+              {isRefreshing ? (
+                <svg className="w-6 h-6 text-blue-600 dark:text-blue-400 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2.5" opacity="0.2" />
+                  <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+                </svg>
+              ) : (
+                <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none">
+                  {/* Background circle track */}
+                  <circle
+                    cx="12" cy="12" r="10"
+                    stroke="currentColor"
+                    className="text-gray-200 dark:text-gray-600"
+                    strokeWidth="2.5"
+                  />
+                  {/* Progress arc */}
+                  <circle
+                    cx="12" cy="12" r="10"
+                    stroke="currentColor"
+                    className={pastThreshold ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeDasharray={`${arcLength} ${circumference}`}
+                    transform="rotate(-90 12 12)"
+                    style={{ transition: 'stroke-dasharray 0.05s linear' }}
+                  />
+                </svg>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Fixed Header - skip for poll, create poll, profile, and home pages */}
       {!isPollPage && !isCreatePollPage && !isProfilePage && pathname !== '/' && (
@@ -395,12 +449,16 @@ export default function Template({ children }: AppTemplateProps) {
       {/* Scrollable Content Area - consistent across all pages */}
       <div
         ref={scrollContainerRef}
-        className="flex-1 overflow-auto safari-scroll-container" 
-        style={{ 
+        className="flex-1 overflow-auto safari-scroll-container"
+        style={{
           paddingTop: '0',
-          paddingLeft: 'max(1rem, env(safe-area-inset-left))', 
+          paddingLeft: 'max(1rem, env(safe-area-inset-left))',
           paddingRight: 'max(1rem, env(safe-area-inset-right))',
-          paddingBottom: '1rem'
+          paddingBottom: '1rem',
+          ...(isIOSPWA && (pullDamped > 0 || isAnimatingBack) ? {
+            transform: `translateY(${pullDamped}px)`,
+            transition: isAnimatingBack ? 'transform 0.3s ease' : 'none',
+          } : {}),
         }}>
         <div>
           {/* Spacer div for header elements that are now rendered in portal */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -284,7 +284,7 @@ export default function Template({ children }: AppTemplateProps) {
     // Suppress native rubber-band overscroll so our custom handler takes over
     scrollContainer.style.overscrollBehaviorY = 'none';
 
-    const THRESHOLD = 120; // px of raw touch movement to trigger refresh
+    const THRESHOLD = 240; // px of raw touch movement to trigger refresh
 
     let startY = 0;
     let isAtTop = true;
@@ -363,7 +363,7 @@ export default function Template({ children }: AppTemplateProps) {
     <>
       {/* Pull-to-refresh indicator — rendered via portal to escape scaling container */}
       {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && isMounted && (() => {
-        const THRESHOLD = 120;
+        const THRESHOLD = 240;
         const INDICATOR_SIZE = 40;
         const progress = Math.min(pullDistance / THRESHOLD, 1);
         const pastThreshold = pullDistance >= THRESHOLD;

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -364,18 +364,18 @@ export default function Template({ children }: AppTemplateProps) {
   return (
     <>
       {/* DEBUG: Boundary lines — remove after testing */}
-      {isIOSPWA && (
-        <div className="fixed inset-0 z-[9999] pointer-events-none" style={{ fontSize: '10px', fontFamily: 'monospace' }}>
-          {/* Line 1: top: 0 (true screen edge) */}
+      {isIOSPWA && isMounted && createPortal(
+        <div style={{ position: 'fixed', inset: 0, zIndex: 9999, pointerEvents: 'none', fontSize: '10px', fontFamily: 'monospace', top: 'calc(-1 * env(safe-area-inset-top, 0px))' }}>
+          {/* Line A: true screen top (0 from viewport) */}
           <div style={{ position: 'absolute', top: 0, left: 0, right: 0 }}>
             <div style={{ borderTop: '2px solid red', position: 'relative' }}>
               <span style={{ position: 'absolute', left: 4, top: 2, color: 'red', background: 'white', padding: '0 4px' }}>
-                A: top: 0
+                A: screen top
               </span>
             </div>
           </div>
 
-          {/* Line 2: env(safe-area-inset-top) */}
+          {/* Line B: safe-area-inset-top (bottom of notch/Dynamic Island) */}
           <div style={{ position: 'absolute', top: 'env(safe-area-inset-top, 0px)', left: 0, right: 0 }}>
             <div style={{ borderTop: '2px solid blue', position: 'relative' }}>
               <span style={{ position: 'absolute', left: 4, top: 2, color: 'blue', background: 'white', padding: '0 4px' }}>
@@ -384,33 +384,25 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           </div>
 
-          {/* Line 3: safe-area-inset-top + 1rem (content padding start) */}
-          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) + 1rem)', left: 0, right: 0 }}>
+          {/* Line C: where content starts (safe-area-inset-top x2 due to html padding) */}
+          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) * 2)', left: 0, right: 0 }}>
             <div style={{ borderTop: '2px solid green', position: 'relative' }}>
               <span style={{ position: 'absolute', left: 4, top: 2, color: 'green', background: 'white', padding: '0 4px' }}>
-                C: safe-area + 1rem
+                C: safe-area x2 (content start?)
               </span>
             </div>
           </div>
 
-          {/* Line 4: safe-area-inset-top + 2rem */}
-          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) + 2rem)', left: 0, right: 0 }}>
-            <div style={{ borderTop: '2px solid orange', position: 'relative' }}>
-              <span style={{ position: 'absolute', left: 4, top: 2, color: 'orange', background: 'white', padding: '0 4px' }}>
-                D: safe-area + 2rem
+          {/* Line D: fixed top:0 inside scaling container (where our indicator currently renders) */}
+          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) + env(safe-area-inset-top, 0px))', left: 0, right: 0 }}>
+            <div style={{ borderTop: '2px dashed orange', position: 'relative' }}>
+              <span style={{ position: 'absolute', right: 4, top: 2, color: 'orange', background: 'white', padding: '0 4px' }}>
+                D: container top:0
               </span>
             </div>
           </div>
-
-          {/* Line 5: 59px (typical iPhone notch inset) */}
-          <div style={{ position: 'absolute', top: '59px', left: 0, right: 0 }}>
-            <div style={{ borderTop: '2px dashed purple', position: 'relative' }}>
-              <span style={{ position: 'absolute', left: 4, top: 2, color: 'purple', background: 'white', padding: '0 4px' }}>
-                E: 59px (typical notch)
-              </span>
-            </div>
-          </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       {/* Pull-to-refresh indicator (iOS PWA only) — fixed at top, fades in as page pulls down */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -363,12 +363,19 @@ export default function Template({ children }: AppTemplateProps) {
 
   return (
     <>
-      {/* Pull-to-refresh indicator (iOS PWA only) — circular progress arc like Safari */}
+      {/* Pull-to-refresh indicator (iOS PWA only) — fixed at top, fades in as page pulls down */}
       {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && (() => {
         const THRESHOLD = 80;
+        const INDICATOR_SIZE = 40; // approx height of circle + padding
         // Progress 0→1 based on how close to threshold
         const progress = Math.min(pullDistance / THRESHOLD, 1);
         const pastThreshold = pullDistance >= THRESHOLD;
+        // Fade in once the page has moved down enough to reveal the indicator
+        const fadeStart = INDICATOR_SIZE * 0.5; // start fading in
+        const fadeEnd = INDICATOR_SIZE;          // fully visible
+        const opacity = isAnimatingBack
+          ? 0
+          : Math.min(Math.max((pullDamped - fadeStart) / (fadeEnd - fadeStart), 0), 1);
         // SVG arc: radius 10, circumference ≈ 62.8
         const circumference = 2 * Math.PI * 10;
         const arcLength = progress * circumference;
@@ -377,9 +384,9 @@ export default function Template({ children }: AppTemplateProps) {
           <div
             className="fixed left-0 right-0 z-50 flex justify-center pointer-events-none"
             style={{
-              top: `calc(env(safe-area-inset-top, 0px) + ${pullDamped - 20}px)`,
-              transition: isAnimatingBack ? 'top 0.3s ease, opacity 0.3s ease' : 'none',
-              opacity: isAnimatingBack ? 0 : 1,
+              top: 'calc(env(safe-area-inset-top, 0px) + 8px)',
+              opacity,
+              transition: isAnimatingBack ? 'opacity 0.3s ease' : 'none',
             }}
           >
             <div className="bg-white dark:bg-gray-800 rounded-full shadow-lg p-2">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -26,10 +26,12 @@ export default function Template({ children }: AppTemplateProps) {
   const bounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isInBounceRef = useRef(false);
 
-  // Pull-to-refresh state
-  const [pullDistance, setPullDistance] = useState(0);  // raw touch delta (drives visuals)
+  // Pull-to-refresh state — uses refs + direct DOM manipulation for 60fps during drag,
+  // React state only for mount/unmount of indicator and final actions (refresh/snap-back).
+  const [pullActive, setPullActive] = useState(false);    // whether indicator is mounted
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [isAnimatingBack, setIsAnimatingBack] = useState(false); // CSS transition active
+  const pullIndicatorRef = useRef<HTMLDivElement>(null);   // direct DOM ref for indicator
+  const pullArcRef = useRef<SVGCircleElement>(null);       // direct DOM ref for arc
   
   // Check if referrer is from a different domain or if this is a new tab/external entry
   // Also determine if back button should show home icon instead
@@ -265,15 +267,9 @@ export default function Template({ children }: AppTemplateProps) {
     };
   }, []);
 
-  // Pull-to-refresh functionality — only for iOS PWA standalone mode
-  // (Native pull-to-refresh works in browsers and Android PWA, but Apple
-  // explicitly disables it in iOS standalone/fullscreen PWA mode.)
-  // Touch listeners must be on the scroll container (not document.body) so that
-  // e.preventDefault() actually suppresses the container's native overscroll bounce.
-  //
-  // Mimics Safari's native pull-to-refresh: the whole page translates down with
-  // a damped drag, a circular progress arc shows how close you are to the
-  // threshold, and dragging back up cancels the gesture.
+  // Pull-to-refresh functionality — only for iOS PWA standalone mode.
+  // Uses direct DOM manipulation during touchmove for smooth 60fps updates,
+  // avoiding React re-renders on every pixel of movement.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (!isIOSPWA) return;
@@ -281,59 +277,95 @@ export default function Template({ children }: AppTemplateProps) {
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) return;
 
-    // Suppress native rubber-band overscroll so our custom handler takes over
     scrollContainer.style.overscrollBehaviorY = 'none';
 
-    const THRESHOLD = 240; // px of raw touch movement to trigger refresh
+    const THRESHOLD = 240;
+    const CIRCUMFERENCE = 2 * Math.PI * 10;
+    const INDICATOR_SIZE = 40;
 
     let startY = 0;
     let isAtTop = true;
     let isDragging = false;
     let currentPullDistance = 0;
+    let refreshing = false;
+
+    // Direct DOM update — no React re-render
+    const updateDOM = (distance: number) => {
+      const damped = distance * 0.5;
+      // Update scroll container position
+      scrollContainer.style.transform = `translateY(${damped}px)`;
+      scrollContainer.style.transition = 'none';
+      // Update indicator
+      const indicator = pullIndicatorRef.current;
+      const arc = pullArcRef.current;
+      if (indicator) {
+        const fadeStart = INDICATOR_SIZE * 0.5;
+        const fadeEnd = INDICATOR_SIZE;
+        const opacity = Math.min(Math.max((damped - fadeStart) / (fadeEnd - fadeStart), 0), 1);
+        indicator.style.opacity = String(opacity);
+        indicator.style.transition = 'none';
+      }
+      if (arc) {
+        const progress = Math.min(distance / THRESHOLD, 1);
+        const arcLength = progress * CIRCUMFERENCE;
+        arc.style.strokeDasharray = `${arcLength} ${CIRCUMFERENCE}`;
+        arc.style.stroke = distance >= THRESHOLD ? '' : '';
+        arc.classList.toggle('text-blue-600', distance >= THRESHOLD);
+        arc.classList.toggle('dark:text-blue-400', distance >= THRESHOLD);
+        arc.classList.toggle('text-gray-400', distance < THRESHOLD);
+        arc.classList.toggle('dark:text-gray-500', distance < THRESHOLD);
+      }
+    };
 
     const handleTouchStart = (e: TouchEvent) => {
-      if (isRefreshing) return;
+      if (refreshing) return;
       startY = e.touches[0].clientY;
       isAtTop = scrollContainer.scrollTop <= 5;
     };
 
     const handleTouchMove = (e: TouchEvent) => {
-      if (isRefreshing || !isAtTop) return;
+      if (refreshing || !isAtTop) return;
 
       const rawDelta = e.touches[0].clientY - startY;
 
       if (rawDelta > 10) {
-        isDragging = true;
+        if (!isDragging) {
+          isDragging = true;
+          setPullActive(true); // mount the indicator (one-time React render)
+        }
         currentPullDistance = rawDelta;
-        setPullDistance(currentPullDistance);
+        // Wait one frame for React to mount the indicator on first drag
+        requestAnimationFrame(() => updateDOM(currentPullDistance));
         e.preventDefault();
       } else if (isDragging && rawDelta <= 10) {
-        // User dragged back up past the start — cancel
         isDragging = false;
         currentPullDistance = 0;
-        setPullDistance(0);
+        updateDOM(0);
+        setPullActive(false);
       }
     };
 
     const handleTouchEnd = () => {
-      if (isRefreshing) return;
+      if (refreshing) return;
 
       if (isDragging && currentPullDistance >= THRESHOLD) {
-        // Show refreshing state, then reload
+        refreshing = true;
         setIsRefreshing(true);
-        setPullDistance(THRESHOLD);
         setTimeout(() => window.location.reload(), 400);
       } else if (isDragging) {
-        // Animate back: enable CSS transition, then set distance to 0 after the
-        // browser has painted the current pulled-down position with transition enabled.
-        setIsAnimatingBack(true);
-        // Double-rAF ensures the transition property is painted before we change the value
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            setPullDistance(0);
-            setTimeout(() => setIsAnimatingBack(false), 300);
-          });
-        });
+        // Snap back with CSS transition
+        scrollContainer.style.transition = 'transform 0.3s ease';
+        scrollContainer.style.transform = 'translateY(0px)';
+        const indicator = pullIndicatorRef.current;
+        if (indicator) {
+          indicator.style.transition = 'opacity 0.3s ease';
+          indicator.style.opacity = '0';
+        }
+        setTimeout(() => {
+          scrollContainer.style.transition = '';
+          scrollContainer.style.transform = '';
+          setPullActive(false);
+        }, 300);
       }
 
       isDragging = false;
@@ -349,11 +381,10 @@ export default function Template({ children }: AppTemplateProps) {
       scrollContainer.removeEventListener('touchmove', handleTouchMove);
       scrollContainer.removeEventListener('touchend', handleTouchEnd);
       scrollContainer.style.overscrollBehaviorY = '';
+      scrollContainer.style.transform = '';
+      scrollContainer.style.transition = '';
     };
-  }, [isIOSPWA, isRefreshing]);
-
-  // Damped visual offset for pull-to-refresh: diminishing returns like rubber band
-  const pullDamped = pullDistance > 0 ? pullDistance * 0.5 : 0;
+  }, [isIOSPWA]);
 
   const isPollPage = pathname.startsWith('/p/');
   const isCreatePollPage = pathname === '/create-poll' || pathname === '/create-poll/';
@@ -361,54 +392,40 @@ export default function Template({ children }: AppTemplateProps) {
 
   return (
     <>
-      {/* Pull-to-refresh indicator — rendered via portal to escape scaling container */}
-      {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && isMounted && (() => {
-        const THRESHOLD = 240;
-        const INDICATOR_SIZE = 40;
-        const progress = Math.min(pullDistance / THRESHOLD, 1);
-        const pastThreshold = pullDistance >= THRESHOLD;
-        // Fade in once page has moved down enough to reveal without overlapping
-        const fadeStart = INDICATOR_SIZE * 0.5;
-        const fadeEnd = INDICATOR_SIZE;
-        const opacity = isAnimatingBack
-          ? 0
-          : Math.min(Math.max((pullDamped - fadeStart) / (fadeEnd - fadeStart), 0), 1);
-        const circumference = 2 * Math.PI * 10;
-        const arcLength = progress * circumference;
-
-        return createPortal(
-          <div
-            className="fixed left-0 right-0 z-[9999] flex justify-center pointer-events-none"
-            style={{
-              top: 'calc(env(safe-area-inset-top, 0px) + 2px)',
-              opacity,
-              transition: isAnimatingBack ? 'opacity 0.3s ease' : 'none',
-            }}
-          >
-            <div className="bg-white dark:bg-gray-800 rounded-full shadow-lg p-2">
-              {isRefreshing ? (
-                <svg className="w-6 h-6 text-blue-600 dark:text-blue-400 animate-spin" viewBox="0 0 24 24" fill="none">
-                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2.5" opacity="0.2" />
-                  <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
-                </svg>
-              ) : (
-                <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none">
-                  <circle cx="12" cy="12" r="10" stroke="currentColor" className="text-gray-200 dark:text-gray-600" strokeWidth="2.5" />
-                  <circle
-                    cx="12" cy="12" r="10" stroke="currentColor"
-                    className={pastThreshold ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}
-                    strokeWidth="2.5" strokeLinecap="round"
-                    strokeDasharray={`${arcLength} ${circumference}`}
-                    transform="rotate(-90 12 12)"
-                    style={{ transition: 'stroke-dasharray 0.05s linear' }}
-                  />
-                </svg>
-              )}
-            </div>
-          </div>,
-          document.body
-        );
-      })()}
+      {/* Pull-to-refresh indicator — rendered via portal to escape scaling container.
+           Uses refs for direct DOM updates during drag (no React re-renders). */}
+      {isIOSPWA && (pullActive || isRefreshing) && isMounted && createPortal(
+        <div
+          ref={pullIndicatorRef}
+          className="fixed left-0 right-0 z-[9999] flex justify-center pointer-events-none"
+          style={{
+            top: 'calc(env(safe-area-inset-top, 0px) + 2px)',
+            opacity: isRefreshing ? 1 : 0,
+          }}
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-full shadow-lg p-2">
+            {isRefreshing ? (
+              <svg className="w-6 h-6 text-blue-600 dark:text-blue-400 animate-spin" viewBox="0 0 24 24" fill="none">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2.5" opacity="0.2" />
+                <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+              </svg>
+            ) : (
+              <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" className="text-gray-200 dark:text-gray-600" strokeWidth="2.5" />
+                <circle
+                  ref={pullArcRef}
+                  cx="12" cy="12" r="10" stroke="currentColor"
+                  className="text-gray-400 dark:text-gray-500"
+                  strokeWidth="2.5" strokeLinecap="round"
+                  strokeDasharray="0 62.83"
+                  transform="rotate(-90 12 12)"
+                />
+              </svg>
+            )}
+          </div>
+        </div>,
+        document.body
+      )}
 
       {/* Fixed Header - skip for poll, create poll, profile, and home pages */}
       {!isPollPage && !isCreatePollPage && !isProfilePage && pathname !== '/' && (
@@ -450,10 +467,6 @@ export default function Template({ children }: AppTemplateProps) {
           paddingLeft: 'max(1rem, env(safe-area-inset-left))',
           paddingRight: 'max(1rem, env(safe-area-inset-right))',
           paddingBottom: '1rem',
-          ...(isIOSPWA && (pullDamped > 0 || isAnimatingBack) ? {
-            transform: `translateY(${pullDamped}px)`,
-            transition: isAnimatingBack ? 'transform 0.3s ease' : 'none',
-          } : {}),
         }}>
         <div>
           {/* Spacer div for header elements that are now rendered in portal */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -363,68 +363,24 @@ export default function Template({ children }: AppTemplateProps) {
 
   return (
     <>
-      {/* DEBUG: Boundary lines — remove after testing */}
-      {isIOSPWA && isMounted && createPortal(
-        <div style={{ position: 'fixed', inset: 0, zIndex: 9999, pointerEvents: 'none', fontSize: '10px', fontFamily: 'monospace', top: 'calc(-1 * env(safe-area-inset-top, 0px))' }}>
-          {/* Line A: true screen top (0 from viewport) */}
-          <div style={{ position: 'absolute', top: 0, left: 0, right: 0 }}>
-            <div style={{ borderTop: '2px solid red', position: 'relative' }}>
-              <span style={{ position: 'absolute', left: 4, top: 2, color: 'red', background: 'white', padding: '0 4px' }}>
-                A: screen top
-              </span>
-            </div>
-          </div>
-
-          {/* Line B: safe-area-inset-top (bottom of notch/Dynamic Island) */}
-          <div style={{ position: 'absolute', top: 'env(safe-area-inset-top, 0px)', left: 0, right: 0 }}>
-            <div style={{ borderTop: '2px solid blue', position: 'relative' }}>
-              <span style={{ position: 'absolute', left: 4, top: 2, color: 'blue', background: 'white', padding: '0 4px' }}>
-                B: safe-area-inset-top
-              </span>
-            </div>
-          </div>
-
-          {/* Line C: where content starts (safe-area-inset-top x2 due to html padding) */}
-          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) * 2)', left: 0, right: 0 }}>
-            <div style={{ borderTop: '2px solid green', position: 'relative' }}>
-              <span style={{ position: 'absolute', left: 4, top: 2, color: 'green', background: 'white', padding: '0 4px' }}>
-                C: safe-area x2 (content start?)
-              </span>
-            </div>
-          </div>
-
-          {/* Line D: fixed top:0 inside scaling container (where our indicator currently renders) */}
-          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) + env(safe-area-inset-top, 0px))', left: 0, right: 0 }}>
-            <div style={{ borderTop: '2px dashed orange', position: 'relative' }}>
-              <span style={{ position: 'absolute', right: 4, top: 2, color: 'orange', background: 'white', padding: '0 4px' }}>
-                D: container top:0
-              </span>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
-
-      {/* Pull-to-refresh indicator (iOS PWA only) — fixed at top, fades in as page pulls down */}
-      {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && (() => {
+      {/* Pull-to-refresh indicator — rendered via portal to escape scaling container */}
+      {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && isMounted && (() => {
         const THRESHOLD = 80;
-        const INDICATOR_SIZE = 40; // approx height of circle + padding
-        // Progress 0→1 based on how close to threshold
+        const INDICATOR_SIZE = 40;
         const progress = Math.min(pullDistance / THRESHOLD, 1);
         const pastThreshold = pullDistance >= THRESHOLD;
-        // Fade in once the page has moved down enough to reveal the indicator
-        const fadeStart = INDICATOR_SIZE * 0.5; // start fading in
-        const fadeEnd = INDICATOR_SIZE;          // fully visible
+        // Fade in once page has moved down enough to reveal without overlapping
+        const fadeStart = INDICATOR_SIZE * 0.5;
+        const fadeEnd = INDICATOR_SIZE;
         const opacity = isAnimatingBack
           ? 0
           : Math.min(Math.max((pullDamped - fadeStart) / (fadeEnd - fadeStart), 0), 1);
-        // SVG arc: radius 10, circumference ≈ 62.8
         const circumference = 2 * Math.PI * 10;
         const arcLength = progress * circumference;
 
-        return (
+        return createPortal(
           <div
-            className="fixed left-0 right-0 z-50 flex justify-center pointer-events-none"
+            className="fixed left-0 right-0 z-[9999] flex justify-center pointer-events-none"
             style={{
               top: '1px',
               opacity,
@@ -439,20 +395,11 @@ export default function Template({ children }: AppTemplateProps) {
                 </svg>
               ) : (
                 <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none">
-                  {/* Background circle track */}
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" className="text-gray-200 dark:text-gray-600" strokeWidth="2.5" />
                   <circle
-                    cx="12" cy="12" r="10"
-                    stroke="currentColor"
-                    className="text-gray-200 dark:text-gray-600"
-                    strokeWidth="2.5"
-                  />
-                  {/* Progress arc */}
-                  <circle
-                    cx="12" cy="12" r="10"
-                    stroke="currentColor"
+                    cx="12" cy="12" r="10" stroke="currentColor"
                     className={pastThreshold ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
+                    strokeWidth="2.5" strokeLinecap="round"
                     strokeDasharray={`${arcLength} ${circumference}`}
                     transform="rotate(-90 12 12)"
                     style={{ transition: 'stroke-dasharray 0.05s linear' }}
@@ -460,7 +407,8 @@ export default function Template({ children }: AppTemplateProps) {
                 </svg>
               )}
             </div>
-          </div>
+          </div>,
+          document.body
         );
       })()}
 
@@ -641,7 +589,7 @@ export default function Template({ children }: AppTemplateProps) {
       <HeaderPortal>
         {/* Back arrow or home button in upper left - only for poll/create/profile pages */}
         {(isPollPage || isCreatePollPage || isProfilePage) && !isExternalReferrer && (
-          <div className="fixed left-4 top-4 z-50">
+          <div className="fixed left-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
             {shouldShowHomeButton ? (
                 <button 
                   onClick={() => window.location.href = '/'}
@@ -668,14 +616,14 @@ export default function Template({ children }: AppTemplateProps) {
         
         {/* Copy link button in upper right for poll pages */}
         {isPollPage && (
-          <div className="fixed right-4 top-4 z-50">
+          <div className="fixed right-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
             <FloatingCopyLinkButton url={typeof window !== 'undefined' ? window.location.href : ''} />
           </div>
         )}
         
         {/* New poll button in upper right for home page */}
         {pathname === '/' && (
-          <div className="fixed right-4 top-4 z-50">
+          <div className="fixed right-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
             <Link
               href="/create-poll"
               className="w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -267,9 +267,17 @@ export default function Template({ children }: AppTemplateProps) {
   // Pull-to-refresh functionality — only for iOS PWA standalone mode
   // (Native pull-to-refresh works in browsers and Android PWA, but Apple
   // explicitly disables it in iOS standalone/fullscreen PWA mode.)
+  // Touch listeners must be on the scroll container (not document.body) so that
+  // e.preventDefault() actually suppresses the container's native overscroll bounce.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (!isIOSPWA) return;
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    // Suppress native rubber-band overscroll so our custom handler takes over
+    scrollContainer.style.overscrollBehaviorY = 'none';
 
     let startY = 0;
     let isAtTop = true;
@@ -278,8 +286,7 @@ export default function Template({ children }: AppTemplateProps) {
 
     const handleTouchStart = (e: TouchEvent) => {
       startY = e.touches[0].clientY;
-      const scrollContainer = scrollContainerRef.current;
-      isAtTop = scrollContainer ? scrollContainer.scrollTop <= 5 : true;
+      isAtTop = scrollContainer.scrollTop <= 5;
     };
 
     const handleTouchMove = (e: TouchEvent) => {
@@ -307,14 +314,15 @@ export default function Template({ children }: AppTemplateProps) {
       setPullDistance(0);
     };
 
-    document.body.addEventListener('touchstart', handleTouchStart, { passive: false });
-    document.body.addEventListener('touchmove', handleTouchMove, { passive: false });
-    document.body.addEventListener('touchend', handleTouchEnd, { passive: true });
+    scrollContainer.addEventListener('touchstart', handleTouchStart, { passive: true });
+    scrollContainer.addEventListener('touchmove', handleTouchMove, { passive: false });
+    scrollContainer.addEventListener('touchend', handleTouchEnd, { passive: true });
 
     return () => {
-      document.body.removeEventListener('touchstart', handleTouchStart);
-      document.body.removeEventListener('touchmove', handleTouchMove);
-      document.body.removeEventListener('touchend', handleTouchEnd);
+      scrollContainer.removeEventListener('touchstart', handleTouchStart);
+      scrollContainer.removeEventListener('touchmove', handleTouchMove);
+      scrollContainer.removeEventListener('touchend', handleTouchEnd);
+      scrollContainer.style.overscrollBehaviorY = '';
     };
   }, [isIOSPWA]);
 

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -384,7 +384,7 @@ export default function Template({ children }: AppTemplateProps) {
           <div
             className="fixed left-0 right-0 z-50 flex justify-center pointer-events-none"
             style={{
-              top: 'calc(env(safe-area-inset-top, 0px) + 8px)',
+              top: 'calc(env(safe-area-inset-top, 0px) + 1px)',
               opacity,
               transition: isAnimatingBack ? 'opacity 0.3s ease' : 'none',
             }}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -284,7 +284,7 @@ export default function Template({ children }: AppTemplateProps) {
     // Suppress native rubber-band overscroll so our custom handler takes over
     scrollContainer.style.overscrollBehaviorY = 'none';
 
-    const THRESHOLD = 80; // px of raw touch movement to trigger refresh
+    const THRESHOLD = 120; // px of raw touch movement to trigger refresh
 
     let startY = 0;
     let isAtTop = true;
@@ -363,7 +363,7 @@ export default function Template({ children }: AppTemplateProps) {
     <>
       {/* Pull-to-refresh indicator — rendered via portal to escape scaling container */}
       {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && isMounted && (() => {
-        const THRESHOLD = 80;
+        const THRESHOLD = 120;
         const INDICATOR_SIZE = 40;
         const progress = Math.min(pullDistance / THRESHOLD, 1);
         const pastThreshold = pullDistance >= THRESHOLD;

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -285,7 +285,6 @@ export default function Template({ children }: AppTemplateProps) {
     scrollContainer.style.overscrollBehaviorY = 'none';
 
     const THRESHOLD = 80; // px of raw touch movement to trigger refresh
-    const MAX_PULL = 140; // visual cap (raw touch px)
 
     let startY = 0;
     let isAtTop = true;
@@ -305,8 +304,7 @@ export default function Template({ children }: AppTemplateProps) {
 
       if (rawDelta > 10) {
         isDragging = true;
-        // Clamp so the indicator doesn't fly off screen
-        currentPullDistance = Math.min(rawDelta, MAX_PULL);
+        currentPullDistance = rawDelta;
         setPullDistance(currentPullDistance);
         e.preventDefault();
       } else if (isDragging && rawDelta <= 10) {

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -12,6 +12,11 @@ interface AppTemplateProps {
   children: React.ReactNode;
 }
 
+// Pull-to-refresh constants (iOS PWA only)
+const PTR_THRESHOLD = 240;  // px of raw touch movement to trigger refresh
+const PTR_CIRCUMFERENCE = 2 * Math.PI * 10; // SVG arc circumference (radius=10)
+const PTR_INDICATOR_SIZE = 40; // approx height of circle + padding
+
 export default function Template({ children }: AppTemplateProps) {
   const pathname = usePathname();
   const router = useRouter();
@@ -267,9 +272,8 @@ export default function Template({ children }: AppTemplateProps) {
     };
   }, []);
 
-  // Pull-to-refresh functionality — only for iOS PWA standalone mode.
-  // Uses direct DOM manipulation during touchmove for smooth 60fps updates,
-  // avoiding React re-renders on every pixel of movement.
+  // Pull-to-refresh for iOS PWA standalone mode only.
+  // Uses direct DOM manipulation during touchmove for 60fps updates.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (!isIOSPWA) return;
@@ -279,63 +283,64 @@ export default function Template({ children }: AppTemplateProps) {
 
     scrollContainer.style.overscrollBehaviorY = 'none';
 
-    const THRESHOLD = 240;
-    const CIRCUMFERENCE = 2 * Math.PI * 10;
-    const INDICATOR_SIZE = 40;
-
     let startY = 0;
     let isAtTop = true;
     let isDragging = false;
     let currentPullDistance = 0;
-    let refreshing = false;
+    let refreshTriggered = false;
+    let rAFPending = false;
+    let snapBackTimeout: ReturnType<typeof setTimeout> | null = null;
 
-    // Direct DOM update — no React re-render
     const updateDOM = (distance: number) => {
       const damped = distance * 0.5;
-      // Update scroll container position
       scrollContainer.style.transform = `translateY(${damped}px)`;
       scrollContainer.style.transition = 'none';
-      // Update indicator
+
       const indicator = pullIndicatorRef.current;
-      const arc = pullArcRef.current;
       if (indicator) {
-        const fadeStart = INDICATOR_SIZE * 0.5;
-        const fadeEnd = INDICATOR_SIZE;
-        const opacity = Math.min(Math.max((damped - fadeStart) / (fadeEnd - fadeStart), 0), 1);
-        indicator.style.opacity = String(opacity);
+        const fadeStart = PTR_INDICATOR_SIZE * 0.5;
+        const fadeEnd = PTR_INDICATOR_SIZE;
+        indicator.style.opacity = String(Math.min(Math.max((damped - fadeStart) / (fadeEnd - fadeStart), 0), 1));
         indicator.style.transition = 'none';
       }
+
+      const arc = pullArcRef.current;
       if (arc) {
-        const progress = Math.min(distance / THRESHOLD, 1);
-        const arcLength = progress * CIRCUMFERENCE;
-        arc.style.strokeDasharray = `${arcLength} ${CIRCUMFERENCE}`;
-        arc.style.stroke = distance >= THRESHOLD ? '' : '';
-        arc.classList.toggle('text-blue-600', distance >= THRESHOLD);
-        arc.classList.toggle('dark:text-blue-400', distance >= THRESHOLD);
-        arc.classList.toggle('text-gray-400', distance < THRESHOLD);
-        arc.classList.toggle('dark:text-gray-500', distance < THRESHOLD);
+        const pastThreshold = distance >= PTR_THRESHOLD;
+        arc.style.strokeDasharray = `${Math.min(distance / PTR_THRESHOLD, 1) * PTR_CIRCUMFERENCE} ${PTR_CIRCUMFERENCE}`;
+        // Tailwind classes toggled imperatively — these classes also exist in the
+        // JSX below (spinner SVG) so they won't be purged from the CSS bundle.
+        arc.classList.toggle('text-blue-600', pastThreshold);
+        arc.classList.toggle('dark:text-blue-400', pastThreshold);
+        arc.classList.toggle('text-gray-400', !pastThreshold);
+        arc.classList.toggle('dark:text-gray-500', !pastThreshold);
       }
     };
 
     const handleTouchStart = (e: TouchEvent) => {
-      if (refreshing) return;
+      if (refreshTriggered) return;
       startY = e.touches[0].clientY;
       isAtTop = scrollContainer.scrollTop <= 5;
     };
 
     const handleTouchMove = (e: TouchEvent) => {
-      if (refreshing || !isAtTop) return;
+      if (refreshTriggered || !isAtTop) return;
 
       const rawDelta = e.touches[0].clientY - startY;
 
       if (rawDelta > 10) {
         if (!isDragging) {
           isDragging = true;
-          setPullActive(true); // mount the indicator (one-time React render)
+          setPullActive(true);
         }
         currentPullDistance = rawDelta;
-        // Wait one frame for React to mount the indicator on first drag
-        requestAnimationFrame(() => updateDOM(currentPullDistance));
+        if (!rAFPending) {
+          rAFPending = true;
+          requestAnimationFrame(() => {
+            rAFPending = false;
+            updateDOM(currentPullDistance);
+          });
+        }
         e.preventDefault();
       } else if (isDragging && rawDelta <= 10) {
         isDragging = false;
@@ -346,14 +351,13 @@ export default function Template({ children }: AppTemplateProps) {
     };
 
     const handleTouchEnd = () => {
-      if (refreshing) return;
+      if (refreshTriggered) return;
 
-      if (isDragging && currentPullDistance >= THRESHOLD) {
-        refreshing = true;
+      if (isDragging && currentPullDistance >= PTR_THRESHOLD) {
+        refreshTriggered = true;
         setIsRefreshing(true);
         setTimeout(() => window.location.reload(), 400);
       } else if (isDragging) {
-        // Snap back with CSS transition
         scrollContainer.style.transition = 'transform 0.3s ease';
         scrollContainer.style.transform = 'translateY(0px)';
         const indicator = pullIndicatorRef.current;
@@ -361,10 +365,11 @@ export default function Template({ children }: AppTemplateProps) {
           indicator.style.transition = 'opacity 0.3s ease';
           indicator.style.opacity = '0';
         }
-        setTimeout(() => {
+        snapBackTimeout = setTimeout(() => {
           scrollContainer.style.transition = '';
           scrollContainer.style.transform = '';
           setPullActive(false);
+          snapBackTimeout = null;
         }, 300);
       }
 
@@ -383,6 +388,7 @@ export default function Template({ children }: AppTemplateProps) {
       scrollContainer.style.overscrollBehaviorY = '';
       scrollContainer.style.transform = '';
       scrollContainer.style.transition = '';
+      if (snapBackTimeout) clearTimeout(snapBackTimeout);
     };
   }, [isIOSPWA]);
 
@@ -417,7 +423,7 @@ export default function Template({ children }: AppTemplateProps) {
                   cx="12" cy="12" r="10" stroke="currentColor"
                   className="text-gray-400 dark:text-gray-500"
                   strokeWidth="2.5" strokeLinecap="round"
-                  strokeDasharray="0 62.83"
+                  strokeDasharray={`0 ${PTR_CIRCUMFERENCE}`}
                   transform="rotate(-90 12 12)"
                 />
               </svg>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -363,6 +363,56 @@ export default function Template({ children }: AppTemplateProps) {
 
   return (
     <>
+      {/* DEBUG: Boundary lines — remove after testing */}
+      {isIOSPWA && (
+        <div className="fixed inset-0 z-[9999] pointer-events-none" style={{ fontSize: '10px', fontFamily: 'monospace' }}>
+          {/* Line 1: top: 0 (true screen edge) */}
+          <div style={{ position: 'absolute', top: 0, left: 0, right: 0 }}>
+            <div style={{ borderTop: '2px solid red', position: 'relative' }}>
+              <span style={{ position: 'absolute', left: 4, top: 2, color: 'red', background: 'white', padding: '0 4px' }}>
+                A: top: 0
+              </span>
+            </div>
+          </div>
+
+          {/* Line 2: env(safe-area-inset-top) */}
+          <div style={{ position: 'absolute', top: 'env(safe-area-inset-top, 0px)', left: 0, right: 0 }}>
+            <div style={{ borderTop: '2px solid blue', position: 'relative' }}>
+              <span style={{ position: 'absolute', left: 4, top: 2, color: 'blue', background: 'white', padding: '0 4px' }}>
+                B: safe-area-inset-top
+              </span>
+            </div>
+          </div>
+
+          {/* Line 3: safe-area-inset-top + 1rem (content padding start) */}
+          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) + 1rem)', left: 0, right: 0 }}>
+            <div style={{ borderTop: '2px solid green', position: 'relative' }}>
+              <span style={{ position: 'absolute', left: 4, top: 2, color: 'green', background: 'white', padding: '0 4px' }}>
+                C: safe-area + 1rem
+              </span>
+            </div>
+          </div>
+
+          {/* Line 4: safe-area-inset-top + 2rem */}
+          <div style={{ position: 'absolute', top: 'calc(env(safe-area-inset-top, 0px) + 2rem)', left: 0, right: 0 }}>
+            <div style={{ borderTop: '2px solid orange', position: 'relative' }}>
+              <span style={{ position: 'absolute', left: 4, top: 2, color: 'orange', background: 'white', padding: '0 4px' }}>
+                D: safe-area + 2rem
+              </span>
+            </div>
+          </div>
+
+          {/* Line 5: 59px (typical iPhone notch inset) */}
+          <div style={{ position: 'absolute', top: '59px', left: 0, right: 0 }}>
+            <div style={{ borderTop: '2px dashed purple', position: 'relative' }}>
+              <span style={{ position: 'absolute', left: 4, top: 2, color: 'purple', background: 'white', padding: '0 4px' }}>
+                E: 59px (typical notch)
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Pull-to-refresh indicator (iOS PWA only) — fixed at top, fades in as page pulls down */}
       {isIOSPWA && (pullDistance > 0 || isAnimatingBack) && (() => {
         const THRESHOLD = 80;

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -185,7 +185,8 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
       {/* Time badge - only shown in dev mode, positioned top center with no top margin */}
       {showTimeBadge && (
         <div
-          className="fixed top-0 left-1/2 -translate-x-1/2 z-[9999] cursor-pointer select-none"
+          className="fixed left-1/2 -translate-x-1/2 z-[9999] cursor-pointer select-none"
+          style={{ top: 'calc(env(safe-area-inset-top, 0px) + 2px)' }}
           onClick={() => setShowModal(true)}
         >
           <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">


### PR DESCRIPTION
## Summary
- **Fix iOS PWA pull-to-refresh** — touch listeners were on `document.body` instead of the scroll container, so `e.preventDefault()` couldn't suppress native overscroll bounce. Page would bounce but never reload.
- **Redesign pull-to-refresh UX** to mimic Safari's native behavior: page translates down with damped drag, circular progress arc fills proportionally, dragging back up cancels, smooth spring-back animation on cancel.
- **60fps performance** — all drag visuals use direct DOM manipulation via refs instead of React state re-renders. rAF coalescing prevents redundant frames on 120Hz displays.
- **Fix safe area positioning** — header buttons, commit time badge, and pull-to-refresh indicator now respect `env(safe-area-inset-top)` so they don't render behind the notch/Dynamic Island in iOS PWA mode.
- **Fix setState-during-render error** on create poll page (moved `debugLog` call from render body to useEffect).

## Test plan
- [ ] iOS PWA: Pull down on home page — page slides down, progress circle fills, release past threshold triggers reload
- [ ] iOS PWA: Pull down and release before threshold — page snaps back, no reload
- [ ] iOS PWA: Pull down and drag back up — gesture cancels smoothly
- [ ] iOS PWA: Verify commit time badge, create poll button, and back button are below the notch
- [ ] iOS Safari (non-PWA): Native pull-to-refresh still works (custom handler is iOS PWA only)
- [ ] Desktop browser: No visual changes, pull-to-refresh not active
- [ ] Create poll page: No console errors about setState during render

https://claude.ai/code/session_01G95vfWNffr6dXnJaRtSCnV