### PR TITLE
Fix gradient button dark theme contrast

### DIFF
--- a/components/GradientBorderButton.tsx
+++ b/components/GradientBorderButton.tsx
@@ -38,10 +38,14 @@ export default function GradientBorderButton({
     return () => observer.disconnect();
   }, []);
 
-  const bgColor = isDark ? 'rgb(17, 24, 39)' : 'white';
-  const gradientColors = gradient === 'blue-purple'
-    ? 'rgb(34, 197, 94), rgb(59, 130, 246), rgb(147, 51, 234)'
-    : 'rgb(239, 68, 68), rgb(249, 115, 22), rgb(234, 179, 8)';
+  const bgColor = isDark ? 'rgb(31, 41, 55)' : 'rgb(249, 250, 251)';
+  const gradientColors = isDark
+    ? (gradient === 'blue-purple'
+      ? 'rgb(34, 160, 80), rgb(59, 120, 210), rgb(130, 60, 200)'
+      : 'rgb(210, 70, 70), rgb(220, 110, 40), rgb(210, 160, 30)')
+    : (gradient === 'blue-purple'
+      ? 'rgb(22, 163, 74), rgb(37, 99, 235), rgb(124, 58, 237)'
+      : 'rgb(220, 38, 38), rgb(234, 88, 12), rgb(202, 138, 4)');
 
   const handleTouchStart = () => {
     if (!disabled) {
@@ -77,7 +81,7 @@ export default function GradientBorderButton({
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseLeave}
-      className={`relative inline-flex items-center gap-2 px-2.5 py-1 text-gray-900 dark:text-gray-100 font-semibold text-lg rounded-full transition-all duration-300 shadow-lg hover:shadow-xl transform hover:scale-105 active:scale-95 active:shadow-md disabled:opacity-50 disabled:cursor-not-allowed ${isPressed ? 'scale-95 shadow-md' : ''} ${className}`}
+      className={`relative inline-flex items-center gap-2 px-2.5 py-1 text-gray-800 dark:text-gray-200 font-semibold text-lg rounded-full transition-all duration-300 shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 active:shadow-sm disabled:opacity-50 disabled:cursor-not-allowed ${isPressed ? 'scale-95 shadow-sm' : ''} ${className}`}
       style={{
         border: '2px solid transparent',
         backgroundImage: `linear-gradient(${bgColor}, ${bgColor}), linear-gradient(to top right, ${gradientColors})`,

--- a/components/GradientBorderButton.tsx
+++ b/components/GradientBorderButton.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 interface GradientBorderButtonProps {
   onClick: () => void;
   disabled?: boolean;
-  gradient: 'blue-purple' | 'red-orange'; // blue-purple for Follow up, red-orange for Vote on it
+  gradient: 'blue-purple' | 'red-orange';
   children: React.ReactNode;
   className?: string;
 }
@@ -17,79 +17,29 @@ export default function GradientBorderButton({
   children,
   className = ""
 }: GradientBorderButtonProps) {
-  const [isDark, setIsDark] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
 
-  useEffect(() => {
-    // Check if dark mode is active
-    const checkDarkMode = () => {
-      setIsDark(document.documentElement.classList.contains('dark'));
-    };
-
-    checkDarkMode();
-
-    // Watch for dark mode changes
-    const observer = new MutationObserver(checkDarkMode);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class']
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  const bgColor = isDark ? 'rgb(31, 41, 55)' : 'rgb(249, 250, 251)';
-  const gradientColors = isDark
-    ? (gradient === 'blue-purple'
-      ? 'rgb(34, 160, 80), rgb(59, 120, 210), rgb(130, 60, 200)'
-      : 'rgb(210, 70, 70), rgb(220, 110, 40), rgb(210, 160, 30)')
-    : (gradient === 'blue-purple'
-      ? 'rgb(22, 163, 74), rgb(37, 99, 235), rgb(124, 58, 237)'
-      : 'rgb(220, 38, 38), rgb(234, 88, 12), rgb(202, 138, 4)');
-
-  const handleTouchStart = () => {
-    if (!disabled) {
-      setIsPressed(true);
-    }
-  };
-
-  const handleTouchEnd = () => {
-    setIsPressed(false);
-  };
-
-  const handleMouseDown = () => {
-    if (!disabled) {
-      setIsPressed(true);
-    }
-  };
-
-  const handleMouseUp = () => {
-    setIsPressed(false);
-  };
-
-  const handleMouseLeave = () => {
-    setIsPressed(false);
-  };
+  const gradientClass = gradient === 'blue-purple'
+    ? 'from-green-600 via-blue-600 to-purple-600 dark:from-green-500 dark:via-blue-500 dark:to-purple-500'
+    : 'from-red-600 via-orange-600 to-yellow-600 dark:from-red-500 dark:via-orange-500 dark:to-yellow-500';
 
   return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseLeave}
-      className={`relative inline-flex items-center gap-2 px-2.5 py-1 text-gray-800 dark:text-gray-200 font-semibold text-lg rounded-full transition-all duration-300 shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 active:shadow-sm disabled:opacity-50 disabled:cursor-not-allowed ${isPressed ? 'scale-95 shadow-sm' : ''} ${className}`}
-      style={{
-        border: '2px solid transparent',
-        backgroundImage: `linear-gradient(${bgColor}, ${bgColor}), linear-gradient(to top right, ${gradientColors})`,
-        backgroundOrigin: 'border-box',
-        backgroundClip: 'padding-box, border-box'
-      }}
+    <div
+      className={`inline-flex rounded-full p-[2px] bg-gradient-to-tr ${gradientClass} ${disabled ? 'opacity-50' : ''}`}
     >
-      {children}
-    </button>
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        onTouchStart={() => !disabled && setIsPressed(true)}
+        onTouchEnd={() => setIsPressed(false)}
+        onTouchCancel={() => setIsPressed(false)}
+        onMouseDown={() => !disabled && setIsPressed(true)}
+        onMouseUp={() => setIsPressed(false)}
+        onMouseLeave={() => setIsPressed(false)}
+        className={`relative inline-flex items-center gap-2 px-2.5 py-1 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 font-semibold text-lg rounded-full transition-all duration-300 shadow-md hover:shadow-lg transform hover:scale-105 active:scale-95 active:shadow-sm disabled:cursor-not-allowed ${isPressed ? 'scale-95 shadow-sm' : ''} ${className}`}
+      >
+        {children}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace JS-based dark mode detection (MutationObserver + useEffect) with CSS-only Tailwind `dark:` variants
- Use standard Tailwind gradient-border pattern (wrapper div with `bg-gradient-to-tr` + `p-[2px]`) instead of fragile `backgroundImage`/`backgroundClip` CSS trick
- Fix button background contrast in dark mode (`bg-gray-50` / `dark:bg-gray-800`)
- Simplify event handlers from named functions to inline arrows

## Test plan
- [ ] Verify gradient border renders correctly in light mode
- [ ] Verify gradient border renders correctly in dark mode
- [ ] Verify disabled state dims the button
- [ ] Verify press animation works on mobile (touch) and desktop (click)

https://claude.ai/code/session_01VGAqQxNZXvLAXq6gVfwa5f