### PR TITLE
Fix bottom bar auto-hide inconsistent behavior

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -195,80 +195,87 @@ export default function Template({ children }: AppTemplateProps) {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
+    let rAFId: number | null = null;
+    let scrollContainer: HTMLElement | null = null;
+
+    const processScroll = () => {
+      rAFId = null;
+      if (!scrollContainer) return;
+
+      const currentScrollY = scrollContainer.scrollTop;
+      const maxScrollY = scrollContainer.scrollHeight - scrollContainer.clientHeight;
+
+      // Always show at the very top (check first to avoid hiding then immediately showing)
+      if (currentScrollY <= 0) {
+        setShowBottomBar(true);
+        lastScrollY.current = currentScrollY;
+        return;
+      }
+
+      // Detect iOS rubber band overshoot
+      const isOvershootBottom = currentScrollY > maxScrollY;
+
+      if (isOvershootBottom) {
+        isInBounceRef.current = true;
+        if (bounceTimeoutRef.current) {
+          clearTimeout(bounceTimeoutRef.current);
+        }
+        bounceTimeoutRef.current = setTimeout(() => {
+          isInBounceRef.current = false;
+          bounceTimeoutRef.current = null;
+        }, 150);
+        // Update lastScrollY to clamped value so we don't get a stale delta after bounce
+        lastScrollY.current = maxScrollY;
+        return;
+      }
+
+      // Still in bounce cooldown — update lastScrollY but skip direction logic
+      if (isInBounceRef.current) {
+        lastScrollY.current = currentScrollY;
+        return;
+      }
+
+      // Normal scroll processing
+      const scrollDifference = Math.abs(currentScrollY - lastScrollY.current);
+
+      if (scrollDifference >= scrollThreshold.current) {
+        if (currentScrollY > lastScrollY.current) {
+          setShowBottomBar(false);
+        } else {
+          setShowBottomBar(true);
+        }
+      }
+
+      lastScrollY.current = currentScrollY;
+    };
+
+    const handleScroll = () => {
+      // Throttle to one update per animation frame
+      if (rAFId === null) {
+        rAFId = requestAnimationFrame(processScroll);
+      }
+    };
+
     // Use a timeout to ensure the ref is attached after render
     const timeoutId = setTimeout(() => {
-      const handleScroll = (e: Event) => {
-        const target = e.target as HTMLElement;
-        const currentScrollY = target.scrollTop;
-        const maxScrollY = target.scrollHeight - target.clientHeight;
-
-        // Detect iOS rubber band overshoot
-        const isOvershootTop = currentScrollY < 0;
-        const isOvershootBottom = currentScrollY > maxScrollY;
-        const isInOvershoot = isOvershootTop || isOvershootBottom;
-
-        // If we detect overshoot, enter bounce mode and ignore this event
-        if (isInOvershoot) {
-          isInBounceRef.current = true;
-
-          // Clear any existing timeout and set a new one to exit bounce mode
-          if (bounceTimeoutRef.current) {
-            clearTimeout(bounceTimeoutRef.current);
-          }
-
-          bounceTimeoutRef.current = setTimeout(() => {
-            isInBounceRef.current = false;
-            bounceTimeoutRef.current = null;
-          }, 150); // Wait 150ms after overshoot ends
-
-          return; // Ignore this scroll event
-        }
-
-        // If we're still in bounce mode from previous overshoot, ignore this event
-        if (isInBounceRef.current) {
-          return;
-        }
-
-        // Normal scroll processing
-        const scrollDifference = Math.abs(currentScrollY - lastScrollY.current);
-
-        // Only trigger if scroll difference is above threshold
-        if (scrollDifference < scrollThreshold.current) return;
-
-        if (currentScrollY > lastScrollY.current) {
-          // Scrolling down - hide bottom bar
-          setShowBottomBar(false);
-        } else if (currentScrollY < lastScrollY.current) {
-          // Scrolling up - show bottom bar
-          setShowBottomBar(true);
-        }
-
-        // Always show at the very top
-        if (currentScrollY === 0) {
-          setShowBottomBar(true);
-        }
-
-        lastScrollY.current = currentScrollY;
-      };
-
-      // Add scroll listener to the scrollable container, not window
-      const scrollContainer = scrollContainerRef.current;
-
+      scrollContainer = scrollContainerRef.current;
       if (scrollContainer) {
         scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
-
-        return () => {
-          scrollContainer.removeEventListener('scroll', handleScroll);
-          // Clean up timeout on unmount
-          if (bounceTimeoutRef.current) {
-            clearTimeout(bounceTimeoutRef.current);
-          }
-        };
       }
     }, 100);
 
     return () => {
       clearTimeout(timeoutId);
+      if (rAFId !== null) {
+        cancelAnimationFrame(rAFId);
+      }
+      // Clean up scroll listener — scrollContainer is captured in closure
+      if (scrollContainer) {
+        scrollContainer.removeEventListener('scroll', handleScroll);
+      }
+      if (bounceTimeoutRef.current) {
+        clearTimeout(bounceTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -547,12 +554,12 @@ export default function Template({ children }: AppTemplateProps) {
       {/* Scroll-aware bottom bar - rendered via portal outside scaled container */}
       {isMounted && createPortal(
         <div
-          className={`fixed left-0 right-0 bottom-0 backdrop-blur-lg bg-white/50 dark:bg-black/50 shadow-lg z-50 transition-opacity duration-200 ease-out ${
-            showBottomBar ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-          }`}
+          className="fixed left-0 right-0 bottom-0 backdrop-blur-lg bg-white/50 dark:bg-black/50 shadow-lg z-50"
           style={{
-            // Extend background into safe area - always apply for proper iOS support
-            paddingBottom: 'env(safe-area-inset-bottom, 0px)'
+            paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+            transform: showBottomBar ? 'translateY(0)' : 'translateY(100%)',
+            transition: 'transform 200ms ease-out',
+            willChange: 'transform',
           }}
         >
         <div className="max-w-4xl mx-auto px-4 py-2 flex items-center justify-center">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -198,6 +198,15 @@ export default function Template({ children }: AppTemplateProps) {
     let rAFId: number | null = null;
     let scrollContainer: HTMLElement | null = null;
 
+    // Track current visibility to avoid no-op setState calls during scroll
+    let isVisible = true;
+    const setVisible = (visible: boolean) => {
+      if (visible !== isVisible) {
+        isVisible = visible;
+        setShowBottomBar(visible);
+      }
+    };
+
     const processScroll = () => {
       rAFId = null;
       if (!scrollContainer) return;
@@ -205,17 +214,14 @@ export default function Template({ children }: AppTemplateProps) {
       const currentScrollY = scrollContainer.scrollTop;
       const maxScrollY = scrollContainer.scrollHeight - scrollContainer.clientHeight;
 
-      // Always show at the very top (check first to avoid hiding then immediately showing)
       if (currentScrollY <= 0) {
-        setShowBottomBar(true);
+        setVisible(true);
         lastScrollY.current = currentScrollY;
         return;
       }
 
-      // Detect iOS rubber band overshoot
-      const isOvershootBottom = currentScrollY > maxScrollY;
-
-      if (isOvershootBottom) {
+      // iOS rubber band past the bottom — ignore and clamp lastScrollY
+      if (currentScrollY > maxScrollY) {
         isInBounceRef.current = true;
         if (bounceTimeoutRef.current) {
           clearTimeout(bounceTimeoutRef.current);
@@ -224,39 +230,31 @@ export default function Template({ children }: AppTemplateProps) {
           isInBounceRef.current = false;
           bounceTimeoutRef.current = null;
         }, 150);
-        // Update lastScrollY to clamped value so we don't get a stale delta after bounce
         lastScrollY.current = maxScrollY;
         return;
       }
 
-      // Still in bounce cooldown — update lastScrollY but skip direction logic
+      // Scroll position is unreliable during bounce cooldown
       if (isInBounceRef.current) {
         lastScrollY.current = currentScrollY;
         return;
       }
 
-      // Normal scroll processing
       const scrollDifference = Math.abs(currentScrollY - lastScrollY.current);
 
       if (scrollDifference >= scrollThreshold.current) {
-        if (currentScrollY > lastScrollY.current) {
-          setShowBottomBar(false);
-        } else {
-          setShowBottomBar(true);
-        }
+        setVisible(currentScrollY < lastScrollY.current);
       }
 
       lastScrollY.current = currentScrollY;
     };
 
     const handleScroll = () => {
-      // Throttle to one update per animation frame
       if (rAFId === null) {
         rAFId = requestAnimationFrame(processScroll);
       }
     };
 
-    // Use a timeout to ensure the ref is attached after render
     const timeoutId = setTimeout(() => {
       scrollContainer = scrollContainerRef.current;
       if (scrollContainer) {
@@ -269,7 +267,6 @@ export default function Template({ children }: AppTemplateProps) {
       if (rAFId !== null) {
         cancelAnimationFrame(rAFId);
       }
-      // Clean up scroll listener — scrollContainer is captured in closure
       if (scrollContainer) {
         scrollContainer.removeEventListener('scroll', handleScroll);
       }
@@ -554,7 +551,9 @@ export default function Template({ children }: AppTemplateProps) {
       {/* Scroll-aware bottom bar - rendered via portal outside scaled container */}
       {isMounted && createPortal(
         <div
-          className="fixed left-0 right-0 bottom-0 backdrop-blur-lg bg-white/50 dark:bg-black/50 shadow-lg z-50"
+          className={`fixed left-0 right-0 bottom-0 backdrop-blur-lg bg-white/50 dark:bg-black/50 shadow-lg z-50 ${
+            showBottomBar ? '' : 'pointer-events-none'
+          }`}
           style={{
             paddingBottom: 'env(safe-area-inset-bottom, 0px)',
             transform: showBottomBar ? 'translateY(0)' : 'translateY(100%)',


### PR DESCRIPTION
## Summary
- Fix scroll listener never being cleaned up — `setTimeout` return value was silently discarded, so `removeEventListener` never ran and listeners stacked on every navigation
- Fix stale `lastScrollY` after iOS bounce causing wrong scroll-direction detection by updating it during bounce/cooldown
- Add `requestAnimationFrame` throttling to coalesce rapid scroll events into one state update per frame
- Guard against no-op `setShowBottomBar` calls to eliminate ~60 redundant re-renders/sec during scroll
- Check top-of-page before direction logic to prevent hide→show flicker
- Switch from opacity to GPU-accelerated `translateY` slide animation with `will-change: transform`
- Restore `pointer-events-none` on hidden bar to prevent keyboard focus on off-screen buttons

## Test plan
- [ ] Scroll down on a poll page — bottom bar slides out of view
- [ ] Scroll up — bottom bar slides back in
- [ ] Navigate between pages — bar should not flicker or behave erratically (the leaked listener fix)
- [ ] On iOS: pull-to-refresh bounce at top/bottom should not trigger false hide/show
- [ ] Tab through page with keyboard — hidden bar buttons should not receive focus