### PR TITLE
Add thumbnails and info links for non-custom poll options

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -67,6 +67,7 @@ function CreatePollContent() {
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
   const [pollContentType, setPollContentType] = useState<PollContentType>('custom');
+  const [optionsMetadata, setOptionsMetadata] = useState<Record<string, { imageUrl?: string; infoUrl?: string }>>({});
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
   const [locationValue, setLocationValue] = useState('');
@@ -438,6 +439,9 @@ function CreatePollContent() {
           if (forkData.poll_content_type) {
             setPollContentType(forkData.poll_content_type);
           }
+          if (forkData.options_metadata) {
+            setOptionsMetadata(forkData.options_metadata);
+          }
         } catch (error) {
           console.error('Error loading fork data:', error);
         }
@@ -519,6 +523,9 @@ function CreatePollContent() {
           }
           if (duplicateData.poll_content_type) {
             setPollContentType(duplicateData.poll_content_type);
+          }
+          if (duplicateData.options_metadata) {
+            setOptionsMetadata(duplicateData.options_metadata);
           }
 
           // Don't clean up the duplicate data yet - keep it until poll is created
@@ -870,6 +877,11 @@ function CreatePollContent() {
         pollData.poll_content_type = pollContentType;
       }
 
+      // Add options metadata (thumbnails & info links from autocomplete)
+      if (Object.keys(optionsMetadata).length > 0) {
+        pollData.options_metadata = optionsMetadata;
+      }
+
       // Add options for ranked choice polls only
       // For nomination polls, initial options become the creator's vote (not poll content)
       if (dbPollType === 'ranked_choice') {
@@ -1209,6 +1221,8 @@ function CreatePollContent() {
               isLoading={isLoading}
               pollType="poll"
               contentType={pollContentType}
+              optionsMetadata={optionsMetadata}
+              onMetadataChange={setOptionsMetadata}
               label={<>Options{' '}<span className="text-gray-500 font-normal">(blank for yes/no)</span></>}
             />
           )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
-import type { PollContentType } from "@/lib/types";
+import type { PollContentType, OptionsMetadata } from "@/lib/types";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -67,7 +67,7 @@ function CreatePollContent() {
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
   const [pollContentType, setPollContentType] = useState<PollContentType>('custom');
-  const [optionsMetadata, setOptionsMetadata] = useState<Record<string, { imageUrl?: string; infoUrl?: string }>>({});
+  const [optionsMetadata, setOptionsMetadata] = useState<OptionsMetadata>({});
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
   const [locationValue, setLocationValue] = useState('');

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -18,6 +18,7 @@ import FollowUpModal from "@/components/FollowUpModal";
 import VoterList from "@/components/VoterList";
 import PollManagementButtons from "@/components/PollManagementButtons";
 import GradientBorderButton from "@/components/GradientBorderButton";
+import OptionLabel from "@/components/OptionLabel";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults } from "@/lib/types";
@@ -52,6 +53,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [yesNoChoice, setYesNoChoice] = useState<'yes' | 'no' | null>(null);
   const [isAbstaining, setIsAbstaining] = useState(false);
   const [nominationChoices, setNominationChoices] = useState<string[]>([]);
+  const [nominationMetadata, setNominationMetadata] = useState<Record<string, { imageUrl?: string; infoUrl?: string }>>({});
   const [existingNominations, setExistingNominations] = useState<string[]>([]);
   const [justCancelledAbstain, setJustCancelledAbstain] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -999,12 +1001,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         // Send null for nominations when abstaining, array with nominations when voting
         // Abstain if explicitly set OR if no nominations provided
         const finalAbstain = isAbstaining || willAbstain;
+        // Filter metadata to only include nominated options
+        const filteredMetadata = Object.keys(nominationMetadata).length > 0
+          ? Object.fromEntries(Object.entries(nominationMetadata).filter(([key]) => filteredNominations.includes(key)))
+          : null;
         voteData = {
           poll_id: poll.id,
           vote_type: 'nomination' as const,
           nominations: finalAbstain ? null : filteredNominations,
           is_abstain: finalAbstain,
-          voter_name: voterName.trim() || null
+          voter_name: voterName.trim() || null,
+          options_metadata: !finalAbstain && filteredMetadata && Object.keys(filteredMetadata).length > 0 ? filteredMetadata : null,
         };
 
         await logToServer('nomination-vote', 'info', 'Nomination voteData created', voteData);
@@ -1251,7 +1258,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               </div>
             ) : pollResults ? (
               <>
-                <PollResultsDisplay results={pollResults} isPollClosed={isPollClosed} userVoteData={userVoteData} />
+                <PollResultsDisplay results={pollResults} isPollClosed={isPollClosed} userVoteData={userVoteData} optionsMetadata={poll.options_metadata} />
                 {pollResults.time_slot_rounds && pollResults.time_slot_rounds.length > 0 && (
                   <div className="mt-4">
                     <TimeSlotRoundsDisplay
@@ -1742,6 +1749,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               loadingNominations={loadingNominations}
               onVoteOnNominationsClick={handleVoteOnNominationsClick}
               autoCreatePreferences={poll.auto_create_preferences}
+              nominationMetadata={nominationMetadata}
+              onNominationMetadataChange={setNominationMetadata}
             />
           ) : (
             <div>
@@ -1808,7 +1817,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
                               ✓
                             </span>
-                            <span>{rankedChoices[0]}</span>
+                            <OptionLabel text={rankedChoices[0]} metadata={poll.options_metadata?.[rankedChoices[0]]} />
                           </div>
                         ) : (
                           rankedChoices.map((choice, index) => (
@@ -1816,7 +1825,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                               <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
                                 {index + 1}
                               </span>
-                              <span>{choice}</span>
+                              <OptionLabel text={choice} metadata={poll.options_metadata?.[choice]} />
                             </div>
                           ))
                         )}
@@ -1910,7 +1919,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                                   : 'bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 text-blue-800 dark:text-blue-200 border-2 border-transparent active:bg-blue-300 dark:active:bg-blue-700'
                               }`}
                             >
-                              {option}
+                              <OptionLabel text={option} metadata={poll.options_metadata?.[option]} />
                             </button>
                           ))}
                         </div>
@@ -1929,6 +1938,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             disabled={isSubmitting || isAbstaining}
                             storageKey={pollId ? `poll-ranking-${pollId}` : undefined}
                             initialRanking={isEditingVote && userVoteData?.ranked_choices ? userVoteData.ranked_choices : undefined}
+                            optionsMetadata={poll.options_metadata}
                           />
                         )}
                       </>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -21,7 +21,7 @@ import GradientBorderButton from "@/components/GradientBorderButton";
 import OptionLabel from "@/components/OptionLabel";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
-import { Poll, PollResults } from "@/lib/types";
+import { Poll, PollResults, OptionsMetadata } from "@/lib/types";
 import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, apiFindDuplicatePoll, ApiVote } from "@/lib/api";
 import VoteOnItModal from "@/components/VoteOnItModal";
 import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
@@ -53,7 +53,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [yesNoChoice, setYesNoChoice] = useState<'yes' | 'no' | null>(null);
   const [isAbstaining, setIsAbstaining] = useState(false);
   const [nominationChoices, setNominationChoices] = useState<string[]>([]);
-  const [nominationMetadata, setNominationMetadata] = useState<Record<string, { imageUrl?: string; infoUrl?: string }>>({});
+  const [nominationMetadata, setNominationMetadata] = useState<OptionsMetadata>({});
   const [existingNominations, setExistingNominations] = useState<string[]>([]);
   const [justCancelledAbstain, setJustCancelledAbstain] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -7,6 +7,7 @@ import type { PollContentType } from "@/lib/types";
 interface AutocompleteInputProps {
   value: string;
   onChange: (value: string) => void;
+  onSelect?: (result: SearchResult) => void;
   contentType: Exclude<PollContentType, 'custom'>;
   disabled?: boolean;
   placeholder?: string;
@@ -18,6 +19,7 @@ interface AutocompleteInputProps {
 export default function AutocompleteInput({
   value,
   onChange,
+  onSelect,
   contentType,
   disabled = false,
   placeholder,
@@ -61,6 +63,7 @@ export default function AutocompleteInput({
 
   const selectSuggestion = (result: SearchResult) => {
     onChange(result.label);
+    onSelect?.(result);
     setSuggestions([]);
     setShowSuggestions(false);
   };

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { PollResults, RankedChoiceRound } from "@/lib/types";
+import { PollResults, RankedChoiceRound, OptionsMetadata } from "@/lib/types";
 import { apiGetVotes, ApiRankedChoiceRound } from "@/lib/api";
 import OptionLabel from "./OptionLabel";
 
@@ -11,7 +11,7 @@ interface CompactRankedChoiceResultsProps {
   isPollClosed?: boolean;
   userVoteData?: any;
   onFollowUpClick?: () => void;
-  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
+  optionsMetadata?: OptionsMetadata | null;
 }
 
 interface RoundVisualization {

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -4,12 +4,14 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { PollResults, RankedChoiceRound } from "@/lib/types";
 import { apiGetVotes, ApiRankedChoiceRound } from "@/lib/api";
+import OptionLabel from "./OptionLabel";
 
 interface CompactRankedChoiceResultsProps {
   results: PollResults;
   isPollClosed?: boolean;
   userVoteData?: any;
   onFollowUpClick?: () => void;
+  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
 }
 
 interface RoundVisualization {
@@ -29,7 +31,7 @@ interface RoundVisualization {
   roundEntries?: RankedChoiceRound[];
 }
 
-export default function CompactRankedChoiceResults({ results, isPollClosed, userVoteData, onFollowUpClick }: CompactRankedChoiceResultsProps) {
+export default function CompactRankedChoiceResults({ results, isPollClosed, userVoteData, onFollowUpClick, optionsMetadata }: CompactRankedChoiceResultsProps) {
   const router = useRouter();
   const [roundVisualizations, setRoundVisualizations] = useState<RoundVisualization[]>([]);
   const [currentRoundIndex, setCurrentRoundIndex] = useState(0);
@@ -425,7 +427,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                             ? 'text-green-900 dark:text-green-100 font-bold'
                             : 'text-gray-700/80 dark:text-gray-300/80 font-medium'
                         }`}>
-                          {candidate.name}
+                          <OptionLabel text={candidate.name} metadata={optionsMetadata?.[candidate.name]} />
                         </div>
                         {/* Show user preference indicator under name */}
                         {userChoiceText && (

--- a/components/DuplicateButton.tsx
+++ b/components/DuplicateButton.tsx
@@ -24,6 +24,7 @@ export default function DuplicateButton({ poll }: DuplicateButtonProps) {
       auto_close_after: poll.auto_close_after,
       details: poll.details,
       poll_content_type: poll.poll_content_type,
+      options_metadata: poll.options_metadata,
     };
 
     debugLog.logObject('Duplicate button clicked', { pollId: poll.id, duplicateData }, 'DuplicateButton');

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -27,6 +27,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
     auto_close_after: poll.auto_close_after,
     details: poll.details,
     poll_content_type: poll.poll_content_type,
+    options_metadata: poll.options_metadata,
     total_votes: totalVotes,
   };
 

--- a/components/ForkButton.tsx
+++ b/components/ForkButton.tsx
@@ -25,6 +25,7 @@ export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
       auto_close_after: poll.auto_close_after,
       details: poll.details,
       poll_content_type: poll.poll_content_type,
+      options_metadata: poll.options_metadata,
     };
 
     debugLog.logObject('Fork button clicked', { pollId: poll.id, forkData }, 'ForkButton');

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useRef, useEffect, Dispatch, SetStateAction } from "react";
 import PollResultsDisplay from "@/components/PollResults";
-import OptionsInput from "@/components/OptionsInput";
+import OptionsInput, { type OptionsMetadata } from "@/components/OptionsInput";
 import NominationsList from "@/components/NominationsList";
+import OptionLabel from "@/components/OptionLabel";
 import PollManagementButtons from "@/components/PollManagementButtons";
 import VoterList from "@/components/VoterList";
 import GradientBorderButton from "@/components/GradientBorderButton";
@@ -39,6 +40,8 @@ interface NominationVotingInterfaceProps {
   loadingNominations: boolean;
   onVoteOnNominationsClick: () => void;
   autoCreatePreferences?: boolean;
+  nominationMetadata?: OptionsMetadata;
+  onNominationMetadataChange?: (metadata: OptionsMetadata) => void;
 }
 
 export default function NominationVotingInterface({
@@ -69,7 +72,9 @@ export default function NominationVotingInterface({
   nominations,
   loadingNominations,
   onVoteOnNominationsClick,
-  autoCreatePreferences
+  autoCreatePreferences,
+  nominationMetadata,
+  onNominationMetadataChange,
 }: NominationVotingInterfaceProps) {
   const [newNominations, setNewNominations] = useState<string[]>([""]);
   const [filteredExistingNominations, setFilteredExistingNominations] = useState<string[]>([]);
@@ -208,6 +213,7 @@ export default function NominationVotingInterface({
               showEditButton={!isPollClosed}
               onEditClick={() => setIsEditingVote(true)}
               isEditDisabled={isLoadingVoteData}
+              optionsMetadata={poll.options_metadata}
             />
           ) : (
             <div className="flex items-center justify-between">
@@ -317,7 +323,7 @@ export default function NominationVotingInterface({
                         : 'bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-700 active:bg-gray-100 dark:active:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
                     }`}
                   >
-                    {nomination}
+                    <OptionLabel text={nomination} metadata={poll.options_metadata?.[nomination]} />
                   </button>
                 );
               })}
@@ -334,6 +340,8 @@ export default function NominationVotingInterface({
             pollType="nomination"
             label={isEditingVote ? "Add new suggestions:" : "Add new suggestions:"}
             contentType={poll.poll_content_type || 'custom'}
+            optionsMetadata={nominationMetadata}
+            onMetadataChange={onNominationMetadataChange}
           />
         </div>
 

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import OptionLabel from "./OptionLabel";
+
 interface Nomination {
   option: string;
   count: number;
@@ -14,6 +16,7 @@ interface NominationsListProps {
   showEditButton?: boolean;
   onEditClick?: () => void;
   isEditDisabled?: boolean;
+  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
 }
 
 export default function NominationsList({
@@ -24,7 +27,8 @@ export default function NominationsList({
   className = "",
   showEditButton = false,
   onEditClick,
-  isEditDisabled = false
+  isEditDisabled = false,
+  optionsMetadata,
 }: NominationsListProps) {
   if (nominations.length === 0) {
     return (
@@ -86,7 +90,7 @@ export default function NominationsList({
                   ? 'text-blue-900 dark:text-blue-100'
                   : 'text-gray-900 dark:text-gray-100'
               }`}>
-                {nomination.option}
+                <OptionLabel text={nomination.option} metadata={optionsMetadata?.[nomination.option]} />
               </span>
               {showVoteCounts && (
                 <span className={`px-2.5 py-1 text-sm font-bold ${

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { OptionsMetadata } from "@/lib/types";
 import OptionLabel from "./OptionLabel";
 
 interface Nomination {
@@ -16,7 +17,7 @@ interface NominationsListProps {
   showEditButton?: boolean;
   onEditClick?: () => void;
   isEditDisabled?: boolean;
-  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
+  optionsMetadata?: OptionsMetadata | null;
 }
 
 export default function NominationsList({

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -16,8 +16,8 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     return <span className={className}>{text}</span>;
   }
 
-  return (
-    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+  const content = (
+    <>
       {metadata.imageUrl && (
         <img
           src={metadata.imageUrl}
@@ -26,20 +26,26 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
         />
       )}
       <span>{text}</span>
-      {metadata.infoUrl && (
-        <a
-          href={metadata.infoUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          className="flex-shrink-0 text-gray-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400 transition-colors"
-          title="More info"
-        >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-          </svg>
-        </a>
-      )}
+    </>
+  );
+
+  if (metadata.infoUrl) {
+    return (
+      <a
+        href={metadata.infoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className={`inline-flex items-center gap-1.5 text-blue-600 dark:text-blue-400 hover:underline ${className}`}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+      {content}
     </span>
   );
 }

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+interface OptionMetadata {
+  imageUrl?: string;
+  infoUrl?: string;
+}
+
+interface OptionLabelProps {
+  text: string;
+  metadata?: OptionMetadata | null;
+  className?: string;
+}
+
+export default function OptionLabel({ text, metadata, className = "" }: OptionLabelProps) {
+  if (!metadata || (!metadata.imageUrl && !metadata.infoUrl)) {
+    return <span className={className}>{text}</span>;
+  }
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+      {metadata.imageUrl && (
+        <img
+          src={metadata.imageUrl}
+          alt=""
+          className="w-5 h-7 object-cover rounded flex-shrink-0"
+        />
+      )}
+      <span>{text}</span>
+      {metadata.infoUrl && (
+        <a
+          href={metadata.infoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="flex-shrink-0 text-gray-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400 transition-colors"
+          title="More info"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+          </svg>
+        </a>
+      )}
+    </span>
+  );
+}

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -23,6 +23,7 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
           src={metadata.imageUrl}
           alt=""
           className="w-5 h-7 object-cover rounded flex-shrink-0"
+          loading="lazy"
         />
       )}
       <span>{text}</span>

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -2,7 +2,10 @@
 
 import { useRef } from "react";
 import type { PollContentType } from "@/lib/types";
+import type { SearchResult } from "@/lib/api";
 import AutocompleteInput from "@/components/AutocompleteInput";
+
+export type OptionsMetadata = Record<string, { imageUrl?: string; infoUrl?: string }>;
 
 interface OptionsInputProps {
   options: string[];
@@ -12,6 +15,8 @@ interface OptionsInputProps {
   label?: React.ReactNode;
   placeholder?: string;
   contentType?: PollContentType;
+  optionsMetadata?: OptionsMetadata;
+  onMetadataChange?: (metadata: OptionsMetadata) => void;
 }
 
 export default function OptionsInput({
@@ -21,7 +26,9 @@ export default function OptionsInput({
   pollType = 'poll',
   label,
   placeholder,
-  contentType = 'custom'
+  contentType = 'custom',
+  optionsMetadata,
+  onMetadataChange,
 }: OptionsInputProps) {
   const optionRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -66,6 +73,14 @@ export default function OptionsInput({
     }
 
     setOptions(newOptions);
+  };
+
+  const handleSelect = (result: SearchResult) => {
+    if (!onMetadataChange || (!result.imageUrl && !result.infoUrl)) return;
+    const entry: { imageUrl?: string; infoUrl?: string } = {};
+    if (result.imageUrl) entry.imageUrl = result.imageUrl;
+    if (result.infoUrl) entry.infoUrl = result.infoUrl;
+    onMetadataChange({ ...optionsMetadata, [result.label]: entry });
   };
 
   const removeOption = (index: number) => {
@@ -145,6 +160,7 @@ export default function OptionsInput({
                   <AutocompleteInput
                     value={option}
                     onChange={(value) => updateOption(index, value)}
+                    onSelect={handleSelect}
                     contentType={contentType as Exclude<PollContentType, 'custom'>}
                     disabled={isLoading}
                     maxLength={100}

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useRef } from "react";
-import type { PollContentType } from "@/lib/types";
+import type { PollContentType, OptionsMetadata } from "@/lib/types";
 import type { SearchResult } from "@/lib/api";
 import AutocompleteInput from "@/components/AutocompleteInput";
 
-export type OptionsMetadata = Record<string, { imageUrl?: string; infoUrl?: string }>;
+export type { OptionsMetadata };
 
 interface OptionsInputProps {
   options: string[];

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -11,9 +11,10 @@ interface PollResultsProps {
   isPollClosed?: boolean;
   userVoteData?: any;
   onFollowUpClick?: () => void;
+  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
 }
 
-export default function PollResultsDisplay({ results, isPollClosed, userVoteData, onFollowUpClick }: PollResultsProps) {
+export default function PollResultsDisplay({ results, isPollClosed, userVoteData, onFollowUpClick, optionsMetadata }: PollResultsProps) {
   if (results.poll_type === 'yes_no') {
     return <YesNoResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} />;
   }
@@ -23,11 +24,11 @@ export default function PollResultsDisplay({ results, isPollClosed, userVoteData
   }
 
   if (results.poll_type === 'ranked_choice') {
-    return <CompactRankedChoiceResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} />;
+    return <CompactRankedChoiceResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} optionsMetadata={optionsMetadata} />;
   }
 
   if (results.poll_type === 'nomination') {
-    return <NominationResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} />;
+    return <NominationResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} optionsMetadata={optionsMetadata} />;
   }
 
   return null;
@@ -508,7 +509,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
   );
 }
 
-function NominationResults({ results, isPollClosed, userVoteData, onFollowUpClick }: { results: PollResults, isPollClosed?: boolean, userVoteData?: any, onFollowUpClick?: () => void }) {
+function NominationResults({ results, isPollClosed, userVoteData, onFollowUpClick, optionsMetadata }: { results: PollResults, isPollClosed?: boolean, userVoteData?: any, onFollowUpClick?: () => void, optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null }) {
   // Use server-side nomination counts from the results endpoint
   const nominations = results.nomination_counts || [];
 
@@ -538,6 +539,7 @@ function NominationResults({ results, isPollClosed, userVoteData, onFollowUpClic
             userNominations={userVoteData?.nominations || []}
             showVoteCounts={true}
             showUserIndicator={true}
+            optionsMetadata={optionsMetadata}
           />
         )}
       </div>

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { PollResults } from "@/lib/types";
+import { PollResults, OptionsMetadata } from "@/lib/types";
 import { apiGetVotes, apiGetParticipants } from "@/lib/api";
 import CompactRankedChoiceResults from "./CompactRankedChoiceResults";
 import NominationsList from "./NominationsList";
@@ -11,7 +11,7 @@ interface PollResultsProps {
   isPollClosed?: boolean;
   userVoteData?: any;
   onFollowUpClick?: () => void;
-  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
+  optionsMetadata?: OptionsMetadata | null;
 }
 
 export default function PollResultsDisplay({ results, isPollClosed, userVoteData, onFollowUpClick, optionsMetadata }: PollResultsProps) {
@@ -509,7 +509,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
   );
 }
 
-function NominationResults({ results, isPollClosed, userVoteData, onFollowUpClick, optionsMetadata }: { results: PollResults, isPollClosed?: boolean, userVoteData?: any, onFollowUpClick?: () => void, optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null }) {
+function NominationResults({ results, isPollClosed, userVoteData, onFollowUpClick, optionsMetadata }: { results: PollResults, isPollClosed?: boolean, userVoteData?: any, onFollowUpClick?: () => void, optionsMetadata?: OptionsMetadata | null }) {
   // Use server-side nomination counts from the results endpoint
   const nominations = results.nomination_counts || [];
 

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { ClientOnlyDragDrop } from './ClientOnly';
+import type { OptionsMetadata } from '@/lib/types';
 import OptionLabel from './OptionLabel';
 
 interface RankableOption {
@@ -16,7 +17,7 @@ interface RankableOptionsProps {
   disabled?: boolean;
   storageKey?: string; // Optional key for localStorage persistence
   initialRanking?: string[]; // Optional initial ranking to override saved state
-  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
+  optionsMetadata?: OptionsMetadata | null;
 }
 
 export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, optionsMetadata }: RankableOptionsProps) {

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { ClientOnlyDragDrop } from './ClientOnly';
+import OptionLabel from './OptionLabel';
 
 interface RankableOption {
   id: string;
@@ -15,9 +16,10 @@ interface RankableOptionsProps {
   disabled?: boolean;
   storageKey?: string; // Optional key for localStorage persistence
   initialRanking?: string[]; // Optional initial ranking to override saved state
+  optionsMetadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
 }
 
-export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking }: RankableOptionsProps) {
+export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, optionsMetadata }: RankableOptionsProps) {
 
   // Load saved state from localStorage
   const loadSavedState = useCallback(() => {
@@ -601,7 +603,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             <div className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
               {rankNumber}
             </div>
-            <span className="font-medium leading-tight line-clamp-2 text-gray-900 dark:text-white">{draggedOption.text}</span>
+            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="font-medium leading-tight line-clamp-2 text-gray-900 dark:text-white" />
           </div>
           <div className="w-6 h-6 flex flex-col items-center justify-center ml-2">
             <div className="w-4 h-0.5 bg-gray-600 mb-1"></div>
@@ -973,13 +975,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                   
                   {/* Center content - not grabbable */}
                   <div className="flex-1 flex items-center px-12">
-                    <span className={`font-medium leading-tight line-clamp-2 ${
-                      disabled 
-                        ? 'text-gray-500 dark:text-gray-400' 
+                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className={`font-medium leading-tight line-clamp-2 ${
+                      disabled
+                        ? 'text-gray-500 dark:text-gray-400'
                         : 'text-gray-900 dark:text-white'
-                    }`}>
-                      {option.text}
-                    </span>
+                    }`} />
                   </div>
                   
                   {/* Right drag handle with grabbable region */}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -599,11 +599,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         style={getDraggedItemStyle()}
       >
         <div className="flex items-center justify-between h-full">
-          <div className="flex items-center">
+          <div className="flex items-center text-gray-900 dark:text-white">
             <div className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
               {rankNumber}
             </div>
-            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="font-medium leading-tight line-clamp-2 text-gray-900 dark:text-white" />
+            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="font-medium leading-tight line-clamp-2" />
           </div>
           <div className="w-6 h-6 flex flex-col items-center justify-center ml-2">
             <div className="w-4 h-0.5 bg-gray-600 mb-1"></div>
@@ -974,12 +974,12 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                   </div>
                   
                   {/* Center content - not grabbable */}
-                  <div className="flex-1 flex items-center px-12">
-                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className={`font-medium leading-tight line-clamp-2 ${
-                      disabled
-                        ? 'text-gray-500 dark:text-gray-400'
-                        : 'text-gray-900 dark:text-white'
-                    }`} />
+                  <div className={`flex-1 flex items-center px-12 ${
+                    disabled
+                      ? 'text-gray-500 dark:text-gray-400'
+                      : 'text-gray-900 dark:text-white'
+                  }`}>
+                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="font-medium leading-tight line-clamp-2" />
                   </div>
                   
                   {/* Right drag handle with grabbable region */}

--- a/database/migrations/075_add_options_metadata_down.sql
+++ b/database/migrations/075_add_options_metadata_down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE polls DROP COLUMN IF EXISTS options_metadata;

--- a/database/migrations/075_add_options_metadata_up.sql
+++ b/database/migrations/075_add_options_metadata_up.sql
@@ -1,0 +1,3 @@
+-- Add options_metadata JSONB column to store thumbnail URLs and info links per option
+-- Format: { "Option Label": { "imageUrl": "...", "infoUrl": "..." }, ... }
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS options_metadata JSONB;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -124,6 +124,7 @@ function toPoll(data: any): Poll {
     day_time_windows: data.day_time_windows ?? undefined,
     duration_window: data.duration_window ?? undefined,
     poll_content_type: data.poll_content_type ?? undefined,
+    options_metadata: data.options_metadata ?? undefined,
   };
 }
 
@@ -191,6 +192,7 @@ export async function apiCreatePoll(params: {
   day_time_windows?: any[];
   duration_window?: any;
   poll_content_type?: string;
+  options_metadata?: Record<string, { imageUrl?: string; infoUrl?: string }>;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',
@@ -240,6 +242,7 @@ export async function apiSubmitVote(pollId: string, params: {
   max_participants?: number | null;
   voter_day_time_windows?: any[] | null;
   voter_duration?: any | null;
+  options_metadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
 }): Promise<ApiVote> {
   return apiFetch(`/${encodeURIComponent(pollId)}/votes`, {
     method: 'POST',
@@ -335,6 +338,7 @@ export interface SearchResult {
   label: string;
   description?: string;
   imageUrl?: string;
+  infoUrl?: string;
   lat?: string;
   lon?: string;
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,7 +3,7 @@
  * Replaces direct Supabase client calls with fetch()-based requests to the FastAPI server.
  */
 
-import type { Poll, PollResults } from './types';
+import type { Poll, PollResults, OptionsMetadata } from './types';
 import { branchToSlug } from './slug';
 
 // API URL resolution:
@@ -192,7 +192,7 @@ export async function apiCreatePoll(params: {
   day_time_windows?: any[];
   duration_window?: any;
   poll_content_type?: string;
-  options_metadata?: Record<string, { imageUrl?: string; infoUrl?: string }>;
+  options_metadata?: OptionsMetadata;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',
@@ -242,7 +242,7 @@ export async function apiSubmitVote(pollId: string, params: {
   max_participants?: number | null;
   voter_day_time_windows?: any[] | null;
   voter_duration?: any | null;
-  options_metadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
+  options_metadata?: OptionsMetadata | null;
 }): Promise<ApiVote> {
   return apiFetch(`/${encodeURIComponent(pollId)}/votes`, {
     method: 'POST',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,7 @@ export interface Poll {
   day_time_windows?: DayTimeWindow[] | null;
   duration_window?: DurationWindow | null;
   poll_content_type?: PollContentType | null;
+  options_metadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
 }
 
 export interface TimeWindow {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,8 @@
 
 export type PollContentType = 'custom' | 'location' | 'movie' | 'video_game';
 
+export type OptionsMetadata = Record<string, { imageUrl?: string; infoUrl?: string }>;
+
 export interface Poll {
   id: string;
   title: string;
@@ -43,7 +45,7 @@ export interface Poll {
   day_time_windows?: DayTimeWindow[] | null;
   duration_window?: DurationWindow | null;
   poll_content_type?: PollContentType | null;
-  options_metadata?: Record<string, { imageUrl?: string; infoUrl?: string }> | null;
+  options_metadata?: OptionsMetadata | null;
 }
 
 export interface TimeWindow {

--- a/server/models.py
+++ b/server/models.py
@@ -53,6 +53,8 @@ class CreatePollRequest(BaseModel):
     duration_window: dict | None = None
     # Content type for autocomplete (nomination/ranked_choice polls)
     poll_content_type: str | None = None
+    # Metadata for options (thumbnail URLs, info links) keyed by option label
+    options_metadata: dict | None = None
 
 
 class SubmitVoteRequest(BaseModel):
@@ -66,6 +68,8 @@ class SubmitVoteRequest(BaseModel):
     max_participants: int | None = None
     voter_day_time_windows: list[dict] | None = None
     voter_duration: dict | None = None
+    # Metadata for nominated options (merged into poll's options_metadata)
+    options_metadata: dict | None = None
 
 
 class EditVoteRequest(BaseModel):
@@ -146,6 +150,7 @@ class PollResponse(BaseModel):
     day_time_windows: list[dict] | None = None
     duration_window: dict | None = None
     poll_content_type: str | None = None
+    options_metadata: dict | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -141,6 +141,10 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
     from datetime import timedelta
     deadline = now + timedelta(minutes=deadline_minutes)
 
+    # Propagate options_metadata from parent for matching nominations
+    parent_metadata = parent_row.get("options_metadata") or {}
+    child_metadata = {nom: parent_metadata[nom] for nom in all_nominations if nom in parent_metadata} or None
+
     # Activate the reserved poll (propagate sub-poll metadata if present)
     conn.execute(
         """
@@ -149,6 +153,7 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
             response_deadline = %(deadline)s,
             is_closed = false,
             updated_at = %(now)s,
+            options_metadata = %(options_metadata)s::jsonb,
             is_sub_poll = COALESCE(%(is_sub_poll)s, is_sub_poll),
             sub_poll_role = COALESCE(%(sub_poll_role)s, sub_poll_role),
             parent_participation_poll_id = COALESCE(%(parent_id)s, parent_participation_poll_id)
@@ -159,6 +164,7 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
             "deadline": deadline.isoformat(),
             "now": now,
             "reserved_id": str(reserved["id"]),
+            "options_metadata": json.dumps(child_metadata) if child_metadata else None,
             "is_sub_poll": parent_row.get("is_sub_poll") or None,
             "sub_poll_role": None,  # Already set at creation for sub-polls
             "parent_id": str(parent_row["parent_participation_poll_id"]) if parent_row.get("parent_participation_poll_id") else None,
@@ -207,6 +213,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         day_time_windows=row.get("day_time_windows"),
         duration_window=row.get("duration_window"),
         poll_content_type=row.get("poll_content_type"),
+        options_metadata=row.get("options_metadata"),
     )
 
 
@@ -421,7 +428,7 @@ def create_poll(req: CreatePollRequest):
                                time_suggestions_deadline_minutes,
                                time_preferences_deadline_minutes,
                                day_time_windows, duration_window,
-                               poll_content_type,
+                               poll_content_type, options_metadata,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
@@ -436,7 +443,7 @@ def create_poll(req: CreatePollRequest):
                     %(time_suggestions_deadline_minutes)s,
                     %(time_preferences_deadline_minutes)s,
                     %(day_time_windows)s::jsonb, %(duration_window)s::jsonb,
-                    %(poll_content_type)s,
+                    %(poll_content_type)s, %(options_metadata)s::jsonb,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -470,6 +477,7 @@ def create_poll(req: CreatePollRequest):
                 "day_time_windows": json.dumps(req.day_time_windows) if req.day_time_windows else None,
                 "duration_window": json.dumps(req.duration_window) if req.duration_window else None,
                 "poll_content_type": req.poll_content_type or "custom",
+                "options_metadata": json.dumps(req.options_metadata) if req.options_metadata else None,
                 "now": now,
             },
         ).fetchone()
@@ -635,6 +643,21 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
                 "now": now,
             },
         ).fetchone()
+
+        # Merge nomination metadata into poll's options_metadata
+        if req.options_metadata and req.nominations:
+            conn.execute(
+                """
+                UPDATE polls
+                SET options_metadata = COALESCE(options_metadata, '{}'::jsonb) || %(new_metadata)s::jsonb
+                WHERE id = %(poll_id)s
+                """,
+                {
+                    "poll_id": poll_id,
+                    "new_metadata": json.dumps(req.options_metadata),
+                },
+            )
+
         _check_auto_close(conn, poll_id)
     return _row_to_vote(row)
 

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -38,6 +38,8 @@ async def search_locations(q: str = Query(..., min_length=2, max_length=100)):
             "description": item.get("type", "").replace("_", " ").title(),
             "lat": item.get("lat"),
             "lon": item.get("lon"),
+            "infoUrl": f"https://www.openstreetmap.org/?mlat={item.get('lat')}&mlon={item.get('lon')}#map=15/{item.get('lat')}/{item.get('lon')}"
+            if item.get("lat") and item.get("lon") else None,
         }
         for item in data
     ]
@@ -66,10 +68,12 @@ async def search_movies(q: str = Query(..., min_length=2, max_length=100)):
         title = movie.get("title", "")
         label = f"{title} ({year})" if year else title
         poster = movie.get("poster_path")
+        movie_id = movie.get("id")
         results.append({
             "label": label,
             "description": (movie.get("overview", "") or "")[:120],
             "imageUrl": f"https://image.tmdb.org/t/p/w92{poster}" if poster else None,
+            "infoUrl": f"https://www.themoviedb.org/movie/{movie_id}" if movie_id else None,
         })
     return results
 
@@ -109,9 +113,11 @@ async def search_video_games(q: str = Query(..., min_length=2, max_length=100)):
         name = game.get("name", "")
         label = f"{name} ({year})" if year else name
         genres = ", ".join(g["name"] for g in game.get("genres", [])[:3])
+        slug = game.get("slug")
         results.append({
             "label": label,
             "description": genres or None,
             "imageUrl": _rawg_crop_image(game.get("background_image")),
+            "infoUrl": f"https://rawg.io/games/{slug}" if slug else None,
         })
     return results


### PR DESCRIPTION
## Summary
- Show thumbnail images and clickable info links for movie, video game, and location poll options everywhere they appear (voting UI, results, nominations, ranked choice)
- Search APIs now return `infoUrl` (TMDB movie pages, RAWG game pages, OpenStreetMap links) alongside existing `imageUrl`
- New `OptionLabel` component renders thumbnail + text as a single clickable link (blue text) when metadata exists, plain text otherwise
- Metadata stored as JSONB `options_metadata` column on polls, captured at autocomplete selection time and propagated through nomination → preference poll flows
- New `OptionsMetadata` type in `lib/types.ts` used consistently across all components

## Test plan
- [ ] Create a movie poll — verify thumbnails and blue links appear in voting UI and results
- [ ] Create a video game poll — verify RAWG links work
- [ ] Create a location poll — verify OpenStreetMap links work
- [ ] Create a nomination poll with movie content type — verify metadata persists through nomination → voting flow
- [ ] Verify custom polls show plain text with no blue styling
- [ ] Verify ranked choice drag handles don't interfere with link clicks
- [ ] Fork/duplicate a poll with metadata — verify metadata carries over

https://claude.ai/code/session_01WmEtAGBfVSJQBzxVJnbtqx