### PR TITLE
Add poll content type with autocomplete

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -255,52 +255,47 @@ function CreatePollContent() {
       }
     }
 
-    const filledOptions = options.filter(opt => opt.trim() !== '');
-    const emptyOptions = options.filter(opt => opt.trim() === '');
-    const pollType = getPollType();
-    
-    // Check for options that exceed character limit (relaxed for autocomplete types)
-    const maxOptionLength = pollContentType === 'custom' ? 35 : 200;
-    const longOptions = filledOptions.filter(opt => opt.length > maxOptionLength);
-    if (longOptions.length > 0) {
-      return `Poll options must be ${maxOptionLength} characters or less.`;
-    }
-    
-    // If we have any filled options, check that there are no empty fields in between
-    if (filledOptions.length > 0) {
-      // Find the last filled option index
-      let lastFilledIndex = -1;
-      for (let i = options.length - 1; i >= 0; i--) {
-        if (options[i].trim() !== '') {
-          lastFilledIndex = i;
-          break;
+    const dbPollType = getPollType();
+
+    // Options validation only applies to ranked_choice (poll tab) — nomination
+    // and participation polls don't use the options array.
+    if (dbPollType !== 'nomination' && dbPollType !== 'participation') {
+      const filledOptions = options.filter(opt => opt.trim() !== '');
+
+      // Check for options that exceed character limit (relaxed for autocomplete types)
+      const maxOptionLength = pollContentType === 'custom' ? 35 : 200;
+      const longOptions = filledOptions.filter(opt => opt.length > maxOptionLength);
+      if (longOptions.length > 0) {
+        return `Poll options must be ${maxOptionLength} characters or less.`;
+      }
+
+      // If we have any filled options, check that there are no empty fields in between
+      if (filledOptions.length > 0) {
+        let lastFilledIndex = -1;
+        for (let i = options.length - 1; i >= 0; i--) {
+          if (options[i].trim() !== '') {
+            lastFilledIndex = i;
+            break;
+          }
+        }
+
+        for (let i = 0; i <= lastFilledIndex; i++) {
+          if (options[i].trim() === '') {
+            return "Please fill in all option fields or remove empty ones.";
+          }
         }
       }
-      
-      // Check if there are any empty fields before the last filled option
-      for (let i = 0; i <= lastFilledIndex; i++) {
-        if (options[i].trim() === '') {
-          return "Please fill in all option fields or remove empty ones.";
-        }
+
+      if (filledOptions.length === 1) {
+        return "Add at least one more option for a ranked choice poll, or leave all options blank for a yes/no poll.";
+      }
+
+      const uniqueOptions = new Set(filledOptions.map(opt => opt.trim()));
+      if (uniqueOptions.size !== filledOptions.length) {
+        return "All poll options must be unique (no duplicates).";
       }
     }
-    
-    // If no options, that's valid for all poll types
-    if (filledOptions.length === 0) {
-      return null;
-    }
-    
-    // If there are options, must have at least 2 for ranked choice, at least 1 for nomination
-    if (filledOptions.length === 1 && pollType !== 'nomination') {
-      return "Add at least one more option for a ranked choice poll, or leave all options blank for a yes/no poll.";
-    }
-    
-    // No two options should be exactly the same
-    const uniqueOptions = new Set(filledOptions.map(opt => opt.trim()));
-    if (uniqueOptions.size !== filledOptions.length) {
-      return "All poll options must be unique (no duplicates).";
-    }
-    
+
     return null;
   };
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -65,6 +65,7 @@ function CreatePollContent() {
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
+  const [pollContentType, setPollContentType] = useState<'custom' | 'location' | 'movie'>('custom');
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
   const [locationValue, setLocationValue] = useState('');
@@ -449,6 +450,9 @@ function CreatePollContent() {
           } else if (forkData.total_votes) {
             setAutoCloseAfter(forkData.total_votes);
           }
+          if (forkData.poll_content_type) {
+            setPollContentType(forkData.poll_content_type);
+          }
         } catch (error) {
           console.error('Error loading fork data:', error);
         }
@@ -527,6 +531,9 @@ function CreatePollContent() {
             setAutoCloseAfter(duplicateData.auto_close_after);
           } else if (duplicateData.total_votes) {
             setAutoCloseAfter(duplicateData.total_votes);
+          }
+          if (duplicateData.poll_content_type) {
+            setPollContentType(duplicateData.poll_content_type);
           }
 
           // Don't clean up the duplicate data yet - keep it until poll is created
@@ -916,6 +923,11 @@ function CreatePollContent() {
         pollData.fork_of = forkOf;
       }
 
+      // Add content type for nomination and ranked_choice polls
+      if ((dbPollType === 'nomination' || dbPollType === 'ranked_choice') && pollContentType !== 'custom') {
+        pollData.poll_content_type = pollContentType;
+      }
+
       // Add options for ranked choice polls only
       // For nomination polls, initial options become the creator's vote (not poll content)
       if (dbPollType === 'ranked_choice') {
@@ -1181,6 +1193,36 @@ function CreatePollContent() {
             />
           </div>
 
+          {/* Content type selector for suggestion and poll types */}
+          {pollType !== 'participation' && (
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Type
+              </label>
+              <div className="flex gap-2">
+                {([
+                  { value: 'custom' as const, label: 'Custom', icon: '✏️' },
+                  { value: 'location' as const, label: 'Location', icon: '📍' },
+                  { value: 'movie' as const, label: 'Movie', icon: '🎬' },
+                ]).map(({ value, label, icon }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setPollContentType(value)}
+                    disabled={isLoading}
+                    className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-all border ${
+                      pollContentType === value
+                        ? 'bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-600 text-blue-700 dark:text-blue-300'
+                        : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'
+                    } disabled:opacity-50 disabled:cursor-not-allowed`}
+                  >
+                    {icon} {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Participant counters for participation polls */}
           {pollType === 'participation' && (
             <ParticipationConditions
@@ -1226,78 +1268,16 @@ function CreatePollContent() {
             </div>
           )}
 
-          {/* Hide options field for nomination and participation polls */}
+          {/* Options field for poll type (ranked choice / yes-no) */}
           {pollType !== 'nomination' && pollType !== 'participation' && (
-            <div>
-              <label className="block text-sm font-medium mb-2">
-                Options{' '}
-                <span className="text-gray-500 font-normal">
-                  (blank for yes/no)
-                </span>
-              </label>
-              <div className="space-y-2">
-                {options.map((option, index) => {
-                  const isDuplicate = isDuplicateOption(index);
-                  return (
-                    <div key={index} className="flex items-center gap-2">
-                      <input
-                        ref={(el) => {
-                          optionRefs.current[index] = el;
-                        }}
-                        type="text"
-                        value={option}
-                        onChange={(e) => updateOption(index, e.target.value)}
-                        disabled={isLoading}
-                        maxLength={35}
-                        className={`flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
-                          isDuplicate 
-                            ? 'bg-red-50 dark:bg-red-900/30 border-red-400 dark:border-red-600 text-red-900 dark:text-red-100' 
-                            : 'border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-                        }`}
-                      placeholder={
-                        (() => {
-                          const filledOptions = options.filter(opt => opt.trim() !== '');
-                          const isLastField = index === options.length - 1;
-                          
-                          if (isLastField) {
-                            return filledOptions.length === 0 ? "Add an option" : "Add another option...";
-                          }
-                          return `Option ${index + 1}`;
-                        })()
-                      }
-                    />
-                    {(() => {
-                      const filledOptions = options.filter(opt => opt.trim() !== '');
-                      const isLastField = index === options.length - 1;
-                      const canDelete = filledOptions.length >= 1;
-                      
-                      if (isLastField) {
-                        // Empty space for alignment on the last "Add another option" field
-                        return <div className="w-9 h-9"></div>;
-                      }
-                      
-                      return (
-                        <button
-                          type="button"
-                          onClick={() => canDelete ? removeOption(index) : undefined}
-                          disabled={isLoading || !canDelete}
-                          className={`p-2 transition-colors ${
-                            canDelete 
-                              ? 'text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 cursor-pointer'
-                              : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                          } disabled:opacity-50`}
-                        >
-                          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                          </svg>
-                        </button>
-                      );
-                    })()}
-                  </div>
-                  );
-                })}
-              </div>
-            </div>
+            <OptionsInput
+              options={options}
+              setOptions={setOptions}
+              isLoading={isLoading}
+              pollType="poll"
+              contentType={pollContentType}
+              label={<>Options{' '}<span className="text-gray-500 font-normal">(blank for yes/no)</span></>}
+            />
           )}
 
           <div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -218,19 +218,7 @@ function CreatePollContent() {
     return filledOptions.length === 0 ? 'yes_no' : 'ranked_choice';
   };
 
-  // Check if an option is a duplicate
-  const isDuplicateOption = (index: number): boolean => {
-    const currentOption = options[index]?.trim().toLowerCase();
-    if (!currentOption) return false;
-    
-    // Check if this option appears elsewhere in the array
-    for (let i = 0; i < options.length; i++) {
-      if (i !== index && options[i]?.trim().toLowerCase() === currentOption) {
-        return true;
-      }
-    }
-    return false;
-  };
+
 
   // Validation for poll options with specific error messages
   const getValidationError = (): string | null => {
@@ -665,49 +653,6 @@ function CreatePollContent() {
     }
   }, [options.length, shouldFocusNewOption]);
 
-
-  // Handle options for ranked choice polls
-  const updateOption = (index: number, value: string) => {
-    const newOptions = [...options];
-    newOptions[index] = value;
-    
-    // If typing in the last field and it now has content, add expansion field
-    if (index === options.length - 1 && value.trim() !== '') {
-      newOptions.push('');
-    }
-    
-    // Remove trailing empty fields but always keep at least 1 field
-    while (newOptions.length > 1) {
-      const lastIndex = newOptions.length - 1;
-      const secondLastIndex = newOptions.length - 2;
-      
-      // Only remove if last two fields are empty
-      if (newOptions[lastIndex] === '' && newOptions[secondLastIndex] === '') {
-        newOptions.pop();
-      } else {
-        break;
-      }
-    }
-    
-    // Ensure we always have at least 1 field
-    if (newOptions.length === 0) {
-      newOptions.push('');
-    }
-    
-    setOptions(newOptions);
-  };
-
-  const removeOption = (index: number) => {
-    // Remove the specific option and collapse array
-    const newOptions = options.filter((_, i) => i !== index);
-    
-    // Ensure we always have at least 1 field
-    if (newOptions.length === 0) {
-      newOptions.push('');
-    }
-    
-    setOptions(newOptions);
-  };
 
   const baseDeadlineOptions = [
     { value: "5min", label: "5 minutes", minutes: 5 },

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -259,10 +259,11 @@ function CreatePollContent() {
     const emptyOptions = options.filter(opt => opt.trim() === '');
     const pollType = getPollType();
     
-    // Check for options that exceed character limit
-    const longOptions = filledOptions.filter(opt => opt.length > 35);
+    // Check for options that exceed character limit (relaxed for autocomplete types)
+    const maxOptionLength = pollContentType === 'custom' ? 35 : 200;
+    const longOptions = filledOptions.filter(opt => opt.length > maxOptionLength);
     if (longOptions.length > 0) {
-      return "Poll options must be 35 characters or less.";
+      return `Poll options must be ${maxOptionLength} characters or less.`;
     }
     
     // If we have any filled options, check that there are no empty fields in between

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1196,30 +1196,20 @@ function CreatePollContent() {
           {/* Content type selector for suggestion and poll types */}
           {pollType !== 'participation' && (
             <div>
-              <label className="block text-sm font-medium mb-2">
+              <label htmlFor="contentType" className="block text-sm font-medium mb-2">
                 Type
               </label>
-              <div className="flex gap-2">
-                {([
-                  { value: 'custom' as const, label: 'Custom', icon: '✏️' },
-                  { value: 'location' as const, label: 'Location', icon: '📍' },
-                  { value: 'movie' as const, label: 'Movie', icon: '🎬' },
-                ]).map(({ value, label, icon }) => (
-                  <button
-                    key={value}
-                    type="button"
-                    onClick={() => setPollContentType(value)}
-                    disabled={isLoading}
-                    className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-all border ${
-                      pollContentType === value
-                        ? 'bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-600 text-blue-700 dark:text-blue-300'
-                        : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500'
-                    } disabled:opacity-50 disabled:cursor-not-allowed`}
-                  >
-                    {icon} {label}
-                  </button>
-                ))}
-              </div>
+              <select
+                id="contentType"
+                value={pollContentType}
+                onChange={(e) => setPollContentType(e.target.value as 'custom' | 'location' | 'movie')}
+                disabled={isLoading}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <option value="custom">Custom</option>
+                <option value="location">Location</option>
+                <option value="movie">Movie</option>
+              </select>
             </div>
           )}
 

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -144,6 +144,11 @@ export default function AutocompleteInput({
               </div>
             </li>
           ))}
+          <li className="px-3 py-1.5 text-[10px] text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700">
+            {contentType === 'movie'
+              ? 'Data from TMDB. Not endorsed by TMDB.'
+              : 'Data \u00A9 OpenStreetMap contributors'}
+          </li>
         </ul>
       )}
     </div>

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { apiSearchLocations, apiSearchMovies, type SearchResult } from "@/lib/api";
+
+interface AutocompleteInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  contentType: 'location' | 'movie';
+  disabled?: boolean;
+  placeholder?: string;
+  maxLength?: number;
+  className?: string;
+  inputRef?: React.RefCallback<HTMLInputElement>;
+}
+
+export default function AutocompleteInput({
+  value,
+  onChange,
+  contentType,
+  disabled = false,
+  placeholder,
+  maxLength = 35,
+  className,
+  inputRef,
+}: AutocompleteInputProps) {
+  const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const localInputRef = useRef<HTMLInputElement>(null);
+
+  const searchFn = contentType === 'location' ? apiSearchLocations : apiSearchMovies;
+
+  const doSearch = useCallback(async (query: string) => {
+    if (query.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    try {
+      const results = await searchFn(query);
+      setSuggestions(results);
+      setShowSuggestions(results.length > 0);
+      setHighlightedIndex(-1);
+    } catch {
+      setSuggestions([]);
+    }
+  }, [searchFn]);
+
+  const handleChange = (newValue: string) => {
+    onChange(newValue);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(newValue), 300);
+  };
+
+  const selectSuggestion = (result: SearchResult) => {
+    onChange(result.label);
+    setSuggestions([]);
+    setShowSuggestions(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!showSuggestions || suggestions.length === 0) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex(i => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && highlightedIndex >= 0) {
+      e.preventDefault();
+      selectSuggestion(suggestions[highlightedIndex]);
+    } else if (e.key === 'Escape') {
+      setShowSuggestions(false);
+    }
+  };
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        ref={(el) => {
+          localInputRef.current = el;
+          if (inputRef) inputRef(el);
+        }}
+        type="text"
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+        onFocus={() => { if (suggestions.length > 0) setShowSuggestions(true); }}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        maxLength={maxLength}
+        className={className}
+        placeholder={placeholder}
+      />
+      {showSuggestions && suggestions.length > 0 && (
+        <ul className="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+          {suggestions.map((result, index) => (
+            <li
+              key={index}
+              onMouseDown={(e) => { e.preventDefault(); selectSuggestion(result); }}
+              onMouseEnter={() => setHighlightedIndex(index)}
+              className={`px-3 py-2 cursor-pointer flex items-start gap-2 ${
+                index === highlightedIndex
+                  ? 'bg-blue-50 dark:bg-blue-900/30'
+                  : 'hover:bg-gray-50 dark:hover:bg-gray-700'
+              }`}
+            >
+              {result.imageUrl && (
+                <img
+                  src={result.imageUrl}
+                  alt=""
+                  className="w-8 h-12 object-cover rounded flex-shrink-0 mt-0.5"
+                />
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                  {result.label}
+                </div>
+                {result.description && (
+                  <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
+                    {result.description}
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/DuplicateButton.tsx
+++ b/components/DuplicateButton.tsx
@@ -23,8 +23,9 @@ export default function DuplicateButton({ poll }: DuplicateButtonProps) {
       max_participants: poll.max_participants,
       auto_close_after: poll.auto_close_after,
       details: poll.details,
+      poll_content_type: poll.poll_content_type,
     };
-    
+
     debugLog.logObject('Duplicate button clicked', { pollId: poll.id, duplicateData }, 'DuplicateButton');
     
     // Store in localStorage for form auto-fill

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -26,6 +26,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
     max_participants: poll.max_participants,
     auto_close_after: poll.auto_close_after,
     details: poll.details,
+    poll_content_type: poll.poll_content_type,
     total_votes: totalVotes,
   };
 

--- a/components/ForkButton.tsx
+++ b/components/ForkButton.tsx
@@ -24,8 +24,9 @@ export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
       max_participants: poll.max_participants,
       auto_close_after: poll.auto_close_after,
       details: poll.details,
+      poll_content_type: poll.poll_content_type,
     };
-    
+
     debugLog.logObject('Fork button clicked', { pollId: poll.id, forkData }, 'ForkButton');
     
     const storageKey = `fork-data-${poll.id}`;

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -333,6 +333,7 @@ export default function NominationVotingInterface({
             isLoading={isSubmitting}
             pollType="nomination"
             label={isEditingVote ? "Add new suggestions:" : "Add new suggestions:"}
+            contentType={poll.poll_content_type || 'custom'}
           />
         </div>
 

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -123,11 +123,14 @@ export default function OptionsInput({
         </label>
       )}
       <div className="space-y-2">
+        {(() => {
+          const filledCount = options.filter(opt => opt.trim() !== '').length;
+          const hasDuplicates = options.some((_, idx) => isDuplicateOption(idx));
+          return (<>
         {options.map((option, index) => {
           const isDuplicate = isDuplicateOption(index);
-          const filledOptions = options.filter(opt => opt.trim() !== '');
           const isLastField = index === options.length - 1;
-          const canDelete = filledOptions.length >= 1;
+          const canDelete = filledCount >= 1;
 
           return (
             <div key={index} className="flex items-start gap-2">
@@ -181,11 +184,13 @@ export default function OptionsInput({
             </div>
           );
         })}
-        {isDuplicateOption(options.findIndex(opt => isDuplicateOption(options.indexOf(opt)))) && (
+        {hasDuplicates && (
           <p className="text-sm text-red-600 dark:text-red-400 mt-1">
             Duplicate options are not allowed.
           </p>
         )}
+          </>);
+        })()}
       </div>
     </div>
   );

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef } from "react";
+import AutocompleteInput from "@/components/AutocompleteInput";
 
 interface OptionsInputProps {
   options: string[];
@@ -9,15 +10,17 @@ interface OptionsInputProps {
   pollType?: 'poll' | 'nomination';
   label?: React.ReactNode;
   placeholder?: string;
+  contentType?: 'custom' | 'location' | 'movie';
 }
 
-export default function OptionsInput({ 
-  options, 
-  setOptions, 
+export default function OptionsInput({
+  options,
+  setOptions,
   isLoading = false,
   pollType = 'poll',
   label,
-  placeholder
+  placeholder,
+  contentType = 'custom'
 }: OptionsInputProps) {
   const optionRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -25,7 +28,7 @@ export default function OptionsInput({
   const isDuplicateOption = (index: number): boolean => {
     const currentOption = options[index]?.trim().toLowerCase();
     if (!currentOption) return false;
-    
+
     for (let i = 0; i < options.length; i++) {
       if (i !== index && options[i]?.trim().toLowerCase() === currentOption) {
         return true;
@@ -37,17 +40,17 @@ export default function OptionsInput({
   const updateOption = (index: number, value: string) => {
     const newOptions = [...options];
     newOptions[index] = value;
-    
+
     // If typing in the last field and it now has content, add expansion field
     if (index === options.length - 1 && value.trim() !== '') {
       newOptions.push('');
     }
-    
+
     // Remove trailing empty fields but always keep at least 1 field
     while (newOptions.length > 1) {
       const lastIndex = newOptions.length - 1;
       const secondLastIndex = newOptions.length - 2;
-      
+
       // Only remove if last two fields are empty
       if (newOptions[lastIndex] === '' && newOptions[secondLastIndex] === '') {
         newOptions.pop();
@@ -55,33 +58,43 @@ export default function OptionsInput({
         break;
       }
     }
-    
+
     // Ensure we always have at least 1 field
     if (newOptions.length === 0) {
       newOptions.push('');
     }
-    
+
     setOptions(newOptions);
   };
 
   const removeOption = (index: number) => {
     const newOptions = options.filter((_, i) => i !== index);
-    
+
     // Ensure we always have at least 1 field
     if (newOptions.length === 0) {
       newOptions.push('');
     }
-    
+
     setOptions(newOptions);
   };
 
   const getPlaceholder = (index: number) => {
     if (placeholder) return placeholder;
-    
+
     const filledOptions = options.filter(opt => opt.trim() !== '');
     const isLastField = index === options.length - 1;
-    
-    if (pollType === 'nomination') {
+
+    if (contentType === 'location') {
+      if (isLastField) {
+        return filledOptions.length === 0 ? "Search for a location..." : "Add another location...";
+      }
+      return `Location ${index + 1}`;
+    } else if (contentType === 'movie') {
+      if (isLastField) {
+        return filledOptions.length === 0 ? "Search for a movie..." : "Add another movie...";
+      }
+      return `Movie ${index + 1}`;
+    } else if (pollType === 'nomination') {
       if (isLastField) {
         return filledOptions.length === 0 ? "Add a suggestion" : "Add another suggestion...";
       }
@@ -93,6 +106,14 @@ export default function OptionsInput({
       return `Option ${index + 1}`;
     }
   };
+
+  const useAutocomplete = contentType === 'location' || contentType === 'movie';
+  const inputClassName = (isDuplicate: boolean) =>
+    `flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
+      isDuplicate
+        ? 'bg-red-50 dark:bg-red-900/30 border-red-400 dark:border-red-600 text-red-900 dark:text-red-100'
+        : 'border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+    }`;
 
   return (
     <div>
@@ -107,25 +128,36 @@ export default function OptionsInput({
           const filledOptions = options.filter(opt => opt.trim() !== '');
           const isLastField = index === options.length - 1;
           const canDelete = filledOptions.length >= 1;
-          
+
           return (
-            <div key={index} className="flex items-center gap-2">
-              <input
-                ref={(el) => {
-                  optionRefs.current[index] = el;
-                }}
-                type="text"
-                value={option}
-                onChange={(e) => updateOption(index, e.target.value)}
-                disabled={isLoading}
-                maxLength={35}
-                className={`flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
-                  isDuplicate 
-                    ? 'bg-red-50 dark:bg-red-900/30 border-red-400 dark:border-red-600 text-red-900 dark:text-red-100' 
-                    : 'border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-                }`}
-                placeholder={getPlaceholder(index)}
-              />
+            <div key={index} className="flex items-start gap-2">
+              {useAutocomplete ? (
+                <div className="flex-1">
+                  <AutocompleteInput
+                    value={option}
+                    onChange={(value) => updateOption(index, value)}
+                    contentType={contentType as 'location' | 'movie'}
+                    disabled={isLoading}
+                    maxLength={100}
+                    placeholder={getPlaceholder(index)}
+                    className={inputClassName(isDuplicate) + ' w-full'}
+                    inputRef={(el) => { optionRefs.current[index] = el; }}
+                  />
+                </div>
+              ) : (
+                <input
+                  ref={(el) => {
+                    optionRefs.current[index] = el;
+                  }}
+                  type="text"
+                  value={option}
+                  onChange={(e) => updateOption(index, e.target.value)}
+                  disabled={isLoading}
+                  maxLength={35}
+                  className={inputClassName(isDuplicate)}
+                  placeholder={getPlaceholder(index)}
+                />
+              )}
               {isLastField ? (
                 // Empty space for alignment on the last field
                 <div className="w-9 h-9"></div>
@@ -135,8 +167,8 @@ export default function OptionsInput({
                   onClick={() => canDelete ? removeOption(index) : undefined}
                   disabled={isLoading || !canDelete}
                   className={`p-2 transition-colors ${
-                    canDelete 
-                      ? 'text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300' 
+                    canDelete
+                      ? 'text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300'
                       : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
                   } disabled:opacity-50 disabled:cursor-not-allowed`}
                   aria-label={canDelete ? "Remove option" : "Cannot remove last option"}

--- a/database/migrations/073_add_poll_content_type_down.sql
+++ b/database/migrations/073_add_poll_content_type_down.sql
@@ -1,0 +1,3 @@
+-- Remove poll_content_type column from polls table
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_content_type_check;
+ALTER TABLE polls DROP COLUMN IF EXISTS poll_content_type;

--- a/database/migrations/073_add_poll_content_type_up.sql
+++ b/database/migrations/073_add_poll_content_type_up.sql
@@ -1,0 +1,9 @@
+-- Add poll_content_type column to polls table
+-- Values: 'custom' (default), 'location', 'movie'
+-- Used by nomination and ranked_choice polls to enable autocomplete and rich display
+
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS poll_content_type VARCHAR(20) DEFAULT 'custom';
+
+-- Add check constraint for valid values
+ALTER TABLE polls ADD CONSTRAINT polls_poll_content_type_check
+    CHECK (poll_content_type IN ('custom', 'location', 'movie'));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://whoeverwants:whoeverwants@db:5432/whoeverwants
+    env_file:
+      - .env.api
     ports:
       - "127.0.0.1:8000:8000"
     depends_on:

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -11,27 +11,25 @@ import { branchToSlug } from './slug';
 // - Server-side: absolute URLs (no browser privacy concerns in SSR)
 // - Client-side: relative /api/polls path, proxied by Next.js rewrites
 //   (keeps requests same-origin, avoiding Safari ITP warnings)
-function getApiBase(): string {
+function getApiEndpoint(endpoint: string): string {
   if (process.env.NEXT_PUBLIC_API_URL) {
-    return process.env.NEXT_PUBLIC_API_URL;
+    return process.env.NEXT_PUBLIC_API_URL.replace(/\/api\/polls\/?$/, `/api/${endpoint}`);
   }
-  // Server-side: use absolute URLs (no browser privacy concerns in SSR)
   if (typeof window === 'undefined') {
     if (process.env.NODE_ENV !== 'production') {
-      return 'http://localhost:8000/api/polls';
+      return `http://localhost:8000/api/${endpoint}`;
     }
     const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_BRANCH || process.env.VERCEL_GIT_COMMIT_REF;
     if (branch && branch !== 'main' && branch !== 'master') {
       const slug = branchToSlug(branch);
-      return `https://${slug}.api.whoeverwants.com/api/polls`;
+      return `https://${slug}.api.whoeverwants.com/api/${endpoint}`;
     }
-    return 'https://api.whoeverwants.com/api/polls';
+    return `https://api.whoeverwants.com/api/${endpoint}`;
   }
-  // Client-side (all environments): relative path, proxied by Next.js rewrites
-  return '/api/polls';
+  return `/api/${endpoint}`;
 }
 
-const API_BASE = getApiBase();
+const API_BASE = getApiEndpoint('polls');
 
 // --- Vote types matching the Python VoteResponse model ---
 
@@ -341,32 +339,18 @@ export interface SearchResult {
   lon?: string;
 }
 
-function getSearchBase(): string {
-  if (process.env.NEXT_PUBLIC_API_URL) {
-    // Replace /api/polls with /api/search
-    return process.env.NEXT_PUBLIC_API_URL.replace(/\/api\/polls\/?$/, '/api/search');
-  }
-  if (typeof window === 'undefined') {
-    if (process.env.NODE_ENV !== 'production') {
-      return 'http://localhost:8000/api/search';
-    }
-    return 'https://api.whoeverwants.com/api/search';
-  }
-  return '/api/search';
-}
+const SEARCH_BASE = getApiEndpoint('search');
 
 export async function apiSearchLocations(query: string): Promise<SearchResult[]> {
-  const base = getSearchBase();
   const params = new URLSearchParams({ q: query });
-  const res = await fetch(`${base}/locations?${params}`);
+  const res = await fetch(`${SEARCH_BASE}/locations?${params}`);
   if (!res.ok) return [];
   return res.json();
 }
 
 export async function apiSearchMovies(query: string): Promise<SearchResult[]> {
-  const base = getSearchBase();
   const params = new URLSearchParams({ q: query });
-  const res = await fetch(`${base}/movies?${params}`);
+  const res = await fetch(`${SEARCH_BASE}/movies?${params}`);
   if (!res.ok) return [];
   return res.json();
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -125,6 +125,7 @@ function toPoll(data: any): Poll {
     time_preferences_deadline_minutes: data.time_preferences_deadline_minutes ?? undefined,
     day_time_windows: data.day_time_windows ?? undefined,
     duration_window: data.duration_window ?? undefined,
+    poll_content_type: data.poll_content_type ?? undefined,
   };
 }
 
@@ -191,6 +192,7 @@ export async function apiCreatePoll(params: {
   time_preferences_deadline_minutes?: number;
   day_time_windows?: any[];
   duration_window?: any;
+  poll_content_type?: string;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',
@@ -327,4 +329,44 @@ export async function apiGetAccessiblePolls(pollIds: string[]): Promise<Poll[]> 
     body: JSON.stringify({ poll_ids: pollIds }),
   });
   return data.map(toPoll);
+}
+
+// --- Search/autocomplete ---
+
+export interface SearchResult {
+  label: string;
+  description?: string;
+  imageUrl?: string;
+  lat?: string;
+  lon?: string;
+}
+
+function getSearchBase(): string {
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    // Replace /api/polls with /api/search
+    return process.env.NEXT_PUBLIC_API_URL.replace(/\/api\/polls\/?$/, '/api/search');
+  }
+  if (typeof window === 'undefined') {
+    if (process.env.NODE_ENV !== 'production') {
+      return 'http://localhost:8000/api/search';
+    }
+    return 'https://api.whoeverwants.com/api/search';
+  }
+  return '/api/search';
+}
+
+export async function apiSearchLocations(query: string): Promise<SearchResult[]> {
+  const base = getSearchBase();
+  const params = new URLSearchParams({ q: query });
+  const res = await fetch(`${base}/locations?${params}`);
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function apiSearchMovies(query: string): Promise<SearchResult[]> {
+  const base = getSearchBase();
+  const params = new URLSearchParams({ q: query });
+  const res = await fetch(`${base}/movies?${params}`);
+  if (!res.ok) return [];
+  return res.json();
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -40,6 +40,7 @@ export interface Poll {
   time_preferences_deadline_minutes?: number | null;
   day_time_windows?: DayTimeWindow[] | null;
   duration_window?: DurationWindow | null;
+  poll_content_type?: 'custom' | 'location' | 'movie' | null;
 }
 
 export interface TimeWindow {

--- a/next.config.ts
+++ b/next.config.ts
@@ -58,6 +58,10 @@ if (process.env.NEXT_OUTPUT === 'standalone') {
         source: '/api/polls/:path*',
         destination: `${apiDest}/api/polls/:path*`,
       },
+      {
+        source: '/api/search/:path*',
+        destination: `${apiDest}/api/search/:path*`,
+      },
     ],
     afterFiles: [],
     fallback: [],

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -257,6 +257,12 @@ start_api() {
     "$UV_BIN" sync --quiet 2>&1 | tail -3 || true
   fi
 
+  # Source API secrets if available
+  local api_env_file="/root/whoeverwants/.env.api"
+  if [ -f "$api_env_file" ]; then
+    set -a; source "$api_env_file"; set +a
+  fi
+
   DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${db_name}" \
     "$UV_BIN" run uvicorn main:app --host 0.0.0.0 --port "$api_port" --workers 1 \
     >> "${dir}/api.log" 2>&1 200>&- &

--- a/server/main.py
+++ b/server/main.py
@@ -6,6 +6,7 @@ import psycopg
 
 from middleware import RateLimitMiddleware
 from routers.polls import router as polls_router
+from routers.search import router as search_router
 
 app = FastAPI(title="WhoeverWants API", redirect_slashes=False)
 
@@ -24,6 +25,7 @@ app.add_middleware(
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
 
 app.include_router(polls_router)
+app.include_router(search_router)
 
 
 @app.get("/health")

--- a/server/models.py
+++ b/server/models.py
@@ -51,6 +51,8 @@ class CreatePollRequest(BaseModel):
     # Time windows for participation polls
     day_time_windows: list[dict] | None = None
     duration_window: dict | None = None
+    # Content type for autocomplete (nomination/ranked_choice polls)
+    poll_content_type: str | None = None
 
 
 class SubmitVoteRequest(BaseModel):
@@ -143,6 +145,7 @@ class PollResponse(BaseModel):
     time_preferences_deadline_minutes: int | None = None
     day_time_windows: list[dict] | None = None
     duration_window: dict | None = None
+    poll_content_type: str | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi>=0.135.1",
     "uvicorn[standard]>=0.42.0",
     "psycopg[binary]>=3.3.3",
+    "httpx>=0.28.1",
 ]
 
 [dependency-groups]

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -206,6 +206,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         time_preferences_deadline_minutes=row.get("time_preferences_deadline_minutes"),
         day_time_windows=row.get("day_time_windows"),
         duration_window=row.get("duration_window"),
+        poll_content_type=row.get("poll_content_type"),
     )
 
 
@@ -420,6 +421,7 @@ def create_poll(req: CreatePollRequest):
                                time_suggestions_deadline_minutes,
                                time_preferences_deadline_minutes,
                                day_time_windows, duration_window,
+                               poll_content_type,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
@@ -434,6 +436,7 @@ def create_poll(req: CreatePollRequest):
                     %(time_suggestions_deadline_minutes)s,
                     %(time_preferences_deadline_minutes)s,
                     %(day_time_windows)s::jsonb, %(duration_window)s::jsonb,
+                    %(poll_content_type)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -466,6 +469,7 @@ def create_poll(req: CreatePollRequest):
                 "time_preferences_deadline_minutes": req.time_preferences_deadline_minutes,
                 "day_time_windows": json.dumps(req.day_time_windows) if req.day_time_windows else None,
                 "duration_window": json.dumps(req.duration_window) if req.duration_window else None,
+                "poll_content_type": req.poll_content_type or "custom",
                 "now": now,
             },
         ).fetchone()
@@ -480,9 +484,11 @@ def create_poll(req: CreatePollRequest):
                 """
                 INSERT INTO polls (title, poll_type, is_closed, follow_up_to,
                                    creator_secret, creator_name,
+                                   poll_content_type,
                                    created_at, updated_at)
                 VALUES (%(title)s, 'ranked_choice', true, %(parent_id)s,
                         %(creator_secret)s, %(creator_name)s,
+                        %(poll_content_type)s,
                         %(now)s, %(now)s)
                 """,
                 {
@@ -490,6 +496,7 @@ def create_poll(req: CreatePollRequest):
                     "parent_id": parent_id,
                     "creator_secret": req.creator_secret,
                     "creator_name": req.creator_name,
+                    "poll_content_type": req.poll_content_type or "custom",
                     "now": now,
                 },
             )

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -1,0 +1,72 @@
+"""Search/autocomplete endpoints for poll content types."""
+
+import os
+
+import httpx
+from fastapi import APIRouter, Query
+
+router = APIRouter(prefix="/api/search", tags=["search"])
+
+TMDB_API_KEY = os.environ.get("TMDB_API_KEY", "")
+
+
+@router.get("/locations")
+async def search_locations(q: str = Query(..., min_length=2, max_length=100)):
+    """Search for locations using OpenStreetMap Nominatim."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            "https://nominatim.openstreetmap.org/search",
+            params={
+                "q": q,
+                "format": "jsonv2",
+                "limit": 6,
+                "addressdetails": 1,
+            },
+            headers={"User-Agent": "WhoeverWants/1.0 (whoeverwants.com)"},
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    results = []
+    for item in data:
+        results.append({
+            "label": item.get("display_name", ""),
+            "description": item.get("type", "").replace("_", " ").title(),
+            "lat": item.get("lat"),
+            "lon": item.get("lon"),
+        })
+    return results
+
+
+@router.get("/movies")
+async def search_movies(q: str = Query(..., min_length=2, max_length=100)):
+    """Search for movies using TMDB API."""
+    if not TMDB_API_KEY:
+        return []
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            "https://api.themoviedb.org/3/search/movie",
+            params={
+                "api_key": TMDB_API_KEY,
+                "query": q,
+                "page": 1,
+            },
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    results = []
+    for movie in data.get("results", [])[:6]:
+        year = movie.get("release_date", "")[:4]
+        title = movie.get("title", "")
+        label = f"{title} ({year})" if year else title
+        poster = movie.get("poster_path")
+        results.append({
+            "label": label,
+            "description": (movie.get("overview", "") or "")[:120],
+            "imageUrl": f"https://image.tmdb.org/t/p/w92{poster}" if poster else None,
+        })
+    return results

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -9,34 +9,34 @@ router = APIRouter(prefix="/api/search", tags=["search"])
 
 TMDB_API_KEY = os.environ.get("TMDB_API_KEY", "")
 
+_http_client = httpx.AsyncClient(timeout=5.0)
+
 
 @router.get("/locations")
 async def search_locations(q: str = Query(..., min_length=2, max_length=100)):
     """Search for locations using OpenStreetMap Nominatim."""
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(
-            "https://nominatim.openstreetmap.org/search",
-            params={
-                "q": q,
-                "format": "jsonv2",
-                "limit": 6,
-                "addressdetails": 1,
-            },
-            headers={"User-Agent": "WhoeverWants/1.0 (whoeverwants.com)"},
-            timeout=5.0,
-        )
-        resp.raise_for_status()
-        data = resp.json()
+    resp = await _http_client.get(
+        "https://nominatim.openstreetmap.org/search",
+        params={
+            "q": q,
+            "format": "jsonv2",
+            "limit": 6,
+            "addressdetails": 1,
+        },
+        headers={"User-Agent": "WhoeverWants/1.0 (whoeverwants.com)"},
+    )
+    resp.raise_for_status()
+    data = resp.json()
 
-    results = []
-    for item in data:
-        results.append({
+    return [
+        {
             "label": item.get("display_name", ""),
             "description": item.get("type", "").replace("_", " ").title(),
             "lat": item.get("lat"),
             "lon": item.get("lon"),
-        })
-    return results
+        }
+        for item in data
+    ]
 
 
 @router.get("/movies")
@@ -45,18 +45,16 @@ async def search_movies(q: str = Query(..., min_length=2, max_length=100)):
     if not TMDB_API_KEY:
         return []
 
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(
-            "https://api.themoviedb.org/3/search/movie",
-            params={
-                "api_key": TMDB_API_KEY,
-                "query": q,
-                "page": 1,
-            },
-            timeout=5.0,
-        )
-        resp.raise_for_status()
-        data = resp.json()
+    resp = await _http_client.get(
+        "https://api.themoviedb.org/3/search/movie",
+        params={
+            "api_key": TMDB_API_KEY,
+            "query": q,
+            "page": 1,
+        },
+    )
+    resp.raise_for_status()
+    data = resp.json()
 
     results = []
     for movie in data.get("results", [])[:6]:

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -638,6 +638,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "psycopg", extra = ["binary"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -652,6 +653,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.135.1" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.42.0" },
 ]


### PR DESCRIPTION
## Summary
- Adds `poll_content_type` field (custom/location/movie) to nomination and ranked choice polls
- Non-custom types show autocomplete suggestions when entering options or nominations (Nominatim for locations, TMDB for movies)
- Content type propagates to auto-created follow-up polls, forks, and duplicates
- Dev server sources `.env.api` for API secrets (TMDB key)

## Changes
- **Database**: Migration 073 adds `poll_content_type` column with check constraint
- **Server**: New `/api/search/locations` and `/api/search/movies` endpoints, `poll_content_type` in poll CRUD
- **Frontend**: `AutocompleteInput` component, content type dropdown on create-poll, autocomplete in `OptionsInput`
- **Infrastructure**: `.env.api` for API secrets, dev-server-manager sources it on startup

## Test plan
- [ ] Create a suggestion poll with Location type, verify autocomplete shows OSM results
- [ ] Create a suggestion poll with Movie type, verify autocomplete shows TMDB results with posters
- [ ] Create a poll (ranked choice) with Location type, verify autocomplete in options
- [ ] Verify Custom type behaves as before (no autocomplete)
- [ ] Duplicate/fork a typed poll and verify content type carries over
- [ ] Verify auto-created preferences poll inherits content type from nomination poll
- [ ] Verify attribution text appears at bottom of autocomplete dropdown