### PR TITLE
Support cross-midnight time ranges in time window input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -837,6 +837,13 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Coalesce requestAnimationFrame calls.** On 120Hz displays, touchmove fires faster than rAF. Use a `rAFPending` flag to skip redundant frames and read the latest value at callback time (not call time).
 - **Touch listeners must go on the scroll container, not document.body.** `e.preventDefault()` on body touchmove doesn't suppress a child scroll container's native overscroll bounce. Attach listeners to the scrollable element directly.
 
+### Cross-Midnight Time Windows
+
+- **Time windows where `max <= min` represent cross-midnight ranges** (e.g., 10 PM–2 AM). Equal start/end means a full 24-hour window. Use `<=` consistently in all cross-midnight detection — `<` misses the equal-times-as-24h case.
+- **String comparison works for HH:MM cross-midnight detection** only because the format is always zero-padded. `"02:00" < "22:00"` is correct lexicographically. If the format ever loses zero-padding (e.g., `"2:00"`), all comparisons silently break.
+- **`_window_effective_end()` in `time_slots.py`** is the canonical backend helper — it adds 1440 minutes when `w_end <= w_start`. The frontend has no shared utility yet; cross-midnight checks are inline in `DayTimeWindowsInput`, `ParticipationConditionsCard`, `TimeSlotRoundsDisplay`, and `TimeGridModal`.
+- **Looping scroll wheels must scroll to the nearest occurrence** of the target index, not the center repetition. Otherwise wraparound (12→1) causes the wheel to scroll the long way around through all values.
+
 ### Service Worker Caching Strategy
 
 - **Never use `url.pathname.startsWith('/')` in service worker URL matching** — it matches ALL paths. Use exact equality (`===`) or more specific prefixes like `/create-poll`.

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -120,6 +120,8 @@ export default function DayTimeWindowsInput({
               {(() => {
                 const minFormatted = formatTime12Hour(window.min);
                 const maxFormatted = formatTime12Hour(window.max);
+                // Cross-midnight: end time is earlier than start time (e.g., 10 PM - 2 AM)
+                const isCrossMidnight = window.max < window.min;
                 return (
                   <>
                     {minFormatted.time}
@@ -131,6 +133,11 @@ export default function DayTimeWindowsInput({
                     <span className={`ml-0.5 ${maxFormatted.period === 'AM' ? 'text-orange-500 dark:text-orange-400' : 'text-purple-600 dark:text-purple-400'}`}>
                       {maxFormatted.period}
                     </span>
+                    {isCrossMidnight && (
+                      <span className="ml-0.5 text-amber-600 dark:text-amber-400 text-xs font-semibold">
+                        +1
+                      </span>
+                    )}
                   </>
                 );
               })()}

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -120,8 +120,7 @@ export default function DayTimeWindowsInput({
               {(() => {
                 const minFormatted = formatTime12Hour(window.min);
                 const maxFormatted = formatTime12Hour(window.max);
-                // Cross-midnight: end time is earlier than start time (e.g., 10 PM - 2 AM)
-                const isCrossMidnight = window.max < window.min;
+                const isCrossMidnight = window.max <= window.min;
                 return (
                   <>
                     {minFormatted.time}

--- a/components/ParticipationConditionsCard.tsx
+++ b/components/ParticipationConditionsCard.tsx
@@ -106,7 +106,7 @@ export default function ParticipationConditionsCard({
         return dayStr; // Just the day, no time windows
       }
       const windowsStr = dtw.windows.map(w => {
-        const isCrossMidnight = w.max < w.min;
+        const isCrossMidnight = w.max <= w.min;
         return `${formatTime(w.min)}-${formatTime(w.max)}${isCrossMidnight ? ' +1' : ''}`;
       }).join(', ');
       return `${dayStr} (${windowsStr})`;

--- a/components/ParticipationConditionsCard.tsx
+++ b/components/ParticipationConditionsCard.tsx
@@ -105,7 +105,10 @@ export default function ParticipationConditionsCard({
       if (dtw.windows.length === 0) {
         return dayStr; // Just the day, no time windows
       }
-      const windowsStr = dtw.windows.map(w => `${formatTime(w.min)}-${formatTime(w.max)}`).join(', ');
+      const windowsStr = dtw.windows.map(w => {
+        const isCrossMidnight = w.max < w.min;
+        return `${formatTime(w.min)}-${formatTime(w.max)}${isCrossMidnight ? ' +1' : ''}`;
+      }).join(', ');
       return `${dayStr} (${windowsStr})`;
     }).join('; ');
   };

--- a/components/ScrollWheel.tsx
+++ b/components/ScrollWheel.tsx
@@ -10,6 +10,7 @@ interface ScrollWheelProps {
   visibleItems?: number;
   width?: number;
   loop?: boolean;
+  hideHighlight?: boolean;
 }
 
 const MIN_FONT_SIZE = 14;
@@ -27,6 +28,7 @@ export default function ScrollWheel({
   visibleItems = 5,
   width,
   loop = false,
+  hideHighlight = false,
 }: ScrollWheelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -235,11 +237,13 @@ export default function ScrollWheel({
 
   return (
     <div className="relative" style={{ height: containerHeight, width }}>
-      {/* Selection highlight band */}
-      <div
-        className="absolute left-0 right-0 pointer-events-none bg-blue-50/50 dark:bg-blue-900/20 z-0"
-        style={{ top: padding, height: itemHeight }}
-      />
+      {/* Selection highlight band (can be hidden when parent provides its own) */}
+      {!hideHighlight && (
+        <div
+          className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-lg"
+          style={{ top: padding, height: itemHeight }}
+        />
+      )}
       {/* Top fade */}
       <div
         className="absolute top-0 left-0 right-0 pointer-events-none z-20 bg-gradient-to-b from-white dark:from-gray-800 to-transparent"

--- a/components/ScrollWheel.tsx
+++ b/components/ScrollWheel.tsx
@@ -130,7 +130,31 @@ export default function ScrollWheel({
     const el = containerRef.current;
     if (el) {
       suppressScrollHandler.current = true;
-      el.scrollTo({ top: selectedToScroll(selectedIndex), behavior: 'smooth' });
+      // For looping wheels, scroll to the nearest occurrence of the target index
+      // instead of always jumping to the center repetition. This prevents the
+      // wheel from scrolling the long way around (e.g., 12→1 going backwards).
+      let targetScroll = selectedToScroll(selectedIndex);
+      if (loop) {
+        const currentRawIndex = Math.round(el.scrollTop / itemHeight);
+        const currentRepStart = Math.floor(currentRawIndex / items.length) * items.length;
+        // Check the occurrence in the current, previous, and next repetitions
+        const candidates = [
+          currentRepStart - items.length + selectedIndex,
+          currentRepStart + selectedIndex,
+          currentRepStart + items.length + selectedIndex,
+        ];
+        let bestCandidate = candidates[1];
+        let bestDist = Math.abs(candidates[1] - currentRawIndex);
+        for (const c of candidates) {
+          const dist = Math.abs(c - currentRawIndex);
+          if (dist < bestDist) {
+            bestDist = dist;
+            bestCandidate = c;
+          }
+        }
+        targetScroll = bestCandidate * itemHeight;
+      }
+      el.scrollTo({ top: targetScroll, behavior: 'smooth' });
       if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
       scrollTimeout.current = setTimeout(() => {
         suppressScrollHandler.current = false;
@@ -140,7 +164,7 @@ export default function ScrollWheel({
     return () => {
       if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
     };
-  }, [selectedIndex, selectedToScroll, items, updateItemStyles]);
+  }, [selectedIndex, selectedToScroll, items, updateItemStyles, loop, itemHeight]);
 
   // Re-center the loop scroll position silently after scrolling stops
   const recenterLoop = useCallback(() => {

--- a/components/ScrollWheel.tsx
+++ b/components/ScrollWheel.tsx
@@ -237,7 +237,7 @@ export default function ScrollWheel({
     <div className="relative" style={{ height: containerHeight, width }}>
       {/* Selection highlight band */}
       <div
-        className="absolute left-0 right-0 pointer-events-none border-y border-blue-400 dark:border-blue-500 bg-blue-50/50 dark:bg-blue-900/20 z-0"
+        className="absolute left-0 right-0 pointer-events-none bg-blue-50/50 dark:bg-blue-900/20 z-0"
         style={{ top: padding, height: itemHeight }}
       />
       {/* Top fade */}

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -128,14 +128,24 @@ export default function TimeCounterInput({
     emit(hourIndex, minuteIndex, newPeriodIndex);
   };
 
+  const itemHeight = 40;
+  const visibleItems = 5;
+  const highlightTop = Math.floor(visibleItems / 2) * itemHeight;
+
   return (
-    <div className={`flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
+    <div className={`relative flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
+      {/* Unified highlight band spanning all wheels */}
+      <div
+        className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-xl"
+        style={{ top: highlightTop, height: itemHeight }}
+      />
       <ScrollWheel
         items={HOUR_LABELS}
         selectedIndex={hourIndex}
         onChange={handleHourChange}
         width={45}
         loop
+        hideHighlight
       />
       <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
       <ScrollWheel
@@ -144,6 +154,7 @@ export default function TimeCounterInput({
         onChange={handleMinuteChange}
         width={45}
         loop
+        hideHighlight
       />
       <div className="w-1" />
       <ScrollWheel
@@ -151,6 +162,7 @@ export default function TimeCounterInput({
         selectedIndex={periodIndex}
         onChange={handlePeriodChange}
         width={42}
+        hideHighlight
       />
     </div>
   );

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -173,11 +173,12 @@ export default function TimeGridModal({
         <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Select Time Window</h3>
           <button
-            onClick={handleCancel}
-            className="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            onClick={handleApply}
+            className="p-1 rounded-full hover:bg-green-50 dark:hover:bg-green-900/30 transition-colors"
           >
-            <svg className="w-5 h-5 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg className="w-7 h-7 text-green-500 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4" />
+              <circle cx="12" cy="12" r="10" strokeWidth={2} />
             </svg>
           </button>
         </div>
@@ -210,22 +211,8 @@ export default function TimeGridModal({
           />
         </div>
 
-        {/* Footer */}
-        <div className="p-4 pt-0 flex justify-end gap-2">
-          <button
-            onClick={handleCancel}
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleApply}
-            disabled={!isValid}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-blue-600"
-          >
-            OK
-          </button>
-        </div>
+        {/* Bottom padding to balance the layout */}
+        <div className="pb-4" />
       </div>
     </div>
   );

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -170,22 +170,22 @@ export default function TimeGridModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-between px-3 pt-2">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Select Time Window</h3>
           <button
             onClick={handleApply}
-            className="p-1 rounded-full hover:bg-green-50 dark:hover:bg-green-900/30 transition-colors"
+            className="p-0.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
           >
-            <svg className="w-7 h-7 text-green-500 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4" />
-              <circle cx="12" cy="12" r="10" strokeWidth={2} />
+            <svg className="w-10 h-10 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4" />
+              <circle cx="12" cy="12" r="10" strokeWidth={1.5} />
             </svg>
           </button>
         </div>
 
         {/* Duration bar */}
         {durationMinutes > 0 && (
-          <div className="px-6 pt-4 flex flex-col items-center gap-1">
+          <div className="px-3 pt-1 flex flex-col items-center gap-0.5">
             <div
               className={`h-7 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center ${transitionsEnabled ? 'transition-all duration-200' : ''}`}
               style={{ width: `${widthPct}%` }}
@@ -201,7 +201,7 @@ export default function TimeGridModal({
         )}
 
         {/* Time selector */}
-        <div className="p-6 pt-3">
+        <div className="px-3 pt-1 pb-3">
           <TimeMinMaxCounter
             minValue={localMinTime}
             maxValue={localMaxTime}
@@ -210,9 +210,6 @@ export default function TimeGridModal({
             increment={15}
           />
         </div>
-
-        {/* Bottom padding to balance the layout */}
-        <div className="pb-4" />
       </div>
     </div>
   );

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -200,7 +200,7 @@ export default function TimeGridModal({
         )}
 
         {/* Time selector */}
-        <div className="px-3 pt-1 pb-3">
+        <div className="px-3 pb-3">
           <TimeMinMaxCounter
             minValue={localMinTime}
             maxValue={localMaxTime}

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -193,11 +193,9 @@ export default function TimeGridModal({
                 {durationLabel}
               </span>
             </div>
-            {crossesMidnight && (
-              <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">
-                Crosses midnight (+1 day)
-              </span>
-            )}
+            <span className={`text-xs font-medium ${crossesMidnight ? 'text-amber-600 dark:text-amber-400' : 'text-transparent'}`}>
+              Crosses midnight (+1 day)
+            </span>
           </div>
         )}
 

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -128,11 +128,11 @@ export default function TimeGridModal({
     onClose();
   };
 
-  // Validation: both times must be set and they can't be identical
-  const isValid = localMinTime !== null && localMaxTime !== null && localMinTime !== localMaxTime;
+  // Validation: both times must be set (equal times = full 24h window)
+  const isValid = localMinTime !== null && localMaxTime !== null;
 
-  // Cross-midnight detection: max < min means the range wraps past midnight
-  const crossesMidnight = isValid && timeToMinutes(localMaxTime!) < timeToMinutes(localMinTime!);
+  // Cross-midnight detection: max <= min means the range wraps past midnight (equal = 24h)
+  const crossesMidnight = isValid && timeToMinutes(localMaxTime!) <= timeToMinutes(localMinTime!);
 
   // Duration bar calculations — handle cross-midnight ranges
   let durationMinutes = 0;
@@ -141,7 +141,7 @@ export default function TimeGridModal({
     const minMins = timeToMinutes(localMinTime);
     const maxMins = timeToMinutes(localMaxTime);
     durationMinutes = crossesMidnight
-      ? (MAX_DURATION - minMins) + maxMins
+      ? (MAX_DURATION - minMins) + maxMins || MAX_DURATION  // 0 means equal times = full 24h
       : maxMins - minMins;
     const hours = Math.floor(durationMinutes / 60);
     const mins = durationMinutes % 60;

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -95,34 +95,13 @@ export default function TimeGridModal({
     setLocalMaxTime(initMaxTime);
   }, [minValue, maxValue, isOpen]);
 
-  // Enforce min < max: when min changes, push max forward if needed
+  // Allow free movement of min and max — cross-midnight ranges (max < min) are valid
   const handleMinChange = useCallback((newMin: string | null) => {
-    if (!newMin) { setLocalMinTime(newMin); return; }
     setLocalMinTime(newMin);
-    setLocalMaxTime((prev: string | null) => {
-      if (!prev) return prev;
-      const minMins = timeToMinutes(newMin);
-      const maxMins = timeToMinutes(prev);
-      if (maxMins <= minMins) {
-        return minutesToTime(minMins + MIN_DURATION);
-      }
-      return prev;
-    });
   }, []);
 
-  // Enforce min < max: when max changes, push min backward if needed
   const handleMaxChange = useCallback((newMax: string | null) => {
-    if (!newMax) { setLocalMaxTime(newMax); return; }
     setLocalMaxTime(newMax);
-    setLocalMinTime((prev: string | null) => {
-      if (!prev) return prev;
-      const maxMins = timeToMinutes(newMax);
-      const minMins = timeToMinutes(prev);
-      if (minMins >= maxMins) {
-        return minutesToTime(maxMins - MIN_DURATION);
-      }
-      return prev;
-    });
   }, []);
 
   // Enable transitions after first render so the duration bar doesn't animate on open
@@ -149,14 +128,21 @@ export default function TimeGridModal({
     onClose();
   };
 
-  // Validation: both times must be set and min must be less than max
-  const isValid = localMinTime !== null && localMaxTime !== null && localMinTime < localMaxTime;
+  // Validation: both times must be set and they can't be identical
+  const isValid = localMinTime !== null && localMaxTime !== null && localMinTime !== localMaxTime;
 
-  // Duration bar calculations
+  // Cross-midnight detection: max < min means the range wraps past midnight
+  const crossesMidnight = isValid && timeToMinutes(localMaxTime!) < timeToMinutes(localMinTime!);
+
+  // Duration bar calculations — handle cross-midnight ranges
   let durationMinutes = 0;
   let durationLabel = '';
   if (localMinTime && localMaxTime && isValid) {
-    durationMinutes = timeToMinutes(localMaxTime) - timeToMinutes(localMinTime);
+    const minMins = timeToMinutes(localMinTime);
+    const maxMins = timeToMinutes(localMaxTime);
+    durationMinutes = crossesMidnight
+      ? (MAX_DURATION - minMins) + maxMins
+      : maxMins - minMins;
     const hours = Math.floor(durationMinutes / 60);
     const mins = durationMinutes % 60;
     if (hours > 0 && mins > 0) {
@@ -198,7 +184,7 @@ export default function TimeGridModal({
 
         {/* Duration bar */}
         {durationMinutes > 0 && (
-          <div className="px-6 pt-4 flex justify-center">
+          <div className="px-6 pt-4 flex flex-col items-center gap-1">
             <div
               className={`h-7 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center ${transitionsEnabled ? 'transition-all duration-200' : ''}`}
               style={{ width: `${widthPct}%` }}
@@ -207,6 +193,11 @@ export default function TimeGridModal({
                 {durationLabel}
               </span>
             </div>
+            {crossesMidnight && (
+              <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">
+                Crosses midnight (+1 day)
+              </span>
+            )}
           </div>
         )}
 

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -140,7 +140,7 @@ export default function TimeGridModal({
     const minMins = timeToMinutes(localMinTime);
     const maxMins = timeToMinutes(localMaxTime);
     durationMinutes = crossesMidnight
-      ? (MAX_DURATION - minMins) + maxMins || MAX_DURATION  // 0 means equal times = full 24h
+      ? (MAX_DURATION - minMins) + maxMins
       : maxMins - minMins;
     const hours = Math.floor(durationMinutes / 60);
     const mins = durationMinutes % 60;

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -98,20 +98,19 @@ export default function TimeGridModal({
   // Allow free movement of min and max — cross-midnight ranges (max < min) are valid
   const handleMinChange = useCallback((newMin: string | null) => {
     setLocalMinTime(newMin);
+    setTransitionsEnabled(true);
   }, []);
 
   const handleMaxChange = useCallback((newMax: string | null) => {
     setLocalMaxTime(newMax);
+    setTransitionsEnabled(true);
   }, []);
 
-  // Enable transitions after first render so the duration bar doesn't animate on open
+  // Reset transitions when modal reopens so the duration bar doesn't animate on open
   useEffect(() => {
     if (!isOpen) {
       setTransitionsEnabled(false);
-      return;
     }
-    const id = requestAnimationFrame(() => setTransitionsEnabled(true));
-    return () => cancelAnimationFrame(id);
   }, [isOpen]);
 
   if (!isOpen) return null;

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -161,7 +161,7 @@ export default function TimeGridModal({
     <div
       ref={backdropRef}
       data-modal
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-[25vh] sm:pb-0 sm:pt-20 bg-black/50"
       onClick={handleCancel}
       style={{ touchAction: 'none' }}
     >

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -166,7 +166,7 @@ export default function TimeGridModal({
       style={{ touchAction: 'none' }}
     >
       <div
-        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full mx-4 flex flex-col"
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl max-w-lg w-full mx-4 flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/components/TimeMinMaxCounter.tsx
+++ b/components/TimeMinMaxCounter.tsx
@@ -20,14 +20,14 @@ export default function TimeMinMaxCounter({
   disabled = false,
 }: TimeMinMaxCounterProps) {
   return (
-    <div className="flex justify-center items-center gap-3">
+    <div className="flex justify-center items-center gap-1.5">
       <TimeCounterInput
         value={minValue}
         onChange={onMinChange}
         increment={increment}
         disabled={disabled}
       />
-      <span className="text-xl text-gray-500 dark:text-gray-400">—</span>
+      <span className="text-base text-gray-400 dark:text-gray-500">–</span>
       <TimeCounterInput
         value={maxValue}
         onChange={onMaxChange}

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -149,7 +149,7 @@ export default function TimeSlotRoundsDisplay({
           >
             <div className="flex items-center justify-between mb-2">
               <div className="font-semibold text-gray-900 dark:text-gray-100">
-                {formatDate(slot.slot_date)} @ {formatTime(slot.slot_start_time)}-{formatTime(slot.slot_end_time, slot.slot_end_time < slot.slot_start_time)}
+                {formatDate(slot.slot_date)} @ {formatTime(slot.slot_start_time)}-{formatTime(slot.slot_end_time, slot.slot_end_time <= slot.slot_start_time)}
               </div>
               <div className="text-sm text-gray-600 dark:text-gray-400">
                 ({formatDuration(slot.duration_hours)})

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -71,11 +71,12 @@ export default function TimeSlotRoundsDisplay({
     });
   };
 
-  const formatTime = (timeStr: string): string => {
+  const formatTime = (timeStr: string, showNextDay?: boolean): string => {
     const [hours, minutes] = timeStr.split(':').map(Number);
     const period = hours >= 12 ? 'PM' : 'AM';
     const displayHours = hours % 12 || 12;
-    return `${displayHours}:${minutes.toString().padStart(2, '0')} ${period}`;
+    const suffix = showNextDay ? ' +1' : '';
+    return `${displayHours}:${minutes.toString().padStart(2, '0')} ${period}${suffix}`;
   };
 
   const formatDuration = (hours: number): string => {
@@ -148,7 +149,7 @@ export default function TimeSlotRoundsDisplay({
           >
             <div className="flex items-center justify-between mb-2">
               <div className="font-semibold text-gray-900 dark:text-gray-100">
-                {formatDate(slot.slot_date)} @ {formatTime(slot.slot_start_time)}-{formatTime(slot.slot_end_time)}
+                {formatDate(slot.slot_date)} @ {formatTime(slot.slot_start_time)}-{formatTime(slot.slot_end_time, slot.slot_end_time < slot.slot_start_time)}
               </div>
               <div className="text-sm text-gray-600 dark:text-gray-400">
                 ({formatDuration(slot.duration_hours)})

--- a/server/algorithms/time_slots.py
+++ b/server/algorithms/time_slots.py
@@ -71,7 +71,10 @@ def _minutes_to_time(minutes: int) -> str:
 
 
 def _window_effective_end(w_start: int, w_end: int) -> int:
-    """Return effective end minutes, adding 24h if the window crosses midnight."""
+    """Return effective end minutes, adding 24h if the window crosses midnight.
+
+    Equal start/end means a full 24-hour window.
+    """
     if w_end <= w_start:
         return w_end + 24 * 60
     return w_end

--- a/server/algorithms/time_slots.py
+++ b/server/algorithms/time_slots.py
@@ -70,9 +70,21 @@ def _minutes_to_time(minutes: int) -> str:
     return f"{h:02d}:{m:02d}"
 
 
+def _window_effective_end(w_start: int, w_end: int) -> int:
+    """Return effective end minutes, adding 24h if the window crosses midnight."""
+    if w_end <= w_start:
+        return w_end + 24 * 60
+    return w_end
+
+
 def _voter_available_at(voter_windows: list[dict], date: str,
                         start_min: int, end_min: int) -> bool:
-    """Check if a voter's day_time_windows cover the given slot."""
+    """Check if a voter's day_time_windows cover the given slot.
+
+    Handles cross-midnight windows (e.g., 22:00-02:00) where end < start.
+    For cross-midnight windows on the given date, the slot's start/end are
+    compared against the effective range [w_start, w_end+24h).
+    """
     for dtw in voter_windows:
         if dtw["day"] != date:
             continue
@@ -83,7 +95,8 @@ def _voter_available_at(voter_windows: list[dict], date: str,
         for w in windows:
             w_start = _time_to_minutes(w["min"])
             w_end = _time_to_minutes(w["max"])
-            if start_min >= w_start and end_min <= w_end:
+            eff_end = _window_effective_end(w_start, w_end)
+            if start_min >= w_start and end_min <= eff_end:
                 return True
     return False
 
@@ -166,13 +179,14 @@ def calculate_time_slot_rounds(
         for window in windows:
             w_start = _time_to_minutes(window["min"])
             w_end = _time_to_minutes(window["max"])
+            eff_end = _window_effective_end(w_start, w_end)
 
             # For each possible duration
             dur = min_duration_min
             while dur <= max_duration_min:
                 # For each possible start time within the window
                 start = w_start
-                while start + dur <= w_end:
+                while start + dur <= eff_end:
                     end = start + dur
 
                     # Find eligible voters for this slot


### PR DESCRIPTION
## Summary
- Allow time windows where end <= start (e.g., 10 PM – 2 AM) to represent cross-midnight ranges, and equal start/end as full 24-hour windows
- Backend `time_slots.py`: new `_window_effective_end()` helper handles cross-midnight in voter availability checks and slot generation
- Redesigned TimeGridModal: checkmark confirm button, click-outside cancel, tighter layout, rounded corners, "Crosses midnight (+1 day)" indicator
- Unified scroll wheel highlight bands per time picker (brighter, rounded, single band across all wheels)
- Fixed looping scroll wheel jumping the long way on wraparound (12→1)
- Cross-midnight "+1" indicators in DayTimeWindowsInput, ParticipationConditionsCard, and TimeSlotRoundsDisplay

## Test plan
- [ ] Open time window modal, set a cross-midnight range (e.g., 10 PM – 2 AM) — verify duration bar and "Crosses midnight (+1 day)" label display correctly
- [ ] Set equal start/end times (e.g., 9 AM – 9 AM) — verify it shows as 24h window
- [ ] Verify "+1" badge appears on cross-midnight time window pills in day view
- [ ] Scroll minutes past 45→00 at 12:xx — verify hour wheel scrolls forward one position (not backwards through all values)
- [ ] Click outside modal to cancel, click checkmark to confirm
- [ ] Create a participation poll with cross-midnight time windows and verify backend correctly generates candidate slots spanning midnight

https://claude.ai/code/session_01GZS3KAuLFsXYTgPrSSdpaD