### PR TITLE
Fix production deploy to apply database migrations

### DIFF
--- a/scripts/apply-migrations.sh
+++ b/scripts/apply-migrations.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Apply all *_up.sql migrations to a dev database.
-# Usage: apply-dev-migrations.sh <db_name> <migrations_dir>
+# Apply all *_up.sql migrations to a database.
+# Usage: apply-migrations.sh <db_name> <migrations_dir>
 #
 # Creates the _migrations table if it doesn't exist, then applies any
 # migration files not yet recorded, in filename order.
 
 set -euo pipefail
 
-DB_NAME="${1:?Usage: apply-dev-migrations.sh <db_name> <migrations_dir>}"
-MIGRATIONS_DIR="${2:?Usage: apply-dev-migrations.sh <db_name> <migrations_dir>}"
+DB_NAME="${1:?Usage: apply-migrations.sh <db_name> <migrations_dir>}"
+MIGRATIONS_DIR="${2:?Usage: apply-migrations.sh <db_name> <migrations_dir>}"
 CONTAINER="whoeverwants-db-1"
 DB_USER="whoeverwants"
 

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -314,7 +314,7 @@ apply_dev_migrations() {
   fi
 
   log "  Applying migrations to $db_name..."
-  bash "$(dirname "$0")/apply-dev-migrations.sh" "$db_name" "$migrations_dir"
+  bash "$(dirname "$0")/apply-migrations.sh" "$db_name" "$migrations_dir"
 }
 
 # Drop a dev database

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -178,8 +178,10 @@ def deploy_production():
 
         # 3. Apply any new database migrations
         log.info("--- Checking for new migrations ---")
+        migrations_dir = os.path.join(REPO_DIR, "database", "migrations")
         result = subprocess.run(
-            ["bash", os.path.join(REPO_DIR, "scripts", "apply-migrations.sh")],
+            ["bash", os.path.join(REPO_DIR, "scripts", "apply-migrations.sh"),
+             "whoeverwants", migrations_dir],
             cwd=REPO_DIR,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary
- Production deploys silently skipped migrations because `deploy_production()` called a non-existent `scripts/apply-migrations.sh`
- Renamed `apply-dev-migrations.sh` → `apply-migrations.sh` (shared by dev servers and production)
- Updated `dev-webhook.py` to call it with the production database name and migrations directory
- Updated `dev-server-manager.sh` reference to match the new name

## Root cause
The webhook logged a warning when the script wasn't found but continued anyway — health check passed because the API container restarted fine, masking the fact that no migrations ran. This caused "failed to create poll" errors on production when merged code referenced columns (`auto_close_after`, `details`) that didn't exist yet.

## Test plan
- [x] Manually applied missing migrations 065-068 to production to fix the immediate issue
- [x] Verified participation poll creation works on production API
- [ ] After merge, push a no-op migration and confirm it gets auto-applied via webhook logs

https://claude.ai/code/session_0183qMgv8otiTGk9dw3u96bm