### PR TITLE
Add video game poll content type with RAWG API

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -65,7 +65,7 @@ function CreatePollContent() {
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
-  const [pollContentType, setPollContentType] = useState<'custom' | 'location' | 'movie'>('custom');
+  const [pollContentType, setPollContentType] = useState<'custom' | 'location' | 'movie' | 'video_game'>('custom');
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
   const [locationValue, setLocationValue] = useState('');
@@ -1143,13 +1143,14 @@ function CreatePollContent() {
               <select
                 id="contentType"
                 value={pollContentType}
-                onChange={(e) => setPollContentType(e.target.value as 'custom' | 'location' | 'movie')}
+                onChange={(e) => setPollContentType(e.target.value as 'custom' | 'location' | 'movie' | 'video_game')}
                 disabled={isLoading}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <option value="custom">Custom</option>
                 <option value="location">Location</option>
                 <option value="movie">Movie</option>
+                <option value="video_game">Video Game</option>
               </select>
             </div>
           )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
+import type { PollContentType } from "@/lib/types";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -65,7 +66,7 @@ function CreatePollContent() {
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
-  const [pollContentType, setPollContentType] = useState<'custom' | 'location' | 'movie' | 'video_game'>('custom');
+  const [pollContentType, setPollContentType] = useState<PollContentType>('custom');
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
   const [locationValue, setLocationValue] = useState('');
@@ -1143,7 +1144,7 @@ function CreatePollContent() {
               <select
                 id="contentType"
                 value={pollContentType}
-                onChange={(e) => setPollContentType(e.target.value as 'custom' | 'location' | 'movie' | 'video_game')}
+                onChange={(e) => setPollContentType(e.target.value as PollContentType)}
                 disabled={isLoading}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
               >

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { apiSearchLocations, apiSearchMovies, apiSearchVideoGames, type SearchResult } from "@/lib/api";
+import type { PollContentType } from "@/lib/types";
 
 interface AutocompleteInputProps {
   value: string;
   onChange: (value: string) => void;
-  contentType: 'location' | 'movie' | 'video_game';
+  contentType: Exclude<PollContentType, 'custom'>;
   disabled?: boolean;
   placeholder?: string;
   maxLength?: number;

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { apiSearchLocations, apiSearchMovies, type SearchResult } from "@/lib/api";
+import { apiSearchLocations, apiSearchMovies, apiSearchVideoGames, type SearchResult } from "@/lib/api";
 
 interface AutocompleteInputProps {
   value: string;
   onChange: (value: string) => void;
-  contentType: 'location' | 'movie';
+  contentType: 'location' | 'movie' | 'video_game';
   disabled?: boolean;
   placeholder?: string;
   maxLength?: number;
@@ -31,7 +31,11 @@ export default function AutocompleteInput({
   const containerRef = useRef<HTMLDivElement>(null);
   const localInputRef = useRef<HTMLInputElement>(null);
 
-  const searchFn = contentType === 'location' ? apiSearchLocations : apiSearchMovies;
+  const searchFn = contentType === 'location'
+    ? apiSearchLocations
+    : contentType === 'video_game'
+      ? apiSearchVideoGames
+      : apiSearchMovies;
 
   const doSearch = useCallback(async (query: string) => {
     if (query.length < 2) {
@@ -147,7 +151,9 @@ export default function AutocompleteInput({
           <li className="px-3 py-1.5 text-[10px] text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700">
             {contentType === 'movie'
               ? 'Data from TMDB. Not endorsed by TMDB.'
-              : 'Data \u00A9 OpenStreetMap contributors'}
+              : contentType === 'video_game'
+                ? 'Data from RAWG Video Games Database'
+                : 'Data \u00A9 OpenStreetMap contributors'}
           </li>
         </ul>
       )}

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -10,7 +10,7 @@ interface OptionsInputProps {
   pollType?: 'poll' | 'nomination';
   label?: React.ReactNode;
   placeholder?: string;
-  contentType?: 'custom' | 'location' | 'movie';
+  contentType?: 'custom' | 'location' | 'movie' | 'video_game';
 }
 
 export default function OptionsInput({
@@ -94,6 +94,11 @@ export default function OptionsInput({
         return filledOptions.length === 0 ? "Search for a movie..." : "Add another movie...";
       }
       return `Movie ${index + 1}`;
+    } else if (contentType === 'video_game') {
+      if (isLastField) {
+        return filledOptions.length === 0 ? "Search for a video game..." : "Add another video game...";
+      }
+      return `Video game ${index + 1}`;
     } else if (pollType === 'nomination') {
       if (isLastField) {
         return filledOptions.length === 0 ? "Add a suggestion" : "Add another suggestion...";
@@ -107,7 +112,7 @@ export default function OptionsInput({
     }
   };
 
-  const useAutocomplete = contentType === 'location' || contentType === 'movie';
+  const useAutocomplete = contentType === 'location' || contentType === 'movie' || contentType === 'video_game';
   const inputClassName = (isDuplicate: boolean) =>
     `flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
       isDuplicate
@@ -139,7 +144,7 @@ export default function OptionsInput({
                   <AutocompleteInput
                     value={option}
                     onChange={(value) => updateOption(index, value)}
-                    contentType={contentType as 'location' | 'movie'}
+                    contentType={contentType as 'location' | 'movie' | 'video_game'}
                     disabled={isLoading}
                     maxLength={100}
                     placeholder={getPlaceholder(index)}

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef } from "react";
+import type { PollContentType } from "@/lib/types";
 import AutocompleteInput from "@/components/AutocompleteInput";
 
 interface OptionsInputProps {
@@ -10,7 +11,7 @@ interface OptionsInputProps {
   pollType?: 'poll' | 'nomination';
   label?: React.ReactNode;
   placeholder?: string;
-  contentType?: 'custom' | 'location' | 'movie' | 'video_game';
+  contentType?: PollContentType;
 }
 
 export default function OptionsInput({
@@ -144,7 +145,7 @@ export default function OptionsInput({
                   <AutocompleteInput
                     value={option}
                     onChange={(value) => updateOption(index, value)}
-                    contentType={contentType as 'location' | 'movie' | 'video_game'}
+                    contentType={contentType as Exclude<PollContentType, 'custom'>}
                     disabled={isLoading}
                     maxLength={100}
                     placeholder={getPlaceholder(index)}

--- a/database/migrations/074_add_video_game_content_type_down.sql
+++ b/database/migrations/074_add_video_game_content_type_down.sql
@@ -1,0 +1,4 @@
+-- Revert poll_content_type check constraint to exclude 'video_game'
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_content_type_check;
+ALTER TABLE polls ADD CONSTRAINT polls_poll_content_type_check
+    CHECK (poll_content_type IN ('custom', 'location', 'movie'));

--- a/database/migrations/074_add_video_game_content_type_up.sql
+++ b/database/migrations/074_add_video_game_content_type_up.sql
@@ -1,0 +1,4 @@
+-- Add 'video_game' to poll_content_type check constraint
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_content_type_check;
+ALTER TABLE polls ADD CONSTRAINT polls_poll_content_type_check
+    CHECK (poll_content_type IN ('custom', 'location', 'movie', 'video_game'));

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -354,3 +354,10 @@ export async function apiSearchMovies(query: string): Promise<SearchResult[]> {
   if (!res.ok) return [];
   return res.json();
 }
+
+export async function apiSearchVideoGames(query: string): Promise<SearchResult[]> {
+  const params = new URLSearchParams({ q: query });
+  const res = await fetch(`${SEARCH_BASE}/video-games?${params}`);
+  if (!res.ok) return [];
+  return res.json();
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,8 @@
 // Core type definitions for WhoeverWants
 // Extracted from lib/supabase.ts during Phase 3 cleanup
 
+export type PollContentType = 'custom' | 'location' | 'movie' | 'video_game';
+
 export interface Poll {
   id: string;
   title: string;
@@ -40,7 +42,7 @@ export interface Poll {
   time_preferences_deadline_minutes?: number | null;
   day_time_windows?: DayTimeWindow[] | null;
   duration_window?: DurationWindow | null;
-  poll_content_type?: 'custom' | 'location' | 'movie' | 'video_game' | null;
+  poll_content_type?: PollContentType | null;
 }
 
 export interface TimeWindow {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -40,7 +40,7 @@ export interface Poll {
   time_preferences_deadline_minutes?: number | null;
   day_time_windows?: DayTimeWindow[] | null;
   duration_window?: DurationWindow | null;
-  poll_content_type?: 'custom' | 'location' | 'movie' | null;
+  poll_content_type?: 'custom' | 'location' | 'movie' | 'video_game' | null;
 }
 
 export interface TimeWindow {

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Query
 router = APIRouter(prefix="/api/search", tags=["search"])
 
 TMDB_API_KEY = os.environ.get("TMDB_API_KEY", "")
+RAWG_API_KEY = os.environ.get("RAWG_API_KEY", "")
 
 _http_client = httpx.AsyncClient(timeout=5.0)
 
@@ -66,5 +67,36 @@ async def search_movies(q: str = Query(..., min_length=2, max_length=100)):
             "label": label,
             "description": (movie.get("overview", "") or "")[:120],
             "imageUrl": f"https://image.tmdb.org/t/p/w92{poster}" if poster else None,
+        })
+    return results
+
+
+@router.get("/video-games")
+async def search_video_games(q: str = Query(..., min_length=2, max_length=100)):
+    """Search for video games using RAWG API."""
+    if not RAWG_API_KEY:
+        return []
+
+    resp = await _http_client.get(
+        "https://api.rawg.io/api/games",
+        params={
+            "key": RAWG_API_KEY,
+            "search": q,
+            "page_size": 6,
+        },
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    results = []
+    for game in data.get("results", [])[:6]:
+        year = (game.get("released") or "")[:4]
+        name = game.get("name", "")
+        label = f"{name} ({year})" if year else name
+        genres = ", ".join(g["name"] for g in game.get("genres", [])[:3])
+        results.append({
+            "label": label,
+            "description": genres or None,
+            "imageUrl": game.get("background_image"),
         })
     return results

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -1,9 +1,12 @@
 """Search/autocomplete endpoints for poll content types."""
 
+import logging
 import os
 
 import httpx
 from fastapi import APIRouter, Query
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/search", tags=["search"])
 
@@ -71,21 +74,33 @@ async def search_movies(q: str = Query(..., min_length=2, max_length=100)):
     return results
 
 
+def _rawg_crop_image(url: str | None, width: int = 200, height: int = 200) -> str | None:
+    """Resize a RAWG media URL to a smaller thumbnail."""
+    if not url or "media.rawg.io" not in url:
+        return url
+    return url.replace("/media/", f"/media/resize/{width}/-/")
+
+
 @router.get("/video-games")
 async def search_video_games(q: str = Query(..., min_length=2, max_length=100)):
     """Search for video games using RAWG API."""
     if not RAWG_API_KEY:
         return []
 
-    resp = await _http_client.get(
-        "https://api.rawg.io/api/games",
-        params={
-            "key": RAWG_API_KEY,
-            "search": q,
-            "page_size": 6,
-        },
-    )
-    resp.raise_for_status()
+    try:
+        resp = await _http_client.get(
+            "https://api.rawg.io/api/games",
+            params={
+                "key": RAWG_API_KEY,
+                "search": q,
+                "page_size": 6,
+            },
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError:
+        logger.warning("RAWG API returned error for query %r", q)
+        return []
+
     data = resp.json()
 
     results = []
@@ -97,6 +112,6 @@ async def search_video_games(q: str = Query(..., min_length=2, max_length=100)):
         results.append({
             "label": label,
             "description": genres or None,
-            "imageUrl": game.get("background_image"),
+            "imageUrl": _rawg_crop_image(game.get("background_image")),
         })
     return results


### PR DESCRIPTION
## Summary
- Adds `video_game` as a new poll content type alongside location and movie
- New `/api/search/video-games` endpoint using RAWG Video Games Database API (displays title, year, genres, and cropped cover art)
- Database migration 074 updates the `poll_content_type` CHECK constraint
- Shared `PollContentType` type alias extracted to `lib/types.ts` to avoid repeating the union across files

## Deployment notes
- `RAWG_API_KEY` env var already set on the droplet in `.env.api`
- Migration 074 needs to be applied to production DB

## Test plan
- [x] Video game search endpoint returns results (tested on dev server with "zelda")
- [ ] Create a ranked choice or nomination poll with "Video Game" type selected
- [ ] Verify autocomplete dropdown shows game titles, years, genres, and thumbnails
- [ ] Verify duplicate/fork/follow-up preserves the video game content type
- [ ] Verify attribution footer shows "Data from RAWG Video Games Database"

https://claude.ai/code/session_01RzBdZAqpZRzuvJoDb1g3FX