### PR TITLE
Fix two-option poll vote submission and UI cleanup

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -350,19 +350,25 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         setOptionsInitialized(true);
         return;
       }
-      
+
       // Parse options if they're stored as JSON string
-      const parsedOptions = typeof poll.options === 'string' 
-        ? JSON.parse(poll.options) 
+      const parsedOptions = typeof poll.options === 'string'
+        ? JSON.parse(poll.options)
         : poll.options;
-      
+
+      // For 2-option polls, start with no selection (user must choose)
+      if (parsedOptions.length === 2) {
+        setOptionsInitialized(true);
+        return;
+      }
+
       // Randomize the order of options for voters (Fisher-Yates shuffle)
       const shuffledOptions = [...parsedOptions];
       for (let i = shuffledOptions.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
         [shuffledOptions[i], shuffledOptions[j]] = [shuffledOptions[j], shuffledOptions[i]];
       }
-      
+
       setRankedChoices(shuffledOptions);
       setOptionsInitialized(true);
     }
@@ -635,6 +641,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     if (!poll.options) return [];
     return typeof poll.options === 'string' ? JSON.parse(poll.options) : poll.options;
   }, [poll.options]);
+
+  // Randomize display order for 2-option polls (stable per mount)
+  const twoOptionDisplayOrder = useMemo(() => {
+    if (pollOptions.length !== 2) return pollOptions;
+    return Math.random() < 0.5 ? [pollOptions[0], pollOptions[1]] : [pollOptions[1], pollOptions[0]];
+  }, [pollOptions]);
 
   const handleYesNoVote = (choice: 'yes' | 'no') => {
     setYesNoChoice(choice);
@@ -1816,7 +1828,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                           Select your preference
                         </h4>
                         <div className="flex gap-2">
-                          {pollOptions.map((option: string) => (
+                          {twoOptionDisplayOrder.map((option: string) => (
                             <button
                               key={option}
                               onClick={() => {
@@ -1824,7 +1836,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                                 handleRankingChange([option, other]);
                                 setIsAbstaining(false);
                               }}
-                              disabled={isSubmitting || isAbstaining}
+                              disabled={isSubmitting}
                               className={`flex-1 py-3 px-4 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                                 rankedChoices[0] === option
                                   ? 'bg-blue-200 dark:bg-blue-800 text-blue-900 dark:text-blue-100 border-2 border-blue-400 dark:border-blue-600 active:bg-blue-300 dark:active:bg-blue-700'

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -642,10 +642,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     return typeof poll.options === 'string' ? JSON.parse(poll.options) : poll.options;
   }, [poll.options]);
 
-  // Randomize display order for 2-option polls (stable per mount)
-  const twoOptionDisplayOrder = useMemo(() => {
-    if (pollOptions.length !== 2) return pollOptions;
-    return Math.random() < 0.5 ? [pollOptions[0], pollOptions[1]] : [pollOptions[1], pollOptions[0]];
+  // Randomize display order for 2-option polls (client-only to avoid hydration mismatch)
+  const [twoOptionDisplayOrder, setTwoOptionDisplayOrder] = useState<string[]>([]);
+  useEffect(() => {
+    if (pollOptions.length === 2) {
+      setTwoOptionDisplayOrder(
+        Math.random() < 0.5 ? [pollOptions[0], pollOptions[1]] : [pollOptions[1], pollOptions[0]]
+      );
+    }
   }, [pollOptions]);
 
   const handleYesNoVote = (choice: 'yes' | 'no') => {
@@ -932,7 +936,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         }
         
         // Additional validation: ensure choices are valid poll options
-        const pollOptions = typeof poll.options === 'string' ? JSON.parse(poll.options) : poll.options;
         const invalidChoices = filteredRankedChoices.filter(choice => !pollOptions.includes(choice));
         
         if (invalidChoices.length > 0) {

--- a/components/AbstainButton.tsx
+++ b/components/AbstainButton.tsx
@@ -22,7 +22,7 @@ export default function AbstainButton({
             : 'bg-yellow-100 hover:bg-yellow-200 dark:bg-yellow-900 dark:hover:bg-yellow-800 text-yellow-800 dark:text-yellow-200 border-2 border-transparent active:bg-yellow-300 dark:active:bg-yellow-700'
         }`}
       >
-        {isAbstaining ? 'Abstaining (click to cancel)' : 'Abstain from this vote'}
+        Abstain
       </button>
     </div>
   );

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -259,7 +259,7 @@ start_api() {
 
   DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${db_name}" \
     "$UV_BIN" run uvicorn main:app --host 0.0.0.0 --port "$api_port" --workers 1 \
-    >> "${dir}/api.log" 2>&1 &
+    >> "${dir}/api.log" 2>&1 200>&- &
   local new_pid=$!
   echo "$new_pid" > "${dir}/.api.pid"
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -35,7 +35,8 @@ router = APIRouter(prefix="/api/polls", tags=["polls"])
 def _check_auto_close(conn, poll_id: str) -> None:
     """Auto-close a poll based on auto_close_after (respondent count) or max_participants."""
     poll = conn.execute(
-        """SELECT poll_type, is_closed, auto_close_after, max_participants, auto_create_preferences
+        """SELECT id, poll_type, is_closed, auto_close_after, max_participants,
+                  auto_create_preferences, auto_preferences_deadline_minutes
            FROM polls WHERE id = %(poll_id)s""",
         {"poll_id": poll_id},
     ).fetchone()


### PR DESCRIPTION
## Summary
- Fix vote submission crash on nomination polls with auto-create preferences: `_check_auto_close` SELECT was missing `id` and `auto_preferences_deadline_minutes` columns, causing `KeyError` in `_activate_reserved_preferences_poll`
- Fix dev server lock inheritance: close flock fd (`200>&-`) before backgrounding the API process to prevent stale locks
- Simplify abstain button text to always say "Abstain"
- Fix hydration risk: move `twoOptionDisplayOrder` randomization from `useMemo` to `useEffect` to avoid server/client `Math.random()` mismatch
- Remove duplicate inline `pollOptions` JSON parsing in vote validation, reuse existing memo

## Test plan
- [ ] Create a nomination poll with auto-create preferences, vote until auto-close triggers — should no longer error
- [ ] Open a 2-option ranked choice poll — buttons should appear in random order with no hydration warnings
- [ ] Verify abstain button always says "Abstain" and toggles yellow highlight on click

https://claude.ai/code/session_01NPribg8pQpHvbyfxMwqAUE