### PR TITLE
Fix Safari privacy warning by proxying API calls through Vercel

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,19 +15,20 @@ function branchToSlug(branch: string): string {
 
 // API URL resolution:
 // 1. NEXT_PUBLIC_API_URL env var overrides everything (for preview environments, etc.)
-// 2. Vercel preview deploys: derive API URL from branch name (VERCEL_GIT_COMMIT_REF)
-// 3. In production (Vercel main branch), call api.whoeverwants.com
-// 4. In development, use relative path (Next.js rewrites proxy to localhost:8000)
+// 2. Server-side (SSR): use absolute URLs to call the API directly
+// 3. Client-side: always use relative /api/polls path, proxied by Next.js rewrites.
+//    This keeps all browser requests same-origin, avoiding Safari's Advanced Tracking
+//    and Fingerprinting Protection warnings from cross-origin fetch calls.
 function getApiBase(): string {
   if (process.env.NEXT_PUBLIC_API_URL) {
     return process.env.NEXT_PUBLIC_API_URL;
   }
-  // Server-side in dev: call Docker API directly
-  if (typeof window === 'undefined' && process.env.NODE_ENV !== 'production') {
-    return 'http://localhost:8000/api/polls';
-  }
-  // Production (Vercel): check if this is a preview deploy (non-main branch)
-  if (process.env.NODE_ENV === 'production') {
+  // Server-side: use absolute URLs (no browser privacy concerns in SSR)
+  if (typeof window === 'undefined') {
+    if (process.env.NODE_ENV !== 'production') {
+      return 'http://localhost:8000/api/polls';
+    }
+    // Production SSR: call API directly
     const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_BRANCH || process.env.VERCEL_GIT_COMMIT_REF;
     if (branch && branch !== 'main' && branch !== 'master') {
       const slug = branchToSlug(branch);
@@ -35,7 +36,7 @@ function getApiBase(): string {
     }
     return 'https://api.whoeverwants.com/api/polls';
   }
-  // Client-side in dev: relative path, proxied by Next.js rewrites
+  // Client-side (all environments): relative path, proxied by Next.js rewrites
   return '/api/polls';
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,21 +4,13 @@
  */
 
 import type { Poll, PollResults } from './types';
-
-// Derive a preview API slug from a git branch name.
-// e.g., "claude/fix-voting-bug-abc123" -> "fix-voting-bug-abc123"
-function branchToSlug(branch: string): string {
-  let slug = branch.replace(/^claude\//, '').toLowerCase();
-  slug = slug.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
-  return slug.slice(0, 50);
-}
+import { branchToSlug } from './slug';
 
 // API URL resolution:
-// 1. NEXT_PUBLIC_API_URL env var overrides everything (for preview environments, etc.)
-// 2. Server-side (SSR): use absolute URLs to call the API directly
-// 3. Client-side: always use relative /api/polls path, proxied by Next.js rewrites.
-//    This keeps all browser requests same-origin, avoiding Safari's Advanced Tracking
-//    and Fingerprinting Protection warnings from cross-origin fetch calls.
+// - NEXT_PUBLIC_API_URL overrides everything
+// - Server-side: absolute URLs (no browser privacy concerns in SSR)
+// - Client-side: relative /api/polls path, proxied by Next.js rewrites
+//   (keeps requests same-origin, avoiding Safari ITP warnings)
 function getApiBase(): string {
   if (process.env.NEXT_PUBLIC_API_URL) {
     return process.env.NEXT_PUBLIC_API_URL;
@@ -28,7 +20,6 @@ function getApiBase(): string {
     if (process.env.NODE_ENV !== 'production') {
       return 'http://localhost:8000/api/polls';
     }
-    // Production SSR: call API directly
     const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_BRANCH || process.env.VERCEL_GIT_COMMIT_REF;
     if (branch && branch !== 'main' && branch !== 'master') {
       const slug = branchToSlug(branch);

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -1,0 +1,7 @@
+// Derive a URL-safe slug from a git branch name.
+// e.g., "claude/fix-voting-bug-abc123" -> "fix-voting-bug-abc123"
+export function branchToSlug(branch: string): string {
+  let slug = branch.replace(/^claude\//, '').toLowerCase();
+  slug = slug.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return slug.slice(0, 50);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,29 @@
 import type { NextConfig } from "next";
 
+// Derive a preview API slug from a git branch name.
+// e.g., "claude/fix-voting-bug-abc123" -> "fix-voting-bug-abc123"
+function branchToSlug(branch: string): string {
+  let slug = branch.replace(/^claude\//, '').toLowerCase();
+  slug = slug.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return slug.slice(0, 50);
+}
+
+// Determine the backend API origin for rewrites.
+// - Standalone (Docker dev servers): no rewrites needed
+// - Vercel production: proxy to api.whoeverwants.com (avoids cross-origin Safari ITP warnings)
+// - Vercel preview: proxy to <slug>.api.whoeverwants.com
+// - Local dev: proxy to localhost:8000
+function getApiRewriteDestination(): string {
+  const branch = process.env.VERCEL_GIT_COMMIT_REF;
+  if (process.env.VERCEL || process.env.NODE_ENV === 'production') {
+    if (branch && branch !== 'main' && branch !== 'master') {
+      return `https://${branchToSlug(branch)}.api.whoeverwants.com`;
+    }
+    return 'https://api.whoeverwants.com';
+  }
+  return process.env.PYTHON_API_URL || 'http://localhost:8000';
+}
+
 const nextConfig: NextConfig = {
   trailingSlash: true,
   // Prevent trailingSlash from issuing 308 redirects on API routes.
@@ -26,22 +50,27 @@ if (process.env.NEXT_OUTPUT === 'standalone') {
   // Docker production build: standalone output for minimal image size
   nextConfig.output = 'standalone';
 } else {
-  // In development, proxy /api/polls requests to the local Python API server
+  const apiDest = getApiRewriteDestination();
+
+  // Proxy /api/polls requests to the backend API.
+  // In dev: proxies to localhost:8000.
+  // On Vercel: proxies to api.whoeverwants.com, making API calls same-origin
+  // and avoiding Safari's Advanced Tracking and Fingerprinting Protection warnings.
   nextConfig.rewrites = async () => ({
     beforeFiles: [
       // API rewrites must be in beforeFiles so they take priority over
       // the trailingSlash redirect (which otherwise 308s API POST requests)
       {
         source: '/api/polls',
-        destination: `${process.env.PYTHON_API_URL || 'http://localhost:8000'}/api/polls`,
+        destination: `${apiDest}/api/polls`,
       },
       {
         source: '/api/polls/',
-        destination: `${process.env.PYTHON_API_URL || 'http://localhost:8000'}/api/polls`,
+        destination: `${apiDest}/api/polls`,
       },
       {
         source: '/api/polls/:path*',
-        destination: `${process.env.PYTHON_API_URL || 'http://localhost:8000'}/api/polls/:path*`,
+        destination: `${apiDest}/api/polls/:path*`,
       },
     ],
     afterFiles: [],

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,20 +1,9 @@
 import type { NextConfig } from "next";
-
-// Derive a preview API slug from a git branch name.
-// e.g., "claude/fix-voting-bug-abc123" -> "fix-voting-bug-abc123"
-function branchToSlug(branch: string): string {
-  let slug = branch.replace(/^claude\//, '').toLowerCase();
-  slug = slug.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
-  return slug.slice(0, 50);
-}
+import { branchToSlug } from "./lib/slug";
 
 // Determine the backend API origin for rewrites.
-// - Standalone (Docker dev servers): no rewrites needed
-// - Vercel production: proxy to api.whoeverwants.com (avoids cross-origin Safari ITP warnings)
-// - Vercel preview: proxy to <slug>.api.whoeverwants.com
-// - Local dev: proxy to localhost:8000
 function getApiRewriteDestination(): string {
-  const branch = process.env.VERCEL_GIT_COMMIT_REF;
+  const branch = process.env.VERCEL_GIT_COMMIT_REF || process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF;
   if (process.env.VERCEL || process.env.NODE_ENV === 'production') {
     if (branch && branch !== 'main' && branch !== 'master') {
       return `https://${branchToSlug(branch)}.api.whoeverwants.com`;
@@ -52,10 +41,7 @@ if (process.env.NEXT_OUTPUT === 'standalone') {
 } else {
   const apiDest = getApiRewriteDestination();
 
-  // Proxy /api/polls requests to the backend API.
-  // In dev: proxies to localhost:8000.
-  // On Vercel: proxies to api.whoeverwants.com, making API calls same-origin
-  // and avoiding Safari's Advanced Tracking and Fingerprinting Protection warnings.
+  // Proxy /api/polls to the backend API (same-origin for Safari ITP compatibility)
   nextConfig.rewrites = async () => ({
     beforeFiles: [
       // API rewrites must be in beforeFiles so they take priority over


### PR DESCRIPTION
## Summary
- Safari's Advanced Tracking and Fingerprinting Protection flags cross-origin fetch calls from whoeverwants.com to api.whoeverwants.com, showing a privacy warning to users
- Route all client-side API calls through Next.js rewrites so they stay same-origin — Vercel proxies `/api/polls/*` to `api.whoeverwants.com` at the edge
- Server-side (SSR) calls continue using absolute URLs directly since no browser is involved
- Extract duplicated `branchToSlug` utility to shared `lib/slug.ts` module

## Test plan
- [ ] Verify production site loads polls without Safari privacy warning
- [ ] Verify Vercel preview deploys route to correct preview API
- [ ] Verify dev server still proxies to localhost:8000

https://claude.ai/code/session_0152sBPGK37YgMHmMwF4ghSa