### PR TITLE
Add optional details field to polls

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1075,10 +1075,17 @@ function CreatePollContent() {
             <textarea
               id="details"
               value={details}
-              onChange={(e) => setDetails(e.target.value)}
+              onChange={(e) => {
+                setDetails(e.target.value);
+                const el = e.target;
+                el.style.height = 'auto';
+                const maxH = 5 * 20 + 16; // 5 lines + padding
+                el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
+                el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
+              }}
               disabled={isLoading}
-              rows={3}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-y text-sm"
+              rows={1}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none text-sm overflow-hidden"
               placeholder="Add more context or instructions..."
             />
           </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -58,6 +58,7 @@ function CreatePollContent() {
   const [autoCreatePreferences, setAutoCreatePreferences] = useState(true);
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
+  const [details, setDetails] = useState("");
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -83,6 +84,7 @@ function CreatePollContent() {
     if (typeof window !== 'undefined') {
       const formState = {
         title,
+        details,
         options,
         deadlineOption,
         customDate,
@@ -91,7 +93,7 @@ function CreatePollContent() {
       };
       localStorage.setItem('pollFormState', JSON.stringify(formState));
     }
-  }, [title, options, deadlineOption, customDate, customTime, creatorName]);
+  }, [title, details, options, deadlineOption, customDate, customTime, creatorName]);
 
   // Get default date/time values (client-side only to avoid hydration mismatch)
   const getDefaultDateTime = () => {
@@ -133,6 +135,7 @@ function CreatePollContent() {
         try {
           const formState = JSON.parse(saved);
           setTitle(formState.title || '');
+          setDetails(formState.details || '');
           setOptions(formState.options || ['']);
           setDeadlineOption(formState.deadlineOption || '10min');
           setCustomDate(formState.customDate || '');
@@ -346,6 +349,7 @@ function CreatePollContent() {
 
           // Auto-fill form with fork data
           setTitle(forkData.title || "");
+          setDetails(forkData.details || "");
 
           // Set poll type and options based on forked poll
           if (forkData.poll_type === 'ranked_choice' && forkData.options) {
@@ -424,6 +428,7 @@ function CreatePollContent() {
 
           // Auto-fill form with duplicate data
           setTitle(duplicateData.title || "");
+          setDetails(duplicateData.details || "");
 
           // Set poll type based on duplicated poll
           if (duplicateData.poll_type === 'ranked_choice') {
@@ -844,6 +849,11 @@ function CreatePollContent() {
         pollData.creator_name = creatorName.trim();
       }
 
+      // Add details if provided
+      if (details.trim()) {
+        pollData.details = details.trim();
+      }
+
       // Add follow-up reference if this is a follow-up poll
       if (followUpTo) {
         pollData.follow_up_to = followUpTo;
@@ -1053,6 +1063,23 @@ function CreatePollContent() {
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
               placeholder="Enter your title..."
               required
+            />
+          </div>
+
+          {/* Optional details field */}
+          <div>
+            <label htmlFor="details" className="block text-sm font-medium mb-2">
+              Details{' '}
+              <span className="text-gray-500 font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="details"
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              disabled={isLoading}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-y text-sm"
+              placeholder="Add more context or instructions..."
             />
           </div>
 

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -28,6 +28,7 @@ import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
 import { getUserName, saveUserName } from "@/lib/userProfile";
 import { usePageTitle } from "@/lib/usePageTitle";
 import ParticipationConditions from "@/components/ParticipationConditions";
+import PollDetails from "@/components/PollDetails";
 
 interface PollPageClientProps {
   poll: Poll;
@@ -1131,6 +1132,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             <>Created {createdDate}</>
           )}
         </div>
+
+        {/* Poll details (expandable) */}
+        {poll.details && <PollDetails details={poll.details} />}
 
         {/* Poll status card - show expired, expiring, or manually closed */}
         {(() => {

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -513,7 +513,7 @@ export default function Template({ children }: AppTemplateProps) {
                     <h1
                       className="text-2xl font-bold mb-1 cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                       onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
-                    >Whoever Wants</h1>
+                    >Whoever Wants!</h1>
                     <div className="h-7 flex items-center justify-center mb-4" id="home-phrase-content">
                       {/* Blue phrase will be injected here */}
                     </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -513,7 +513,7 @@ export default function Template({ children }: AppTemplateProps) {
                     <h1
                       className="text-2xl font-bold mb-1 cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                       onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
-                    >Whoever Wants!</h1>
+                    >Whoever Wants</h1>
                     <div className="h-7 flex items-center justify-center mb-4" id="home-phrase-content">
                       {/* Blue phrase will be injected here */}
                     </div>

--- a/components/DuplicateButton.tsx
+++ b/components/DuplicateButton.tsx
@@ -22,6 +22,7 @@ export default function DuplicateButton({ poll }: DuplicateButtonProps) {
       min_participants: poll.min_participants,
       max_participants: poll.max_participants,
       auto_close_after: poll.auto_close_after,
+      details: poll.details,
     };
     
     debugLog.logObject('Duplicate button clicked', { pollId: poll.id, duplicateData }, 'DuplicateButton');

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -25,6 +25,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
     min_participants: poll.min_participants,
     max_participants: poll.max_participants,
     auto_close_after: poll.auto_close_after,
+    details: poll.details,
     total_votes: totalVotes,
   };
 

--- a/components/ForkButton.tsx
+++ b/components/ForkButton.tsx
@@ -23,6 +23,7 @@ export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
       min_participants: poll.min_participants,
       max_participants: poll.max_participants,
       auto_close_after: poll.auto_close_after,
+      details: poll.details,
     };
     
     debugLog.logObject('Fork button clicked', { pollId: poll.id, forkData }, 'ForkButton');

--- a/components/PollDetails.tsx
+++ b/components/PollDetails.tsx
@@ -6,26 +6,23 @@ interface PollDetailsProps {
   details: string;
 }
 
+// text-sm line-height = 1.25rem = 20px
+const LINE_HEIGHT = 20;
+const COLLAPSED_LINES = 3;
+const EXPANDED_LINES = 20;
+const COLLAPSED_HEIGHT = COLLAPSED_LINES * LINE_HEIGHT;
+const EXPANDED_HEIGHT = EXPANDED_LINES * LINE_HEIGHT;
+
 export default function PollDetails({ details }: PollDetailsProps) {
   const [expanded, setExpanded] = useState(false);
   const [needsTruncation, setNeedsTruncation] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
   const collapsedRef = useRef<HTMLDivElement>(null);
-
-  // Line height in px (text-sm = 1.25rem line-height = 20px)
-  const lineHeight = 20;
-  const collapsedLines = 3;
-  const expandedLines = 20;
-  const collapsedHeight = collapsedLines * lineHeight;
-  const expandedHeight = expandedLines * lineHeight;
 
   useEffect(() => {
     if (collapsedRef.current) {
-      // Check if content exceeds 3 lines
-      const scrollHeight = collapsedRef.current.scrollHeight;
-      setNeedsTruncation(scrollHeight > collapsedHeight + 2);
+      setNeedsTruncation(collapsedRef.current.scrollHeight > COLLAPSED_HEIGHT + 2);
     }
-  }, [details, collapsedHeight]);
+  }, [details]);
 
   if (!details) return null;
 
@@ -37,15 +34,15 @@ export default function PollDetails({ details }: PollDetailsProps) {
           ref={collapsedRef}
           className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words overflow-hidden"
           style={{
-            maxHeight: expanded ? expandedHeight : collapsedHeight,
+            maxHeight: expanded ? EXPANDED_HEIGHT : COLLAPSED_HEIGHT,
             overflowY: expanded ? 'auto' : 'hidden',
             ...(needsTruncation && !expanded ? {
-              maskImage: `linear-gradient(to bottom, black ${collapsedHeight - lineHeight}px, transparent ${collapsedHeight}px)`,
-              WebkitMaskImage: `linear-gradient(to bottom, black ${collapsedHeight - lineHeight}px, transparent ${collapsedHeight}px)`,
+              maskImage: `linear-gradient(to bottom, black ${COLLAPSED_HEIGHT - LINE_HEIGHT}px, transparent ${COLLAPSED_HEIGHT}px)`,
+              WebkitMaskImage: `linear-gradient(to bottom, black ${COLLAPSED_HEIGHT - LINE_HEIGHT}px, transparent ${COLLAPSED_HEIGHT}px)`,
             } : {}),
           }}
         >
-          <div ref={contentRef}>{details}</div>
+          {details}
         </div>
       </div>
 

--- a/components/PollDetails.tsx
+++ b/components/PollDetails.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+interface PollDetailsProps {
+  details: string;
+}
+
+export default function PollDetails({ details }: PollDetailsProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [needsTruncation, setNeedsTruncation] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const collapsedRef = useRef<HTMLDivElement>(null);
+
+  // Line height in px (text-sm = 1.25rem line-height = 20px)
+  const lineHeight = 20;
+  const collapsedLines = 3;
+  const expandedLines = 20;
+  const collapsedHeight = collapsedLines * lineHeight;
+  const expandedHeight = expandedLines * lineHeight;
+
+  useEffect(() => {
+    if (collapsedRef.current) {
+      // Check if content exceeds 3 lines
+      const scrollHeight = collapsedRef.current.scrollHeight;
+      setNeedsTruncation(scrollHeight > collapsedHeight + 2);
+    }
+  }, [details, collapsedHeight]);
+
+  if (!details) return null;
+
+  return (
+    <div className="mb-4">
+      <div className="relative">
+        {/* Content area */}
+        <div
+          ref={collapsedRef}
+          className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words overflow-hidden"
+          style={{
+            maxHeight: expanded ? expandedHeight : collapsedHeight,
+            overflowY: expanded ? 'auto' : 'hidden',
+          }}
+        >
+          <div ref={contentRef}>{details}</div>
+        </div>
+
+        {/* Fade overlay on 4th line when collapsed */}
+        {needsTruncation && !expanded && (
+          <div
+            className="absolute bottom-0 left-0 right-0 pointer-events-none"
+            style={{
+              height: lineHeight,
+              background: 'linear-gradient(to bottom, transparent, var(--fade-color, white))',
+            }}
+          >
+            <style>{`
+              @media (prefers-color-scheme: dark) {
+                .poll-details-fade { --fade-color: rgb(17, 24, 39) !important; }
+              }
+              .poll-details-fade { --fade-color: white; }
+            `}</style>
+            <div className="poll-details-fade w-full h-full" style={{
+              background: 'linear-gradient(to bottom, transparent, var(--fade-color))',
+            }} />
+          </div>
+        )}
+      </div>
+
+      {/* Expand/collapse arrow */}
+      {needsTruncation && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full flex justify-center py-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+          aria-label={expanded ? "Collapse details" : "Expand details"}
+        >
+          <svg
+            className={`w-6 h-3 transition-transform ${expanded ? 'rotate-180' : ''}`}
+            viewBox="0 0 24 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M4 2 L12 10 L20 2" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/PollDetails.tsx
+++ b/components/PollDetails.tsx
@@ -32,38 +32,21 @@ export default function PollDetails({ details }: PollDetailsProps) {
   return (
     <div className="mb-4">
       <div className="relative">
-        {/* Content area */}
+        {/* Content area — mask fades out the bottom line when collapsed */}
         <div
           ref={collapsedRef}
           className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words overflow-hidden"
           style={{
             maxHeight: expanded ? expandedHeight : collapsedHeight,
             overflowY: expanded ? 'auto' : 'hidden',
+            ...(needsTruncation && !expanded ? {
+              maskImage: `linear-gradient(to bottom, black ${collapsedHeight - lineHeight}px, transparent ${collapsedHeight}px)`,
+              WebkitMaskImage: `linear-gradient(to bottom, black ${collapsedHeight - lineHeight}px, transparent ${collapsedHeight}px)`,
+            } : {}),
           }}
         >
           <div ref={contentRef}>{details}</div>
         </div>
-
-        {/* Fade overlay on 4th line when collapsed */}
-        {needsTruncation && !expanded && (
-          <div
-            className="absolute bottom-0 left-0 right-0 pointer-events-none"
-            style={{
-              height: lineHeight,
-              background: 'linear-gradient(to bottom, transparent, var(--fade-color, white))',
-            }}
-          >
-            <style>{`
-              @media (prefers-color-scheme: dark) {
-                .poll-details-fade { --fade-color: rgb(17, 24, 39) !important; }
-              }
-              .poll-details-fade { --fade-color: white; }
-            `}</style>
-            <div className="poll-details-fade w-full h-full" style={{
-              background: 'linear-gradient(to bottom, transparent, var(--fade-color))',
-            }} />
-          </div>
-        )}
       </div>
 
       {/* Expand/collapse arrow */}

--- a/database/migrations/068_add_details_to_polls_down.sql
+++ b/database/migrations/068_add_details_to_polls_down.sql
@@ -1,0 +1,2 @@
+-- Remove details field from polls
+ALTER TABLE polls DROP COLUMN IF EXISTS details;

--- a/database/migrations/068_add_details_to_polls_up.sql
+++ b/database/migrations/068_add_details_to_polls_up.sql
@@ -1,0 +1,2 @@
+-- Add optional details field to polls
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS details TEXT;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -105,6 +105,7 @@ function toPoll(data: any): Poll {
     short_id: data.short_id ?? undefined,
     auto_create_preferences: data.auto_create_preferences ?? undefined,
     auto_preferences_deadline_minutes: data.auto_preferences_deadline_minutes ?? undefined,
+    details: data.details ?? undefined,
   };
 }
 
@@ -157,6 +158,7 @@ export async function apiCreatePoll(params: {
   auto_create_preferences?: boolean;
   auto_preferences_deadline_minutes?: number;
   auto_close_after?: number;
+  details?: string;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,6 +21,7 @@ export interface Poll {
   auto_create_preferences?: boolean;
   auto_preferences_deadline_minutes?: number;
   auto_close_after?: number;
+  details?: string;
 }
 
 export interface Vote {

--- a/server/models.py
+++ b/server/models.py
@@ -36,6 +36,7 @@ class CreatePollRequest(BaseModel):
     auto_create_preferences: bool = False
     auto_preferences_deadline_minutes: int | None = None
     auto_close_after: int | None = None
+    details: str | None = None
 
 
 class SubmitVoteRequest(BaseModel):
@@ -105,6 +106,7 @@ class PollResponse(BaseModel):
     auto_create_preferences: bool = False
     auto_preferences_deadline_minutes: int | None = None
     auto_close_after: int | None = None
+    details: str | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -175,6 +175,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         auto_create_preferences=row.get("auto_create_preferences", False),
         auto_preferences_deadline_minutes=row.get("auto_preferences_deadline_minutes"),
         auto_close_after=row.get("auto_close_after"),
+        details=row.get("details"),
     )
 
 
@@ -210,13 +211,13 @@ def create_poll(req: CreatePollRequest):
                                creator_secret, creator_name, follow_up_to,
                                fork_of, min_participants, max_participants,
                                auto_create_preferences, auto_preferences_deadline_minutes,
-                               auto_close_after,
+                               auto_close_after, details,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
                     %(fork_of)s, %(min_participants)s, %(max_participants)s,
                     %(auto_create_preferences)s, %(auto_preferences_deadline_minutes)s,
-                    %(auto_close_after)s,
+                    %(auto_close_after)s, %(details)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -234,6 +235,7 @@ def create_poll(req: CreatePollRequest):
                 "auto_create_preferences": req.auto_create_preferences,
                 "auto_preferences_deadline_minutes": req.auto_preferences_deadline_minutes,
                 "auto_close_after": req.auto_close_after,
+                "details": req.details,
                 "now": now,
             },
         ).fetchone()


### PR DESCRIPTION
## Summary
- Adds an optional "Details" text field to all poll types, spanning the full stack: database migration, Python backend, TypeScript types/API client, creation form, and poll display
- On the creation form, details appears as a single-line textarea that auto-grows up to 5 lines then scrolls
- On the poll display page, details are shown collapsed (3 lines) with a CSS mask fade and expand/collapse arrow for longer content (up to 20 scrollable lines)
- Empty details are hidden entirely on the poll page
- Details are preserved through fork, duplicate, and follow-up flows

## Test plan
- [ ] Create a poll with no details — verify the field doesn't appear on the poll page
- [ ] Create a poll with short details (1-2 lines) — verify it displays fully, no arrow
- [ ] Create a poll with long details (5+ lines) — verify 3-line collapse with fade and expand/collapse arrow
- [ ] Verify expand shows up to 20 lines then scrolls, collapse snaps back to 3
- [ ] Verify fade looks correct in both light and dark mode
- [ ] Fork/duplicate/follow-up a poll with details — verify details carry over to the creation form
- [ ] Test the auto-growing textarea: starts 1 line, grows to 5, then scrolls
- [ ] Apply migration 068 on the database