### PR TITLE
Fix dark mode poll type selector visibility

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -982,10 +982,10 @@ function CreatePollContent() {
                   hasLoadedPollType ? 'transition-all duration-200 ease-in-out' : ''
                 } ${
                   pollType === 'nomination'
-                    ? 'bg-blue-100 dark:bg-blue-900/30'
+                    ? 'bg-blue-100 dark:bg-blue-700/50'
                     : pollType === 'poll'
-                    ? 'bg-green-100 dark:bg-green-900/30'
-                    : 'bg-purple-100 dark:bg-purple-900/30'
+                    ? 'bg-green-100 dark:bg-green-700/50'
+                    : 'bg-purple-100 dark:bg-purple-700/50'
                 }`}
                 style={{
                   width: 'calc(33.333% - 4px)',


### PR DESCRIPTION
## Summary
- Increase dark mode background opacity for the poll type sliding indicator from `900/30` to `700/50`
- Affects all three poll types: nomination (blue), poll (green), participation (purple)
- The previous colors were nearly invisible against the `dark:bg-gray-800` container

## Test plan
- [ ] Open /create-poll in dark mode
- [ ] Verify the sliding indicator behind the selected poll type emoji is clearly visible
- [ ] Switch between all three poll types and confirm each color is distinct and vibrant

https://claude.ai/code/session_01XpxtSfvmrtcdqZdYK6sRct