### PR TITLE
Add auto-create preferences poll for nominations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,16 +75,22 @@ The droplet is hardened with:
 
 ### Development Workflow
 
-**Frontend** (Next.js — auto-deployed per-user dev servers):
+**Full-Stack Dev Servers** (auto-deployed per-user on push):
 1. **Write code** in this environment (Claude Code sandbox)
 2. **Commit and push** to GitHub
-3. GitHub webhook auto-updates your dev server on the droplet (hot reload — no rebuild)
+3. GitHub webhook creates/updates your full-stack dev server on the droplet
 4. Your dev site URL (based on `GIT_AUTHOR_EMAIL`) stays the same across all branches
+
+Each dev server gets its own:
+- **Next.js frontend** on port 3001-3005
+- **FastAPI backend** on port 8001-8005 (runs via `uv run uvicorn`, 1 worker)
+- **PostgreSQL database** (separate DB in the shared PostgreSQL container, e.g., `dev_sam_at_samcarey_com`)
+- **All migrations from the branch** auto-applied on creation and update
 
 **Production Frontend** (Vercel):
 - Vercel auto-deploys on push to `main` → `whoeverwants.com`
 
-**Backend** (Python API on droplet — auto-deployed on push to main):
+**Production Backend** (Python API on droplet — auto-deployed on push to main):
 - Merging/pushing to `main` auto-triggers: git pull → Docker rebuild → migration check → health verify
 - Deploy logs: `bash scripts/remote.sh "tail -50 /var/log/dev-webhook.log" /root`
 - Manual rebuild: `bash scripts/remote.sh "docker compose up -d --build" /root/whoeverwants`
@@ -93,26 +99,33 @@ The droplet is hardened with:
 You do NOT need SSH — all server management goes through `scripts/remote.sh`.
 
 **Per-User Dev Servers** (automatic on push):
-- Every push to GitHub auto-updates your dev server via webhook
-- Uses `next dev` (hot reload) — file changes apply in seconds, no full rebuild
-- Restarts only if `package-lock.json` changes (new dependencies) or the process died — commit SHA changes alone use hot reload
-- **After pushing, wait for the dev server to be ready before telling the user.** The server takes ~45-60 seconds to restart. Poll with `bash scripts/remote.sh "curl -s -o /dev/null -w '%{http_code}' http://localhost:<port>"` until it returns 200, then notify the user.
+- Every push to GitHub auto-updates your dev server via webhook (restarts both frontend and API)
+- Frontend uses `next dev` with `PYTHON_API_URL` pointing to the local API
+- API runs via `uv run uvicorn` with `DATABASE_URL` pointing to the dev database
+- Migrations from the branch are auto-applied to the dev database on each update
+- **After pushing, wait for the dev server to be ready.** The server takes ~30-60 seconds. Poll with `bash scripts/remote.sh "curl -s -o /dev/null -w '%{http_code}' http://localhost:<port>"` until it returns 200.
 - URL is based on your `GIT_AUTHOR_EMAIL`: `<email-slug>.dev.whoeverwants.com`
   - Example: `sam@example.com` → `https://sam-at-example-com.dev.whoeverwants.com`
 - URL stays the same regardless of branch — bookmark it
 - Claude/bot emails (`*@anthropic.com`) are ignored
-- Dev servers use the production API — they test frontend changes only
+- Dev servers are fully isolated — each has its own API and database
 - Auto-cleaned after 7 days of inactivity
 
 ```bash
-# List active dev servers
+# List active dev servers (shows frontend and API status)
 bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh list"
 
 # Manually trigger a dev server update
 bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh upsert user@example.com claude/my-branch" /root 600
 
-# Destroy a dev server
+# Destroy a dev server (also drops its database)
 bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh destroy user-at-example-com"
+
+# Check dev API health
+bash scripts/remote.sh "curl -s http://localhost:<api_port>/health"
+
+# Check dev API logs
+bash scripts/remote.sh "tail -50 /root/dev-servers/<slug>/api.log"
 ```
 
 **Preview Environments** (per-branch API testing):

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -55,7 +55,7 @@ function CreatePollContent() {
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
-  const [autoCreatePreferences, setAutoCreatePreferences] = useState(false);
+  const [autoCreatePreferences, setAutoCreatePreferences] = useState(true);
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
 
   // Helper to re-enable form elements

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -55,6 +55,8 @@ function CreatePollContent() {
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
+  const [autoCreatePreferences, setAutoCreatePreferences] = useState(false);
+  const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -851,6 +853,16 @@ function CreatePollContent() {
         pollData.options = filledOptions;
       }
 
+      // Add auto-create preferences settings for nomination polls
+      if (dbPollType === 'nomination' && autoCreatePreferences) {
+        pollData.auto_create_preferences = true;
+        const deadlineMinutesMap: Record<string, number> = {
+          '5min': 5, '10min': 10, '15min': 15, '30min': 30,
+          '1hr': 60, '2hr': 120, '4hr': 240,
+        };
+        pollData.auto_preferences_deadline_minutes = deadlineMinutesMap[autoPreferencesDeadline] || 10;
+      }
+
       // Add min/max participants for participation polls
       if (dbPollType === 'participation') {
         // Min is always required
@@ -1176,6 +1188,46 @@ function CreatePollContent() {
                   />
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* Auto-create preferences poll checkbox - nomination polls only */}
+          {pollType === 'nomination' && (
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={autoCreatePreferences}
+                  onChange={(e) => setAutoCreatePreferences(e.target.checked)}
+                  disabled={isLoading}
+                  className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Ask for preferences when closed
+                </span>
+              </label>
+              {autoCreatePreferences && (
+                <div className="ml-6">
+                  <label htmlFor="autoPreferencesDeadline" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                    Preferences poll deadline
+                  </label>
+                  <select
+                    id="autoPreferencesDeadline"
+                    value={autoPreferencesDeadline}
+                    onChange={(e) => setAutoPreferencesDeadline(e.target.value)}
+                    disabled={isLoading}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                  >
+                    <option value="5min">5 minutes</option>
+                    <option value="10min">10 minutes</option>
+                    <option value="15min">15 minutes</option>
+                    <option value="30min">30 minutes</option>
+                    <option value="1hr">1 hour</option>
+                    <option value="2hr">2 hours</option>
+                    <option value="4hr">4 hours</option>
+                  </select>
+                </div>
+              )}
             </div>
           )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -856,11 +856,8 @@ function CreatePollContent() {
       // Add auto-create preferences settings for nomination polls
       if (dbPollType === 'nomination' && autoCreatePreferences) {
         pollData.auto_create_preferences = true;
-        const deadlineMinutesMap: Record<string, number> = {
-          '5min': 5, '10min': 10, '15min': 15, '30min': 30,
-          '1hr': 60, '2hr': 120, '4hr': 240,
-        };
-        pollData.auto_preferences_deadline_minutes = deadlineMinutesMap[autoPreferencesDeadline] || 10;
+        pollData.auto_preferences_deadline_minutes =
+          baseDeadlineOptions.find(o => o.value === autoPreferencesDeadline)?.minutes || 10;
       }
 
       // Add min/max participants for participation polls

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAppPrefetch } from "@/lib/prefetch";
@@ -87,6 +87,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [showVoteOnItModal, setShowVoteOnItModal] = useState(false);
   const [nominations, setNominations] = useState<string[]>([]);
   const [loadingNominations, setLoadingNominations] = useState(false);
+  const autoCloseTriggeredRef = useRef(false);
 
   // Participation poll voter conditions - initialize with poll's constraints
   const [voterMinParticipants, setVoterMinParticipants] = useState<number | null>(poll.min_participants ?? 1);
@@ -548,10 +549,30 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     const updateTimer = () => {
       const now = new Date();
       setCurrentTime(now);
-      
+
       // If poll just expired, automatically fetch results
       if (now >= deadline && !isPollClosed) {
         fetchPollResults();
+
+        // For nomination polls with auto_create_preferences, call apiClosePoll
+        // to trigger server-side activation of the reserved preferences poll.
+        if (
+          poll.poll_type === 'nomination' &&
+          poll.auto_create_preferences &&
+          !autoCloseTriggeredRef.current
+        ) {
+          autoCloseTriggeredRef.current = true;
+          const creatorSecret = getCreatorSecret(poll.id);
+          if (creatorSecret) {
+            apiClosePoll(poll.id, creatorSecret, 'deadline')
+              .then(() => {
+                setPollClosed(true);
+              })
+              .catch((err) => {
+                console.error('Auto-close for preferences failed:', err);
+              });
+          }
+        }
       }
     };
 
@@ -562,7 +583,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     const interval = setInterval(updateTimer, 1000);
 
     return () => clearInterval(interval);
-  }, [poll.response_deadline, pollClosed, isPollClosed, fetchPollResults]);
+  }, [poll.response_deadline, pollClosed, isPollClosed, fetchPollResults, poll.poll_type, poll.auto_create_preferences, poll.id]);
 
   // Real-time subscription to listen for poll status changes (with polling fallback)
   useEffect(() => {
@@ -689,6 +710,20 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         setPollClosed(true);
         setManuallyReopened(false); // Reset manually reopened flag when closing
         await fetchPollResults();
+
+        // If this nomination poll had auto_create_preferences, find and navigate
+        // to the activated preferences poll.
+        if (poll.poll_type === 'nomination' && poll.auto_create_preferences) {
+          try {
+            const followUp = await apiFindDuplicatePoll(poll.title, poll.id);
+            if (followUp && !followUp.is_closed) {
+              const shortId = followUp.short_id || followUp.id;
+              router.push(`/p/${shortId}`);
+            }
+          } catch {
+            // Non-critical — user can still find it via follow-up links
+          }
+        }
       } else {
         alert('Failed to close poll. Please try again.');
       }
@@ -1622,6 +1657,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               nominations={nominations}
               loadingNominations={loadingNominations}
               onVoteOnNominationsClick={handleVoteOnNominationsClick}
+              autoCreatePreferences={poll.auto_create_preferences}
             />
           ) : (
             <div>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -550,28 +550,27 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       const now = new Date();
       setCurrentTime(now);
 
-      // If poll just expired, automatically fetch results
+      // If poll just expired, automatically fetch results.
+      // For nomination polls with auto_create_preferences, the server-side
+      // get_results endpoint auto-closes and activates the preferences poll.
       if (now >= deadline && !isPollClosed) {
         fetchPollResults();
 
-        // For nomination polls with auto_create_preferences, call apiClosePoll
-        // to trigger server-side activation of the reserved preferences poll.
         if (
           poll.poll_type === 'nomination' &&
           poll.auto_create_preferences &&
           !autoCloseTriggeredRef.current
         ) {
           autoCloseTriggeredRef.current = true;
-          const creatorSecret = getCreatorSecret(poll.id);
-          if (creatorSecret) {
-            apiClosePoll(poll.id, creatorSecret, 'deadline')
-              .then(() => {
-                setPollClosed(true);
-              })
-              .catch((err) => {
-                console.error('Auto-close for preferences failed:', err);
-              });
-          }
+          setPollClosed(true);
+          apiFindDuplicatePoll(poll.title, poll.id)
+            .then((followUp) => {
+              if (followUp && !followUp.is_closed) {
+                const shortId = followUp.short_id || followUp.id;
+                router.push(`/p/${shortId}`);
+              }
+            })
+            .catch(() => {});
         }
       }
     };
@@ -583,7 +582,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     const interval = setInterval(updateTimer, 1000);
 
     return () => clearInterval(interval);
-  }, [poll.response_deadline, pollClosed, isPollClosed, fetchPollResults, poll.poll_type, poll.auto_create_preferences, poll.id]);
+  }, [poll.response_deadline, pollClosed, isPollClosed, fetchPollResults, poll.poll_type, poll.auto_create_preferences, poll.id, poll.title, router]);
 
   // Real-time subscription to listen for poll status changes (with polling fallback)
   useEffect(() => {

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -38,6 +38,7 @@ interface NominationVotingInterfaceProps {
   nominations: string[];
   loadingNominations: boolean;
   onVoteOnNominationsClick: () => void;
+  autoCreatePreferences?: boolean;
 }
 
 export default function NominationVotingInterface({
@@ -67,7 +68,8 @@ export default function NominationVotingInterface({
   onFollowUpClick,
   nominations,
   loadingNominations,
-  onVoteOnNominationsClick
+  onVoteOnNominationsClick,
+  autoCreatePreferences
 }: NominationVotingInterfaceProps) {
   const [newNominations, setNewNominations] = useState<string[]>([""]);
   const [filteredExistingNominations, setFilteredExistingNominations] = useState<string[]>([]);
@@ -235,7 +237,7 @@ export default function NominationVotingInterface({
               </svg>
               <span className="font-semibold">Follow up</span>
             </GradientBorderButton>
-            {nominations.length >= 2 && (
+            {nominations.length >= 2 && !autoCreatePreferences && (
               <GradientBorderButton
                 onClick={onVoteOnNominationsClick}
                 disabled={loadingNominations}
@@ -259,6 +261,15 @@ export default function NominationVotingInterface({
                 )}
               </GradientBorderButton>
             )}
+          </div>
+        )}
+
+        {/* Auto-preferences note */}
+        {!isPollClosed && !isLoadingVoteData && autoCreatePreferences && (
+          <div className="mt-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+            <p className="text-xs text-blue-700 dark:text-blue-300">
+              A preferences poll will be created automatically when this poll closes.
+            </p>
           </div>
         )}
 

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -264,13 +264,10 @@ export default function NominationVotingInterface({
           </div>
         )}
 
-        {/* Auto-preferences note */}
         {!isPollClosed && !isLoadingVoteData && autoCreatePreferences && (
-          <div className="mt-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
-            <p className="text-xs text-blue-700 dark:text-blue-300">
-              A preferences poll will be created automatically when this poll closes.
-            </p>
-          </div>
+          <p className="mt-3 px-3 py-2 text-xs text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+            A preferences poll will be created automatically when this poll closes.
+          </p>
         )}
 
         {/* Show follow-up/fork header after Follow up button when voted */}

--- a/database/migrations/066_auto_create_preferences_down.sql
+++ b/database/migrations/066_auto_create_preferences_down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE polls DROP COLUMN IF EXISTS auto_preferences_deadline_minutes;
+ALTER TABLE polls DROP COLUMN IF EXISTS auto_create_preferences;

--- a/database/migrations/066_auto_create_preferences_up.sql
+++ b/database/migrations/066_auto_create_preferences_up.sql
@@ -1,0 +1,7 @@
+-- Add columns for auto-creating a preferences (ranked_choice) poll when a nomination poll closes.
+-- auto_create_preferences: if true, a placeholder ranked_choice poll is reserved at creation time
+--   and activated with nominations when the parent nomination poll closes.
+-- auto_preferences_deadline_minutes: how many minutes the auto-created preferences poll stays open.
+
+ALTER TABLE polls ADD COLUMN auto_create_preferences BOOLEAN DEFAULT false;
+ALTER TABLE polls ADD COLUMN auto_preferences_deadline_minutes INT;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -103,6 +103,8 @@ function toPoll(data: any): Poll {
     min_participants: data.min_participants ?? undefined,
     max_participants: data.max_participants ?? undefined,
     short_id: data.short_id ?? undefined,
+    auto_create_preferences: data.auto_create_preferences ?? undefined,
+    auto_preferences_deadline_minutes: data.auto_preferences_deadline_minutes ?? undefined,
   };
 }
 
@@ -152,6 +154,8 @@ export async function apiCreatePoll(params: {
   fork_of?: string;
   min_participants?: number;
   max_participants?: number;
+  auto_create_preferences?: boolean;
+  auto_preferences_deadline_minutes?: number;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,8 @@ export interface Poll {
   min_participants?: number;
   max_participants?: number;
   short_id?: string;
+  auto_create_preferences?: boolean;
+  auto_preferences_deadline_minutes?: number;
 }
 
 export interface Vote {

--- a/scripts/apply-dev-migrations.sh
+++ b/scripts/apply-dev-migrations.sh
@@ -35,12 +35,14 @@ pending=0
 for f in "$MIGRATIONS_DIR"/*_up.sql; do
   [ -f "$f" ] || continue
   basename=$(basename "$f")
+  # Re-read applied list each iteration (some migrations like 000_* insert tracking rows)
+  applied=$(docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -t -A -c "SELECT filename FROM _migrations;" 2>/dev/null || echo "")
   if echo "$applied" | grep -qxF "$basename"; then
     continue
   fi
   echo "  Applying: $basename"
   run_sql_file "$f"
-  run_sql "INSERT INTO _migrations (filename) VALUES ('$basename');" >/dev/null
+  run_sql "INSERT INTO _migrations (filename) VALUES ('$basename') ON CONFLICT DO NOTHING;" >/dev/null
   pending=$((pending + 1))
 done
 

--- a/scripts/apply-dev-migrations.sh
+++ b/scripts/apply-dev-migrations.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Apply all *_up.sql migrations to a dev database.
+# Usage: apply-dev-migrations.sh <db_name> <migrations_dir>
+#
+# Creates the _migrations table if it doesn't exist, then applies any
+# migration files not yet recorded, in filename order.
+
+set -euo pipefail
+
+DB_NAME="${1:?Usage: apply-dev-migrations.sh <db_name> <migrations_dir>}"
+MIGRATIONS_DIR="${2:?Usage: apply-dev-migrations.sh <db_name> <migrations_dir>}"
+CONTAINER="whoeverwants-db-1"
+DB_USER="whoeverwants"
+
+run_sql() {
+  docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "$1"
+}
+
+run_sql_file() {
+  docker exec -i "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" < "$1"
+}
+
+# Ensure _migrations table exists
+run_sql "CREATE TABLE IF NOT EXISTS _migrations (
+  id SERIAL PRIMARY KEY,
+  filename TEXT NOT NULL UNIQUE,
+  applied_at TIMESTAMPTZ DEFAULT NOW()
+);" >/dev/null 2>&1
+
+# Get already-applied migrations
+applied=$(docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -t -A -c "SELECT filename FROM _migrations;")
+
+# Find and apply pending *_up.sql migrations
+pending=0
+for f in "$MIGRATIONS_DIR"/*_up.sql; do
+  [ -f "$f" ] || continue
+  basename=$(basename "$f")
+  if echo "$applied" | grep -qxF "$basename"; then
+    continue
+  fi
+  echo "  Applying: $basename"
+  run_sql_file "$f"
+  run_sql "INSERT INTO _migrations (filename) VALUES ('$basename');" >/dev/null
+  pending=$((pending + 1))
+done
+
+if [ "$pending" -eq 0 ]; then
+  echo "  All migrations already applied."
+else
+  echo "  Applied $pending migration(s)."
+fi

--- a/scripts/apply-dev-migrations.sh
+++ b/scripts/apply-dev-migrations.sh
@@ -35,6 +35,11 @@ pending=0
 for f in "$MIGRATIONS_DIR"/*_up.sql; do
   [ -f "$f" ] || continue
   basename=$(basename "$f")
+  # Skip 000_populate_tracking_table — it's for production DBs that already
+  # have all tables. Fresh dev DBs need to run actual migrations from scratch.
+  if [[ "$basename" == 000_* ]]; then
+    continue
+  fi
   # Re-read applied list each iteration (some migrations like 000_* insert tracking rows)
   applied=$(docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -t -A -c "SELECT filename FROM _migrations;" 2>/dev/null || echo "")
   if echo "$applied" | grep -qxF "$basename"; then

--- a/scripts/apply-dev-migrations.sh
+++ b/scripts/apply-dev-migrations.sh
@@ -40,14 +40,13 @@ for f in "$MIGRATIONS_DIR"/*_up.sql; do
   if [[ "$basename" == 000_* ]]; then
     continue
   fi
-  # Re-read applied list each iteration (some migrations like 000_* insert tracking rows)
-  applied=$(docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -t -A -c "SELECT filename FROM _migrations;" 2>/dev/null || echo "")
   if echo "$applied" | grep -qxF "$basename"; then
     continue
   fi
   echo "  Applying: $basename"
   run_sql_file "$f"
   run_sql "INSERT INTO _migrations (filename) VALUES ('$basename') ON CONFLICT DO NOTHING;" >/dev/null
+  applied="${applied}"$'\n'"${basename}"
   pending=$((pending + 1))
 done
 

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# Per-user dev server manager for the WhoeverWants droplet.
-# Each developer (identified by git author email) gets their own Next.js
-# frontend server that auto-updates when they push new commits.
+# Per-user FULL-STACK dev server manager for the WhoeverWants droplet.
+# Each developer (identified by git author email) gets their own:
+#   - Next.js frontend on a unique port (3001-3005)
+#   - FastAPI backend on a unique port (8001-8005)
+#   - PostgreSQL database (shared instance, separate DB per dev server)
+#   - All migrations from their branch auto-applied
 #
 # Usage (run on droplet):
 #   dev-server-manager.sh upsert <email> <branch>
@@ -9,16 +12,6 @@
 #   dev-server-manager.sh destroy <email-slug>
 #   dev-server-manager.sh destroy-all
 #   dev-server-manager.sh cleanup [days]
-#
-# Each dev server gets:
-#   - A clone of the repo at /root/dev-servers/<email-slug>/
-#   - A Next.js dev server (hot reload) on a unique port
-#   - A Caddy route at <email-slug>.dev.whoeverwants.com
-#   - Uses the production API (api.whoeverwants.com)
-#
-# Dev mode: Uses `next dev` for instant hot reload. On push, files are
-# updated via git and Next.js auto-detects changes — no rebuild needed.
-# Server only restarts if package-lock.json changes or the process died.
 #
 # Email-to-slug mapping:
 #   sam@example.com -> sam-at-example-com
@@ -29,11 +22,23 @@ set -euo pipefail
 DEV_DIR="/root/dev-servers"
 CADDY_DEV_DIR="/etc/caddy/dev-servers"
 REPO_URL="https://github.com/samcarey/whoeverwants.git"
-PORT_START=3001
-PORT_MAX=3005
+FRONTEND_PORT_START=3001
+FRONTEND_PORT_MAX=3005
+API_PORT_START=8001
+API_PORT_MAX=8005
 MAX_DEV_SERVERS=3
 LOCK_DIR="/tmp/dev-server-locks"
 LOG_FILE="/var/log/dev-server-manager.log"
+
+# Database connection (shared PostgreSQL container)
+DB_CONTAINER="whoeverwants-db-1"
+DB_USER="whoeverwants"
+DB_PASSWORD="whoeverwants"
+DB_HOST="127.0.0.1"
+DB_PORT="5432"
+
+# Path to uv (installed via astral.sh)
+UV_BIN="/root/.local/bin/uv"
 
 # Claude/bot email patterns to ignore
 IGNORE_EMAIL_PATTERNS=(
@@ -60,6 +65,13 @@ email_to_slug() {
     | sed 's/^-//; s/-$//'
 }
 
+# Convert slug to database name (replace hyphens with underscores)
+# sam-at-example-com -> dev_sam_at_example_com
+slug_to_dbname() {
+  local slug="$1"
+  echo "dev_${slug//-/_}"
+}
+
 # Check if email should be ignored (Claude, bots, etc.)
 is_ignored_email() {
   local email="$1"
@@ -75,15 +87,17 @@ is_ignored_email() {
   return 1
 }
 
-# Find an available port
-find_available_port() {
-  for port in $(seq $PORT_START $PORT_MAX); do
+# Find an available port in a range
+find_available_port_in_range() {
+  local start="$1"
+  local max="$2"
+  for port in $(seq "$start" "$max"); do
     if ! ss -tlnp 2>/dev/null | grep -q ":${port} "; then
       echo "$port"
       return 0
     fi
   done
-  log "ERROR: No available ports in range $PORT_START-$PORT_MAX"
+  log "ERROR: No available ports in range $start-$max"
   return 1
 }
 
@@ -96,10 +110,18 @@ get_dev_port() {
   fi
 }
 
+# Get API port from existing dev server metadata
+get_api_port() {
+  local slug="$1"
+  local meta="${DEV_DIR}/${slug}/.dev-meta.json"
+  if [ -f "$meta" ]; then
+    python3 -c "import json; print(json.load(open('$meta')).get('api_port', ''))" 2>/dev/null || echo ""
+  fi
+}
+
+# --- Process management ---
+
 # Stop the Next.js process for a dev server
-# npm run dev spawns child processes (npm -> next -> node), so killing the
-# parent PID alone may leave orphaned children holding the port open.
-# We kill by PID first, then ensure nothing is left on the port.
 stop_nextjs() {
   local slug="$1"
   local dir="${DEV_DIR}/${slug}"
@@ -112,15 +134,12 @@ stop_nextjs() {
     pid=$(cat "$pid_file")
     if kill -0 "$pid" 2>/dev/null; then
       log "Stopping Next.js for $slug (PID $pid)..."
-      # Kill the entire process group (next dev + child processes)
       kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
-      # Wait up to 10 seconds for graceful shutdown
       local waited=0
       while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt 10 ]; do
         sleep 1
         waited=$((waited + 1))
       done
-      # Force kill if still running
       if kill -0 "$pid" 2>/dev/null; then
         kill -9 -- -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
         sleep 1
@@ -129,8 +148,7 @@ stop_nextjs() {
     rm -f "$pid_file"
   fi
 
-  # Kill any orphaned processes still holding the port (child node processes
-  # that survived the parent kill)
+  # Kill any orphaned processes still holding the port
   if [ -n "$port" ]; then
     local port_pids
     port_pids=$(fuser "${port}/tcp" 2>/dev/null || true)
@@ -142,34 +160,73 @@ stop_nextjs() {
   fi
 }
 
-# Start the Next.js dev server (hot reload mode)
+# Stop the FastAPI process for a dev server
+stop_api() {
+  local slug="$1"
+  local dir="${DEV_DIR}/${slug}"
+  local pid_file="${dir}/.api.pid"
+  local port
+  port=$(get_api_port "$slug")
+
+  if [ -f "$pid_file" ]; then
+    local pid
+    pid=$(cat "$pid_file")
+    if kill -0 "$pid" 2>/dev/null; then
+      log "Stopping API for $slug (PID $pid)..."
+      kill "$pid" 2>/dev/null || true
+      local waited=0
+      while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt 5 ]; do
+        sleep 1
+        waited=$((waited + 1))
+      done
+      if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+        sleep 1
+      fi
+    fi
+    rm -f "$pid_file"
+  fi
+
+  # Kill any orphaned processes still holding the API port
+  if [ -n "$port" ]; then
+    local port_pids
+    port_pids=$(fuser "${port}/tcp" 2>/dev/null || true)
+    if [ -n "$port_pids" ]; then
+      log "Killing orphaned processes on API port $port: $port_pids"
+      fuser -k "${port}/tcp" 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+}
+
+# Start the Next.js dev server
 # NOTE: Only the PID is written to stdout (for capture). All log messages go to stderr.
 start_nextjs() {
   local slug="$1"
-  local port="$2"
+  local frontend_port="$2"
+  local api_port="$3"
   local dir="${DEV_DIR}/${slug}"
 
   cd "$dir"
 
-  log "Starting Next.js dev server for $slug on port $port..."
+  log "Starting Next.js dev server for $slug on port $frontend_port (API on $api_port)..."
 
-  # Resolve git commit info so CommitInfo component works in dev mode
   local git_sha git_branch
   git_sha=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
   git_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
-  # Use `npm run dev` so flags (--webpack, etc.) stay in sync with package.json.
-  # Extra args are passed after `--`.
-  NEXT_PUBLIC_API_URL="https://api.whoeverwants.com/api/polls" \
+  # PYTHON_API_URL tells next.config.ts where to proxy /api/polls requests.
+  # NEXT_PUBLIC_API_URL tells lib/api.ts where to make server-side requests.
+  PYTHON_API_URL="http://localhost:${api_port}" \
+  NEXT_PUBLIC_API_URL="http://localhost:${api_port}/api/polls" \
   NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA="$git_sha" \
   NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF="$git_branch" \
   HOSTNAME=0.0.0.0 \
-    npm run dev -- -p "$port" \
+    npm run dev -- -p "$frontend_port" \
     >> "${dir}/nextjs.log" 2>&1 200>&- &
   local new_pid=$!
   echo "$new_pid" > "${dir}/.nextjs.pid"
 
-  # Wait and verify it started
   sleep 5
   if ! kill -0 "$new_pid" 2>/dev/null; then
     log "ERROR: Next.js dev server failed to start for $slug. Last 20 lines of log:"
@@ -177,12 +234,91 @@ start_nextjs() {
     return 1
   fi
 
-  log "Next.js dev server started for $slug (PID $new_pid, port $port)"
-  # Only output the PID — log() already wrote to the log file
+  log "Next.js dev server started for $slug (PID $new_pid, port $frontend_port)"
   echo "$new_pid"
 }
 
-# Ensure the Caddy import line for dev-servers exists
+# Start the FastAPI dev server
+# NOTE: Only the PID is written to stdout (for capture). All log messages go to stderr.
+start_api() {
+  local slug="$1"
+  local api_port="$2"
+  local db_name="$3"
+  local dir="${DEV_DIR}/${slug}"
+
+  cd "${dir}/server"
+
+  log "Starting API server for $slug on port $api_port (DB: $db_name)..."
+
+  # Install Python deps if needed (first time or pyproject.toml changed)
+  if [ ! -d "${dir}/server/.venv" ]; then
+    log "  Installing Python dependencies..."
+    "$UV_BIN" sync --quiet 2>&1 | tail -3 || true
+  fi
+
+  DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${db_name}" \
+    "$UV_BIN" run uvicorn main:app --host 0.0.0.0 --port "$api_port" --workers 1 \
+    >> "${dir}/api.log" 2>&1 &
+  local new_pid=$!
+  echo "$new_pid" > "${dir}/.api.pid"
+
+  sleep 3
+  if ! kill -0 "$new_pid" 2>/dev/null; then
+    log "ERROR: API server failed to start for $slug. Last 20 lines of log:"
+    tail -20 "${dir}/api.log" 2>/dev/null || true
+    return 1
+  fi
+
+  log "API server started for $slug (PID $new_pid, port $api_port, DB: $db_name)"
+  echo "$new_pid"
+}
+
+# --- Database management ---
+
+# Create a dev database if it doesn't exist
+create_dev_database() {
+  local db_name="$1"
+  local exists
+  exists=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -tAc \
+    "SELECT 1 FROM pg_database WHERE datname = '$db_name';" 2>/dev/null || echo "")
+  if [ "$exists" != "1" ]; then
+    log "  Creating database: $db_name"
+    docker exec "$DB_CONTAINER" psql -U "$DB_USER" -c "CREATE DATABASE $db_name;" >/dev/null
+  fi
+}
+
+# Apply migrations from the dev server's branch
+apply_dev_migrations() {
+  local db_name="$1"
+  local migrations_dir="$2"
+
+  if [ ! -d "$migrations_dir" ]; then
+    log "  No migrations directory found at $migrations_dir"
+    return
+  fi
+
+  log "  Applying migrations to $db_name..."
+  bash "$(dirname "$0")/apply-dev-migrations.sh" "$db_name" "$migrations_dir"
+}
+
+# Drop a dev database
+drop_dev_database() {
+  local db_name="$1"
+  local exists
+  exists=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -tAc \
+    "SELECT 1 FROM pg_database WHERE datname = '$db_name';" 2>/dev/null || echo "")
+  if [ "$exists" = "1" ]; then
+    # Terminate existing connections first
+    docker exec "$DB_CONTAINER" psql -U "$DB_USER" -c \
+      "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$db_name' AND pid <> pg_backend_pid();" \
+      >/dev/null 2>&1 || true
+    docker exec "$DB_CONTAINER" psql -U "$DB_USER" -c "DROP DATABASE $db_name;" >/dev/null
+    log "  Dropped database: $db_name"
+  fi
+}
+
+# --- Caddy management ---
+
 ensure_caddy_import() {
   mkdir -p "$CADDY_DEV_DIR"
   if ! grep -q "dev-servers" /etc/caddy/Caddyfile 2>/dev/null; then
@@ -192,7 +328,6 @@ ensure_caddy_import() {
   fi
 }
 
-# Add or update Caddy config for a dev server
 configure_caddy() {
   local slug="$1"
   local port="$2"
@@ -209,7 +344,6 @@ EOF
   log "Caddy configured for ${slug}.dev.whoeverwants.com -> port $port"
 }
 
-# Remove Caddy config for a dev server
 remove_caddy() {
   local slug="$1"
   rm -f "${CADDY_DEV_DIR}/${slug}.caddy"
@@ -217,9 +351,8 @@ remove_caddy() {
   log "Caddy config removed for $slug"
 }
 
-# Evict oldest dev servers to stay within MAX_DEV_SERVERS limit.
-# Keeps the most recently updated servers, destroys the rest.
-# The current_slug (about to be upserted) is never evicted.
+# --- Eviction ---
+
 evict_excess_servers() {
   local current_slug="$1"
 
@@ -227,7 +360,6 @@ evict_excess_servers() {
     return
   fi
 
-  # Collect all slugs with their updated_at timestamps, sorted oldest first
   local servers=()
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
@@ -237,7 +369,6 @@ evict_excess_servers() {
     servers+=("${updated}|${slug}")
   done
 
-  # Count how many will exist after this upsert
   local total=${#servers[@]}
   local current_exists=false
   for entry in "${servers[@]}"; do
@@ -255,7 +386,6 @@ evict_excess_servers() {
     return
   fi
 
-  # Sort oldest first and evict until we're at the limit
   local sorted
   sorted=$(printf '%s\n' "${servers[@]}" | sort)
   local to_evict=$((total - MAX_DEV_SERVERS))
@@ -284,7 +414,6 @@ cmd_upsert() {
     return 0
   fi
 
-  # Evict oldest dev servers if at capacity
   evict_excess_servers "$slug"
 
   # Lock to prevent concurrent updates for same user
@@ -299,12 +428,14 @@ cmd_upsert() {
   log "=== Upsert dev server: $email (slug: $slug, branch: $branch) ==="
 
   local dir="${DEV_DIR}/${slug}"
+  local db_name
+  db_name=$(slug_to_dbname "$slug")
   local is_new=false
-  local needs_restart=false
+  local needs_npm_install=false
 
   if [ ! -d "$dir/.git" ]; then
     is_new=true
-    needs_restart=true
+    needs_npm_install=true
     log "--- Cloning repository ---"
     mkdir -p "$DEV_DIR"
     rm -rf "$dir"
@@ -313,79 +444,90 @@ cmd_upsert() {
 
   cd "$dir"
 
-  # Save current package-lock hash to detect dependency changes
+  # Save current hashes to detect dependency changes
   local old_lockfile_hash=""
+  local old_pyproject_hash=""
   if [ -f "package-lock.json" ]; then
     old_lockfile_hash=$(md5sum package-lock.json | cut -d' ' -f1)
+  fi
+  if [ -f "server/pyproject.toml" ]; then
+    old_pyproject_hash=$(md5sum server/pyproject.toml | cut -d' ' -f1)
   fi
 
   # Fetch and checkout the branch
   log "--- Fetching and checking out $branch ---"
   git fetch origin "$branch" --depth 50
-  # Use FETCH_HEAD since shallow clones may not have remote tracking branches
   git checkout "$branch" 2>/dev/null \
     || git checkout -b "$branch" FETCH_HEAD 2>/dev/null \
     || git checkout "$branch"
   git reset --hard FETCH_HEAD
 
-  # Check if dependencies changed
+  # Check if JS dependencies changed
   local new_lockfile_hash=""
   if [ -f "package-lock.json" ]; then
     new_lockfile_hash=$(md5sum package-lock.json | cut -d' ' -f1)
   fi
   if [ "$old_lockfile_hash" != "$new_lockfile_hash" ]; then
-    log "package-lock.json changed — reinstalling deps and restarting"
-    needs_restart=true
+    log "package-lock.json changed — will reinstall JS deps"
+    needs_npm_install=true
   fi
 
-  # Check if server process is still running
-  local current_pid=""
-  if [ -f "${dir}/.nextjs.pid" ]; then
-    current_pid=$(cat "${dir}/.nextjs.pid")
-    if ! kill -0 "$current_pid" 2>/dev/null; then
-      log "Dev server process not running — needs restart"
-      needs_restart=true
-      current_pid=""
-    fi
-  else
-    needs_restart=true
+  # Check if Python dependencies changed
+  local needs_uv_sync=false
+  local new_pyproject_hash=""
+  if [ -f "server/pyproject.toml" ]; then
+    new_pyproject_hash=$(md5sum server/pyproject.toml | cut -d' ' -f1)
+  fi
+  if [ "$old_pyproject_hash" != "$new_pyproject_hash" ] || [ ! -d "server/.venv" ]; then
+    needs_uv_sync=true
   fi
 
-  # Determine port (reuse existing or find new)
-  local port
-  port=$(get_dev_port "$slug")
-  if [ -z "$port" ]; then
-    port=$(find_available_port)
+  # --- Database setup ---
+  log "--- Setting up database ---"
+  create_dev_database "$db_name"
+  apply_dev_migrations "$db_name" "${dir}/database/migrations"
+
+  # --- Python dependencies ---
+  if [ "$needs_uv_sync" = true ]; then
+    log "--- Installing Python dependencies ---"
+    cd "${dir}/server"
+    "$UV_BIN" sync --quiet 2>&1 | tail -3 || true
+    cd "$dir"
   fi
 
-  if [ "$needs_restart" = true ]; then
-    # Full restart: stop, reinstall deps, start
-    stop_nextjs "$slug"
+  # --- Determine ports (reuse existing or find new) ---
+  local frontend_port api_port
+  frontend_port=$(get_dev_port "$slug")
+  api_port=$(get_api_port "$slug")
+  if [ -z "$frontend_port" ]; then
+    frontend_port=$(find_available_port_in_range "$FRONTEND_PORT_START" "$FRONTEND_PORT_MAX")
+  fi
+  if [ -z "$api_port" ]; then
+    api_port=$(find_available_port_in_range "$API_PORT_START" "$API_PORT_MAX")
+  fi
 
-    log "--- Installing dependencies ---"
+  # --- Stop existing processes ---
+  stop_api "$slug"
+  stop_nextjs "$slug"
+
+  # --- Install JS deps if needed ---
+  if [ "$needs_npm_install" = true ]; then
+    log "--- Installing JS dependencies ---"
     npm ci --prefer-offline 2>&1 | tail -5
-
-    # Clear .next cache on fresh installs for clean state
     if [ "$is_new" = true ]; then
       rm -rf .next
     fi
-
-    local pid
-    pid=$(start_nextjs "$slug" "$port")
-    log "  Mode:   Full restart (deps changed or new server)"
-  else
-    # Light restart: stop and start without reinstalling deps.
-    # Always restart so that NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA env var
-    # updates and Next.js reliably picks up all file changes (hot reload
-    # via file watcher is unreliable for git reset --hard across many files).
-    stop_nextjs "$slug"
-
-    local pid
-    pid=$(start_nextjs "$slug" "$port")
-    log "  Mode:   Light restart (no dep changes)"
   fi
 
-  # Write metadata
+  # --- Start API server ---
+  local api_pid
+  api_pid=$(start_api "$slug" "$api_port" "$db_name")
+
+  # --- Start Next.js frontend ---
+  local frontend_pid
+  frontend_pid=$(start_nextjs "$slug" "$frontend_port" "$api_port")
+
+  # --- Write metadata ---
   local commit_sha
   commit_sha=$(git rev-parse HEAD)
   cat > "${dir}/.dev-meta.json" <<EOF
@@ -393,8 +535,11 @@ cmd_upsert() {
   "slug": "${slug}",
   "email": "${email}",
   "branch": "${branch}",
-  "port": ${port},
-  "pid": ${pid},
+  "port": ${frontend_port},
+  "api_port": ${api_port},
+  "db_name": "${db_name}",
+  "pid": ${frontend_pid},
+  "api_pid": ${api_pid},
   "commit": "${commit_sha}",
   "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "url": "https://${slug}.dev.whoeverwants.com"
@@ -404,30 +549,26 @@ EOF
   # Configure Caddy (on first create, config missing, or port changed)
   local current_caddy_port=""
   if [ -f "${CADDY_DEV_DIR}/${slug}.caddy" ]; then
-    current_caddy_port=$(grep -oP '127\.0\.0\.1:\K[0-9]+' "${CADDY_DEV_DIR}/${slug}.caddy" || echo "")
+    current_caddy_port=$(grep -oP '127\.0\.0\.1:\K[0-9]+' "${CADDY_DEV_DIR}/${slug}.caddy" | head -1 || echo "")
   fi
-  if [ "$is_new" = true ] || [ ! -f "${CADDY_DEV_DIR}/${slug}.caddy" ] || [ "$current_caddy_port" != "$port" ]; then
-    configure_caddy "$slug" "$port"
+  if [ "$is_new" = true ] || [ ! -f "${CADDY_DEV_DIR}/${slug}.caddy" ] || [ "$current_caddy_port" != "$frontend_port" ]; then
+    configure_caddy "$slug" "$frontend_port"
   fi
 
   log ""
   log "=== Dev server ready ==="
-  log "  URL:    https://${slug}.dev.whoeverwants.com"
-  log "  Email:  $email"
-  log "  Branch: $branch"
-  log "  Commit: ${commit_sha:0:8}"
-  log "  Port:   $port"
-  log "  PID:    $pid"
-  if [ "$needs_restart" = true ]; then
-    log "  Mode:   Full restart (deps changed or new server)"
-  else
-    log "  Mode:   Hot reload (files updated, no restart needed)"
-  fi
+  log "  URL:       https://${slug}.dev.whoeverwants.com"
+  log "  Email:     $email"
+  log "  Branch:    $branch"
+  log "  Commit:    ${commit_sha:0:8}"
+  log "  Frontend:  port $frontend_port (PID $frontend_pid)"
+  log "  API:       port $api_port (PID $api_pid)"
+  log "  Database:  $db_name"
 }
 
 cmd_list() {
-  printf "%-35s %-30s %-30s %-5s %-20s %s\n" "SLUG" "EMAIL" "BRANCH" "PORT" "UPDATED" "URL"
-  printf "%-35s %-30s %-30s %-5s %-20s %s\n" "----" "-----" "------" "----" "-------" "---"
+  printf "%-35s %-30s %-30s %-5s %-5s %-20s %s\n" "SLUG" "EMAIL" "BRANCH" "FE" "API" "UPDATED" "STATUS"
+  printf "%-35s %-30s %-30s %-5s %-5s %-20s %s\n" "----" "-----" "------" "--" "---" "-------" "------"
 
   if [ ! -d "$DEV_DIR" ]; then
     echo "(no dev servers)"
@@ -438,22 +579,27 @@ cmd_list() {
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
     found=1
-    local slug branch email port updated url pid running
+    local slug branch email port api_port updated pid api_pid fe_status api_status
     slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
     email=$(python3 -c "import json; print(json.load(open('$meta'))['email'])")
     branch=$(python3 -c "import json; print(json.load(open('$meta'))['branch'])")
     port=$(python3 -c "import json; print(json.load(open('$meta'))['port'])")
+    api_port=$(python3 -c "import json; print(json.load(open('$meta')).get('api_port', 'N/A'))")
     updated=$(python3 -c "import json; print(json.load(open('$meta'))['updated_at'][:19])")
-    url=$(python3 -c "import json; print(json.load(open('$meta'))['url'])")
     pid=$(python3 -c "import json; print(json.load(open('$meta')).get('pid', 'N/A'))")
+    api_pid=$(python3 -c "import json; print(json.load(open('$meta')).get('api_pid', 'N/A'))")
 
-    # Check if process is running
-    running="STOPPED"
+    fe_status="DOWN"
     if [ "$pid" != "N/A" ] && kill -0 "$pid" 2>/dev/null; then
-      running="RUNNING"
+      fe_status="UP"
+    fi
+    api_status="DOWN"
+    if [ "$api_pid" != "N/A" ] && kill -0 "$api_pid" 2>/dev/null; then
+      api_status="UP"
     fi
 
-    printf "%-35s %-30s %-30s %-5s %-20s %s [%s]\n" "$slug" "$email" "$branch" "$port" "$updated" "$url" "$running"
+    printf "%-35s %-30s %-30s %-5s %-5s %-20s FE:%s API:%s\n" \
+      "$slug" "$email" "$branch" "$port" "$api_port" "$updated" "$fe_status" "$api_status"
   done
 
   if [ "$found" -eq 0 ]; then
@@ -463,16 +609,22 @@ cmd_list() {
 
 cmd_destroy() {
   local slug="${1:?Usage: dev-server-manager.sh destroy <email-slug>}"
+  local db_name
+  db_name=$(slug_to_dbname "$slug")
 
   log "=== Destroying dev server: $slug ==="
 
-  # Stop Next.js
+  # Stop processes
+  stop_api "$slug"
   stop_nextjs "$slug"
 
   # Remove Caddy config
   remove_caddy "$slug"
 
-  # Kill any lingering node processes rooted in this directory
+  # Drop the dev database
+  drop_dev_database "$db_name"
+
+  # Kill any lingering processes rooted in this directory
   local dir="${DEV_DIR:?}/${slug}"
   local pids
   pids=$(lsof +D "$dir" 2>/dev/null | awk 'NR>1{print $2}' | sort -u || true)
@@ -482,7 +634,7 @@ cmd_destroy() {
     sleep 1
   fi
 
-  # Remove clone (retry once if directory not empty due to race)
+  # Remove clone
   log "--- Removing clone ---"
   rm -rf "$dir" 2>/dev/null || { sleep 2; rm -rf "$dir"; }
 
@@ -543,18 +695,41 @@ cmd_revive() {
 
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
-    local slug port pid
+    local slug port api_port db_name pid api_pid
     slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
     port=$(python3 -c "import json; print(json.load(open('$meta'))['port'])")
+    api_port=$(python3 -c "import json; print(json.load(open('$meta')).get('api_port', ''))")
+    db_name=$(python3 -c "import json; print(json.load(open('$meta')).get('db_name', ''))")
     pid=$(python3 -c "import json; print(json.load(open('$meta')).get('pid', '0'))")
+    api_pid=$(python3 -c "import json; print(json.load(open('$meta')).get('api_pid', '0'))")
 
+    local dir="${DEV_DIR}/${slug}"
+
+    # Revive API if not running
+    if [ -n "$api_port" ] && [ -n "$db_name" ] && ! kill -0 "$api_pid" 2>/dev/null; then
+      if [ -d "${dir}/server/.venv" ]; then
+        log "API for '$slug' is not running, restarting on port $api_port..."
+        local new_api_pid
+        new_api_pid=$(start_api "$slug" "$api_port" "$db_name")
+        python3 -c "
+import json
+with open('$meta', 'r+') as f:
+    d = json.load(f)
+    d['api_pid'] = $new_api_pid
+    f.seek(0)
+    json.dump(d, f, indent=2)
+    f.truncate()
+"
+        log "Revived API for '$slug' with PID $new_api_pid"
+      fi
+    fi
+
+    # Revive frontend if not running
     if ! kill -0 "$pid" 2>/dev/null; then
-      log "Dev server '$slug' is not running, restarting on port $port..."
-      local dir="${DEV_DIR}/${slug}"
-      if [ -d "$dir/node_modules" ]; then
+      if [ -d "$dir/node_modules" ] && [ -n "$api_port" ]; then
+        log "Frontend for '$slug' is not running, restarting on port $port..."
         local new_pid
-        new_pid=$(start_nextjs "$slug" "$port")
-        # Update PID in metadata
+        new_pid=$(start_nextjs "$slug" "$port" "$api_port")
         python3 -c "
 import json
 with open('$meta', 'r+') as f:
@@ -564,9 +739,9 @@ with open('$meta', 'r+') as f:
     json.dump(d, f, indent=2)
     f.truncate()
 "
-        log "Revived '$slug' with PID $new_pid"
+        log "Revived frontend for '$slug' with PID $new_pid"
       else
-        log "No node_modules found for '$slug', skipping (needs full upsert)"
+        log "Missing node_modules or api_port for '$slug', skipping (needs full upsert)"
       fi
     fi
   done
@@ -584,16 +759,18 @@ case "${1:-help}" in
     echo "Usage: dev-server-manager.sh <command> [args]"
     echo ""
     echo "Commands:"
-    echo "  upsert <email> <branch>   Create or update a dev server for a user"
+    echo "  upsert <email> <branch>   Create or update a full-stack dev server"
     echo "  list                      List all active dev servers"
-    echo "  destroy <email-slug>      Destroy a specific dev server"
+    echo "  destroy <email-slug>      Destroy a specific dev server (including database)"
     echo "  destroy-all               Destroy all dev servers"
     echo "  cleanup [days]            Destroy dev servers not updated in N days (default: 7)"
     echo "  revive                    Restart any stopped dev servers"
     echo ""
-    echo "Email-to-slug mapping:"
-    echo "  sam@example.com -> sam-at-example-com"
-    echo "  user@company.co.uk -> user-at-company-co-uk"
+    echo "Each dev server gets:"
+    echo "  - Next.js frontend (port 3001-3005)"
+    echo "  - FastAPI backend (port 8001-8005)"
+    echo "  - PostgreSQL database (shared instance, separate DB)"
+    echo "  - Migrations auto-applied from branch"
     exit 1
     ;;
 esac

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -440,6 +440,9 @@ cmd_upsert() {
     mkdir -p "$DEV_DIR"
     rm -rf "$dir"
     git clone --depth 50 "$REPO_URL" "$dir"
+  elif [ ! -d "$dir/node_modules" ]; then
+    # Clone exists from a previous failed attempt but deps weren't installed
+    needs_npm_install=true
   fi
 
   cd "$dir"
@@ -482,10 +485,12 @@ cmd_upsert() {
     needs_uv_sync=true
   fi
 
-  # --- Database setup ---
+  # --- Database setup (non-fatal — don't block frontend/API on migration errors) ---
   log "--- Setting up database ---"
   create_dev_database "$db_name"
+  set +e
   apply_dev_migrations "$db_name" "${dir}/database/migrations"
+  set -e
 
   # --- Python dependencies ---
   if [ "$needs_uv_sync" = true ]; then

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -216,9 +216,10 @@ start_nextjs() {
   git_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
   # PYTHON_API_URL tells next.config.ts where to proxy /api/polls requests.
-  # NEXT_PUBLIC_API_URL tells lib/api.ts where to make server-side requests.
+  # Do NOT set NEXT_PUBLIC_API_URL — it leaks into the client bundle and
+  # the browser can't reach localhost on the server. Client uses relative
+  # /api/polls path, proxied by Next.js rewrites via PYTHON_API_URL.
   PYTHON_API_URL="http://localhost:${api_port}" \
-  NEXT_PUBLIC_API_URL="http://localhost:${api_port}/api/polls" \
   NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA="$git_sha" \
   NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF="$git_branch" \
   HOSTNAME=0.0.0.0 \

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -338,10 +338,6 @@ cmd_upsert() {
     needs_restart=true
   fi
 
-  # Commit SHA changes alone don't trigger restart. NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
-  # is set at startup, so the displayed SHA reflects what's actually running —
-  # if a restart fails, the old SHA stays visible, making staleness obvious.
-
   # Check if server process is still running
   local current_pid=""
   if [ -f "${dir}/.nextjs.pid" ]; then
@@ -363,10 +359,9 @@ cmd_upsert() {
   fi
 
   if [ "$needs_restart" = true ]; then
-    # Stop existing server if running
+    # Full restart: stop, reinstall deps, start
     stop_nextjs "$slug"
 
-    # Install dependencies
     log "--- Installing dependencies ---"
     npm ci --prefer-offline 2>&1 | tail -5
 
@@ -375,12 +370,19 @@ cmd_upsert() {
       rm -rf .next
     fi
 
-    # Start the dev server
     local pid
     pid=$(start_nextjs "$slug" "$port")
+    log "  Mode:   Full restart (deps changed or new server)"
   else
-    local pid="$current_pid"
-    log "Files updated — Next.js dev server will hot-reload automatically"
+    # Light restart: stop and start without reinstalling deps.
+    # Always restart so that NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA env var
+    # updates and Next.js reliably picks up all file changes (hot reload
+    # via file watcher is unreliable for git reset --hard across many files).
+    stop_nextjs "$slug"
+
+    local pid
+    pid=$(start_nextjs "$slug" "$port")
+    log "  Mode:   Light restart (no dep changes)"
   fi
 
   # Write metadata

--- a/server/models.py
+++ b/server/models.py
@@ -33,6 +33,8 @@ class CreatePollRequest(BaseModel):
     fork_of: str | None = None
     min_participants: int | None = None
     max_participants: int | None = None
+    auto_create_preferences: bool = False
+    auto_preferences_deadline_minutes: int | None = None
 
 
 class SubmitVoteRequest(BaseModel):
@@ -99,6 +101,8 @@ class PollResponse(BaseModel):
     min_participants: int | None = None
     max_participants: int | None = None
     short_id: str | None = None
+    auto_create_preferences: bool = False
+    auto_preferences_deadline_minutes: int | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -55,6 +55,77 @@ def _check_auto_close(conn, poll_id: str) -> None:
         )
 
 
+def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -> None:
+    """Activate the reserved ranked_choice follow-up when a nomination poll closes.
+
+    Collects all nominations from votes, finds the reserved placeholder poll,
+    and updates it with the nominations as options, a deadline, and opens it.
+    """
+    import json
+
+    parent_id = str(parent_row["id"])
+    deadline_minutes = parent_row.get("auto_preferences_deadline_minutes") or 10
+
+    # Collect unique nominations from all votes on the parent poll
+    votes = conn.execute(
+        "SELECT nominations FROM votes WHERE poll_id = %(poll_id)s AND nominations IS NOT NULL",
+        {"poll_id": parent_id},
+    ).fetchall()
+
+    all_nominations: list[str] = []
+    seen: set[str] = set()
+    for v in votes:
+        for nom in (v["nominations"] or []):
+            lower = nom.strip().lower()
+            if lower and lower not in seen:
+                seen.add(lower)
+                all_nominations.append(nom.strip())
+
+    if len(all_nominations) < 2:
+        # Not enough nominations to create a meaningful ranked choice poll.
+        # Leave the reserved poll closed.
+        return
+
+    # Find the reserved placeholder poll
+    reserved = conn.execute(
+        """
+        SELECT id FROM polls
+        WHERE follow_up_to = %(parent_id)s
+          AND poll_type = 'ranked_choice'
+          AND is_closed = true
+          AND options IS NULL
+        ORDER BY created_at ASC
+        LIMIT 1
+        """,
+        {"parent_id": parent_id},
+    ).fetchone()
+
+    if not reserved:
+        return  # No reserved poll found (shouldn't happen)
+
+    # Calculate deadline from now
+    from datetime import timedelta
+    deadline = now + timedelta(minutes=deadline_minutes)
+
+    # Activate the reserved poll
+    conn.execute(
+        """
+        UPDATE polls
+        SET options = %(options)s::jsonb,
+            response_deadline = %(deadline)s,
+            is_closed = false,
+            updated_at = %(now)s
+        WHERE id = %(reserved_id)s
+        """,
+        {
+            "options": json.dumps(all_nominations),
+            "deadline": deadline.isoformat(),
+            "now": now,
+            "reserved_id": str(reserved["id"]),
+        },
+    )
+
+
 def _row_to_poll(row: dict) -> PollResponse:
     """Convert a database row to a PollResponse."""
     return PollResponse(
@@ -74,6 +145,8 @@ def _row_to_poll(row: dict) -> PollResponse:
         min_participants=row.get("min_participants"),
         max_participants=row.get("max_participants"),
         short_id=row.get("short_id"),
+        auto_create_preferences=row.get("auto_create_preferences", False),
+        auto_preferences_deadline_minutes=row.get("auto_preferences_deadline_minutes"),
     )
 
 
@@ -108,10 +181,12 @@ def create_poll(req: CreatePollRequest):
             INSERT INTO polls (title, poll_type, options, response_deadline,
                                creator_secret, creator_name, follow_up_to,
                                fork_of, min_participants, max_participants,
+                               auto_create_preferences, auto_preferences_deadline_minutes,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
                     %(fork_of)s, %(min_participants)s, %(max_participants)s,
+                    %(auto_create_preferences)s, %(auto_preferences_deadline_minutes)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -126,9 +201,34 @@ def create_poll(req: CreatePollRequest):
                 "fork_of": req.fork_of,
                 "min_participants": req.min_participants,
                 "max_participants": req.max_participants,
+                "auto_create_preferences": req.auto_create_preferences,
+                "auto_preferences_deadline_minutes": req.auto_preferences_deadline_minutes,
                 "now": now,
             },
         ).fetchone()
+
+        # If this is a nomination poll with auto_create_preferences, reserve a
+        # placeholder ranked_choice follow-up poll so no one else can create a
+        # conflicting follow-up with the same title.
+        if req.poll_type == PollType.nomination and req.auto_create_preferences:
+            conn.execute(
+                """
+                INSERT INTO polls (title, poll_type, is_closed, follow_up_to,
+                                   creator_secret, creator_name,
+                                   created_at, updated_at)
+                VALUES (%(title)s, 'ranked_choice', true, %(parent_id)s,
+                        %(creator_secret)s, %(creator_name)s,
+                        %(now)s, %(now)s)
+                """,
+                {
+                    "title": req.title,
+                    "parent_id": str(row["id"]),
+                    "creator_secret": req.creator_secret,
+                    "creator_name": req.creator_name,
+                    "now": now,
+                },
+            )
+
     return _row_to_poll(row)
 
 
@@ -314,6 +414,7 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
 @router.get("/{poll_id}/results", response_model=PollResultsResponse)
 def get_results(poll_id: str):
     """Compute and return poll results."""
+    now = datetime.now(timezone.utc)
     with get_db() as conn:
         poll = conn.execute(
             "SELECT * FROM polls WHERE id = %(poll_id)s",
@@ -321,6 +422,23 @@ def get_results(poll_id: str):
         ).fetchone()
         if not poll:
             raise HTTPException(status_code=404, detail="Poll not found")
+
+        # Auto-close nomination polls with auto_create_preferences when deadline
+        # has passed. This activates the reserved preferences poll server-side
+        # regardless of which client fetches results first.
+        if (
+            poll["poll_type"] == "nomination"
+            and poll.get("auto_create_preferences")
+            and not poll["is_closed"]
+            and poll.get("response_deadline")
+            and poll["response_deadline"] <= now
+        ):
+            conn.execute(
+                """UPDATE polls SET is_closed = true, close_reason = 'deadline', updated_at = %(now)s
+                   WHERE id = %(poll_id)s AND is_closed = false""",
+                {"poll_id": poll_id, "now": now},
+            )
+            _activate_reserved_preferences_poll(conn, dict(poll), now)
 
         votes = conn.execute(
             "SELECT * FROM votes WHERE poll_id = %(poll_id)s",
@@ -491,6 +609,7 @@ def get_participants(poll_id: str):
 @router.post("/{poll_id}/close", response_model=PollResponse)
 def close_poll(poll_id: str, req: ClosePollRequest):
     """Close a poll. Requires creator_secret."""
+    now = datetime.now(timezone.utc)
     with get_db() as conn:
         row = conn.execute(
             """
@@ -505,11 +624,17 @@ def close_poll(poll_id: str, req: ClosePollRequest):
                 "poll_id": poll_id,
                 "creator_secret": req.creator_secret,
                 "close_reason": req.close_reason.value,
-                "now": datetime.now(timezone.utc),
+                "now": now,
             },
         ).fetchone()
-    if not row:
-        raise HTTPException(status_code=403, detail="Invalid creator secret or poll not found")
+        if not row:
+            raise HTTPException(status_code=403, detail="Invalid creator secret or poll not found")
+
+        # If this is a nomination poll with auto_create_preferences, activate
+        # the reserved ranked_choice follow-up poll.
+        if row["poll_type"] == "nomination" and row.get("auto_create_preferences"):
+            _activate_reserved_preferences_poll(conn, row, now)
+
     return _row_to_poll(row)
 
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -434,12 +434,13 @@ def get_results(poll_id: str):
             and poll.get("response_deadline")
             and poll["response_deadline"] <= now
         ):
-            conn.execute(
+            result = conn.execute(
                 """UPDATE polls SET is_closed = true, close_reason = 'deadline', updated_at = %(now)s
                    WHERE id = %(poll_id)s AND is_closed = false""",
                 {"poll_id": poll_id, "now": now},
             )
-            _activate_reserved_preferences_poll(conn, dict(poll), now)
+            if result.rowcount == 1:
+                _activate_reserved_preferences_poll(conn, dict(poll), now)
 
         votes = conn.execute(
             "SELECT * FROM votes WHERE poll_id = %(poll_id)s",

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -13,6 +13,7 @@ from models import (
     ParticipantResponse,
     PollResponse,
     PollResultsResponse,
+    PollType,
     RankedChoiceRoundResponse,
     RelatedPollsRequest,
     RelatedPollsResponse,


### PR DESCRIPTION
## Summary
- When creating a nomination poll, a checkbox lets creators opt into auto-creating a ranked-choice preferences poll when the nomination closes
- A placeholder preferences poll is reserved at creation time (closed, no options), then activated with the collected nominations when the parent poll closes
- Server-side auto-close in `get_results` ensures activation happens regardless of which client fetches results first
- Full-stack dev servers: each dev server now gets its own FastAPI backend (port 8001-8005) and PostgreSQL database with auto-applied migrations

## Changes
- **Frontend**: Checkbox + deadline selector on create-poll page, auto-navigation to preferences poll on close, info note on nomination polls
- **Backend**: Reservation logic in `create_poll`, activation in `close_poll` and `get_results`, new `auto_create_preferences` and `auto_preferences_deadline_minutes` columns
- **Infrastructure**: `dev-server-manager.sh` rewritten for full-stack (frontend + API + DB per dev server), new `apply-dev-migrations.sh` script

## Test plan
- [ ] Create a nomination poll with "Ask for preferences when closed" checked
- [ ] Add nominations and let the deadline expire
- [ ] Verify a ranked-choice preferences poll is auto-created with the nominations as options
- [ ] Verify the preferences poll deadline matches the configured duration
- [ ] Create a nomination poll without the checkbox — verify no preferences poll is created
- [ ] Test manual close of nomination poll with auto-preferences — verify navigation to preferences poll

https://claude.ai/code/session_01U9nNBMC9CXoHyszjTewdGC