### PR TITLE
Add location & time fields for participation polls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -816,6 +816,19 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 
 **Time-saving tip**: Don't guess at the problem. Add logging, get the exact error, then fix the specific constraint.
 
+### Migration Constraint Naming
+
+- **Use consistent constraint names across migrations.** If migration 043 creates `vote_type_check` and migration 048 drops/recreates `votes_vote_type_check` (different name!), both constraints coexist. New migrations that only update one name leave the other stale. Always `DROP CONSTRAINT IF EXISTS` for ALL known aliases before creating the updated constraint.
+- **When adding new enum values to CHECK constraints**, search all migrations for every constraint on that column (names may vary) and drop all of them before adding the new one. Use `SELECT conname FROM pg_constraint WHERE conrelid = 'table'::regclass` to audit.
+
+### Sub-Poll Architecture (Location/Time Fields)
+
+- **Participation polls support optional Location and Time fields** with three modes: `set` (static value), `preferences` (creator-provided options → ranked choice sub-poll), `suggestions` (nomination sub-poll → auto-created ranked choice).
+- **Sub-polls are hidden from the main poll list** via `is_sub_poll = true` and filtered in `get_accessible_polls`. They're only accessible from the parent poll via `SubPollField` component.
+- **Sub-poll resolution**: When a ranked choice sub-poll with `sub_poll_role` closes, `_resolve_sub_poll_winner()` computes the IRV winner and writes it to the parent's `resolved_location` or `resolved_time` column.
+- **Creator secret propagation**: Sub-polls share the parent's `creator_secret`. The browser propagates it via `SubPollField` on page load since localStorage only stores secrets for directly-created polls.
+- **Column whitelist**: `_resolve_sub_poll_winner` uses an f-string for the column name — the field value MUST be validated against `("location", "time")` before interpolation.
+
 ### PWA / Pull-to-Refresh
 
 - **Native pull-to-refresh works everywhere except iOS PWA standalone mode.** Apple explicitly disables it. Don't use `overscroll-behavior: contain` globally — that blocks the native gesture on all platforms. Only use a custom touch-based pull-to-refresh for iOS PWA (detect with `navigator.standalone === true` — do NOT use UA sniffing).

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -15,6 +15,7 @@ import { debugLog } from "@/lib/debugLogger";
 import OptionsInput from "@/components/OptionsInput";
 import MinMaxCounter from "@/components/MinMaxCounter";
 import ParticipationConditions from "@/components/ParticipationConditions";
+import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
 export const dynamic = 'force-dynamic';
 
 function CreatePollContent() {
@@ -65,13 +66,11 @@ function CreatePollContent() {
   const [locationOptions, setLocationOptions] = useState<string[]>(['', '']);
   const [locationSuggestionsDeadline, setLocationSuggestionsDeadline] = useState('10min');
   const [locationPreferencesDeadline, setLocationPreferencesDeadline] = useState('10min');
-  const [showLocationOptionsModal, setShowLocationOptionsModal] = useState(false);
   const [timeMode, setTimeMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
   const [timeValue, setTimeValue] = useState('');
   const [timeOptions, setTimeOptions] = useState<string[]>(['', '']);
   const [timeSuggestionsDeadline, setTimeSuggestionsDeadline] = useState('10min');
   const [timePreferencesDeadline, setTimePreferencesDeadline] = useState('10min');
-  const [showTimeOptionsModal, setShowTimeOptionsModal] = useState(false);
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -1153,133 +1152,36 @@ function CreatePollContent() {
           {/* Location/Time fields for participation polls */}
           {pollType === 'participation' && (
             <div className="space-y-3">
-              {/* Location field */}
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  Location{' '}
-                  <span className="text-gray-500 font-normal">(optional)</span>
-                </label>
-                <select
-                  value={locationMode}
-                  onChange={(e) => setLocationMode(e.target.value as any)}
-                  disabled={isLoading}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-                >
-                  <option value="none">None</option>
-                  <option value="suggestions">Ask for Suggestions</option>
-                  <option value="preferences">
-                    Ask for Preferences{locationOptions.filter(o => o.trim()).length >= 2 ? ` (${locationOptions.filter(o => o.trim()).length})` : ''}
-                  </option>
-                  <option value="set">Set</option>
-                </select>
-                {locationMode === 'set' && (
-                  <input
-                    type="text"
-                    value={locationValue}
-                    onChange={(e) => setLocationValue(e.target.value)}
-                    disabled={isLoading}
-                    placeholder="Enter location..."
-                    className="w-full mt-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-                  />
-                )}
-                {locationMode === 'preferences' && (
-                  <div className="mt-2 space-y-2">
-                    <button
-                      type="button"
-                      onClick={() => setShowLocationOptionsModal(true)}
-                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                    >
-                      Edit options ({locationOptions.filter(o => o.trim()).length})
-                    </button>
-                    <div>
-                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences deadline</label>
-                      <select value={locationPreferencesDeadline} onChange={(e) => setLocationPreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
-                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                      </select>
-                    </div>
-                  </div>
-                )}
-                {locationMode === 'suggestions' && (
-                  <div className="mt-2 space-y-2">
-                    <div>
-                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Suggestions phase deadline</label>
-                      <select value={locationSuggestionsDeadline} onChange={(e) => setLocationSuggestionsDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
-                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                      </select>
-                    </div>
-                    <div>
-                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences phase deadline</label>
-                      <select value={locationPreferencesDeadline} onChange={(e) => setLocationPreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
-                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                      </select>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {/* Time field */}
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  Time{' '}
-                  <span className="text-gray-500 font-normal">(optional)</span>
-                </label>
-                <select
-                  value={timeMode}
-                  onChange={(e) => setTimeMode(e.target.value as any)}
-                  disabled={isLoading}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-                >
-                  <option value="none">None</option>
-                  <option value="suggestions">Ask for Suggestions</option>
-                  <option value="preferences">
-                    Ask for Preferences{timeOptions.filter(o => o.trim()).length >= 2 ? ` (${timeOptions.filter(o => o.trim()).length})` : ''}
-                  </option>
-                  <option value="set">Set</option>
-                </select>
-                {timeMode === 'set' && (
-                  <input
-                    type="text"
-                    value={timeValue}
-                    onChange={(e) => setTimeValue(e.target.value)}
-                    disabled={isLoading}
-                    placeholder="Enter time..."
-                    className="w-full mt-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-                  />
-                )}
-                {timeMode === 'preferences' && (
-                  <div className="mt-2 space-y-2">
-                    <button
-                      type="button"
-                      onClick={() => setShowTimeOptionsModal(true)}
-                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                    >
-                      Edit options ({timeOptions.filter(o => o.trim()).length})
-                    </button>
-                    <div>
-                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences deadline</label>
-                      <select value={timePreferencesDeadline} onChange={(e) => setTimePreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
-                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                      </select>
-                    </div>
-                  </div>
-                )}
-                {timeMode === 'suggestions' && (
-                  <div className="mt-2 space-y-2">
-                    <div>
-                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Suggestions phase deadline</label>
-                      <select value={timeSuggestionsDeadline} onChange={(e) => setTimeSuggestionsDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
-                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                      </select>
-                    </div>
-                    <div>
-                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences phase deadline</label>
-                      <select value={timePreferencesDeadline} onChange={(e) => setTimePreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
-                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                      </select>
-                    </div>
-                  </div>
-                )}
-              </div>
+              <LocationTimeFieldConfig
+                label="Location"
+                mode={locationMode}
+                onModeChange={setLocationMode}
+                value={locationValue}
+                onValueChange={setLocationValue}
+                options={locationOptions}
+                onOptionsChange={setLocationOptions}
+                suggestionsDeadline={locationSuggestionsDeadline}
+                onSuggestionsDeadlineChange={setLocationSuggestionsDeadline}
+                preferencesDeadline={locationPreferencesDeadline}
+                onPreferencesDeadlineChange={setLocationPreferencesDeadline}
+                deadlineOptions={baseDeadlineOptions}
+                isLoading={isLoading}
+              />
+              <LocationTimeFieldConfig
+                label="Time"
+                mode={timeMode}
+                onModeChange={setTimeMode}
+                value={timeValue}
+                onValueChange={setTimeValue}
+                options={timeOptions}
+                onOptionsChange={setTimeOptions}
+                suggestionsDeadline={timeSuggestionsDeadline}
+                onSuggestionsDeadlineChange={setTimeSuggestionsDeadline}
+                preferencesDeadline={timePreferencesDeadline}
+                onPreferencesDeadlineChange={setTimePreferencesDeadline}
+                deadlineOptions={baseDeadlineOptions}
+                isLoading={isLoading}
+              />
             </div>
           )}
 
@@ -1577,42 +1479,6 @@ function CreatePollContent() {
         confirmText="Create"
         cancelText="Cancel"
       />
-
-      {/* Location options modal */}
-      {showLocationOptionsModal && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={() => setShowLocationOptionsModal(false)}>
-          <div className="bg-white dark:bg-gray-900 rounded-lg p-4 w-full max-w-md max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-sm font-medium mb-3">Location Options</h3>
-            <OptionsInput
-              options={locationOptions}
-              setOptions={setLocationOptions}
-              isLoading={isLoading}
-              placeholder="Add a location option..."
-            />
-            <button type="button" onClick={() => setShowLocationOptionsModal(false)} className="mt-3 w-full py-2 bg-gray-100 dark:bg-gray-800 rounded-md text-sm hover:bg-gray-200 dark:hover:bg-gray-700">
-              Done
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Time options modal */}
-      {showTimeOptionsModal && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={() => setShowTimeOptionsModal(false)}>
-          <div className="bg-white dark:bg-gray-900 rounded-lg p-4 w-full max-w-md max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-sm font-medium mb-3">Time Options</h3>
-            <OptionsInput
-              options={timeOptions}
-              setOptions={setTimeOptions}
-              isLoading={isLoading}
-              placeholder="Add a time option..."
-            />
-            <button type="button" onClick={() => setShowTimeOptionsModal(false)} className="mt-3 w-full py-2 bg-gray-100 dark:bg-gray-800 rounded-md text-sm hover:bg-gray-200 dark:hover:bg-gray-700">
-              Done
-            </button>
-          </div>
-        </div>
-      )}
 
     </div>
   );

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -907,36 +907,31 @@ function CreatePollContent() {
 
       // Add location/time fields for participation polls
       if (dbPollType === 'participation') {
-        if (locationMode !== 'none') {
-          pollData.location_mode = locationMode;
-          if (locationMode === 'set') {
-            pollData.location_value = locationValue.trim();
-          } else if (locationMode === 'preferences') {
-            pollData.location_options = locationOptions.filter(o => o.trim() !== '');
-            pollData.location_preferences_deadline_minutes =
-              baseDeadlineOptions.find(o => o.value === locationPreferencesDeadline)?.minutes || 10;
-          } else if (locationMode === 'suggestions') {
-            pollData.location_suggestions_deadline_minutes =
-              baseDeadlineOptions.find(o => o.value === locationSuggestionsDeadline)?.minutes || 10;
-            pollData.location_preferences_deadline_minutes =
-              baseDeadlineOptions.find(o => o.value === locationPreferencesDeadline)?.minutes || 10;
+        const addFieldData = (
+          fieldName: 'location' | 'time',
+          mode: string,
+          fieldValue: string,
+          fieldOptions: string[],
+          sugDeadline: string,
+          prefDeadline: string,
+        ) => {
+          if (mode === 'none') return;
+          pollData[`${fieldName}_mode`] = mode;
+          if (mode === 'set') {
+            pollData[`${fieldName}_value`] = fieldValue.trim();
+          } else if (mode === 'preferences') {
+            pollData[`${fieldName}_options`] = fieldOptions.filter(o => o.trim() !== '');
+            pollData[`${fieldName}_preferences_deadline_minutes`] =
+              baseDeadlineOptions.find(o => o.value === prefDeadline)?.minutes || 10;
+          } else if (mode === 'suggestions') {
+            pollData[`${fieldName}_suggestions_deadline_minutes`] =
+              baseDeadlineOptions.find(o => o.value === sugDeadline)?.minutes || 10;
+            pollData[`${fieldName}_preferences_deadline_minutes`] =
+              baseDeadlineOptions.find(o => o.value === prefDeadline)?.minutes || 10;
           }
-        }
-        if (timeMode !== 'none') {
-          pollData.time_mode = timeMode;
-          if (timeMode === 'set') {
-            pollData.time_value = timeValue.trim();
-          } else if (timeMode === 'preferences') {
-            pollData.time_options = timeOptions.filter(o => o.trim() !== '');
-            pollData.time_preferences_deadline_minutes =
-              baseDeadlineOptions.find(o => o.value === timePreferencesDeadline)?.minutes || 10;
-          } else if (timeMode === 'suggestions') {
-            pollData.time_suggestions_deadline_minutes =
-              baseDeadlineOptions.find(o => o.value === timeSuggestionsDeadline)?.minutes || 10;
-            pollData.time_preferences_deadline_minutes =
-              baseDeadlineOptions.find(o => o.value === timePreferencesDeadline)?.minutes || 10;
-          }
-        }
+        };
+        addFieldData('location', locationMode, locationValue, locationOptions, locationSuggestionsDeadline, locationPreferencesDeadline);
+        addFieldData('time', timeMode, timeValue, timeOptions, timeSuggestionsDeadline, timePreferencesDeadline);
       }
 
       // Add auto-close after N respondents

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -59,6 +59,19 @@ function CreatePollContent() {
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
+  // Location/time fields for participation polls
+  const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
+  const [locationValue, setLocationValue] = useState('');
+  const [locationOptions, setLocationOptions] = useState<string[]>(['', '']);
+  const [locationSuggestionsDeadline, setLocationSuggestionsDeadline] = useState('10min');
+  const [locationPreferencesDeadline, setLocationPreferencesDeadline] = useState('10min');
+  const [showLocationOptionsModal, setShowLocationOptionsModal] = useState(false);
+  const [timeMode, setTimeMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
+  const [timeValue, setTimeValue] = useState('');
+  const [timeOptions, setTimeOptions] = useState<string[]>(['', '']);
+  const [timeSuggestionsDeadline, setTimeSuggestionsDeadline] = useState('10min');
+  const [timePreferencesDeadline, setTimePreferencesDeadline] = useState('10min');
+  const [showTimeOptionsModal, setShowTimeOptionsModal] = useState(false);
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -893,6 +906,40 @@ function CreatePollContent() {
         }
       }
 
+      // Add location/time fields for participation polls
+      if (dbPollType === 'participation') {
+        if (locationMode !== 'none') {
+          pollData.location_mode = locationMode;
+          if (locationMode === 'set') {
+            pollData.location_value = locationValue.trim();
+          } else if (locationMode === 'preferences') {
+            pollData.location_options = locationOptions.filter(o => o.trim() !== '');
+            pollData.location_preferences_deadline_minutes =
+              baseDeadlineOptions.find(o => o.value === locationPreferencesDeadline)?.minutes || 10;
+          } else if (locationMode === 'suggestions') {
+            pollData.location_suggestions_deadline_minutes =
+              baseDeadlineOptions.find(o => o.value === locationSuggestionsDeadline)?.minutes || 10;
+            pollData.location_preferences_deadline_minutes =
+              baseDeadlineOptions.find(o => o.value === locationPreferencesDeadline)?.minutes || 10;
+          }
+        }
+        if (timeMode !== 'none') {
+          pollData.time_mode = timeMode;
+          if (timeMode === 'set') {
+            pollData.time_value = timeValue.trim();
+          } else if (timeMode === 'preferences') {
+            pollData.time_options = timeOptions.filter(o => o.trim() !== '');
+            pollData.time_preferences_deadline_minutes =
+              baseDeadlineOptions.find(o => o.value === timePreferencesDeadline)?.minutes || 10;
+          } else if (timeMode === 'suggestions') {
+            pollData.time_suggestions_deadline_minutes =
+              baseDeadlineOptions.find(o => o.value === timeSuggestionsDeadline)?.minutes || 10;
+            pollData.time_preferences_deadline_minutes =
+              baseDeadlineOptions.find(o => o.value === timePreferencesDeadline)?.minutes || 10;
+          }
+        }
+      }
+
       // Add auto-close after N respondents
       if (autoCloseAfter !== null && autoCloseAfter > 0) {
         pollData.auto_close_after = autoCloseAfter;
@@ -1101,6 +1148,139 @@ function CreatePollContent() {
               onMaxEnabledChange={setMaxEnabled}
               disabled={isLoading}
             />
+          )}
+
+          {/* Location/Time fields for participation polls */}
+          {pollType === 'participation' && (
+            <div className="space-y-3">
+              {/* Location field */}
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  Location{' '}
+                  <span className="text-gray-500 font-normal">(optional)</span>
+                </label>
+                <select
+                  value={locationMode}
+                  onChange={(e) => setLocationMode(e.target.value as any)}
+                  disabled={isLoading}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                >
+                  <option value="none">None</option>
+                  <option value="suggestions">Ask for Suggestions</option>
+                  <option value="preferences">
+                    Ask for Preferences{locationOptions.filter(o => o.trim()).length >= 2 ? ` (${locationOptions.filter(o => o.trim()).length})` : ''}
+                  </option>
+                  <option value="set">Set</option>
+                </select>
+                {locationMode === 'set' && (
+                  <input
+                    type="text"
+                    value={locationValue}
+                    onChange={(e) => setLocationValue(e.target.value)}
+                    disabled={isLoading}
+                    placeholder="Enter location..."
+                    className="w-full mt-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                  />
+                )}
+                {locationMode === 'preferences' && (
+                  <div className="mt-2 space-y-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowLocationOptionsModal(true)}
+                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      Edit options ({locationOptions.filter(o => o.trim()).length})
+                    </button>
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences deadline</label>
+                      <select value={locationPreferencesDeadline} onChange={(e) => setLocationPreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
+                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      </select>
+                    </div>
+                  </div>
+                )}
+                {locationMode === 'suggestions' && (
+                  <div className="mt-2 space-y-2">
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Suggestions phase deadline</label>
+                      <select value={locationSuggestionsDeadline} onChange={(e) => setLocationSuggestionsDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
+                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences phase deadline</label>
+                      <select value={locationPreferencesDeadline} onChange={(e) => setLocationPreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
+                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      </select>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Time field */}
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  Time{' '}
+                  <span className="text-gray-500 font-normal">(optional)</span>
+                </label>
+                <select
+                  value={timeMode}
+                  onChange={(e) => setTimeMode(e.target.value as any)}
+                  disabled={isLoading}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                >
+                  <option value="none">None</option>
+                  <option value="suggestions">Ask for Suggestions</option>
+                  <option value="preferences">
+                    Ask for Preferences{timeOptions.filter(o => o.trim()).length >= 2 ? ` (${timeOptions.filter(o => o.trim()).length})` : ''}
+                  </option>
+                  <option value="set">Set</option>
+                </select>
+                {timeMode === 'set' && (
+                  <input
+                    type="text"
+                    value={timeValue}
+                    onChange={(e) => setTimeValue(e.target.value)}
+                    disabled={isLoading}
+                    placeholder="Enter time..."
+                    className="w-full mt-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                  />
+                )}
+                {timeMode === 'preferences' && (
+                  <div className="mt-2 space-y-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowTimeOptionsModal(true)}
+                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      Edit options ({timeOptions.filter(o => o.trim()).length})
+                    </button>
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences deadline</label>
+                      <select value={timePreferencesDeadline} onChange={(e) => setTimePreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
+                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      </select>
+                    </div>
+                  </div>
+                )}
+                {timeMode === 'suggestions' && (
+                  <div className="mt-2 space-y-2">
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Suggestions phase deadline</label>
+                      <select value={timeSuggestionsDeadline} onChange={(e) => setTimeSuggestionsDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
+                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences phase deadline</label>
+                      <select value={timePreferencesDeadline} onChange={(e) => setTimePreferencesDeadline(e.target.value)} disabled={isLoading} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm">
+                        {baseDeadlineOptions.filter(o => o.value !== 'custom').map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                      </select>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
           )}
 
           {/* Hide options field for nomination and participation polls */}
@@ -1397,7 +1577,43 @@ function CreatePollContent() {
         confirmText="Create"
         cancelText="Cancel"
       />
-      
+
+      {/* Location options modal */}
+      {showLocationOptionsModal && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={() => setShowLocationOptionsModal(false)}>
+          <div className="bg-white dark:bg-gray-900 rounded-lg p-4 w-full max-w-md max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-medium mb-3">Location Options</h3>
+            <OptionsInput
+              options={locationOptions}
+              setOptions={setLocationOptions}
+              isLoading={isLoading}
+              placeholder="Add a location option..."
+            />
+            <button type="button" onClick={() => setShowLocationOptionsModal(false)} className="mt-3 w-full py-2 bg-gray-100 dark:bg-gray-800 rounded-md text-sm hover:bg-gray-200 dark:hover:bg-gray-700">
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Time options modal */}
+      {showTimeOptionsModal && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={() => setShowTimeOptionsModal(false)}>
+          <div className="bg-white dark:bg-gray-900 rounded-lg p-4 w-full max-w-md max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-medium mb-3">Time Options</h3>
+            <OptionsInput
+              options={timeOptions}
+              setOptions={setTimeOptions}
+              isLoading={isLoading}
+              placeholder="Add a time option..."
+            />
+            <button type="button" onClick={() => setShowTimeOptionsModal(false)} className="mt-3 w-full py-2 bg-gray-100 dark:bg-gray-800 rounded-md text-sm hover:bg-gray-200 dark:hover:bg-gray-700">
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+
     </div>
   );
 }

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -29,6 +29,7 @@ import { getUserName, saveUserName } from "@/lib/userProfile";
 import { usePageTitle } from "@/lib/usePageTitle";
 import ParticipationConditions from "@/components/ParticipationConditions";
 import PollDetails from "@/components/PollDetails";
+import SubPollField from "@/components/SubPollField";
 
 interface PollPageClientProps {
   poll: Poll;
@@ -1136,6 +1137,15 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         {/* Poll details (expandable) */}
         {poll.details && <PollDetails details={poll.details} />}
 
+        {/* Sub-poll back navigation */}
+        {poll.is_sub_poll && poll.parent_participation_poll_id && (
+          <div className="mb-3 text-center">
+            <Link href={`/p/${poll.parent_participation_poll_id}`} className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+              Back to main poll
+            </Link>
+          </div>
+        )}
+
         {/* Poll status card - show expired, expiring, or manually closed */}
         {(() => {
           const deadline = poll.response_deadline ? new Date(poll.response_deadline) : null;
@@ -1478,6 +1488,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             </div>
           ) : poll.poll_type === 'participation' ? (
             <div>
+              {(poll.location_mode || poll.time_mode) && (
+                <SubPollField poll={poll} />
+              )}
               {isPollClosed ? (
                 <div className="py-6">
                   {loadingResults ? (

--- a/components/LocationTimeFieldConfig.tsx
+++ b/components/LocationTimeFieldConfig.tsx
@@ -47,6 +47,15 @@ export default function LocationTimeFieldConfig({
   const selectClass = "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm";
   const filteredDeadlineOptions = deadlineOptions.filter(o => o.value !== 'custom');
 
+  const DeadlineSelect = ({ dlLabel, dlValue, onChange }: { dlLabel: string; dlValue: string; onChange: (v: string) => void }) => (
+    <div>
+      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{dlLabel}</label>
+      <select value={dlValue} onChange={(e) => onChange(e.target.value)} disabled={isLoading} className={selectClass}>
+        {filteredDeadlineOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+    </div>
+  );
+
   return (
     <>
       <div>
@@ -88,29 +97,14 @@ export default function LocationTimeFieldConfig({
             >
               Edit options ({validOptionCount})
             </button>
-            <div>
-              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences deadline</label>
-              <select value={preferencesDeadline} onChange={(e) => onPreferencesDeadlineChange(e.target.value)} disabled={isLoading} className={selectClass}>
-                {filteredDeadlineOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-              </select>
-            </div>
+            <DeadlineSelect dlLabel="Preferences deadline" dlValue={preferencesDeadline} onChange={onPreferencesDeadlineChange} />
           </div>
         )}
 
         {mode === 'suggestions' && (
           <div className="mt-2 space-y-2">
-            <div>
-              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Suggestions phase deadline</label>
-              <select value={suggestionsDeadline} onChange={(e) => onSuggestionsDeadlineChange(e.target.value)} disabled={isLoading} className={selectClass}>
-                {filteredDeadlineOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-              </select>
-            </div>
-            <div>
-              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences phase deadline</label>
-              <select value={preferencesDeadline} onChange={(e) => onPreferencesDeadlineChange(e.target.value)} disabled={isLoading} className={selectClass}>
-                {filteredDeadlineOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-              </select>
-            </div>
+            <DeadlineSelect dlLabel="Suggestions phase deadline" dlValue={suggestionsDeadline} onChange={onSuggestionsDeadlineChange} />
+            <DeadlineSelect dlLabel="Preferences phase deadline" dlValue={preferencesDeadline} onChange={onPreferencesDeadlineChange} />
           </div>
         )}
       </div>

--- a/components/LocationTimeFieldConfig.tsx
+++ b/components/LocationTimeFieldConfig.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import OptionsInput from "@/components/OptionsInput";
+
+type FieldMode = 'none' | 'set' | 'preferences' | 'suggestions';
+
+interface DeadlineOption {
+  value: string;
+  label: string;
+  minutes: number;
+}
+
+interface LocationTimeFieldConfigProps {
+  label: string;
+  mode: FieldMode;
+  onModeChange: (mode: FieldMode) => void;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: string[];
+  onOptionsChange: (options: string[]) => void;
+  suggestionsDeadline: string;
+  onSuggestionsDeadlineChange: (deadline: string) => void;
+  preferencesDeadline: string;
+  onPreferencesDeadlineChange: (deadline: string) => void;
+  deadlineOptions: DeadlineOption[];
+  isLoading: boolean;
+}
+
+export default function LocationTimeFieldConfig({
+  label,
+  mode,
+  onModeChange,
+  value,
+  onValueChange,
+  options,
+  onOptionsChange,
+  suggestionsDeadline,
+  onSuggestionsDeadlineChange,
+  preferencesDeadline,
+  onPreferencesDeadlineChange,
+  deadlineOptions,
+  isLoading,
+}: LocationTimeFieldConfigProps) {
+  const [showOptionsModal, setShowOptionsModal] = useState(false);
+  const validOptionCount = options.filter(o => o.trim()).length;
+  const selectClass = "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm";
+  const filteredDeadlineOptions = deadlineOptions.filter(o => o.value !== 'custom');
+
+  return (
+    <>
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          {label}{' '}
+          <span className="text-gray-500 font-normal">(optional)</span>
+        </label>
+        <select
+          value={mode}
+          onChange={(e) => onModeChange(e.target.value as FieldMode)}
+          disabled={isLoading}
+          className={selectClass}
+        >
+          <option value="none">None</option>
+          <option value="suggestions">Ask for Suggestions</option>
+          <option value="preferences">
+            Ask for Preferences{validOptionCount >= 2 ? ` (${validOptionCount})` : ''}
+          </option>
+          <option value="set">Set</option>
+        </select>
+
+        {mode === 'set' && (
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+            disabled={isLoading}
+            placeholder={`Enter ${label.toLowerCase()}...`}
+            className="w-full mt-2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+          />
+        )}
+
+        {mode === 'preferences' && (
+          <div className="mt-2 space-y-2">
+            <button
+              type="button"
+              onClick={() => setShowOptionsModal(true)}
+              className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Edit options ({validOptionCount})
+            </button>
+            <div>
+              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences deadline</label>
+              <select value={preferencesDeadline} onChange={(e) => onPreferencesDeadlineChange(e.target.value)} disabled={isLoading} className={selectClass}>
+                {filteredDeadlineOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+          </div>
+        )}
+
+        {mode === 'suggestions' && (
+          <div className="mt-2 space-y-2">
+            <div>
+              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Suggestions phase deadline</label>
+              <select value={suggestionsDeadline} onChange={(e) => onSuggestionsDeadlineChange(e.target.value)} disabled={isLoading} className={selectClass}>
+                {filteredDeadlineOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Preferences phase deadline</label>
+              <select value={preferencesDeadline} onChange={(e) => onPreferencesDeadlineChange(e.target.value)} disabled={isLoading} className={selectClass}>
+                {filteredDeadlineOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showOptionsModal && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={() => setShowOptionsModal(false)}>
+          <div className="bg-white dark:bg-gray-900 rounded-lg p-4 w-full max-w-md max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-medium mb-3">{label} Options</h3>
+            <OptionsInput
+              options={options}
+              setOptions={onOptionsChange}
+              isLoading={isLoading}
+              placeholder={`Add a ${label.toLowerCase()} option...`}
+            />
+            <button type="button" onClick={() => setShowOptionsModal(false)} className="mt-3 w-full py-2 bg-gray-100 dark:bg-gray-800 rounded-md text-sm hover:bg-gray-200 dark:hover:bg-gray-700">
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/LocationTimeFieldConfig.tsx
+++ b/components/LocationTimeFieldConfig.tsx
@@ -47,7 +47,7 @@ export default function LocationTimeFieldConfig({
   const selectClass = "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm";
   const filteredDeadlineOptions = deadlineOptions.filter(o => o.value !== 'custom');
 
-  const DeadlineSelect = ({ dlLabel, dlValue, onChange }: { dlLabel: string; dlValue: string; onChange: (v: string) => void }) => (
+  const renderDeadlineSelect = (dlLabel: string, dlValue: string, onChange: (v: string) => void) => (
     <div>
       <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{dlLabel}</label>
       <select value={dlValue} onChange={(e) => onChange(e.target.value)} disabled={isLoading} className={selectClass}>
@@ -97,14 +97,14 @@ export default function LocationTimeFieldConfig({
             >
               Edit options ({validOptionCount})
             </button>
-            <DeadlineSelect dlLabel="Preferences deadline" dlValue={preferencesDeadline} onChange={onPreferencesDeadlineChange} />
+            {renderDeadlineSelect("Preferences deadline", preferencesDeadline, onPreferencesDeadlineChange)}
           </div>
         )}
 
         {mode === 'suggestions' && (
           <div className="mt-2 space-y-2">
-            <DeadlineSelect dlLabel="Suggestions phase deadline" dlValue={suggestionsDeadline} onChange={onSuggestionsDeadlineChange} />
-            <DeadlineSelect dlLabel="Preferences phase deadline" dlValue={preferencesDeadline} onChange={onPreferencesDeadlineChange} />
+            {renderDeadlineSelect("Suggestions phase deadline", suggestionsDeadline, onSuggestionsDeadlineChange)}
+            {renderDeadlineSelect("Preferences phase deadline", preferencesDeadline, onPreferencesDeadlineChange)}
           </div>
         )}
       </div>

--- a/components/SubPollField.tsx
+++ b/components/SubPollField.tsx
@@ -14,10 +14,9 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
   const [subPolls, setSubPolls] = useState<Poll[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const hasLocationField = poll.location_mode && poll.location_mode !== 'set';
-  const hasTimeField = poll.time_mode && poll.time_mode !== 'set';
-
   useEffect(() => {
+    const hasLocationField = poll.location_mode && poll.location_mode !== 'set';
+    const hasTimeField = poll.time_mode && poll.time_mode !== 'set';
     if (!hasLocationField && !hasTimeField) {
       setLoading(false);
       return;
@@ -36,7 +35,8 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
       })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [poll.id, hasLocationField, hasTimeField]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poll.id]);
 
   if (!poll.location_mode && !poll.time_mode) return null;
 

--- a/components/SubPollField.tsx
+++ b/components/SubPollField.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Poll } from "@/lib/types";
+import { apiGetSubPolls } from "@/lib/api";
+import { getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
+
+interface SubPollFieldProps {
+  poll: Poll;
+}
+
+export default function SubPollField({ poll }: SubPollFieldProps) {
+  const [subPolls, setSubPolls] = useState<Poll[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const hasLocationField = poll.location_mode && poll.location_mode !== 'set';
+  const hasTimeField = poll.time_mode && poll.time_mode !== 'set';
+
+  useEffect(() => {
+    if (!hasLocationField && !hasTimeField) {
+      setLoading(false);
+      return;
+    }
+    apiGetSubPolls(poll.id)
+      .then((polls) => {
+        setSubPolls(polls);
+        // Propagate creator secret from parent to sub-polls
+        const parentSecret = getCreatorSecret(poll.id);
+        if (parentSecret) {
+          for (const sp of polls) {
+            if (!getCreatorSecret(sp.id)) {
+              recordPollCreation(sp.id, parentSecret);
+            }
+          }
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [poll.id, hasLocationField, hasTimeField]);
+
+  if (!poll.location_mode && !poll.time_mode) return null;
+
+  const renderField = (label: string, mode: string | null | undefined, resolvedValue: string | null | undefined, staticValue: string | null | undefined, role: string) => {
+    if (!mode) return null;
+
+    // 'set' mode - show static value
+    if (mode === 'set' && staticValue) {
+      return (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-medium text-gray-600 dark:text-gray-400">{label}:</span>
+          <span>{staticValue}</span>
+        </div>
+      );
+    }
+
+    // Resolved value (sub-poll chain completed)
+    if (resolvedValue) {
+      const prefsPoll = subPolls.find(sp => sp.sub_poll_role === `${role}_preferences`);
+      return (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-medium text-gray-600 dark:text-gray-400">{label}:</span>
+          {prefsPoll?.short_id ? (
+            <Link href={`/p/${prefsPoll.short_id}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+              {resolvedValue}
+            </Link>
+          ) : (
+            <span>{resolvedValue}</span>
+          )}
+        </div>
+      );
+    }
+
+    // Sub-poll still active
+    if (loading) {
+      return (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-medium text-gray-600 dark:text-gray-400">{label}:</span>
+          <span className="text-gray-400 dark:text-gray-500">Loading...</span>
+        </div>
+      );
+    }
+
+    // Find active sub-poll
+    const suggestionsPoll = subPolls.find(sp => sp.sub_poll_role === `${role}_suggestions` && !sp.is_closed);
+    const prefsPoll = subPolls.find(sp => sp.sub_poll_role === `${role}_preferences` && !sp.is_closed);
+    const activePoll = suggestionsPoll || prefsPoll;
+
+    if (activePoll) {
+      const actionText = suggestionsPoll ? `Suggest a ${label.toLowerCase()}` : `Vote on ${label.toLowerCase()}`;
+      return (
+        <div className="text-sm">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-gray-600 dark:text-gray-400">{label}:</span>
+            <Link
+              href={`/p/${activePoll.short_id || activePoll.id}`}
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {actionText}
+            </Link>
+          </div>
+        </div>
+      );
+    }
+
+    // Between phases or pending
+    return (
+      <div className="flex items-center gap-2 text-sm">
+        <span className="font-medium text-gray-600 dark:text-gray-400">{label}:</span>
+        <span className="text-gray-400 dark:text-gray-500 italic">Resolving...</span>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-2 mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+      {renderField("Location", poll.location_mode, poll.resolved_location, poll.location_value, "location")}
+      {renderField("Time", poll.time_mode, poll.resolved_time, poll.time_value, "time")}
+    </div>
+  );
+}

--- a/components/SubPollField.tsx
+++ b/components/SubPollField.tsx
@@ -25,7 +25,6 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
     apiGetSubPolls(poll.id)
       .then((polls) => {
         setSubPolls(polls);
-        // Propagate creator secret from parent to sub-polls
         const parentSecret = getCreatorSecret(poll.id);
         if (parentSecret) {
           for (const sp of polls) {
@@ -44,7 +43,6 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
   const renderField = (label: string, mode: string | null | undefined, resolvedValue: string | null | undefined, staticValue: string | null | undefined, role: string) => {
     if (!mode) return null;
 
-    // 'set' mode - show static value
     if (mode === 'set' && staticValue) {
       return (
         <div className="flex items-center gap-2 text-sm">
@@ -54,7 +52,6 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
       );
     }
 
-    // Resolved value (sub-poll chain completed)
     if (resolvedValue) {
       const prefsPoll = subPolls.find(sp => sp.sub_poll_role === `${role}_preferences`);
       return (
@@ -71,7 +68,6 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
       );
     }
 
-    // Sub-poll still active
     if (loading) {
       return (
         <div className="flex items-center gap-2 text-sm">
@@ -81,7 +77,6 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
       );
     }
 
-    // Find active sub-poll
     const suggestionsPoll = subPolls.find(sp => sp.sub_poll_role === `${role}_suggestions` && !sp.is_closed);
     const prefsPoll = subPolls.find(sp => sp.sub_poll_role === `${role}_preferences` && !sp.is_closed);
     const activePoll = suggestionsPoll || prefsPoll;
@@ -103,7 +98,6 @@ export default function SubPollField({ poll }: SubPollFieldProps) {
       );
     }
 
-    // Between phases or pending
     return (
       <div className="flex items-center gap-2 text-sm">
         <span className="font-medium text-gray-600 dark:text-gray-400">{label}:</span>

--- a/database/migrations/069_add_location_time_fields_down.sql
+++ b/database/migrations/069_add_location_time_fields_down.sql
@@ -1,0 +1,14 @@
+-- Remove location/time fields from polls
+ALTER TABLE polls DROP COLUMN IF EXISTS time_preferences_deadline_minutes;
+ALTER TABLE polls DROP COLUMN IF EXISTS time_suggestions_deadline_minutes;
+ALTER TABLE polls DROP COLUMN IF EXISTS location_preferences_deadline_minutes;
+ALTER TABLE polls DROP COLUMN IF EXISTS location_suggestions_deadline_minutes;
+ALTER TABLE polls DROP COLUMN IF EXISTS parent_participation_poll_id;
+ALTER TABLE polls DROP COLUMN IF EXISTS sub_poll_role;
+ALTER TABLE polls DROP COLUMN IF EXISTS is_sub_poll;
+ALTER TABLE polls DROP COLUMN IF EXISTS resolved_time;
+ALTER TABLE polls DROP COLUMN IF EXISTS resolved_location;
+ALTER TABLE polls DROP COLUMN IF EXISTS time_value;
+ALTER TABLE polls DROP COLUMN IF EXISTS location_value;
+ALTER TABLE polls DROP COLUMN IF EXISTS time_mode;
+ALTER TABLE polls DROP COLUMN IF EXISTS location_mode;

--- a/database/migrations/069_add_location_time_fields_up.sql
+++ b/database/migrations/069_add_location_time_fields_up.sql
@@ -1,0 +1,26 @@
+-- Add location/time fields for participation polls
+-- Mode selection for each field
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS location_mode TEXT CHECK (location_mode IN ('set', 'preferences', 'suggestions'));
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS time_mode TEXT CHECK (time_mode IN ('set', 'preferences', 'suggestions'));
+
+-- Static values for 'set' mode
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS location_value TEXT;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS time_value TEXT;
+
+-- Resolved values (populated when sub-poll chain completes)
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS resolved_location TEXT;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS resolved_time TEXT;
+
+-- Sub-poll metadata
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS is_sub_poll BOOLEAN DEFAULT false;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS sub_poll_role TEXT CHECK (sub_poll_role IN (
+  'location_preferences', 'location_suggestions',
+  'time_preferences', 'time_suggestions'
+));
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS parent_participation_poll_id UUID REFERENCES polls(id);
+
+-- Phase deadlines (in minutes)
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS location_suggestions_deadline_minutes INT;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS location_preferences_deadline_minutes INT;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS time_suggestions_deadline_minutes INT;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS time_preferences_deadline_minutes INT;

--- a/database/migrations/070_add_location_time_options_down.sql
+++ b/database/migrations/070_add_location_time_options_down.sql
@@ -1,0 +1,3 @@
+-- Remove location/time options columns
+ALTER TABLE polls DROP COLUMN IF EXISTS time_options;
+ALTER TABLE polls DROP COLUMN IF EXISTS location_options;

--- a/database/migrations/070_add_location_time_options_up.sql
+++ b/database/migrations/070_add_location_time_options_up.sql
@@ -1,0 +1,3 @@
+-- Add options columns for 'preferences' mode (creator-provided options)
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS location_options TEXT[];
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS time_options TEXT[];

--- a/database/migrations/071_add_parent_poll_index_down.sql
+++ b/database/migrations/071_add_parent_poll_index_down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_polls_parent_participation;

--- a/database/migrations/071_add_parent_poll_index_up.sql
+++ b/database/migrations/071_add_parent_poll_index_up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_polls_parent_participation ON polls(parent_participation_poll_id);

--- a/docs/participation-poll-fields-plan.md
+++ b/docs/participation-poll-fields-plan.md
@@ -1,0 +1,331 @@
+# Implementation Plan: Location & Time Fields for Participation Polls
+
+## Feature Summary
+
+Participation polls get two new optional fields: **Location** and **Time**. Each has a dropdown with 3 modes:
+
+1. **Set** — creator types a value directly
+2. **Ask for Preferences** — creator provides options, system auto-creates a ranked choice sub-poll
+3. **Ask for Suggestions** — system auto-creates a nomination sub-poll, which auto-creates a ranked choice preferences poll when it closes
+
+### Key Behaviors
+
+- Participation poll launches immediately and is votable before sub-polls resolve
+- Sub-polls are hidden from the main poll list, only accessible from the participation poll
+- Location and Time sub-polls run in parallel (independent)
+- Creator sets independent durations per phase per field
+- Validation: sub-poll deadlines < participation poll deadline; preferences deadline > suggestions deadline
+- When nomination poll closes → auto-create preferences poll from nominations (existing mechanism)
+- When preferences poll closes → resolved value auto-populates on participation poll
+- Resolved values on participation poll link to final results
+- Preferences poll shows nomination results as "Round 0" in rounds navigation
+- "Ask for Preferences" mode opens a modal reusing the existing `OptionsInput` component (no code duplication). When closed, show option count in parentheses after "Preferences"
+- No curation of nominations before they flow into preferences poll
+- Fully automated chain, no creator intervention needed
+
+---
+
+## Phase 1: Database Migrations
+
+### Migration 069: Add location/time fields to polls
+
+New columns on `polls` table:
+
+```sql
+-- Mode selection for each field
+location_mode TEXT CHECK (location_mode IN ('set', 'preferences', 'suggestions')),
+time_mode TEXT CHECK (time_mode IN ('set', 'preferences', 'suggestions')),
+
+-- Static values for 'set' mode
+location_value TEXT,
+time_value TEXT,
+
+-- Resolved values (populated when sub-poll chain completes)
+resolved_location TEXT,
+resolved_time TEXT,
+
+-- Sub-poll metadata
+is_sub_poll BOOLEAN DEFAULT false,
+sub_poll_role TEXT CHECK (sub_poll_role IN (
+  'location_preferences', 'location_suggestions',
+  'time_preferences', 'time_suggestions'
+)),
+parent_participation_poll_id UUID REFERENCES polls(id),
+
+-- Phase deadlines (in minutes)
+location_suggestions_deadline_minutes INT,
+location_preferences_deadline_minutes INT,
+time_suggestions_deadline_minutes INT,
+time_preferences_deadline_minutes INT
+```
+
+Down migration drops all these columns.
+
+### Migration 070: Add location/time options columns
+
+```sql
+-- Options for 'preferences' mode (creator-provided)
+location_options TEXT[],
+time_options TEXT[]
+```
+
+These store the options the creator provides when selecting "Ask for Preferences" mode. They're sent to the API at creation time and used to populate the ranked choice sub-poll.
+
+---
+
+## Phase 2: Python API Changes
+
+### 2a. Update `server/models.py`
+
+**CreatePollRequest** — add fields:
+- `location_mode: str | None = None`
+- `location_value: str | None = None`
+- `location_options: list[str] | None = None`
+- `time_mode: str | None = None`
+- `time_value: str | None = None`
+- `time_options: list[str] | None = None`
+- `location_suggestions_deadline_minutes: int | None = None`
+- `location_preferences_deadline_minutes: int | None = None`
+- `time_suggestions_deadline_minutes: int | None = None`
+- `time_preferences_deadline_minutes: int | None = None`
+
+**PollResponse** — add fields:
+- All the above, plus: `resolved_location`, `resolved_time`, `is_sub_poll`, `sub_poll_role`, `parent_participation_poll_id`
+
+### 2b. Update `create_poll` in `server/routers/polls.py`
+
+After inserting the main participation poll, for each field (location, time):
+
+**"set" mode:**
+- Store value in `location_value`/`time_value` and also in `resolved_location`/`resolved_time` (already resolved)
+
+**"preferences" mode:**
+- Create a ranked_choice sub-poll with:
+  - `is_sub_poll=true`
+  - `sub_poll_role='location_preferences'` or `'time_preferences'`
+  - `parent_participation_poll_id=<parent_id>`
+  - `options=<creator-provided options>`
+  - `title="Location for <parent title>"` or `"Time for <parent title>"`
+  - `creator_secret=<parent's creator_secret>`
+  - `response_deadline = now + preferences_deadline_minutes`
+  - `is_closed=false`
+
+**"suggestions" mode:**
+- Create a nomination sub-poll with:
+  - `is_sub_poll=true`
+  - `sub_poll_role='location_suggestions'` or `'time_suggestions'`
+  - `parent_participation_poll_id=<parent_id>`
+  - `auto_create_preferences=true`
+  - `title="Location for <parent title>"` or `"Time for <parent title>"`
+  - `creator_secret=<parent's creator_secret>`
+  - `response_deadline = now + suggestions_deadline_minutes`
+- Create a reserved ranked_choice sub-poll (placeholder, existing pattern):
+  - `is_sub_poll=true`
+  - `sub_poll_role='location_preferences'` or `'time_preferences'`
+  - `parent_participation_poll_id=<parent_id>`
+  - `follow_up_to=<nomination sub-poll id>`
+  - `is_closed=true`, `options=NULL`
+  - `auto_preferences_deadline_minutes=<preferences_deadline_minutes>`
+
+This reuses the existing `_activate_reserved_preferences_poll` mechanism exactly.
+
+### 2c. New endpoint: `GET /api/polls/{poll_id}/sub-polls`
+
+Returns all sub-polls for a participation poll. Query:
+```sql
+SELECT * FROM polls WHERE parent_participation_poll_id = :poll_id ORDER BY created_at
+```
+
+### 2d. Resolution logic: `_resolve_sub_poll_winner()`
+
+New helper function called when a ranked_choice sub-poll with `sub_poll_role` closes:
+
+1. Compute the IRV winner from ranked choice results
+2. Find parent via `parent_participation_poll_id`
+3. Update parent's `resolved_location` or `resolved_time` with winner text
+
+Called from:
+- `_check_auto_close()` — after vote-triggered auto-close
+- `close_poll()` — after manual close
+- `get_results()` — after deadline-triggered lazy close
+
+Must also propagate `parent_participation_poll_id` and `is_sub_poll=true` in `_activate_reserved_preferences_poll()` when it activates the reserved ranked_choice poll from a nomination sub-poll.
+
+### 2e. Hide sub-polls from main list
+
+In `get_accessible_polls`, add filter: `AND (is_sub_poll = false OR is_sub_poll IS NULL)`
+
+### 2f. Validation in `create_poll`
+
+- `location_mode`/`time_mode` only valid when `poll_type='participation'`
+- "preferences" mode requires `location_options`/`time_options` with >= 2 items
+- "set" mode requires non-empty `location_value`/`time_value`
+- Sub-poll deadlines must be before participation poll's `response_deadline`
+- For "suggestions" mode: suggestions deadline < preferences deadline (preferences starts after suggestions ends)
+
+---
+
+## Phase 3: Frontend — Types & API Client
+
+### 3a. Update `lib/types.ts`
+
+Add to `Poll` interface:
+```typescript
+location_mode?: 'set' | 'preferences' | 'suggestions' | null;
+location_value?: string | null;
+location_options?: string[] | null;
+resolved_location?: string | null;
+time_mode?: 'set' | 'preferences' | 'suggestions' | null;
+time_value?: string | null;
+time_options?: string[] | null;
+resolved_time?: string | null;
+is_sub_poll?: boolean;
+sub_poll_role?: string | null;
+parent_participation_poll_id?: string | null;
+location_suggestions_deadline_minutes?: number | null;
+location_preferences_deadline_minutes?: number | null;
+time_suggestions_deadline_minutes?: number | null;
+time_preferences_deadline_minutes?: number | null;
+```
+
+### 3b. Update `lib/api.ts`
+
+- Add new fields to `apiCreatePoll` params and `toPoll` mapping
+- Add `apiGetSubPolls(pollId: string): Promise<Poll[]>` function
+
+---
+
+## Phase 4: Frontend — Create Poll UI
+
+### 4a. New state in `app/create-poll/page.tsx`
+
+```typescript
+const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('suggestions');
+const [locationValue, setLocationValue] = useState('');
+const [locationOptions, setLocationOptions] = useState<string[]>(['', '']);
+const [locationSuggestionsDeadline, setLocationSuggestionsDeadline] = useState('');
+const [locationPreferencesDeadline, setLocationPreferencesDeadline] = useState('');
+const [showLocationOptionsModal, setShowLocationOptionsModal] = useState(false);
+// Same for time_*
+```
+
+Default mode is "Ask for Suggestions" (most common use case).
+
+### 4b. UI layout (only when `pollType === 'participation'`)
+
+Below existing participation poll settings, add two sections:
+
+**Location:**
+```
+[Label: "Location"]  [Dropdown: Ask for Suggestions ▼]
+                      - Ask for Suggestions (default)
+                      - Ask for Preferences (3)  ← count shown when modal has been used
+                      - Set
+```
+
+- **Ask for Suggestions**: Show two deadline dropdowns (suggestions phase, preferences phase)
+- **Ask for Preferences**: Clicking opens modal with `OptionsInput` component. After closing, show option count. Show one deadline dropdown (preferences phase)
+- **Set**: Show text input
+
+**Time:** Same structure.
+
+### 4c. Preferences modal
+
+Reuse existing `OptionsInput` component inside a modal overlay. No submit button — modal closes on tap-away. The options state persists after close. Show count in dropdown label: "Ask for Preferences (3)"
+
+### 4d. Form submission
+
+In `handleConfirmSubmit`, include location/time fields in the API request. Map deadline dropdown values to minutes using existing `baseDeadlineOptions` lookup.
+
+### 4e. Client-side validation
+
+- Sub-poll deadlines < main poll deadline
+- "suggestions" mode: preferences deadline > suggestions deadline
+- "set" mode: non-empty value
+- "preferences" mode: >= 2 options
+
+---
+
+## Phase 5: Frontend — Participation Poll Display
+
+### 5a. Fetch sub-polls in `PollPageClient.tsx`
+
+On mount, if poll has `location_mode` or `time_mode` (non-null, not 'set'), call `apiGetSubPolls(pollId)`.
+
+### 5b. New component: `SubPollField.tsx`
+
+Displays a location or time field on the participation poll page:
+
+- **Resolved** (`resolved_location`/`resolved_time` set): Show the value as a clickable link → navigates to the preferences sub-poll results
+- **Sub-poll open** (nomination or ranked_choice): Show "Vote on location"/"Suggest a time" button → navigates to active sub-poll. Show countdown.
+- **Between phases** (nomination closed, preferences pending): Show "Resolving suggestions..." status
+- **Set mode**: Show static value (no link)
+
+### 5c. Sub-poll back navigation
+
+On sub-poll pages (where `parent_participation_poll_id` is set), show a "Back to <participation poll title>" link.
+
+### 5d. Creator secret propagation
+
+When navigating from participation poll to sub-poll, propagate the parent's creator secret to the sub-poll in localStorage. Follow existing pattern from `browserPollAccess.ts`.
+
+---
+
+## Phase 6: Round 0 — Nomination Results in Ranked Choice
+
+### Update `CompactRankedChoiceResults.tsx`
+
+When the ranked_choice poll has `follow_up_to` pointing to a nomination poll:
+
+1. Detect: check if parent poll is nomination type (fetch parent poll data)
+2. Fetch parent nomination poll results
+3. Prepend "Round 0: Suggestions" to the round visualizations
+4. Use the `NominationsList` component (pills with vote counts) for Round 0 display
+5. Adjust round navigation to start from 0
+
+---
+
+## Implementation Order
+
+| Step | What | Files |
+|------|------|-------|
+| 1 | Database migration 069 (all new columns) | `database/migrations/069_*` |
+| 2 | Database migration 070 (options columns) | `database/migrations/070_*` |
+| 3 | Python models | `server/models.py` |
+| 4 | API: create_poll sub-poll creation | `server/routers/polls.py` |
+| 5 | API: sub-polls endpoint | `server/routers/polls.py` |
+| 6 | API: resolution logic | `server/routers/polls.py` |
+| 7 | API: hide sub-polls from list | `server/routers/polls.py` |
+| 8 | API: validation | `server/routers/polls.py` |
+| 9 | TypeScript types | `lib/types.ts` |
+| 10 | API client | `lib/api.ts` |
+| 11 | Create-poll UI | `app/create-poll/page.tsx` |
+| 12 | SubPollField component | `components/SubPollField.tsx` |
+| 13 | Participation poll display | `app/p/[shortId]/PollPageClient.tsx` |
+| 14 | Round 0 in ranked choice results | `components/CompactRankedChoiceResults.tsx` |
+| 15 | Python tests | `server/tests/` |
+| 16 | Frontend tests | `tests/__tests__/` |
+
+---
+
+## Risks & Mitigations
+
+- **Constraint stacking**: PostgreSQL only reports first failing constraint. Add logging before each INSERT, test incrementally.
+- **Deadline validation**: Multiple nested deadline relationships. Validate all server-side in `create_poll`.
+- **Creator secret propagation**: Sub-polls share parent's `creator_secret`. Frontend must use `recordPollCreation()` when navigating to sub-polls.
+- **Race conditions on resolution**: Use `WHERE is_closed = false` in UPDATE (existing pattern).
+- **`_activate_reserved_preferences_poll` must propagate sub-poll metadata**: When activating the reserved ranked_choice poll, copy `parent_participation_poll_id`, `is_sub_poll`, and `sub_poll_role` from the nomination sub-poll.
+
+---
+
+## Existing Code to Reuse
+
+| Pattern | Where | Reuse How |
+|---------|-------|-----------|
+| `auto_create_preferences` + reserved placeholder | `server/routers/polls.py` lines 246-257 | Nomination → preferences chain for "suggestions" mode |
+| `_activate_reserved_preferences_poll` | `server/routers/polls.py` lines 85-153 | Fires when nomination sub-poll closes |
+| `_check_auto_close` | `server/routers/polls.py` line 369 | Hook resolution logic after auto-close |
+| `OptionsInput` component | `components/OptionsInput.tsx` | Reuse in preferences modal (no duplication) |
+| `NominationsList` component | `components/NominationsList.tsx` | Reuse for Round 0 display |
+| Deadline lazy-close in `get_results` | `server/routers/polls.py` lines 459-475 | Same pattern for sub-poll deadline expiry |
+| `baseDeadlineOptions` | `app/create-poll/page.tsx` | Map deadline dropdown values to minutes |

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -106,6 +106,21 @@ function toPoll(data: any): Poll {
     auto_create_preferences: data.auto_create_preferences ?? undefined,
     auto_preferences_deadline_minutes: data.auto_preferences_deadline_minutes ?? undefined,
     details: data.details ?? undefined,
+    location_mode: data.location_mode ?? undefined,
+    location_value: data.location_value ?? undefined,
+    location_options: data.location_options ?? undefined,
+    resolved_location: data.resolved_location ?? undefined,
+    time_mode: data.time_mode ?? undefined,
+    time_value: data.time_value ?? undefined,
+    time_options: data.time_options ?? undefined,
+    resolved_time: data.resolved_time ?? undefined,
+    is_sub_poll: data.is_sub_poll ?? undefined,
+    sub_poll_role: data.sub_poll_role ?? undefined,
+    parent_participation_poll_id: data.parent_participation_poll_id ?? undefined,
+    location_suggestions_deadline_minutes: data.location_suggestions_deadline_minutes ?? undefined,
+    location_preferences_deadline_minutes: data.location_preferences_deadline_minutes ?? undefined,
+    time_suggestions_deadline_minutes: data.time_suggestions_deadline_minutes ?? undefined,
+    time_preferences_deadline_minutes: data.time_preferences_deadline_minutes ?? undefined,
   };
 }
 
@@ -159,12 +174,27 @@ export async function apiCreatePoll(params: {
   auto_preferences_deadline_minutes?: number;
   auto_close_after?: number;
   details?: string;
+  location_mode?: string;
+  location_value?: string;
+  location_options?: string[];
+  time_mode?: string;
+  time_value?: string;
+  time_options?: string[];
+  location_suggestions_deadline_minutes?: number;
+  location_preferences_deadline_minutes?: number;
+  time_suggestions_deadline_minutes?: number;
+  time_preferences_deadline_minutes?: number;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',
     body: JSON.stringify(params),
   });
   return toPoll(data);
+}
+
+export async function apiGetSubPolls(pollId: string): Promise<Poll[]> {
+  const data: any[] = await apiFetch(`/${encodeURIComponent(pollId)}/sub-polls`);
+  return data.map(toPoll);
 }
 
 export async function apiGetPollByShortId(shortId: string): Promise<Poll> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,22 @@ export interface Poll {
   auto_preferences_deadline_minutes?: number;
   auto_close_after?: number;
   details?: string;
+  // Location/time fields for participation polls
+  location_mode?: 'set' | 'preferences' | 'suggestions' | null;
+  location_value?: string | null;
+  location_options?: string[] | null;
+  resolved_location?: string | null;
+  time_mode?: 'set' | 'preferences' | 'suggestions' | null;
+  time_value?: string | null;
+  time_options?: string[] | null;
+  resolved_time?: string | null;
+  is_sub_poll?: boolean;
+  sub_poll_role?: string | null;
+  parent_participation_poll_id?: string | null;
+  location_suggestions_deadline_minutes?: number | null;
+  location_preferences_deadline_minutes?: number | null;
+  time_suggestions_deadline_minutes?: number | null;
+  time_preferences_deadline_minutes?: number | null;
 }
 
 export interface Vote {

--- a/server/models.py
+++ b/server/models.py
@@ -37,6 +37,17 @@ class CreatePollRequest(BaseModel):
     auto_preferences_deadline_minutes: int | None = None
     auto_close_after: int | None = None
     details: str | None = None
+    # Location/time fields for participation polls
+    location_mode: str | None = None
+    location_value: str | None = None
+    location_options: list[str] | None = None
+    time_mode: str | None = None
+    time_value: str | None = None
+    time_options: list[str] | None = None
+    location_suggestions_deadline_minutes: int | None = None
+    location_preferences_deadline_minutes: int | None = None
+    time_suggestions_deadline_minutes: int | None = None
+    time_preferences_deadline_minutes: int | None = None
 
 
 class SubmitVoteRequest(BaseModel):
@@ -107,6 +118,22 @@ class PollResponse(BaseModel):
     auto_preferences_deadline_minutes: int | None = None
     auto_close_after: int | None = None
     details: str | None = None
+    # Location/time fields
+    location_mode: str | None = None
+    location_value: str | None = None
+    location_options: list[str] | None = None
+    resolved_location: str | None = None
+    time_mode: str | None = None
+    time_value: str | None = None
+    time_options: list[str] | None = None
+    resolved_time: str | None = None
+    is_sub_poll: bool = False
+    sub_poll_role: str | None = None
+    parent_participation_poll_id: str | None = None
+    location_suggestions_deadline_minutes: int | None = None
+    location_preferences_deadline_minutes: int | None = None
+    time_suggestions_deadline_minutes: int | None = None
+    time_preferences_deadline_minutes: int | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -343,6 +343,8 @@ def _resolve_sub_poll_winner(conn, poll_row: dict) -> None:
 
     # Determine which field to resolve
     field = sub_poll_role.replace("_preferences", "")  # "location" or "time"
+    if field not in ("location", "time"):
+        return
     resolved_column = f"resolved_{field}"
 
     # Get the winner from the ranked choice results

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -76,10 +76,21 @@ def _check_auto_close(conn, poll_id: str) -> None:
             )
             closed = True
 
-    # If we just closed a nomination poll, activate the reserved preferences poll
-    if closed and poll.get("auto_create_preferences"):
-        now = datetime.now(timezone.utc)
-        _activate_reserved_preferences_poll(conn, dict(poll), now)
+    if closed:
+        # If we just closed a nomination poll, activate the reserved preferences poll
+        if poll.get("auto_create_preferences"):
+            now = datetime.now(timezone.utc)
+            _activate_reserved_preferences_poll(conn, dict(poll), now)
+
+        # If we just closed a ranked_choice sub-poll, resolve the winner to parent
+        if poll["poll_type"] == "ranked_choice" and poll.get("sub_poll_role"):
+            # Re-fetch to get full row for resolution
+            full_poll = conn.execute(
+                "SELECT * FROM polls WHERE id = %(poll_id)s",
+                {"poll_id": poll_id},
+            ).fetchone()
+            if full_poll:
+                _resolve_sub_poll_winner(conn, dict(full_poll))
 
 
 def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -> None:
@@ -134,14 +145,17 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
     from datetime import timedelta
     deadline = now + timedelta(minutes=deadline_minutes)
 
-    # Activate the reserved poll
+    # Activate the reserved poll (propagate sub-poll metadata if present)
     conn.execute(
         """
         UPDATE polls
         SET options = %(options)s::jsonb,
             response_deadline = %(deadline)s,
             is_closed = false,
-            updated_at = %(now)s
+            updated_at = %(now)s,
+            is_sub_poll = COALESCE(%(is_sub_poll)s, is_sub_poll),
+            sub_poll_role = COALESCE(%(sub_poll_role)s, sub_poll_role),
+            parent_participation_poll_id = COALESCE(%(parent_id)s, parent_participation_poll_id)
         WHERE id = %(reserved_id)s
         """,
         {
@@ -149,6 +163,9 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
             "deadline": deadline.isoformat(),
             "now": now,
             "reserved_id": str(reserved["id"]),
+            "is_sub_poll": parent_row.get("is_sub_poll") or None,
+            "sub_poll_role": None,  # Already set at creation for sub-polls
+            "parent_id": str(parent_row["parent_participation_poll_id"]) if parent_row.get("parent_participation_poll_id") else None,
         },
     )
 
@@ -176,6 +193,21 @@ def _row_to_poll(row: dict) -> PollResponse:
         auto_preferences_deadline_minutes=row.get("auto_preferences_deadline_minutes"),
         auto_close_after=row.get("auto_close_after"),
         details=row.get("details"),
+        location_mode=row.get("location_mode"),
+        location_value=row.get("location_value"),
+        location_options=row.get("location_options"),
+        resolved_location=row.get("resolved_location"),
+        time_mode=row.get("time_mode"),
+        time_value=row.get("time_value"),
+        time_options=row.get("time_options"),
+        resolved_time=row.get("resolved_time"),
+        is_sub_poll=row.get("is_sub_poll", False),
+        sub_poll_role=row.get("sub_poll_role"),
+        parent_participation_poll_id=str(row["parent_participation_poll_id"]) if row.get("parent_participation_poll_id") else None,
+        location_suggestions_deadline_minutes=row.get("location_suggestions_deadline_minutes"),
+        location_preferences_deadline_minutes=row.get("location_preferences_deadline_minutes"),
+        time_suggestions_deadline_minutes=row.get("time_suggestions_deadline_minutes"),
+        time_preferences_deadline_minutes=row.get("time_preferences_deadline_minutes"),
     )
 
 
@@ -197,6 +229,152 @@ def _row_to_vote(row: dict) -> VoteResponse:
     )
 
 
+def _create_sub_polls_for_field(
+    conn, now, parent_id, parent_title, creator_secret, creator_name,
+    field: str, mode: str | None, options: list[str] | None,
+    suggestions_deadline_minutes: int | None,
+    preferences_deadline_minutes: int | None,
+) -> None:
+    """Create sub-polls for a location or time field on a participation poll."""
+    import json
+    from datetime import timedelta
+
+    if not mode or mode == "set":
+        return
+
+    label = "Location" if field == "location" else "Time"
+    sub_title = f"{label} for {parent_title}"
+
+    if mode == "preferences":
+        # Create a ranked_choice sub-poll with creator-provided options
+        deadline_mins = preferences_deadline_minutes or 10
+        deadline = now + timedelta(minutes=deadline_mins)
+        conn.execute(
+            """
+            INSERT INTO polls (title, poll_type, options, response_deadline,
+                               creator_secret, creator_name,
+                               is_sub_poll, sub_poll_role,
+                               parent_participation_poll_id,
+                               is_closed, created_at, updated_at)
+            VALUES (%(title)s, 'ranked_choice', %(options)s::jsonb, %(deadline)s,
+                    %(creator_secret)s, %(creator_name)s,
+                    true, %(sub_poll_role)s,
+                    %(parent_id)s,
+                    false, %(now)s, %(now)s)
+            """,
+            {
+                "title": sub_title,
+                "options": json.dumps(options),
+                "deadline": deadline.isoformat(),
+                "creator_secret": creator_secret,
+                "creator_name": creator_name,
+                "sub_poll_role": f"{field}_preferences",
+                "parent_id": parent_id,
+                "now": now,
+            },
+        )
+
+    elif mode == "suggestions":
+        # Create a nomination sub-poll
+        sug_deadline_mins = suggestions_deadline_minutes or 10
+        sug_deadline = now + timedelta(minutes=sug_deadline_mins)
+        nom_row = conn.execute(
+            """
+            INSERT INTO polls (title, poll_type, response_deadline,
+                               creator_secret, creator_name,
+                               is_sub_poll, sub_poll_role,
+                               parent_participation_poll_id,
+                               auto_create_preferences,
+                               auto_preferences_deadline_minutes,
+                               is_closed, created_at, updated_at)
+            VALUES (%(title)s, 'nomination', %(deadline)s,
+                    %(creator_secret)s, %(creator_name)s,
+                    true, %(sub_poll_role)s,
+                    %(parent_id)s,
+                    true, %(pref_deadline_mins)s,
+                    false, %(now)s, %(now)s)
+            RETURNING id
+            """,
+            {
+                "title": sub_title,
+                "deadline": sug_deadline.isoformat(),
+                "creator_secret": creator_secret,
+                "creator_name": creator_name,
+                "sub_poll_role": f"{field}_suggestions",
+                "parent_id": parent_id,
+                "pref_deadline_mins": preferences_deadline_minutes or 10,
+                "now": now,
+            },
+        ).fetchone()
+
+        # Create a reserved ranked_choice sub-poll (placeholder)
+        conn.execute(
+            """
+            INSERT INTO polls (title, poll_type, is_closed, follow_up_to,
+                               creator_secret, creator_name,
+                               is_sub_poll, sub_poll_role,
+                               parent_participation_poll_id,
+                               created_at, updated_at)
+            VALUES (%(title)s, 'ranked_choice', true, %(nom_id)s,
+                    %(creator_secret)s, %(creator_name)s,
+                    true, %(sub_poll_role)s,
+                    %(parent_id)s,
+                    %(now)s, %(now)s)
+            """,
+            {
+                "title": sub_title,
+                "nom_id": str(nom_row["id"]),
+                "creator_secret": creator_secret,
+                "creator_name": creator_name,
+                "sub_poll_role": f"{field}_preferences",
+                "parent_id": parent_id,
+                "now": now,
+            },
+        )
+
+
+def _resolve_sub_poll_winner(conn, poll_row: dict) -> None:
+    """When a ranked_choice sub-poll with sub_poll_role closes, resolve the winner
+    back to the parent participation poll."""
+    sub_poll_role = poll_row.get("sub_poll_role")
+    parent_id = poll_row.get("parent_participation_poll_id")
+    if not sub_poll_role or not parent_id or not sub_poll_role.endswith("_preferences"):
+        return
+
+    # Determine which field to resolve
+    field = sub_poll_role.replace("_preferences", "")  # "location" or "time"
+    resolved_column = f"resolved_{field}"
+
+    # Get the winner from the ranked choice results
+    from algorithms.ranked_choice import calculate_ranked_choice_winner
+    import json
+
+    poll_id = str(poll_row["id"])
+    votes = conn.execute(
+        "SELECT * FROM votes WHERE poll_id = %(poll_id)s",
+        {"poll_id": poll_id},
+    ).fetchall()
+
+    raw_options = poll_row.get("options")
+    poll_options = []
+    if raw_options:
+        poll_options = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
+
+    if not poll_options or not votes:
+        return
+
+    result = calculate_ranked_choice_winner([dict(v) for v in votes], poll_options)
+    if result.winner:
+        conn.execute(
+            f"UPDATE polls SET {resolved_column} = %(winner)s, updated_at = %(now)s WHERE id = %(parent_id)s",
+            {
+                "winner": result.winner,
+                "now": datetime.now(timezone.utc),
+                "parent_id": str(parent_id),
+            },
+        )
+
+
 # --- Poll CRUD ---
 
 
@@ -204,7 +382,26 @@ def _row_to_vote(row: dict) -> VoteResponse:
 def create_poll(req: CreatePollRequest):
     """Create a new poll."""
     now = datetime.now(timezone.utc)
+
+    # Validation for location/time fields
+    if req.location_mode or req.time_mode:
+        if req.poll_type != PollType.participation:
+            raise HTTPException(status_code=400, detail="Location/time modes are only valid for participation polls")
+
+    if req.location_mode == "set" and not req.location_value:
+        raise HTTPException(status_code=400, detail="Location value is required for 'set' mode")
+    if req.time_mode == "set" and not req.time_value:
+        raise HTTPException(status_code=400, detail="Time value is required for 'set' mode")
+    if req.location_mode == "preferences" and (not req.location_options or len(req.location_options) < 2):
+        raise HTTPException(status_code=400, detail="At least 2 location options are required for 'preferences' mode")
+    if req.time_mode == "preferences" and (not req.time_options or len(req.time_options) < 2):
+        raise HTTPException(status_code=400, detail="At least 2 time options are required for 'preferences' mode")
+
     with get_db() as conn:
+        # Determine resolved values for 'set' mode
+        resolved_location = req.location_value if req.location_mode == "set" else None
+        resolved_time = req.time_value if req.time_mode == "set" else None
+
         row = conn.execute(
             """
             INSERT INTO polls (title, poll_type, options, response_deadline,
@@ -212,12 +409,26 @@ def create_poll(req: CreatePollRequest):
                                fork_of, min_participants, max_participants,
                                auto_create_preferences, auto_preferences_deadline_minutes,
                                auto_close_after, details,
+                               location_mode, location_value, resolved_location,
+                               time_mode, time_value, resolved_time,
+                               location_options, time_options,
+                               location_suggestions_deadline_minutes,
+                               location_preferences_deadline_minutes,
+                               time_suggestions_deadline_minutes,
+                               time_preferences_deadline_minutes,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
                     %(fork_of)s, %(min_participants)s, %(max_participants)s,
                     %(auto_create_preferences)s, %(auto_preferences_deadline_minutes)s,
                     %(auto_close_after)s, %(details)s,
+                    %(location_mode)s, %(location_value)s, %(resolved_location)s,
+                    %(time_mode)s, %(time_value)s, %(resolved_time)s,
+                    %(location_options)s, %(time_options)s,
+                    %(location_suggestions_deadline_minutes)s,
+                    %(location_preferences_deadline_minutes)s,
+                    %(time_suggestions_deadline_minutes)s,
+                    %(time_preferences_deadline_minutes)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -236,9 +447,23 @@ def create_poll(req: CreatePollRequest):
                 "auto_preferences_deadline_minutes": req.auto_preferences_deadline_minutes,
                 "auto_close_after": req.auto_close_after,
                 "details": req.details,
+                "location_mode": req.location_mode,
+                "location_value": req.location_value,
+                "resolved_location": resolved_location,
+                "time_mode": req.time_mode,
+                "time_value": req.time_value,
+                "resolved_time": resolved_time,
+                "location_options": req.location_options,
+                "time_options": req.time_options,
+                "location_suggestions_deadline_minutes": req.location_suggestions_deadline_minutes,
+                "location_preferences_deadline_minutes": req.location_preferences_deadline_minutes,
+                "time_suggestions_deadline_minutes": req.time_suggestions_deadline_minutes,
+                "time_preferences_deadline_minutes": req.time_preferences_deadline_minutes,
                 "now": now,
             },
         ).fetchone()
+
+        parent_id = str(row["id"])
 
         # If this is a nomination poll with auto_create_preferences, reserve a
         # placeholder ranked_choice follow-up poll so no one else can create a
@@ -255,14 +480,39 @@ def create_poll(req: CreatePollRequest):
                 """,
                 {
                     "title": req.title,
-                    "parent_id": str(row["id"]),
+                    "parent_id": parent_id,
                     "creator_secret": req.creator_secret,
                     "creator_name": req.creator_name,
                     "now": now,
                 },
             )
 
+        # Create sub-polls for location/time fields
+        _create_sub_polls_for_field(
+            conn, now, parent_id, req.title, req.creator_secret, req.creator_name,
+            "location", req.location_mode, req.location_options,
+            req.location_suggestions_deadline_minutes,
+            req.location_preferences_deadline_minutes,
+        )
+        _create_sub_polls_for_field(
+            conn, now, parent_id, req.title, req.creator_secret, req.creator_name,
+            "time", req.time_mode, req.time_options,
+            req.time_suggestions_deadline_minutes,
+            req.time_preferences_deadline_minutes,
+        )
+
     return _row_to_poll(row)
+
+
+@router.get("/{poll_id}/sub-polls", response_model=list[PollResponse])
+def get_sub_polls(poll_id: str):
+    """Get all sub-polls for a participation poll."""
+    with get_db() as conn:
+        rows = conn.execute(
+            "SELECT * FROM polls WHERE parent_participation_poll_id = %(poll_id)s ORDER BY created_at",
+            {"poll_id": poll_id},
+        ).fetchall()
+    return [_row_to_poll(r) for r in rows]
 
 
 @router.get("/find-duplicate", response_model=PollResponse)
@@ -474,6 +724,22 @@ def get_results(poll_id: str):
             if result.rowcount == 1:
                 _activate_reserved_preferences_poll(conn, dict(poll), now)
 
+        # Auto-close ranked_choice sub-polls when deadline passes, and resolve winner
+        if (
+            poll["poll_type"] == "ranked_choice"
+            and poll.get("sub_poll_role")
+            and not poll["is_closed"]
+            and poll.get("response_deadline")
+            and poll["response_deadline"] <= now
+        ):
+            result = conn.execute(
+                """UPDATE polls SET is_closed = true, close_reason = 'deadline', updated_at = %(now)s
+                   WHERE id = %(poll_id)s AND is_closed = false""",
+                {"poll_id": poll_id, "now": now},
+            )
+            if result.rowcount == 1:
+                _resolve_sub_poll_winner(conn, dict(poll))
+
         votes = conn.execute(
             "SELECT * FROM votes WHERE poll_id = %(poll_id)s",
             {"poll_id": poll_id},
@@ -669,6 +935,10 @@ def close_poll(poll_id: str, req: ClosePollRequest):
         if row["poll_type"] == "nomination" and row.get("auto_create_preferences"):
             _activate_reserved_preferences_poll(conn, row, now)
 
+        # If this is a ranked_choice sub-poll, resolve the winner to parent
+        if row["poll_type"] == "ranked_choice" and row.get("sub_poll_role"):
+            _resolve_sub_poll_winner(conn, dict(row))
+
     return _row_to_poll(row)
 
 
@@ -706,7 +976,7 @@ def get_accessible_polls(req: AccessiblePollsRequest):
         return []
     with get_db() as conn:
         rows = conn.execute(
-            "SELECT * FROM polls WHERE id = ANY(%(poll_ids)s) ORDER BY created_at DESC",
+            "SELECT * FROM polls WHERE id = ANY(%(poll_ids)s) AND (is_sub_poll = false OR is_sub_poll IS NULL) ORDER BY created_at DESC",
             {"poll_ids": req.poll_ids},
         ).fetchall()
     return [_row_to_poll(r) for r in rows]

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -36,7 +36,8 @@ def _check_auto_close(conn, poll_id: str) -> None:
     """Auto-close a poll based on auto_close_after (respondent count) or max_participants."""
     poll = conn.execute(
         """SELECT id, poll_type, is_closed, auto_close_after, max_participants,
-                  auto_create_preferences, auto_preferences_deadline_minutes
+                  auto_create_preferences, auto_preferences_deadline_minutes,
+                  sub_poll_role, parent_participation_poll_id, options
            FROM polls WHERE id = %(poll_id)s""",
         {"poll_id": poll_id},
     ).fetchone()
@@ -84,13 +85,7 @@ def _check_auto_close(conn, poll_id: str) -> None:
 
         # If we just closed a ranked_choice sub-poll, resolve the winner to parent
         if poll["poll_type"] == "ranked_choice" and poll.get("sub_poll_role"):
-            # Re-fetch to get full row for resolution
-            full_poll = conn.execute(
-                "SELECT * FROM polls WHERE id = %(poll_id)s",
-                {"poll_id": poll_id},
-            ).fetchone()
-            if full_poll:
-                _resolve_sub_poll_winner(conn, dict(full_poll))
+            _resolve_sub_poll_winner(conn, dict(poll))
 
 
 def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -> None:


### PR DESCRIPTION
## Summary
- Add optional Location and Time fields to participation polls with three modes: **Set** (static value), **Ask for Preferences** (ranked choice sub-poll), **Ask for Suggestions** (nomination → ranked choice chain)
- Sub-polls are hidden from the main poll list and accessible only from the parent poll
- When a ranked choice sub-poll closes, the IRV winner auto-populates the parent's resolved location/time
- Creator secrets propagate from parent to sub-polls for management access

## Changes
- **Database**: Migrations 069-071 add 15 columns to polls table + index on `parent_participation_poll_id`
- **Backend**: Sub-poll creation in `create_poll`, resolution logic in `_resolve_sub_poll_winner`, new `/sub-polls` endpoint, sub-poll filtering in poll list
- **Frontend**: `LocationTimeFieldConfig` component for create-poll UI, `SubPollField` component for poll display, types/API client updates
- **Cleanup**: Deduplicated submission logic, extracted DeadlineSelect helper, removed redundant DB re-fetch, stabilized useEffect deps, added SQL injection whitelist

## Test plan
- [ ] Create participation poll with Location set to "Set" mode — verify static value displays
- [ ] Create participation poll with Location set to "Ask for Preferences" with 3 options — verify ranked choice sub-poll is created and accessible
- [ ] Create participation poll with Time set to "Ask for Suggestions" — verify nomination sub-poll is created, and closing it auto-creates preferences poll
- [ ] Verify sub-polls don't appear in the main poll list
- [ ] Verify closing a preferences sub-poll resolves the winner back to the parent poll
- [ ] Verify creator can manage sub-polls (secret propagation works)

https://claude.ai/code/session_01Ld6AE5u7NS7HhP9fht5mgF