### PR TITLE
Fix poll respondents list flickering on refresh

### DIFF
--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { apiGetVotes } from '@/lib/api';
 
 interface Voter {
@@ -19,45 +19,44 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [anonymousCount, setAnonymousCount] = useState(0);
+  const voterIdsRef = useRef('');
 
-  const fetchVoters = async () => {
+  const fetchVoters = useCallback(async () => {
     try {
       const votes = await apiGetVotes(pollId);
       const voterData: Voter[] = votes.map(v => ({ id: v.id, voter_name: v.voter_name }));
-      setVoters(voterData);
-      const anonymousVotes = voterData.filter(vote => !vote.voter_name || vote.voter_name.trim() === '');
-      setAnonymousCount(anonymousVotes.length);
+
+      // Skip state updates if voter list hasn't changed
+      const newKey = voterData.map(v => `${v.id}:${v.voter_name ?? ''}`).join(',');
+      if (newKey !== voterIdsRef.current) {
+        voterIdsRef.current = newKey;
+        setVoters(voterData);
+        setAnonymousCount(voterData.filter(v => !v.voter_name || v.voter_name.trim() === '').length);
+      }
       setError(null);
     } catch (err) {
       console.error('Error fetching voters:', err);
-      // Only show error if we have no data yet
-      if (voters.length === 0) {
+      if (!voterIdsRef.current) {
         setError('Failed to load voter list');
       }
     } finally {
       setInitialLoading(false);
     }
-  };
+  }, [pollId]);
 
   useEffect(() => {
     if (pollId) {
       fetchVoters();
-
-      // Poll for changes every 10 seconds (no real-time subscription without Supabase)
       const interval = setInterval(fetchVoters, 10000);
-
-      return () => {
-        clearInterval(interval);
-      };
+      return () => clearInterval(interval);
     }
-  }, [pollId]);
+  }, [pollId, fetchVoters]);
 
-  // Trigger refresh when refreshTrigger changes
   useEffect(() => {
     if (refreshTrigger && pollId) {
       fetchVoters();
     }
-  }, [refreshTrigger]);
+  }, [refreshTrigger, pollId, fetchVoters]);
 
   if (initialLoading) {
     return (

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -16,25 +16,26 @@ interface VoterListProps {
 
 export default function VoterList({ pollId, className = "", refreshTrigger }: VoterListProps) {
   const [voters, setVoters] = useState<Voter[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [anonymousCount, setAnonymousCount] = useState(0);
 
   const fetchVoters = async () => {
-    setLoading(true);
-    setError(null);
-
     try {
       const votes = await apiGetVotes(pollId);
       const voterData: Voter[] = votes.map(v => ({ id: v.id, voter_name: v.voter_name }));
       setVoters(voterData);
       const anonymousVotes = voterData.filter(vote => !vote.voter_name || vote.voter_name.trim() === '');
       setAnonymousCount(anonymousVotes.length);
+      setError(null);
     } catch (err) {
       console.error('Error fetching voters:', err);
-      setError('Failed to load voter list');
+      // Only show error if we have no data yet
+      if (voters.length === 0) {
+        setError('Failed to load voter list');
+      }
     } finally {
-      setLoading(false);
+      setInitialLoading(false);
     }
   };
 
@@ -58,7 +59,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
     }
   }, [refreshTrigger]);
 
-  if (loading) {
+  if (initialLoading) {
     return (
       <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm ${className}`}>
         <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- Only show loading skeleton on initial fetch; subsequent 10-second polls silently update the voter list
- Track voter data fingerprint via ref to skip no-op re-renders when data hasn't changed
- Fix stale closure bug where `voters.length` in the catch block always captured the initial empty array
- Add proper `useCallback` and dependency arrays to prevent stale closures

## Test plan
- [ ] Visit a closed poll and verify the respondents list loads once, then stays visible without flickering
- [ ] Wait 10+ seconds and confirm no shimmer/skeleton appears during background refreshes
- [ ] Submit a vote on an open poll and confirm the voter list updates immediately

https://claude.ai/code/session_016MMYUHRTvMiaBiX5XjEDoS