### PR TITLE
Poll duplicate detection & VoteOnIt modal

### DIFF
--- a/app/api/git-info/route.ts
+++ b/app/api/git-info/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+export const dynamic = 'force-dynamic';
+
+async function readGitHead(): Promise<string | null> {
+  try {
+    const gitDir = join(process.cwd(), '.git');
+    const headContent = (await readFile(join(gitDir, 'HEAD'), 'utf-8')).trim();
+
+    if (headContent.startsWith('ref: ')) {
+      const refPath = join(gitDir, headContent.slice(5));
+      return (await readFile(refPath, 'utf-8')).trim();
+    }
+    // Detached HEAD — content is the SHA itself
+    return headContent;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET() {
+  const sha = await readGitHead();
+  if (!sha) {
+    return NextResponse.json({ error: 'Could not read git HEAD' }, { status: 500 });
+  }
+  return NextResponse.json({ sha });
+}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { apiCreatePoll } from "@/lib/api";
+import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -863,6 +863,20 @@ function CreatePollContent() {
         }
       }
 
+
+      // Check for duplicate follow-up poll before creating
+      if (followUpTo) {
+        try {
+          const existing = await apiFindDuplicatePoll(title, followUpTo);
+          if (existing) {
+            const shortId = existing.short_id || existing.id;
+            router.push(`/p/${shortId}`);
+            return;
+          }
+        } catch {
+          // If the check fails, proceed with creation
+        }
+      }
 
       let createdPoll;
       try {

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -21,7 +21,8 @@ import GradientBorderButton from "@/components/GradientBorderButton";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults } from "@/lib/types";
-import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
+import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, apiFindDuplicatePoll, ApiVote } from "@/lib/api";
+import VoteOnItModal from "@/components/VoteOnItModal";
 import { isCreatedByThisBrowser, getCreatorSecret } from "@/lib/browserPollAccess";
 import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
 import { getUserName, saveUserName } from "@/lib/userProfile";
@@ -83,6 +84,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [voterName, setVoterName] = useState<string>("");
   const [voterListRefresh, setVoterListRefresh] = useState(0);
   const [showFollowUpModal, setShowFollowUpModal] = useState(false);
+  const [showVoteOnItModal, setShowVoteOnItModal] = useState(false);
   const [nominations, setNominations] = useState<string[]>([]);
   const [loadingNominations, setLoadingNominations] = useState(false);
 
@@ -786,17 +788,25 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     setShowVoteConfirmModal(true);
   };
 
-  const handleVoteOnNominationsClick = () => {
-    // Store data for the new preference poll
-    const voteData = {
-      title: poll.title,
-      options: nominations,
-      followUpTo: poll.id
-    };
-    localStorage.setItem(`vote-from-nomination-${poll.id}`, JSON.stringify(voteData));
+  const handleVoteOnNominationsClick = async () => {
+    // Check if a follow-up preference poll already exists with the same title
+    setLoadingNominations(true);
+    try {
+      const existing = await apiFindDuplicatePoll(poll.title, poll.id);
+      if (existing) {
+        // Navigate directly to the existing poll
+        const shortId = existing.short_id || existing.id;
+        router.push(`/p/${shortId}`);
+        return;
+      }
+    } catch {
+      // If the check fails, fall through to show the modal
+    } finally {
+      setLoadingNominations(false);
+    }
 
-    // Navigate to create-poll page with vote parameter
-    router.push(`/create-poll?voteFromNomination=${poll.id}`);
+    // No duplicate found — show the creation modal
+    setShowVoteOnItModal(true);
   };
 
   const submitVote = async () => {
@@ -1942,6 +1952,15 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         isOpen={showFollowUpModal}
         poll={poll}
         onClose={() => setShowFollowUpModal(false)}
+      />
+
+      {/* Vote on It Modal */}
+      <VoteOnItModal
+        isOpen={showVoteOnItModal}
+        pollId={poll.id}
+        pollTitle={poll.title}
+        nominations={nominations}
+        onClose={() => setShowVoteOnItModal(false)}
       />
 
     </>

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -94,8 +94,26 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
   const [copyLabel, setCopyLabel] = useState('Copy All Logs');
   const logsEndRef = useRef<HTMLDivElement>(null);
 
-  const commitHash = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA || '';
+  const vercelHash = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA || '';
   const branchName = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF || '';
+  const [commitHash, setCommitHash] = useState(vercelHash);
+
+  // In dev mode, fetch the current git SHA from the server on mount and on visibility change
+  useEffect(() => {
+    if (vercelHash) return; // Vercel build — SHA is baked in
+    const fetchGitSha = async () => {
+      try {
+        const res = await fetch('/api/git-info');
+        if (!res.ok) return;
+        const { sha } = await res.json();
+        if (sha) setCommitHash(sha);
+      } catch { /* ignore */ }
+    };
+    fetchGitSha();
+    const onVisibility = () => { if (document.visibilityState === 'visible') fetchGitSha(); };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [vercelHash]);
 
   const fetchCommitInfo = useCallback(async () => {
     if (!commitHash) {

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -106,7 +106,7 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
         const res = await fetch('/api/git-info');
         if (!res.ok) return;
         const { sha } = await res.json();
-        if (sha) setCommitHash(sha);
+        if (sha) setCommitHash(prev => prev === sha ? prev : sha);
       } catch { /* ignore */ }
     };
     fetchGitSha();

--- a/components/VoteOnItModal.tsx
+++ b/components/VoteOnItModal.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import ModalPortal from "@/components/ModalPortal";
+import { apiFindDuplicatePoll, apiCreatePoll } from "@/lib/api";
+import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
+import { getUserName } from "@/lib/userProfile";
+
+interface VoteOnItModalProps {
+  isOpen: boolean;
+  pollId: string;
+  pollTitle: string;
+  nominations: string[];
+  onClose: () => void;
+}
+
+const DEADLINE_OPTIONS = [
+  { value: "5min", label: "5 minutes", minutes: 5 },
+  { value: "10min", label: "10 minutes", minutes: 10 },
+  { value: "15min", label: "15 minutes", minutes: 15 },
+  { value: "30min", label: "30 minutes", minutes: 30 },
+  { value: "1hr", label: "1 hour", minutes: 60 },
+  { value: "2hr", label: "2 hours", minutes: 120 },
+  { value: "4hr", label: "4 hours", minutes: 240 },
+];
+
+export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, onClose }: VoteOnItModalProps) {
+  const router = useRouter();
+  const [deadlineOption, setDeadlineOption] = useState("10min");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setDeadlineOption("10min");
+      setIsSubmitting(false);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleCreate = async () => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // Check for existing duplicate first
+      const existing = await apiFindDuplicatePoll(pollTitle, pollId);
+      if (existing) {
+        // Duplicate exists — navigate to it
+        const shortId = existing.short_id || existing.id;
+        router.push(`/p/${shortId}`);
+        onClose();
+        return;
+      }
+
+      // No duplicate — create the poll
+      const option = DEADLINE_OPTIONS.find(opt => opt.value === deadlineOption);
+      const deadline = new Date(Date.now() + (option?.minutes ?? 10) * 60 * 1000);
+
+      const creatorSecret = generateCreatorSecret();
+      const creatorName = getUserName() || undefined;
+
+      const poll = await apiCreatePoll({
+        title: pollTitle,
+        poll_type: "ranked_choice",
+        options: nominations,
+        response_deadline: deadline.toISOString(),
+        creator_secret: creatorSecret,
+        creator_name: creatorName,
+        follow_up_to: pollId,
+      });
+
+      recordPollCreation(poll.id, creatorSecret);
+      const shortId = poll.short_id || poll.id;
+      router.push(`/p/${shortId}`);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create poll");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleEdit = () => {
+    // Fall back to the existing flow — navigate to create-poll form
+    const voteData = {
+      title: pollTitle,
+      options: nominations,
+      followUpTo: pollId,
+    };
+    localStorage.setItem(`vote-from-nomination-${pollId}`, JSON.stringify(voteData));
+    router.push(`/create-poll?voteFromNomination=${pollId}`);
+    onClose();
+  };
+
+  return (
+    <ModalPortal>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 dark:bg-black/70 z-[100] animate-fade-in"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="fixed bottom-0 left-0 right-0 z-[110] animate-slide-up">
+        <div className="bg-white dark:bg-gray-800 rounded-t-2xl shadow-xl p-6 pb-8 max-h-[80vh] overflow-y-auto">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 text-center">
+            Create Preference Poll
+          </h3>
+
+          {/* Title */}
+          <div className="mb-3">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Title</label>
+            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg text-sm text-gray-900 dark:text-white">
+              {pollTitle}
+            </div>
+          </div>
+
+          {/* Options */}
+          <div className="mb-3">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Options ({nominations.length})
+            </label>
+            <div className="space-y-1 max-h-40 overflow-y-auto">
+              {nominations.map((nom, i) => (
+                <div key={i} className="px-3 py-1.5 bg-gray-50 dark:bg-gray-700 rounded text-sm text-gray-800 dark:text-gray-200">
+                  {nom}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Deadline picker */}
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Deadline</label>
+            <div className="grid grid-cols-4 gap-1.5">
+              {DEADLINE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => setDeadlineOption(opt.value)}
+                  disabled={isSubmitting}
+                  className={`px-2 py-1.5 text-xs font-medium rounded-lg transition-all ${
+                    deadlineOption === opt.value
+                      ? "bg-blue-600 text-white"
+                      : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+                  } disabled:opacity-50`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {error && (
+            <div className="mb-3 p-2 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-3">
+            <button
+              onClick={handleCreate}
+              disabled={isSubmitting}
+              className="flex-1 py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 active:scale-95 disabled:bg-gray-400 text-white font-medium text-sm rounded-lg transition-all disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? "Creating..." : "Create Poll"}
+            </button>
+            <button
+              onClick={handleEdit}
+              disabled={isSubmitting}
+              className="flex-1 py-3 px-4 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 active:scale-95 text-gray-900 dark:text-white font-medium text-sm rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-600"
+            >
+              Edit First
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/VoteOnItModal.tsx
+++ b/components/VoteOnItModal.tsx
@@ -108,51 +108,24 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
       {/* Modal */}
       <div className="fixed bottom-0 left-0 right-0 z-[110] animate-slide-up">
         <div className="bg-white dark:bg-gray-800 rounded-t-2xl shadow-xl p-6 pb-8 max-h-[80vh] overflow-y-auto">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 text-center">
-            Create Preference Poll
-          </h3>
-
-          {/* Title */}
-          <div className="mb-3">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Title</label>
-            <div className="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg text-sm text-gray-900 dark:text-white">
-              {pollTitle}
-            </div>
-          </div>
-
-          {/* Options */}
-          <div className="mb-3">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Options ({nominations.length})
-            </label>
-            <div className="space-y-1 max-h-40 overflow-y-auto">
-              {nominations.map((nom, i) => (
-                <div key={i} className="px-3 py-1.5 bg-gray-50 dark:bg-gray-700 rounded text-sm text-gray-800 dark:text-gray-200">
-                  {nom}
-                </div>
-              ))}
-            </div>
-          </div>
-
           {/* Deadline picker */}
           <div className="mb-4">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Deadline</label>
-            <div className="grid grid-cols-4 gap-1.5">
+            <label htmlFor="vote-deadline" className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
+              Response Deadline
+            </label>
+            <select
+              id="vote-deadline"
+              value={deadlineOption}
+              onChange={(e) => setDeadlineOption(e.target.value)}
+              disabled={isSubmitting}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+            >
               {DEADLINE_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  onClick={() => setDeadlineOption(opt.value)}
-                  disabled={isSubmitting}
-                  className={`px-2 py-1.5 text-xs font-medium rounded-lg transition-all ${
-                    deadlineOption === opt.value
-                      ? "bg-blue-600 text-white"
-                      : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
-                  } disabled:opacity-50`}
-                >
+                <option key={opt.value} value={opt.value}>
                   {opt.label}
-                </button>
+                </option>
               ))}
-            </div>
+            </select>
           </div>
 
           {error && (
@@ -161,19 +134,19 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
             </div>
           )}
 
-          {/* Action buttons */}
-          <div className="flex gap-3">
+          {/* Action buttons - stacked and centered */}
+          <div className="flex flex-col gap-2">
             <button
               onClick={handleCreate}
               disabled={isSubmitting}
-              className="flex-1 py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 active:scale-95 disabled:bg-gray-400 text-white font-medium text-sm rounded-lg transition-all disabled:cursor-not-allowed"
+              className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 active:scale-95 disabled:bg-gray-400 text-white font-medium text-sm rounded-lg transition-all disabled:cursor-not-allowed"
             >
               {isSubmitting ? "Creating..." : "Create Poll"}
             </button>
             <button
               onClick={handleEdit}
               disabled={isSubmitting}
-              className="flex-1 py-3 px-4 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 active:scale-95 text-gray-900 dark:text-white font-medium text-sm rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-600"
+              className="w-full py-3 px-4 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 active:bg-gray-300 dark:active:bg-gray-500 active:scale-95 text-gray-900 dark:text-white font-medium text-sm rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed border border-gray-200 dark:border-gray-600"
             >
               Edit First
             </button>

--- a/components/VoteOnItModal.tsx
+++ b/components/VoteOnItModal.tsx
@@ -108,6 +108,10 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
       {/* Modal */}
       <div className="fixed bottom-0 left-0 right-0 z-[110] animate-slide-up">
         <div className="bg-white dark:bg-gray-800 rounded-t-2xl shadow-xl p-6 pb-8 max-h-[80vh] overflow-y-auto">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 text-center">
+            Ask for Preferences
+          </h3>
+
           {/* Deadline picker */}
           <div className="mb-4">
             <label htmlFor="vote-deadline" className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">

--- a/components/VoteOnItModal.tsx
+++ b/components/VoteOnItModal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import ModalPortal from "@/components/ModalPortal";
-import { apiFindDuplicatePoll, apiCreatePoll } from "@/lib/api";
+import { apiCreatePoll } from "@/lib/api";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import { getUserName } from "@/lib/userProfile";
 
@@ -31,7 +31,6 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset state when modal opens
   useEffect(() => {
     if (isOpen) {
       setDeadlineOption("10min");
@@ -47,17 +46,6 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
     setError(null);
 
     try {
-      // Check for existing duplicate first
-      const existing = await apiFindDuplicatePoll(pollTitle, pollId);
-      if (existing) {
-        // Duplicate exists — navigate to it
-        const shortId = existing.short_id || existing.id;
-        router.push(`/p/${shortId}`);
-        onClose();
-        return;
-      }
-
-      // No duplicate — create the poll
       const option = DEADLINE_OPTIONS.find(opt => opt.value === deadlineOption);
       const deadline = new Date(Date.now() + (option?.minutes ?? 10) * 60 * 1000);
 
@@ -86,7 +74,6 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
   };
 
   const handleEdit = () => {
-    // Fall back to the existing flow — navigate to create-poll form
     const voteData = {
       title: pollTitle,
       options: nominations,
@@ -99,20 +86,17 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
 
   return (
     <ModalPortal>
-      {/* Backdrop */}
       <div
         className="fixed inset-0 bg-black/50 dark:bg-black/70 z-[100] animate-fade-in"
         onClick={onClose}
       />
 
-      {/* Modal */}
       <div className="fixed bottom-0 left-0 right-0 z-[110] animate-slide-up">
         <div className="bg-white dark:bg-gray-800 rounded-t-2xl shadow-xl p-6 pb-8 max-h-[80vh] overflow-y-auto">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 text-center">
             Ask for Preferences
           </h3>
 
-          {/* Deadline picker */}
           <div className="mb-4">
             <label htmlFor="vote-deadline" className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
               Response Deadline
@@ -138,7 +122,6 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
             </div>
           )}
 
-          {/* Action buttons - stacked and centered */}
           <div className="flex flex-col gap-2">
             <button
               onClick={handleCreate}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -170,6 +170,19 @@ export async function apiGetPollById(pollId: string): Promise<Poll> {
   return toPoll(data);
 }
 
+export async function apiFindDuplicatePoll(title: string, followUpTo: string): Promise<Poll | null> {
+  try {
+    const params = new URLSearchParams({ title, follow_up_to: followUpTo });
+    const data = await apiFetch(`/find-duplicate?${params}`);
+    return toPoll(data);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
 // --- Voting ---
 
 export async function apiSubmitVote(pollId: string, params: {

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -132,6 +132,25 @@ def create_poll(req: CreatePollRequest):
     return _row_to_poll(row)
 
 
+@router.get("/find-duplicate", response_model=PollResponse)
+def find_duplicate_poll(title: str, follow_up_to: str):
+    """Find an existing poll that is a follow-up to the same parent with the same title (case-insensitive)."""
+    with get_db() as conn:
+        row = conn.execute(
+            """
+            SELECT * FROM polls
+            WHERE LOWER(title) = LOWER(%(title)s)
+              AND follow_up_to = %(follow_up_to)s
+            ORDER BY created_at ASC
+            LIMIT 1
+            """,
+            {"title": title, "follow_up_to": follow_up_to},
+        ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="No duplicate poll found")
+    return _row_to_poll(row)
+
+
 @router.get("/by-short-id/{short_id}", response_model=PollResponse)
 def get_poll_by_short_id(short_id: str):
     """Get a poll by its short ID."""


### PR DESCRIPTION
## Summary
- Add `/find-duplicate` API endpoint to detect existing follow-up polls with the same title
- Replace navigation to create-poll form with inline VoteOnItModal (deadline picker + one-tap creation)
- Duplicate detection in both the modal trigger and create-poll form prevents accidental duplicate polls
- Add `/api/git-info` endpoint so dev server shows live commit info without restart (reads `.git/HEAD` on each request, refreshes on tab visibility change)

## Test plan
- [ ] Create a nomination poll, add nominations, tap "Vote on It" — modal appears with deadline picker
- [ ] Create a follow-up poll from the modal — redirects to the new poll
- [ ] Tap "Vote on It" again on the same nomination poll — redirects to existing follow-up (no duplicate)
- [ ] Tap "Edit First" in modal — navigates to create-poll form with pre-filled data
- [ ] On dev server, push a commit and verify commit info updates after tab switch

https://claude.ai/code/session_01DTEE4kygB6uaa1kSibt6DJ