### PR TITLE
Fix time range modal: enforce min < max dynamically

### DIFF
--- a/components/ScrollWheel.tsx
+++ b/components/ScrollWheel.tsx
@@ -115,7 +115,9 @@ export default function ScrollWheel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // When selectedIndex changes externally, sync scroll
+  // When selectedIndex changes externally, sync scroll.
+  // Suppress the scroll handler during programmatic scrolls so intermediate
+  // positions during the smooth animation don't fire onChange with stale indices.
   useEffect(() => {
     if (!didMount.current) return;
     if (suppressScrollHandler.current) return;
@@ -124,9 +126,16 @@ export default function ScrollWheel({
     lastReportedIndex.current = selectedIndex;
     const el = containerRef.current;
     if (el) {
+      suppressScrollHandler.current = true;
       el.scrollTo({ top: selectedToScroll(selectedIndex), behavior: 'smooth' });
+      // Re-enable after the smooth scroll settles
+      if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+      scrollTimeout.current = setTimeout(() => {
+        suppressScrollHandler.current = false;
+        updateItemStyles();
+      }, 300);
     }
-  }, [selectedIndex, selectedToScroll, items]);
+  }, [selectedIndex, selectedToScroll, items, updateItemStyles]);
 
   // Re-center the loop scroll position silently after scrolling stops
   const recenterLoop = useCallback(() => {

--- a/components/ScrollWheel.tsx
+++ b/components/ScrollWheel.tsx
@@ -17,6 +17,7 @@ const MAX_FONT_SIZE = 18;
 const MIN_OPACITY = 0.35;
 const LOOP_REPEATS = 40; // total copies of the item list when looping
 const LOOP_CENTER = Math.floor(LOOP_REPEATS / 2); // which repetition to center on
+const SMOOTH_SCROLL_SETTLE_MS = 300;
 
 export default function ScrollWheel({
   items,
@@ -128,13 +129,15 @@ export default function ScrollWheel({
     if (el) {
       suppressScrollHandler.current = true;
       el.scrollTo({ top: selectedToScroll(selectedIndex), behavior: 'smooth' });
-      // Re-enable after the smooth scroll settles
       if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
       scrollTimeout.current = setTimeout(() => {
         suppressScrollHandler.current = false;
         updateItemStyles();
-      }, 300);
+      }, SMOOTH_SCROLL_SETTLE_MS);
     }
+    return () => {
+      if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+    };
   }, [selectedIndex, selectedToScroll, items, updateItemStyles]);
 
   // Re-center the loop scroll position silently after scrolling stops

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -156,9 +156,7 @@ export default function TimeGridModal({
   let durationMinutes = 0;
   let durationLabel = '';
   if (localMinTime && localMaxTime && isValid) {
-    const [minH, minM] = localMinTime.split(':').map(Number);
-    const [maxH, maxM] = localMaxTime.split(':').map(Number);
-    durationMinutes = (maxH * 60 + maxM) - (minH * 60 + minM);
+    durationMinutes = timeToMinutes(localMaxTime) - timeToMinutes(localMinTime);
     const hours = Math.floor(durationMinutes / 60);
     const mins = durationMinutes % 60;
     if (hours > 0 && mins > 0) {

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import TimeMinMaxCounter from './TimeMinMaxCounter';
 
 // Duration bar width scaling constants
@@ -8,6 +8,20 @@ const MIN_DURATION = 15; // minutes
 const MAX_DURATION = 24 * 60;
 const MIN_WIDTH_PCT = 10;
 const MAX_WIDTH_PCT = 100;
+
+/** Convert "HH:MM" to total minutes since midnight */
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** Convert total minutes since midnight to "HH:MM" */
+function minutesToTime(totalMinutes: number): string {
+  const clamped = Math.max(0, Math.min(23 * 60 + 45, totalMinutes));
+  const h = Math.floor(clamped / 60);
+  const m = clamped % 60;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
 
 interface TimeGridModalProps {
   isOpen: boolean;
@@ -80,6 +94,36 @@ export default function TimeGridModal({
     setLocalMinTime(initMinTime);
     setLocalMaxTime(initMaxTime);
   }, [minValue, maxValue, isOpen]);
+
+  // Enforce min < max: when min changes, push max forward if needed
+  const handleMinChange = useCallback((newMin: string | null) => {
+    if (!newMin) { setLocalMinTime(newMin); return; }
+    setLocalMinTime(newMin);
+    setLocalMaxTime((prev: string | null) => {
+      if (!prev) return prev;
+      const minMins = timeToMinutes(newMin);
+      const maxMins = timeToMinutes(prev);
+      if (maxMins <= minMins) {
+        return minutesToTime(minMins + MIN_DURATION);
+      }
+      return prev;
+    });
+  }, []);
+
+  // Enforce min < max: when max changes, push min backward if needed
+  const handleMaxChange = useCallback((newMax: string | null) => {
+    if (!newMax) { setLocalMaxTime(newMax); return; }
+    setLocalMaxTime(newMax);
+    setLocalMinTime((prev: string | null) => {
+      if (!prev) return prev;
+      const maxMins = timeToMinutes(newMax);
+      const minMins = timeToMinutes(prev);
+      if (minMins >= maxMins) {
+        return minutesToTime(maxMins - MIN_DURATION);
+      }
+      return prev;
+    });
+  }, []);
 
   // Enable transitions after first render so the duration bar doesn't animate on open
   useEffect(() => {
@@ -173,8 +217,8 @@ export default function TimeGridModal({
           <TimeMinMaxCounter
             minValue={localMinTime}
             maxValue={localMaxTime}
-            onMinChange={setLocalMinTime}
-            onMaxChange={setLocalMaxTime}
+            onMinChange={handleMinChange}
+            onMaxChange={handleMaxChange}
             increment={15}
           />
         </div>


### PR DESCRIPTION
## Summary
- When scrolling the min time wheel past the max, the max wheel automatically pushes forward (and vice versa), maintaining at least a 15-minute gap
- Fix feedback loop where ScrollWheel's smooth scroll animation fired onChange with stale intermediate positions, causing the pushed wheel to fight back and corrupt the duration display
- Clean up: reuse `timeToMinutes()` in duration calculation, extract scroll settle timeout to named constant, add useEffect cleanup

## Test plan
- [ ] Open time range modal, set range to 7:00–7:15
- [ ] Scroll min to 8:00 — max should push to 8:15, duration should show 15m
- [ ] Scroll max below min — min should push backward, duration stays correct
- [ ] Scroll wheels that aren't being pushed still work smoothly (no jank from suppression)
- [ ] Verify other ScrollWheel usages (hour/minute/AM-PM) still work normally