### PR TITLE
Fix service worker stale cache breaking PWA pull-to-refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -808,6 +808,13 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Coalesce requestAnimationFrame calls.** On 120Hz displays, touchmove fires faster than rAF. Use a `rAFPending` flag to skip redundant frames and read the latest value at callback time (not call time).
 - **Touch listeners must go on the scroll container, not document.body.** `e.preventDefault()` on body touchmove doesn't suppress a child scroll container's native overscroll bounce. Attach listeners to the scrollable element directly.
 
+### Service Worker Caching Strategy
+
+- **Never use `url.pathname.startsWith('/')` in service worker URL matching** — it matches ALL paths. Use exact equality (`===`) or more specific prefixes like `/create-poll`.
+- **Use network-first for HTML navigation, cache-first only for immutable assets.** Cache-first for navigation causes the PWA to serve stale HTML that references old JS bundles (also cached), making it impossible for users to get new code. Network-first ensures fresh HTML on every load; cache is only a fallback for offline.
+- **Skip API requests in the service worker** — let them go directly to the network. Caching API responses causes stale poll data with no visible error.
+- **Bump `CACHE_NAME` version when changing caching strategy** to force old caches to be deleted on activation. Without this, users keep stale cached content indefinitely.
+
 ### iOS PWA Safe Area Positioning
 
 - **`position: fixed; top: 0` goes behind the notch** in iOS PWA with `viewport-fit: cover` and `black-translucent` status bar. All fixed header elements must use `calc(env(safe-area-inset-top, 0px) + offset)`.

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -280,10 +280,17 @@ export default function Template({ children }: AppTemplateProps) {
   // Uses direct DOM manipulation during touchmove for 60fps updates.
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    if (!isIOSPWA) return;
+    if (!isIOSPWA) {
+      console.log('[PTR] skipped: isIOSPWA =', isIOSPWA);
+      return;
+    }
 
     const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer) return;
+    if (!scrollContainer) {
+      console.warn('[PTR] skipped: scrollContainerRef.current is null');
+      return;
+    }
+    console.log('[PTR] attaching touch handlers to scroll container');
 
     scrollContainer.style.overscrollBehaviorY = 'none';
 

--- a/public/sw-mobile.js
+++ b/public/sw-mobile.js
@@ -1,24 +1,20 @@
 // Enhanced Service Worker for Mobile Instant Loading
-const CACHE_NAME = 'whoeverwants-mobile-v2';
-const CRITICAL_PAGES = [
-  '/',
-  '/create-poll',
-];
+const CACHE_NAME = 'whoeverwants-mobile-v3';
+
+const STATIC_FILE_RE = /\.(json|png|svg|ico|woff2?)$/;
 
 const ASSETS_TO_CACHE = [
-  '/',
-  '/create-poll',
   '/manifest.json',
 ];
 
 // Install event - cache critical resources immediately
 self.addEventListener('install', (event) => {
-  console.log('SW: Installing enhanced mobile service worker');
-  
+  console.log('SW: Installing enhanced mobile service worker v3');
+
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then((cache) => {
-        console.log('SW: Caching critical pages for mobile');
+        console.log('SW: Caching critical assets');
         return cache.addAll(ASSETS_TO_CACHE);
       })
       .then(() => {
@@ -33,8 +29,8 @@ self.addEventListener('install', (event) => {
 
 // Activate event - clean up old caches
 self.addEventListener('activate', (event) => {
-  console.log('SW: Activating enhanced mobile service worker');
-  
+  console.log('SW: Activating enhanced mobile service worker v3');
+
   event.waitUntil(
     Promise.all([
       // Clean up old caches
@@ -42,7 +38,10 @@ self.addEventListener('activate', (event) => {
         return Promise.all(
           cacheNames
             .filter((cacheName) => cacheName !== CACHE_NAME)
-            .map((cacheName) => caches.delete(cacheName))
+            .map((cacheName) => {
+              console.log('SW: Deleting old cache', cacheName);
+              return caches.delete(cacheName);
+            })
         );
       }),
       // Take control immediately
@@ -51,66 +50,43 @@ self.addEventListener('activate', (event) => {
   );
 });
 
-// Fetch event - serve from cache first for instant loading
+// Fetch event - network-first for pages, cache-first for static assets
 self.addEventListener('fetch', (event) => {
   const request = event.request;
   const url = new URL(request.url);
-  
+
   // Only handle same-origin requests
   if (url.origin !== location.origin) return;
-  
-  // Handle page requests with cache-first strategy for instant loading
-  if (request.mode === 'navigate' || 
-      CRITICAL_PAGES.some(page => url.pathname.startsWith(page))) {
-    
+
+  // Skip API requests — always go to network
+  if (url.pathname.startsWith('/api/')) return;
+
+  // Handle navigation requests with network-first strategy
+  // This ensures users always get the latest HTML (which references correct JS bundles)
+  if (request.mode === 'navigate') {
     event.respondWith(
-      // Try cache first for instant loading
-      caches.match(request)
-        .then((cachedResponse) => {
-          if (cachedResponse) {
-            console.log('SW: Serving from cache (instant):', url.pathname);
-            
-            // Fetch in background to update cache
-            fetch(request).then((networkResponse) => {
-              if (networkResponse && networkResponse.status === 200) {
-                const responseClone = networkResponse.clone();
-                caches.open(CACHE_NAME).then((cache) => {
-                  cache.put(request, responseClone);
-                });
-              }
-            }).catch(() => {
-              // Network failed, cached version is still good
+      fetch(request)
+        .then((networkResponse) => {
+          if (networkResponse && networkResponse.status === 200) {
+            const responseClone = networkResponse.clone();
+            caches.open(CACHE_NAME).then((cache) => {
+              cache.put(request, responseClone);
             });
-            
-            return cachedResponse;
           }
-          
-          // Not in cache, fetch from network
-          console.log('SW: Fetching from network:', url.pathname);
-          return fetch(request).then((networkResponse) => {
-            if (networkResponse && networkResponse.status === 200) {
-              const responseClone = networkResponse.clone();
-              caches.open(CACHE_NAME).then((cache) => {
-                cache.put(request, responseClone);
-              });
-            }
-            return networkResponse;
-          });
+          return networkResponse;
         })
-        .catch((error) => {
-          console.error('SW: Fetch failed:', error);
-          // Return offline page if available
-          return caches.match('/');
+        .catch(() => {
+          // Network failed, try cache as fallback for offline support
+          return caches.match(request).then((cachedResponse) => {
+            return cachedResponse || caches.match('/');
+          });
         })
     );
     return;
   }
-  
-  // Handle static assets
-  if (request.url.includes('/_next/static/') || 
-      request.url.includes('.css') || 
-      request.url.includes('.js')) {
-    
+
+  // Handle static assets with cache-first (content-hashed filenames are immutable)
+  if (url.pathname.startsWith('/_next/static/')) {
     event.respondWith(
       caches.match(request)
         .then((cachedResponse) => {
@@ -127,13 +103,34 @@ self.addEventListener('fetch', (event) => {
     );
     return;
   }
+
+  // Handle other static files (manifest, icons, etc.) with cache-first + background update
+  if (STATIC_FILE_RE.test(url.pathname)) {
+    event.respondWith(
+      caches.match(request)
+        .then((cachedResponse) => {
+          const fetchPromise = fetch(request).then((networkResponse) => {
+            if (networkResponse && networkResponse.status === 200) {
+              const responseClone = networkResponse.clone();
+              caches.open(CACHE_NAME).then((cache) => {
+                cache.put(request, responseClone);
+              });
+            }
+            return networkResponse;
+          }).catch(() => cachedResponse);
+
+          return cachedResponse || fetchPromise;
+        })
+    );
+    return;
+  }
 });
 
 // Background sync for pre-caching pages
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'PRECACHE_PAGES') {
     const pages = event.data.pages || [];
-    
+
     event.waitUntil(
       caches.open(CACHE_NAME).then((cache) => {
         return Promise.all(
@@ -150,11 +147,10 @@ self.addEventListener('message', (event) => {
       })
     );
   }
-  
+
   if (event.data && event.data.type === 'WARM_PAGE') {
     const page = event.data.page;
     if (page) {
-      // Warm up page by fetching it
       fetch(page).then((response) => {
         if (response && response.status === 200) {
           return caches.open(CACHE_NAME).then((cache) => {
@@ -168,4 +164,4 @@ self.addEventListener('message', (event) => {
   }
 });
 
-console.log('SW: Enhanced mobile service worker loaded');
+console.log('SW: Enhanced mobile service worker v3 loaded');


### PR DESCRIPTION
## Summary
- Fix critical bug in `sw-mobile.js` where `CRITICAL_PAGES` included `'/'` with `startsWith()` matching, causing ALL same-origin requests to be cache-first (HTML, JS bundles, API calls)
- Switch to network-first for navigation requests so users always get fresh HTML referencing correct JS bundles
- Cache-first only for `/_next/static/` (content-hashed, immutable) and static assets
- Skip API requests in service worker entirely (always fresh data)
- Bump cache version v2→v3 to force stale cache deletion
- Add `[PTR]` diagnostic logging to pull-to-refresh for production debugging
- Add Service Worker Caching Strategy section to CLAUDE.md

## Root Cause
The service worker's `url.pathname.startsWith('/')` matched every URL, making the entire site cache-first. In iOS PWA standalone mode, cached HTML referenced old JS bundles (also cached), so the app ran stale code that predated the pull-to-refresh feature.

## Test plan
- [ ] Deploy to production (merge to main)
- [ ] On iOS, close the PWA from app switcher and reopen
- [ ] Verify pull-to-refresh circle appears when pulling down at top of page
- [ ] Check browser console for `[PTR]` diagnostic logs via CommitInfo Logs tab
- [ ] Verify poll data loads fresh (not stale cached API responses)