### PR TITLE
Add poll auto-close after N respondents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -854,6 +854,12 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Catch-all fallthrough in `get_results()`**: When adding new poll types, `server/routers/polls.py` has a catch-all return at the bottom returning `yes_count=None`. Any poll type without an explicit handler silently falls through and the frontend interprets `None` as `0`. Always add an explicit handler for each poll type.
 - **Frontend TODO stubs cause silent failures**: If the backend adds a new endpoint, check whether the frontend has TODO stubs (e.g., `setParticipants([])`) that need to be connected. Stubs cause incorrect UI without errors.
 
+### Auto-Created Follow-Up Polls & Creator Secrets
+
+- **Auto-created polls share the parent's `creator_secret`**, but the browser only stores secrets for polls it created directly. When navigating to an auto-created follow-up poll (e.g., preferences poll from a nomination poll), the browser must propagate the parent's secret to the child. Do this both on navigation (in the close handler) and on page load (check `poll.follow_up_to` and propagate if the parent's secret is known).
+- **Use `recordPollCreation()` from `lib/browserPollAccess.ts`** instead of calling `storeCreatorSecret()` + `addAccessiblePollId()` separately. The higher-level function already does both.
+- **Poll data snapshots (fork/duplicate/follow-up)** are passed between pages via localStorage. When adding new poll fields, update all snapshot construction sites: `FollowUpModal.tsx`, `DuplicateButton.tsx`, and `ForkButton.tsx`. Extract a shared object to avoid drift.
+
 ### CI/GitHub Actions Pitfalls
 
 - **Vitest 3.x requires `@vitest/coverage-v8`** — the old `c8` provider is removed. Match the coverage package version to the vitest major version.

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -57,6 +57,7 @@ function CreatePollContent() {
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
   const [autoCreatePreferences, setAutoCreatePreferences] = useState(true);
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
+  const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -391,6 +392,11 @@ function CreatePollContent() {
           if (forkData.creator_name) {
             setCreatorName(forkData.creator_name);
           }
+          if (forkData.auto_close_after != null) {
+            setAutoCloseAfter(forkData.auto_close_after);
+          } else if (forkData.total_votes) {
+            setAutoCloseAfter(forkData.total_votes);
+          }
         } catch (error) {
           console.error('Error loading fork data:', error);
         }
@@ -463,6 +469,11 @@ function CreatePollContent() {
           }
           if (duplicateData.creator_name) {
             setCreatorName(duplicateData.creator_name);
+          }
+          if (duplicateData.auto_close_after != null) {
+            setAutoCloseAfter(duplicateData.auto_close_after);
+          } else if (duplicateData.total_votes) {
+            setAutoCloseAfter(duplicateData.total_votes);
           }
 
           // Don't clean up the duplicate data yet - keep it until poll is created
@@ -872,6 +883,10 @@ function CreatePollContent() {
         }
       }
 
+      // Add auto-close after N respondents
+      if (autoCloseAfter !== null && autoCloseAfter > 0) {
+        pollData.auto_close_after = autoCloseAfter;
+      }
 
       // Check for duplicate follow-up poll before creating
       if (followUpTo) {
@@ -1187,6 +1202,39 @@ function CreatePollContent() {
               </div>
             </div>
           )}
+
+          {/* Auto-close after N responses */}
+          <div>
+            <label className="block text-sm font-medium mb-2">Auto-close</label>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600 dark:text-gray-400">After</span>
+              <input
+                type="number"
+                min="1"
+                value={autoCloseAfter ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val) || 1));
+                }}
+                disabled={isLoading}
+                placeholder="—"
+                className="w-16 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
+              />
+              <span className="text-sm text-gray-600 dark:text-gray-400">responses</span>
+              {autoCloseAfter !== null && (
+                <button
+                  type="button"
+                  onClick={() => setAutoCloseAfter(null)}
+                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 ml-1"
+                  title="Disable auto-close"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
 
           {/* Auto-create preferences poll checkbox - nomination polls only */}
           {pollType === 'nomination' && (

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1214,7 +1214,7 @@ function CreatePollContent() {
                 value={autoCloseAfter ?? ''}
                 onChange={(e) => {
                   const val = e.target.value;
-                  setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val) || 1));
+                  setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val, 10) || 1));
                 }}
                 disabled={isLoading}
                 placeholder="—"

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -23,7 +23,7 @@ import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults } from "@/lib/types";
 import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, apiFindDuplicatePoll, ApiVote } from "@/lib/api";
 import VoteOnItModal from "@/components/VoteOnItModal";
-import { isCreatedByThisBrowser, getCreatorSecret, storeCreatorSecret, addAccessiblePollId } from "@/lib/browserPollAccess";
+import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
 import { getUserName, saveUserName } from "@/lib/userProfile";
 import { usePageTitle } from "@/lib/usePageTitle";
@@ -384,16 +384,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       setPollUrl(window.location.href.split('?')[0]);
     }
     
-    // Check if this browser created the poll.
-    // For auto-created follow-up polls (e.g. preferences from nomination), the
-    // creator_secret matches the parent poll. If we have the parent's secret
-    // but not the child's, propagate it so close/reopen work on the child too.
+    // Auto-created follow-up polls share the parent's creator_secret.
+    // Propagate so close/reopen work on the child too.
     if (!getCreatorSecret(poll.id) && poll.follow_up_to) {
       const parentSecret = getCreatorSecret(poll.follow_up_to);
-      if (parentSecret) {
-        storeCreatorSecret(poll.id, parentSecret);
-        addAccessiblePollId(poll.id);
-      }
+      if (parentSecret) recordPollCreation(poll.id, parentSecret);
     }
     setIsCreator(isCreatedByThisBrowser(poll.id));
 
@@ -726,12 +721,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           try {
             const followUp = await apiFindDuplicatePoll(poll.title, poll.id);
             if (followUp && !followUp.is_closed) {
-              // The auto-created preferences poll shares the parent's creator_secret.
-              // Store it so the browser can close/manage the follow-up poll too.
-              if (creatorSecret) {
-                storeCreatorSecret(followUp.id, creatorSecret);
-                addAccessiblePollId(followUp.id);
-              }
+              if (creatorSecret) recordPollCreation(followUp.id, creatorSecret);
               const shortId = followUp.short_id || followUp.id;
               router.push(`/p/${shortId}`);
             }

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1987,6 +1987,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         isOpen={showFollowUpModal}
         poll={poll}
         onClose={() => setShowFollowUpModal(false)}
+        totalVotes={pollResults?.total_votes}
       />
 
       {/* Vote on It Modal */}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -23,7 +23,7 @@ import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults } from "@/lib/types";
 import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, apiFindDuplicatePoll, ApiVote } from "@/lib/api";
 import VoteOnItModal from "@/components/VoteOnItModal";
-import { isCreatedByThisBrowser, getCreatorSecret } from "@/lib/browserPollAccess";
+import { isCreatedByThisBrowser, getCreatorSecret, storeCreatorSecret, addAccessiblePollId } from "@/lib/browserPollAccess";
 import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
 import { getUserName, saveUserName } from "@/lib/userProfile";
 import { usePageTitle } from "@/lib/usePageTitle";
@@ -384,9 +384,19 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       setPollUrl(window.location.href.split('?')[0]);
     }
     
-    // Check if this browser created the poll
+    // Check if this browser created the poll.
+    // For auto-created follow-up polls (e.g. preferences from nomination), the
+    // creator_secret matches the parent poll. If we have the parent's secret
+    // but not the child's, propagate it so close/reopen work on the child too.
+    if (!getCreatorSecret(poll.id) && poll.follow_up_to) {
+      const parentSecret = getCreatorSecret(poll.follow_up_to);
+      if (parentSecret) {
+        storeCreatorSecret(poll.id, parentSecret);
+        addAccessiblePollId(poll.id);
+      }
+    }
     setIsCreator(isCreatedByThisBrowser(poll.id));
-    
+
     // Check if browser has any data for this poll
     setHasPollDataState(hasPollData(poll.id));
     
@@ -716,6 +726,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           try {
             const followUp = await apiFindDuplicatePoll(poll.title, poll.id);
             if (followUp && !followUp.is_closed) {
+              // The auto-created preferences poll shares the parent's creator_secret.
+              // Store it so the browser can close/manage the follow-up poll too.
+              if (creatorSecret) {
+                storeCreatorSecret(followUp.id, creatorSecret);
+                addAccessiblePollId(followUp.id);
+              }
               const shortId = followUp.short_id || followUp.id;
               router.push(`/p/${shortId}`);
             }

--- a/components/DuplicateButton.tsx
+++ b/components/DuplicateButton.tsx
@@ -20,7 +20,8 @@ export default function DuplicateButton({ poll }: DuplicateButtonProps) {
       response_deadline: poll.response_deadline,
       creator_name: poll.creator_name,
       min_participants: poll.min_participants,
-      max_participants: poll.max_participants
+      max_participants: poll.max_participants,
+      auto_close_after: poll.auto_close_after,
     };
     
     debugLog.logObject('Duplicate button clicked', { pollId: poll.id, duplicateData }, 'DuplicateButton');

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -8,9 +8,10 @@ interface FollowUpModalProps {
   isOpen: boolean;
   poll: Poll;
   onClose: () => void;
+  totalVotes?: number;
 }
 
-export default function FollowUpModal({ isOpen, poll, onClose }: FollowUpModalProps) {
+export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: FollowUpModalProps) {
   const router = useRouter();
 
   if (!isOpen) return null;
@@ -50,7 +51,9 @@ export default function FollowUpModal({ isOpen, poll, onClose }: FollowUpModalPr
                   response_deadline: poll.response_deadline,
                   creator_name: poll.creator_name,
                   min_participants: poll.min_participants,
-                  max_participants: poll.max_participants
+                  max_participants: poll.max_participants,
+                  auto_close_after: poll.auto_close_after,
+                  total_votes: totalVotes,
                 };
                 localStorage.setItem(`duplicate-data-${poll.id}`, JSON.stringify(duplicateData));
                 router.push(`/create-poll?duplicate=${poll.id}`);
@@ -75,7 +78,9 @@ export default function FollowUpModal({ isOpen, poll, onClose }: FollowUpModalPr
                   response_deadline: poll.response_deadline,
                   creator_name: poll.creator_name,
                   min_participants: poll.min_participants,
-                  max_participants: poll.max_participants
+                  max_participants: poll.max_participants,
+                  auto_close_after: poll.auto_close_after,
+                  total_votes: totalVotes,
                 };
                 localStorage.setItem(`fork-data-${poll.id}`, JSON.stringify(forkData));
                 router.push(`/create-poll?fork=${poll.id}`);

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -16,6 +16,18 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
 
   if (!isOpen) return null;
 
+  const pollSnapshot = {
+    title: poll.title,
+    poll_type: poll.poll_type,
+    options: poll.options,
+    response_deadline: poll.response_deadline,
+    creator_name: poll.creator_name,
+    min_participants: poll.min_participants,
+    max_participants: poll.max_participants,
+    auto_close_after: poll.auto_close_after,
+    total_votes: totalVotes,
+  };
+
   return (
     <ModalPortal>
       {/* Backdrop */}
@@ -43,19 +55,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
 
             <button
               onClick={() => {
-                // Store poll data for duplication
-                const duplicateData = {
-                  title: poll.title,
-                  poll_type: poll.poll_type,
-                  options: poll.options,
-                  response_deadline: poll.response_deadline,
-                  creator_name: poll.creator_name,
-                  min_participants: poll.min_participants,
-                  max_participants: poll.max_participants,
-                  auto_close_after: poll.auto_close_after,
-                  total_votes: totalVotes,
-                };
-                localStorage.setItem(`duplicate-data-${poll.id}`, JSON.stringify(duplicateData));
+                localStorage.setItem(`duplicate-data-${poll.id}`, JSON.stringify(pollSnapshot));
                 router.push(`/create-poll?duplicate=${poll.id}`);
                 onClose();
               }}
@@ -70,19 +70,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
 
             <button
               onClick={() => {
-                // Store poll data for fork
-                const forkData = {
-                  title: poll.title,
-                  poll_type: poll.poll_type,
-                  options: poll.options,
-                  response_deadline: poll.response_deadline,
-                  creator_name: poll.creator_name,
-                  min_participants: poll.min_participants,
-                  max_participants: poll.max_participants,
-                  auto_close_after: poll.auto_close_after,
-                  total_votes: totalVotes,
-                };
-                localStorage.setItem(`fork-data-${poll.id}`, JSON.stringify(forkData));
+                localStorage.setItem(`fork-data-${poll.id}`, JSON.stringify(pollSnapshot));
                 router.push(`/create-poll?fork=${poll.id}`);
                 onClose();
               }}

--- a/components/ForkButton.tsx
+++ b/components/ForkButton.tsx
@@ -21,7 +21,8 @@ export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
       response_deadline: poll.response_deadline,
       creator_name: poll.creator_name,
       min_participants: poll.min_participants,
-      max_participants: poll.max_participants
+      max_participants: poll.max_participants,
+      auto_close_after: poll.auto_close_after,
     };
     
     debugLog.logObject('Fork button clicked', { pollId: poll.id, forkData }, 'ForkButton');

--- a/database/migrations/067_add_auto_close_after_down.sql
+++ b/database/migrations/067_add_auto_close_after_down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE polls DROP COLUMN IF EXISTS auto_close_after;

--- a/database/migrations/067_add_auto_close_after_up.sql
+++ b/database/migrations/067_add_auto_close_after_up.sql
@@ -1,0 +1,3 @@
+-- Add auto_close_after column to polls table.
+-- When set, the poll automatically closes after this many unique respondents.
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS auto_close_after integer;

--- a/docs/droplet-setup.md
+++ b/docs/droplet-setup.md
@@ -143,6 +143,7 @@ Cron jobs:
 | `/var/log/whoeverwants-health.log` | Health check log |
 | `/root/whoeverwants/` | Repository clone |
 | `/root/whoeverwants/docker-compose.yml` | Docker Compose config (db + api only) |
+| `/root/.local/bin/uv` | uv Python package manager (required by dev servers, installed via astral.sh) |
 | `/root/whoeverwants/server/` | FastAPI application source (uses uv for dependency management) |
 | `/root/whoeverwants/database/migrations/` | SQL migration files |
 | `/root/previews/` | Git worktrees for preview environments |

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -156,6 +156,7 @@ export async function apiCreatePoll(params: {
   max_participants?: number;
   auto_create_preferences?: boolean;
   auto_preferences_deadline_minutes?: number;
+  auto_close_after?: number;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,7 @@ export interface Poll {
   short_id?: string;
   auto_create_preferences?: boolean;
   auto_preferences_deadline_minutes?: number;
+  auto_close_after?: number;
 }
 
 export interface Vote {

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -270,6 +270,21 @@ start_api() {
     return 1
   fi
 
+  # Verify API is actually responding (process running != API healthy)
+  local health_ok=false
+  for i in 1 2 3 4 5; do
+    if curl -sf "http://localhost:${api_port}/health" >/dev/null 2>&1; then
+      health_ok=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$health_ok" = false ]; then
+    log "WARNING: API process running but /health not responding on port $api_port after 10s"
+    log "  Last 10 lines of api.log:"
+    tail -10 "${dir}/api.log" >&2 2>/dev/null || true
+  fi
+
   log "API server started for $slug (PID $new_pid, port $api_port, DB: $db_name)"
   echo "$new_pid"
 }
@@ -413,6 +428,12 @@ cmd_upsert() {
   if is_ignored_email "$email"; then
     log "Ignoring email: $email"
     return 0
+  fi
+
+  # Validate prerequisites
+  if [ ! -x "$UV_BIN" ]; then
+    log "ERROR: uv not found at $UV_BIN. Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    return 1
   fi
 
   evict_excess_servers "$slug"

--- a/scripts/provision-droplet.sh
+++ b/scripts/provision-droplet.sh
@@ -158,13 +158,22 @@ systemctl daemon-reload
 systemctl enable --now cmd-api
 
 # ── 5. Install Node.js (for per-user dev servers) ────────────────────
-echo "=== 5/15 Installing Node.js ==="
+echo "=== 5a/15 Installing Node.js ==="
 if ! command -v node &>/dev/null; then
   curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
   apt-get install -y -qq nodejs
   echo "Node.js installed: $(node --version)"
 else
   echo "Node.js already installed: $(node --version)"
+fi
+
+# ── 5b. Install uv (Python package manager, needed by dev servers) ──
+echo "=== 5b/15 Installing uv ==="
+if ! command -v /root/.local/bin/uv &>/dev/null; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  echo "uv installed: $(/root/.local/bin/uv --version)"
+else
+  echo "uv already installed: $(/root/.local/bin/uv --version)"
 fi
 
 # ── 6. Add swap ──────────────────────────────────────────────────────

--- a/server/models.py
+++ b/server/models.py
@@ -35,6 +35,7 @@ class CreatePollRequest(BaseModel):
     max_participants: int | None = None
     auto_create_preferences: bool = False
     auto_preferences_deadline_minutes: int | None = None
+    auto_close_after: int | None = None
 
 
 class SubmitVoteRequest(BaseModel):
@@ -103,6 +104,7 @@ class PollResponse(BaseModel):
     short_id: str | None = None
     auto_create_preferences: bool = False
     auto_preferences_deadline_minutes: int | None = None
+    auto_close_after: int | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -33,13 +33,28 @@ router = APIRouter(prefix="/api/polls", tags=["polls"])
 
 
 def _check_auto_close(conn, poll_id: str) -> None:
-    """Auto-close a participation poll if yes votes >= max_participants."""
+    """Auto-close a poll based on auto_close_after (respondent count) or max_participants."""
     poll = conn.execute(
-        "SELECT poll_type, is_closed, max_participants FROM polls WHERE id = %(poll_id)s",
+        "SELECT poll_type, is_closed, max_participants, auto_close_after FROM polls WHERE id = %(poll_id)s",
         {"poll_id": poll_id},
     ).fetchone()
-    if not poll:
+    if not poll or poll["is_closed"]:
         return
+
+    # Check auto_close_after (works for all poll types)
+    if poll["auto_close_after"] is not None:
+        respondent_count = conn.execute(
+            "SELECT COUNT(DISTINCT id) as cnt FROM votes WHERE poll_id = %(poll_id)s",
+            {"poll_id": poll_id},
+        ).fetchone()["cnt"]
+        if respondent_count >= poll["auto_close_after"]:
+            conn.execute(
+                "UPDATE polls SET is_closed = true, close_reason = 'max_capacity' WHERE id = %(poll_id)s",
+                {"poll_id": poll_id},
+            )
+            return
+
+    # Check max_participants (participation polls only)
     yes_count = conn.execute(
         """SELECT COUNT(*) as cnt FROM votes
            WHERE poll_id = %(poll_id)s
@@ -148,6 +163,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         short_id=row.get("short_id"),
         auto_create_preferences=row.get("auto_create_preferences", False),
         auto_preferences_deadline_minutes=row.get("auto_preferences_deadline_minutes"),
+        auto_close_after=row.get("auto_close_after"),
     )
 
 
@@ -183,11 +199,13 @@ def create_poll(req: CreatePollRequest):
                                creator_secret, creator_name, follow_up_to,
                                fork_of, min_participants, max_participants,
                                auto_create_preferences, auto_preferences_deadline_minutes,
+                               auto_close_after,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
                     %(fork_of)s, %(min_participants)s, %(max_participants)s,
                     %(auto_create_preferences)s, %(auto_preferences_deadline_minutes)s,
+                    %(auto_close_after)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -204,6 +222,7 @@ def create_poll(req: CreatePollRequest):
                 "max_participants": req.max_participants,
                 "auto_create_preferences": req.auto_create_preferences,
                 "auto_preferences_deadline_minutes": req.auto_preferences_deadline_minutes,
+                "auto_close_after": req.auto_close_after,
                 "now": now,
             },
         ).fetchone()

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -35,11 +35,13 @@ router = APIRouter(prefix="/api/polls", tags=["polls"])
 def _check_auto_close(conn, poll_id: str) -> None:
     """Auto-close a poll based on auto_close_after (respondent count) or max_participants."""
     poll = conn.execute(
-        "SELECT poll_type, is_closed, max_participants, auto_close_after FROM polls WHERE id = %(poll_id)s",
+        "SELECT * FROM polls WHERE id = %(poll_id)s",
         {"poll_id": poll_id},
     ).fetchone()
     if not poll or poll["is_closed"]:
         return
+
+    closed = False
 
     # Check auto_close_after (works for all poll types)
     if poll["auto_close_after"] is not None:
@@ -52,23 +54,30 @@ def _check_auto_close(conn, poll_id: str) -> None:
                 "UPDATE polls SET is_closed = true, close_reason = 'max_capacity' WHERE id = %(poll_id)s",
                 {"poll_id": poll_id},
             )
-            return
+            closed = True
 
     # Check max_participants (participation polls only)
-    yes_count = conn.execute(
-        """SELECT COUNT(*) as cnt FROM votes
-           WHERE poll_id = %(poll_id)s
-             AND vote_type = 'participation'
-             AND yes_no_choice = 'yes'""",
-        {"poll_id": poll_id},
-    ).fetchone()["cnt"]
-    if should_auto_close(
-        poll["poll_type"], poll["is_closed"], poll["max_participants"], yes_count
-    ):
-        conn.execute(
-            "UPDATE polls SET is_closed = true, close_reason = 'max_capacity' WHERE id = %(poll_id)s",
+    if not closed:
+        yes_count = conn.execute(
+            """SELECT COUNT(*) as cnt FROM votes
+               WHERE poll_id = %(poll_id)s
+                 AND vote_type = 'participation'
+                 AND yes_no_choice = 'yes'""",
             {"poll_id": poll_id},
-        )
+        ).fetchone()["cnt"]
+        if should_auto_close(
+            poll["poll_type"], poll["is_closed"], poll["max_participants"], yes_count
+        ):
+            conn.execute(
+                "UPDATE polls SET is_closed = true, close_reason = 'max_capacity' WHERE id = %(poll_id)s",
+                {"poll_id": poll_id},
+            )
+            closed = True
+
+    # If we just closed a nomination poll, activate the reserved preferences poll
+    if closed and poll.get("auto_create_preferences"):
+        now = datetime.now(timezone.utc)
+        _activate_reserved_preferences_poll(conn, dict(poll), now)
 
 
 def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -> None:

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -35,7 +35,8 @@ router = APIRouter(prefix="/api/polls", tags=["polls"])
 def _check_auto_close(conn, poll_id: str) -> None:
     """Auto-close a poll based on auto_close_after (respondent count) or max_participants."""
     poll = conn.execute(
-        "SELECT * FROM polls WHERE id = %(poll_id)s",
+        """SELECT poll_type, is_closed, auto_close_after, max_participants, auto_create_preferences
+           FROM polls WHERE id = %(poll_id)s""",
         {"poll_id": poll_id},
     ).fetchone()
     if not poll or poll["is_closed"]:
@@ -46,7 +47,7 @@ def _check_auto_close(conn, poll_id: str) -> None:
     # Check auto_close_after (works for all poll types)
     if poll["auto_close_after"] is not None:
         respondent_count = conn.execute(
-            "SELECT COUNT(DISTINCT id) as cnt FROM votes WHERE poll_id = %(poll_id)s",
+            "SELECT COUNT(*) as cnt FROM votes WHERE poll_id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()["cnt"]
         if respondent_count >= poll["auto_close_after"]:
@@ -57,7 +58,7 @@ def _check_auto_close(conn, poll_id: str) -> None:
             closed = True
 
     # Check max_participants (participation polls only)
-    if not closed:
+    if not closed and poll["poll_type"] == "participation" and poll["max_participants"] is not None:
         yes_count = conn.execute(
             """SELECT COUNT(*) as cnt FROM votes
                WHERE poll_id = %(poll_id)s


### PR DESCRIPTION
## Summary
- Add `auto_close_after` field to polls — automatically closes a poll after N unique respondents vote
- New UI on create-poll page to set the auto-close threshold
- Fix: propagate creator secret to auto-created follow-up polls (preferences from nomination) so the creator can close/manage them
- Carry `auto_close_after` through fork/duplicate/follow-up flows
- DB migration 067 adds the `auto_close_after` integer column

## Key changes
- **Backend**: `_check_auto_close()` now handles both `auto_close_after` (all poll types) and `max_participants` (participation only), with guarded queries to skip unnecessary DB round-trips
- **Frontend**: Creator secret propagation on page load for follow-up polls, using existing `recordPollCreation()` utility
- **Infra**: Dev server manager validates `uv` prerequisite, adds API health check after start; provision script installs `uv`

## Test plan
- [ ] Create a yes/no poll with auto-close after 2 responses — verify it closes after 2 votes
- [ ] Create a nomination poll with auto-create preferences, close it, verify the preferences poll is manageable (close/reopen) by the creator
- [ ] Fork and duplicate a poll with auto_close_after set — verify the value carries over
- [ ] Create a poll without auto-close — verify normal behavior unchanged

https://claude.ai/code/session_01KfsWav2z3VJeKHNCfUCgia