### PR TITLE
Add reference location for proximity-based place search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -869,6 +869,13 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **`npm run dev` spawns a process chain** (`npm` -> `next` -> `node`). Killing the parent PID doesn't reliably kill child processes holding the TCP port. After PID-based kill, always `fuser -k <port>/tcp` to clean up orphaned children — otherwise the next start gets `EADDRINUSE`.
 - **Dev server shows stale commit info** when the restart fails silently. The old process keeps serving pages. Always check `dev-server-manager.sh list` for `[STOPPED]` status after a push if the commit info doesn't update.
 
+### Nominatim / Location Search
+
+- **Nominatim does full-word matching, not prefix matching.** Searching "Burger K" won't find "Burger King" because "K" isn't a complete word. The frontend compensates with client-side result caching in `AutocompleteInput.tsx`: previous results are cached in `lastResultsRef`, and when a continuation query returns results, they're merged with cached results filtered by all query words. This way "Burger K" retains the "Burger King" result from the "Burger" query.
+- **Use `bounded=1` with viewbox AND a hard distance cutoff** for proximity searches. Nominatim's viewbox is a bias, not a hard filter — results outside the box can still appear. Always post-filter with `_haversine_miles()` against `max_distance`.
+- **Always set `Accept-Language: en`** in Nominatim requests to avoid foreign-language results.
+- **Reference location is stored per-poll** (`reference_latitude`, `reference_longitude`, `reference_location_label` columns) and per-user in localStorage (`lib/userProfile.ts: UserLocation`). The poll creation page auto-fills from localStorage.
+
 ### API Development Pitfalls
 
 - **Catch-all fallthrough in `get_results()`**: When adding new poll types, `server/routers/polls.py` has a catch-all return at the bottom returning `yes_count=None`. Any poll type without an explicit handler silently falls through and the frontend interprets `None` as `0`. Always add an explicit handler for each poll type.

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -84,6 +84,7 @@ function CreatePollContent() {
   const [refLatitude, setRefLatitude] = useState<number | undefined>(undefined);
   const [refLongitude, setRefLongitude] = useState<number | undefined>(undefined);
   const [refLocationLabel, setRefLocationLabel] = useState("");
+  const [searchRadius, setSearchRadius] = useState(25);
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -1191,6 +1192,8 @@ function CreatePollContent() {
                 setRefLongitude(lng);
                 setRefLocationLabel(lbl);
               }}
+              searchRadius={searchRadius}
+              onSearchRadiusChange={setSearchRadius}
               disabled={isLoading}
             />
           )}
@@ -1252,6 +1255,7 @@ function CreatePollContent() {
               onMetadataChange={setOptionsMetadata}
               referenceLatitude={refLatitude}
               referenceLongitude={refLongitude}
+              searchRadius={searchRadius}
               label={<>Options{' '}<span className="text-gray-500 font-normal">(blank for yes/no)</span></>}
             />
           )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -17,6 +17,7 @@ import OptionsInput from "@/components/OptionsInput";
 import MinMaxCounter from "@/components/MinMaxCounter";
 import ParticipationConditions, { DayTimeWindow } from "@/components/ParticipationConditions";
 import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
+import ReferenceLocationInput from "@/components/ReferenceLocationInput";
 export const dynamic = 'force-dynamic';
 
 function CreatePollContent() {
@@ -79,6 +80,10 @@ function CreatePollContent() {
   const [timeOptions, setTimeOptions] = useState<string[]>(['', '']);
   const [timeSuggestionsDeadline, setTimeSuggestionsDeadline] = useState('10min');
   const [timePreferencesDeadline, setTimePreferencesDeadline] = useState('10min');
+  // Reference location for proximity-based search
+  const [refLatitude, setRefLatitude] = useState<number | undefined>(undefined);
+  const [refLongitude, setRefLongitude] = useState<number | undefined>(undefined);
+  const [refLocationLabel, setRefLocationLabel] = useState("");
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -877,6 +882,13 @@ function CreatePollContent() {
         pollData.poll_content_type = pollContentType;
       }
 
+      // Add reference location if set
+      if (refLatitude !== undefined && refLongitude !== undefined) {
+        pollData.reference_latitude = refLatitude;
+        pollData.reference_longitude = refLongitude;
+        pollData.reference_location_label = refLocationLabel;
+      }
+
       // Add options metadata (thumbnails & info links from autocomplete)
       if (Object.keys(optionsMetadata).length > 0) {
         pollData.options_metadata = optionsMetadata;
@@ -1168,6 +1180,21 @@ function CreatePollContent() {
             </div>
           )}
 
+          {/* Reference location for location polls */}
+          {(pollContentType === 'location' || (pollType === 'participation' && locationMode !== 'none')) && (
+            <ReferenceLocationInput
+              latitude={refLatitude}
+              longitude={refLongitude}
+              label={refLocationLabel}
+              onLocationChange={(lat, lng, lbl) => {
+                setRefLatitude(lat);
+                setRefLongitude(lng);
+                setRefLocationLabel(lbl);
+              }}
+              disabled={isLoading}
+            />
+          )}
+
           {/* Participant counters for participation polls */}
           {pollType === 'participation' && (
             <ParticipationConditions
@@ -1223,6 +1250,8 @@ function CreatePollContent() {
               contentType={pollContentType}
               optionsMetadata={optionsMetadata}
               onMetadataChange={setOptionsMetadata}
+              referenceLatitude={refLatitude}
+              referenceLongitude={refLongitude}
               label={<>Options{' '}<span className="text-gray-500 font-normal">(blank for yes/no)</span></>}
             />
           )}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1168,6 +1168,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         {/* Poll details (expandable) */}
         {poll.details && <PollDetails details={poll.details} />}
 
+        {/* Reference location badge */}
+        {poll.reference_location_label && (
+          <div className="mb-3 flex items-center justify-center gap-1.5 text-sm text-gray-500 dark:text-gray-400">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            <span>Near {poll.reference_location_label}</span>
+          </div>
+        )}
+
         {/* Sub-poll back navigation */}
         {poll.is_sub_poll && poll.parent_participation_poll_id && (
           <div className="mb-3 text-center">

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,12 +2,16 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getUserName, saveUserName, clearUserName } from "@/lib/userProfile";
+import { getUserName, saveUserName, clearUserName, getUserLocation, saveUserLocation, clearUserLocation, type UserLocation } from "@/lib/userProfile";
+import { apiGeocode } from "@/lib/api";
 
 export default function ProfilePage() {
   const router = useRouter();
   const [name, setName] = useState("");
+  const [locationInput, setLocationInput] = useState("");
+  const [savedLocation, setSavedLocation] = useState<UserLocation | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isGeolocating, setIsGeolocating] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null);
 
   useEffect(() => {
@@ -15,34 +19,92 @@ export default function ProfilePage() {
     if (savedName) {
       setName(savedName);
     }
+    const loc = getUserLocation();
+    if (loc) {
+      setSavedLocation(loc);
+    }
   }, []);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     setIsLoading(true);
     setMessage(null);
-    
+
     try {
       saveUserName(name);
-      setMessage({ type: 'success', text: 'Name saved successfully!' });
-      
-      // Redirect back after a short delay
+
+      // Geocode location input if provided and different from saved
+      if (locationInput.trim()) {
+        const result = await apiGeocode(locationInput.trim());
+        if (result && result.lat && result.lon) {
+          const loc: UserLocation = {
+            latitude: parseFloat(result.lat),
+            longitude: parseFloat(result.lon),
+            label: result.label,
+          };
+          saveUserLocation(loc);
+          setSavedLocation(loc);
+          setLocationInput("");
+        } else {
+          setMessage({ type: 'error', text: 'Could not find that location. Try a zip code or city name.' });
+          setIsLoading(false);
+          return;
+        }
+      }
+
+      setMessage({ type: 'success', text: 'Profile saved!' });
       setTimeout(() => {
         router.back();
       }, 1000);
-    } catch (error) {
-      setMessage({ type: 'error', text: 'Failed to save name' });
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to save profile' });
     } finally {
       setIsLoading(false);
     }
   };
 
-  const handleSignOut = () => {
-    if (confirm('Are you sure you want to clear your name?')) {
+  const handleDetectLocation = () => {
+    if (!navigator.geolocation) {
+      setMessage({ type: 'error', text: 'Geolocation is not supported by your browser' });
+      return;
+    }
+
+    setIsGeolocating(true);
+    setMessage(null);
+
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        try {
+          const { latitude, longitude } = position.coords;
+          // Reverse geocode to get a label
+          const result = await apiGeocode(`${latitude}, ${longitude}`);
+          const label = result?.label || `${latitude.toFixed(2)}, ${longitude.toFixed(2)}`;
+          const loc: UserLocation = { latitude, longitude, label };
+          saveUserLocation(loc);
+          setSavedLocation(loc);
+          setLocationInput("");
+          setMessage({ type: 'success', text: `Location set to ${label}` });
+        } catch {
+          setMessage({ type: 'error', text: 'Failed to determine your location' });
+        } finally {
+          setIsGeolocating(false);
+        }
+      },
+      () => {
+        setMessage({ type: 'error', text: 'Location access denied' });
+        setIsGeolocating(false);
+      },
+      { enableHighAccuracy: false, timeout: 10000 }
+    );
+  };
+
+  const handleClearAll = () => {
+    if (confirm('Are you sure you want to clear your profile?')) {
       clearUserName();
+      clearUserLocation();
       setName("");
-      setMessage({ type: 'success', text: 'Name cleared successfully!' });
-      
-      // Redirect to home after a short delay
+      setSavedLocation(null);
+      setLocationInput("");
+      setMessage({ type: 'success', text: 'Profile cleared!' });
       setTimeout(() => {
         router.push('/');
       }, 1000);
@@ -71,9 +133,63 @@ export default function ProfilePage() {
         </p>
       </div>
 
+      {/* Location Section */}
+      <div className="mb-6">
+        <label htmlFor="location" className="block text-sm font-medium mb-2">
+          Your Location
+        </label>
+        {savedLocation && (
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-sm text-gray-600 dark:text-gray-400">Current:</span>
+            <span className="text-sm font-medium">{savedLocation.label}</span>
+            <button
+              type="button"
+              onClick={() => { clearUserLocation(); setSavedLocation(null); }}
+              className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            >
+              Clear
+            </button>
+          </div>
+        )}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            id="location"
+            value={locationInput}
+            onChange={(e) => setLocationInput(e.target.value)}
+            placeholder={savedLocation ? "Update location..." : "Zip code or city name..."}
+            maxLength={200}
+            className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
+            disabled={isLoading || isGeolocating}
+          />
+          <button
+            type="button"
+            onClick={handleDetectLocation}
+            disabled={isLoading || isGeolocating}
+            className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Detect my location"
+          >
+            {isGeolocating ? (
+              <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            ) : (
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            )}
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Used to find nearby places when creating location polls
+        </p>
+      </div>
+
       {message && (
         <div className={`mb-4 p-3 rounded-md text-sm ${
-          message.type === 'success' 
+          message.type === 'success'
             ? 'bg-green-100 dark:bg-green-900/20 text-green-700 dark:text-green-300 border border-green-400 dark:border-green-600'
             : 'bg-red-100 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-400 dark:border-red-600'
         }`}>
@@ -83,22 +199,22 @@ export default function ProfilePage() {
 
       <button
         onClick={handleSave}
-        disabled={isLoading || !name.trim()}
+        disabled={isLoading || (!name.trim() && !locationInput.trim())}
         className="w-full rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-base h-12 disabled:opacity-50 disabled:cursor-not-allowed mb-6"
       >
-        {isLoading ? 'Saving...' : 'Save Name'}
+        {isLoading ? 'Saving...' : 'Save'}
       </button>
 
       {/* Divider */}
       <div className="border-t border-gray-200 dark:border-gray-700 pt-6 mb-6">
         <button
-          onClick={handleSignOut}
+          onClick={handleClearAll}
           className="w-full rounded-full border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors flex items-center justify-center font-medium text-base h-12"
         >
-          Clear Name
+          Clear Profile
         </button>
         <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
-          Remove your saved name from this browser
+          Remove your saved name and location from this browser
         </p>
       </div>
 

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -41,13 +41,13 @@ export default function AutocompleteInput({
   const localInputRef = useRef<HTMLInputElement>(null);
 
   const lastSuccessfulQueryRef = useRef("");
-  const lastSuccessfulCountRef = useRef(0);
+  const lastResultsRef = useRef<SearchResult[]>([]);
 
   const doSearch = useCallback(async (query: string) => {
     if (query.length < 2) {
       setSuggestions([]);
       lastSuccessfulQueryRef.current = "";
-      lastSuccessfulCountRef.current = 0;
+      lastResultsRef.current = [];
       return;
     }
     try {
@@ -59,17 +59,24 @@ export default function AutocompleteInput({
       } else {
         results = await apiSearchMovies(query);
       }
-      // If query extends the previous successful query but returns fewer
-      // results, keep showing old results (typing more should refine, not lose results)
-      if (results.length < lastSuccessfulCountRef.current && lastSuccessfulQueryRef.current && query.startsWith(lastSuccessfulQueryRef.current)) {
-        return;
+      // When query extends previous, client-side filter cached results
+      // and use them if they match better (handles partial words like "Burger K"
+      // where Nominatim returns garbage but cached "Burger" results contain "Burger King")
+      if (lastSuccessfulQueryRef.current && query.startsWith(lastSuccessfulQueryRef.current)) {
+        const words = query.toLowerCase().split(/\s+/);
+        const filtered = lastResultsRef.current.filter(r =>
+          words.every(w => r.label.toLowerCase().includes(w))
+        );
+        if (filtered.length >= results.length) {
+          results = filtered;
+        }
       }
       setSuggestions(results);
       setShowSuggestions(results.length > 0);
       setHighlightedIndex(-1);
       if (results.length > 0) {
         lastSuccessfulQueryRef.current = query;
-        lastSuccessfulCountRef.current = results.length;
+        lastResultsRef.current = results;
       }
     } catch {
       // On error, keep existing suggestions

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -16,6 +16,7 @@ interface AutocompleteInputProps {
   inputRef?: React.RefCallback<HTMLInputElement>;
   referenceLatitude?: number;
   referenceLongitude?: number;
+  searchRadius?: number;
 }
 
 export default function AutocompleteInput({
@@ -30,6 +31,7 @@ export default function AutocompleteInput({
   inputRef,
   referenceLatitude,
   referenceLongitude,
+  searchRadius,
 }: AutocompleteInputProps) {
   const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
@@ -46,7 +48,7 @@ export default function AutocompleteInput({
     try {
       let results: SearchResult[];
       if (contentType === 'location') {
-        results = await apiSearchLocations(query, referenceLatitude, referenceLongitude);
+        results = await apiSearchLocations(query, referenceLatitude, referenceLongitude, searchRadius);
       } else if (contentType === 'video_game') {
         results = await apiSearchVideoGames(query);
       } else {
@@ -58,7 +60,7 @@ export default function AutocompleteInput({
     } catch {
       setSuggestions([]);
     }
-  }, [contentType, referenceLatitude, referenceLongitude]);
+  }, [contentType, referenceLatitude, referenceLongitude, searchRadius]);
 
   const handleChange = (newValue: string) => {
     onChange(newValue);

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -40,9 +40,12 @@ export default function AutocompleteInput({
   const containerRef = useRef<HTMLDivElement>(null);
   const localInputRef = useRef<HTMLInputElement>(null);
 
+  const lastSuccessfulQueryRef = useRef("");
+
   const doSearch = useCallback(async (query: string) => {
     if (query.length < 2) {
       setSuggestions([]);
+      lastSuccessfulQueryRef.current = "";
       return;
     }
     try {
@@ -54,11 +57,19 @@ export default function AutocompleteInput({
       } else {
         results = await apiSearchMovies(query);
       }
+      // If no results and query extends the previous successful query,
+      // keep showing old results (typing more should refine, not lose results)
+      if (results.length === 0 && lastSuccessfulQueryRef.current && query.startsWith(lastSuccessfulQueryRef.current)) {
+        return;
+      }
       setSuggestions(results);
       setShowSuggestions(results.length > 0);
       setHighlightedIndex(-1);
+      if (results.length > 0) {
+        lastSuccessfulQueryRef.current = query;
+      }
     } catch {
-      setSuggestions([]);
+      // On error, keep existing suggestions
     }
   }, [contentType, referenceLatitude, referenceLongitude, searchRadius]);
 

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -41,11 +41,13 @@ export default function AutocompleteInput({
   const localInputRef = useRef<HTMLInputElement>(null);
 
   const lastSuccessfulQueryRef = useRef("");
+  const lastSuccessfulCountRef = useRef(0);
 
   const doSearch = useCallback(async (query: string) => {
     if (query.length < 2) {
       setSuggestions([]);
       lastSuccessfulQueryRef.current = "";
+      lastSuccessfulCountRef.current = 0;
       return;
     }
     try {
@@ -57,9 +59,9 @@ export default function AutocompleteInput({
       } else {
         results = await apiSearchMovies(query);
       }
-      // If no results and query extends the previous successful query,
-      // keep showing old results (typing more should refine, not lose results)
-      if (results.length === 0 && lastSuccessfulQueryRef.current && query.startsWith(lastSuccessfulQueryRef.current)) {
+      // If query extends the previous successful query but returns fewer
+      // results, keep showing old results (typing more should refine, not lose results)
+      if (results.length < lastSuccessfulCountRef.current && lastSuccessfulQueryRef.current && query.startsWith(lastSuccessfulQueryRef.current)) {
         return;
       }
       setSuggestions(results);
@@ -67,6 +69,7 @@ export default function AutocompleteInput({
       setHighlightedIndex(-1);
       if (results.length > 0) {
         lastSuccessfulQueryRef.current = query;
+        lastSuccessfulCountRef.current = results.length;
       }
     } catch {
       // On error, keep existing suggestions

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -59,16 +59,19 @@ export default function AutocompleteInput({
       } else {
         results = await apiSearchMovies(query);
       }
-      // When query extends previous, client-side filter cached results
-      // and use them if they match better (handles partial words like "Burger K"
-      // where Nominatim returns garbage but cached "Burger" results contain "Burger King")
+      // When query extends previous, merge API results with client-side
+      // filtered cache (handles partial words like "Burger K" where Nominatim
+      // returns garbage but cached "Burger" results contain "Burger King")
       if (lastSuccessfulQueryRef.current && query.startsWith(lastSuccessfulQueryRef.current)) {
         const words = query.toLowerCase().split(/\s+/);
         const filtered = lastResultsRef.current.filter(r =>
           words.every(w => r.label.toLowerCase().includes(w))
         );
-        if (filtered.length >= results.length) {
-          results = filtered;
+        const seen = new Set(results.map(r => r.label));
+        for (const r of filtered) {
+          if (!seen.has(r.label)) {
+            results.push(r);
+          }
         }
       }
       setSuggestions(results);

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -14,6 +14,8 @@ interface AutocompleteInputProps {
   maxLength?: number;
   className?: string;
   inputRef?: React.RefCallback<HTMLInputElement>;
+  referenceLatitude?: number;
+  referenceLongitude?: number;
 }
 
 export default function AutocompleteInput({
@@ -26,6 +28,8 @@ export default function AutocompleteInput({
   maxLength = 35,
   className,
   inputRef,
+  referenceLatitude,
+  referenceLongitude,
 }: AutocompleteInputProps) {
   const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
@@ -34,26 +38,27 @@ export default function AutocompleteInput({
   const containerRef = useRef<HTMLDivElement>(null);
   const localInputRef = useRef<HTMLInputElement>(null);
 
-  const searchFn = contentType === 'location'
-    ? apiSearchLocations
-    : contentType === 'video_game'
-      ? apiSearchVideoGames
-      : apiSearchMovies;
-
   const doSearch = useCallback(async (query: string) => {
     if (query.length < 2) {
       setSuggestions([]);
       return;
     }
     try {
-      const results = await searchFn(query);
+      let results: SearchResult[];
+      if (contentType === 'location') {
+        results = await apiSearchLocations(query, referenceLatitude, referenceLongitude);
+      } else if (contentType === 'video_game') {
+        results = await apiSearchVideoGames(query);
+      } else {
+        results = await apiSearchMovies(query);
+      }
       setSuggestions(results);
       setShowSuggestions(results.length > 0);
       setHighlightedIndex(-1);
     } catch {
       setSuggestions([]);
     }
-  }, [searchFn]);
+  }, [contentType, referenceLatitude, referenceLongitude]);
 
   const handleChange = (newValue: string) => {
     onChange(newValue);
@@ -144,11 +149,18 @@ export default function AutocompleteInput({
                 <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
                   {result.label}
                 </div>
-                {result.description && (
-                  <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
-                    {result.description}
-                  </div>
-                )}
+                <div className="flex items-center gap-2">
+                  {result.description && (
+                    <span className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
+                      {result.description}
+                    </span>
+                  )}
+                  {result.distance_miles !== undefined && (
+                    <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                      {result.distance_miles < 0.1 ? '<0.1' : result.distance_miles} mi
+                    </span>
+                  )}
+                </div>
               </div>
             </li>
           ))}

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -342,6 +342,8 @@ export default function NominationVotingInterface({
             contentType={poll.poll_content_type || 'custom'}
             optionsMetadata={nominationMetadata}
             onMetadataChange={onNominationMetadataChange}
+            referenceLatitude={poll.reference_latitude}
+            referenceLongitude={poll.reference_longitude}
           />
         </div>
 

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -78,6 +78,7 @@ export default function NominationVotingInterface({
 }: NominationVotingInterfaceProps) {
   const [newNominations, setNewNominations] = useState<string[]>([""]);
   const [filteredExistingNominations, setFilteredExistingNominations] = useState<string[]>([]);
+  const [searchRadius, setSearchRadius] = useState(25);
 
   // Helper function to convert existingNominations to format expected by NominationsList
   const getNominationsWithCounts = () => {
@@ -333,6 +334,20 @@ export default function NominationVotingInterface({
 
         {/* Add new nominations using shared component */}
         <div className={filteredExistingNominations.length > 0 ? "mt-3 pt-3 border-t border-gray-200 dark:border-gray-600" : ""}>
+          {poll.poll_content_type === 'location' && poll.reference_latitude && (
+            <div className="mb-2 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+              <span>Search within</span>
+              <select
+                value={searchRadius}
+                onChange={(e) => setSearchRadius(Number(e.target.value))}
+                className="px-1.5 py-0.5 border border-gray-300 dark:border-gray-600 rounded text-xs bg-white dark:bg-gray-800"
+              >
+                {[5, 10, 25, 50, 100, 250].map((r) => (
+                  <option key={r} value={r}>{r} mi</option>
+                ))}
+              </select>
+            </div>
+          )}
           <OptionsInput
             options={newNominations}
             setOptions={setNewNominations}
@@ -344,6 +359,7 @@ export default function NominationVotingInterface({
             onMetadataChange={onNominationMetadataChange}
             referenceLatitude={poll.reference_latitude}
             referenceLongitude={poll.reference_longitude}
+            searchRadius={searchRadius}
           />
         </div>
 

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -19,6 +19,7 @@ interface OptionsInputProps {
   onMetadataChange?: (metadata: OptionsMetadata) => void;
   referenceLatitude?: number;
   referenceLongitude?: number;
+  searchRadius?: number;
 }
 
 export default function OptionsInput({
@@ -33,6 +34,7 @@ export default function OptionsInput({
   onMetadataChange,
   referenceLatitude,
   referenceLongitude,
+  searchRadius,
 }: OptionsInputProps) {
   const optionRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -173,6 +175,7 @@ export default function OptionsInput({
                     inputRef={(el) => { optionRefs.current[index] = el; }}
                     referenceLatitude={referenceLatitude}
                     referenceLongitude={referenceLongitude}
+                    searchRadius={searchRadius}
                   />
                 </div>
               ) : (

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -17,6 +17,8 @@ interface OptionsInputProps {
   contentType?: PollContentType;
   optionsMetadata?: OptionsMetadata;
   onMetadataChange?: (metadata: OptionsMetadata) => void;
+  referenceLatitude?: number;
+  referenceLongitude?: number;
 }
 
 export default function OptionsInput({
@@ -29,6 +31,8 @@ export default function OptionsInput({
   contentType = 'custom',
   optionsMetadata,
   onMetadataChange,
+  referenceLatitude,
+  referenceLongitude,
 }: OptionsInputProps) {
   const optionRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -167,6 +171,8 @@ export default function OptionsInput({
                     placeholder={getPlaceholder(index)}
                     className={inputClassName(isDuplicate) + ' w-full'}
                     inputRef={(el) => { optionRefs.current[index] = el; }}
+                    referenceLatitude={referenceLatitude}
+                    referenceLongitude={referenceLongitude}
                   />
                 </div>
               ) : (

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -4,11 +4,15 @@ import { useState, useEffect } from "react";
 import { getUserLocation, saveUserLocation, type UserLocation } from "@/lib/userProfile";
 import { apiGeocode } from "@/lib/api";
 
+const RADIUS_OPTIONS = [5, 10, 25, 50, 100, 250];
+
 interface ReferenceLocationInputProps {
   latitude: number | undefined;
   longitude: number | undefined;
   label: string;
   onLocationChange: (lat: number, lng: number, label: string) => void;
+  searchRadius: number;
+  onSearchRadiusChange: (radius: number) => void;
   disabled?: boolean;
 }
 
@@ -17,12 +21,15 @@ export default function ReferenceLocationInput({
   longitude,
   label,
   onLocationChange,
+  searchRadius,
+  onSearchRadiusChange,
   disabled = false,
 }: ReferenceLocationInputProps) {
   const [input, setInput] = useState("");
   const [isGeocoding, setIsGeocoding] = useState(false);
   const [isGeolocating, setIsGeolocating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showRadiusModal, setShowRadiusModal] = useState(false);
 
   // Auto-fill from saved location on mount
   useEffect(() => {
@@ -95,7 +102,7 @@ export default function ReferenceLocationInput({
         Your Location
       </label>
       {hasLocation && (
-        <div className="mb-2 flex items-center gap-2 text-sm">
+        <div className="mb-2 flex items-center gap-2 text-sm flex-wrap">
           <svg className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -103,11 +110,41 @@ export default function ReferenceLocationInput({
           <span className="text-gray-700 dark:text-gray-300">{label}</span>
           <button
             type="button"
+            onClick={() => setShowRadiusModal(true)}
+            className="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 rounded-full hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
+          >
+            {searchRadius} mi
+          </button>
+          <button
+            type="button"
             onClick={() => onLocationChange(undefined as any, undefined as any, "")}
             className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
           >
             Change
           </button>
+        </div>
+      )}
+      {showRadiusModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowRadiusModal(false)}>
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 w-64" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-medium mb-3 text-gray-900 dark:text-white">Search Radius</h3>
+            <div className="grid grid-cols-3 gap-2">
+              {RADIUS_OPTIONS.map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => { onSearchRadiusChange(r); setShowRadiusModal(false); }}
+                  className={`py-2 rounded-md text-sm font-medium transition-colors ${
+                    r === searchRadius
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  {r} mi
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
       )}
       {!hasLocation && (

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { getUserLocation, saveUserLocation, type UserLocation } from "@/lib/userProfile";
 import { apiGeocode } from "@/lib/api";
-
-const RADIUS_OPTIONS = [5, 10, 25, 50, 100, 250];
 
 interface ReferenceLocationInputProps {
   latitude: number | undefined;
@@ -30,6 +28,8 @@ export default function ReferenceLocationInput({
   const [isGeolocating, setIsGeolocating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showRadiusModal, setShowRadiusModal] = useState(false);
+  const [radiusInput, setRadiusInput] = useState(String(searchRadius));
+  const radiusInputRef = useRef<HTMLInputElement>(null);
 
   // Auto-fill from saved location on mount
   useEffect(() => {
@@ -41,6 +41,14 @@ export default function ReferenceLocationInput({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Focus the radius input when modal opens
+  useEffect(() => {
+    if (showRadiusModal) {
+      setRadiusInput(String(searchRadius));
+      setTimeout(() => radiusInputRef.current?.select(), 0);
+    }
+  }, [showRadiusModal, searchRadius]);
+
   const handleGeocode = async () => {
     if (!input.trim()) return;
     setIsGeocoding(true);
@@ -51,7 +59,6 @@ export default function ReferenceLocationInput({
         const lat = parseFloat(result.lat);
         const lon = parseFloat(result.lon);
         onLocationChange(lat, lon, result.label);
-        // Save for future use
         saveUserLocation({ latitude: lat, longitude: lon, label: result.label });
         setInput("");
       } else {
@@ -94,6 +101,14 @@ export default function ReferenceLocationInput({
     );
   };
 
+  const applyRadius = () => {
+    const val = parseInt(radiusInput, 10);
+    if (val > 0) {
+      onSearchRadiusChange(val);
+    }
+    setShowRadiusModal(false);
+  };
+
   const hasLocation = latitude !== undefined && longitude !== undefined;
 
   return (
@@ -107,7 +122,13 @@ export default function ReferenceLocationInput({
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
-          <span className="text-gray-700 dark:text-gray-300">{label}</span>
+          <button
+            type="button"
+            onClick={() => onLocationChange(undefined as any, undefined as any, "")}
+            className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+          >
+            {label}
+          </button>
           <button
             type="button"
             onClick={() => setShowRadiusModal(true)}
@@ -115,35 +136,32 @@ export default function ReferenceLocationInput({
           >
             {searchRadius} mi
           </button>
-          <button
-            type="button"
-            onClick={() => onLocationChange(undefined as any, undefined as any, "")}
-            className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-          >
-            Change
-          </button>
         </div>
       )}
       {showRadiusModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowRadiusModal(false)}>
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 w-64" onClick={(e) => e.stopPropagation()}>
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 w-56" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-sm font-medium mb-3 text-gray-900 dark:text-white">Search Radius</h3>
-            <div className="grid grid-cols-3 gap-2">
-              {RADIUS_OPTIONS.map((r) => (
-                <button
-                  key={r}
-                  type="button"
-                  onClick={() => { onSearchRadiusChange(r); setShowRadiusModal(false); }}
-                  className={`py-2 rounded-md text-sm font-medium transition-colors ${
-                    r === searchRadius
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                  }`}
-                >
-                  {r} mi
-                </button>
-              ))}
+            <div className="flex items-center gap-2">
+              <input
+                ref={radiusInputRef}
+                type="number"
+                min="1"
+                max="10000"
+                value={radiusInput}
+                onChange={(e) => setRadiusInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') applyRadius(); }}
+                className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+              />
+              <span className="text-sm text-gray-500 dark:text-gray-400">mi</span>
             </div>
+            <button
+              type="button"
+              onClick={applyRadius}
+              className="mt-3 w-full py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium"
+            >
+              Apply
+            </button>
           </div>
         </div>
       )}

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -129,12 +129,13 @@ export default function ReferenceLocationInput({
           >
             {label}
           </button>
+          <div className="flex-1" />
           <button
             type="button"
             onClick={() => setShowRadiusModal(true)}
             className="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 rounded-full hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
           >
-            {searchRadius} mi
+            Within {searchRadius} mi
           </button>
         </div>
       )}

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -8,7 +8,7 @@ interface ReferenceLocationInputProps {
   latitude: number | undefined;
   longitude: number | undefined;
   label: string;
-  onLocationChange: (lat: number, lng: number, label: string) => void;
+  onLocationChange: (lat: number | undefined, lng: number | undefined, label: string) => void;
   searchRadius: number;
   onSearchRadiusChange: (radius: number) => void;
   disabled?: boolean;
@@ -124,7 +124,7 @@ export default function ReferenceLocationInput({
           </svg>
           <button
             type="button"
-            onClick={() => onLocationChange(undefined as any, undefined as any, "")}
+            onClick={() => onLocationChange(undefined, undefined, "")}
             className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
           >
             {label}

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getUserLocation, saveUserLocation, type UserLocation } from "@/lib/userProfile";
+import { apiGeocode } from "@/lib/api";
+
+interface ReferenceLocationInputProps {
+  latitude: number | undefined;
+  longitude: number | undefined;
+  label: string;
+  onLocationChange: (lat: number, lng: number, label: string) => void;
+  disabled?: boolean;
+}
+
+export default function ReferenceLocationInput({
+  latitude,
+  longitude,
+  label,
+  onLocationChange,
+  disabled = false,
+}: ReferenceLocationInputProps) {
+  const [input, setInput] = useState("");
+  const [isGeocoding, setIsGeocoding] = useState(false);
+  const [isGeolocating, setIsGeolocating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-fill from saved location on mount
+  useEffect(() => {
+    if (latitude !== undefined) return; // Already set
+    const saved = getUserLocation();
+    if (saved) {
+      onLocationChange(saved.latitude, saved.longitude, saved.label);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleGeocode = async () => {
+    if (!input.trim()) return;
+    setIsGeocoding(true);
+    setError(null);
+    try {
+      const result = await apiGeocode(input.trim());
+      if (result && result.lat && result.lon) {
+        const lat = parseFloat(result.lat);
+        const lon = parseFloat(result.lon);
+        onLocationChange(lat, lon, result.label);
+        // Save for future use
+        saveUserLocation({ latitude: lat, longitude: lon, label: result.label });
+        setInput("");
+      } else {
+        setError("Location not found. Try a zip code or city name.");
+      }
+    } catch {
+      setError("Failed to look up location");
+    } finally {
+      setIsGeocoding(false);
+    }
+  };
+
+  const handleDetect = () => {
+    if (!navigator.geolocation) {
+      setError("Geolocation not supported");
+      return;
+    }
+    setIsGeolocating(true);
+    setError(null);
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        try {
+          const { latitude: lat, longitude: lon } = position.coords;
+          const result = await apiGeocode(`${lat}, ${lon}`);
+          const lbl = result?.label || `${lat.toFixed(2)}, ${lon.toFixed(2)}`;
+          onLocationChange(lat, lon, lbl);
+          saveUserLocation({ latitude: lat, longitude: lon, label: lbl });
+          setInput("");
+        } catch {
+          setError("Failed to determine location");
+        } finally {
+          setIsGeolocating(false);
+        }
+      },
+      () => {
+        setError("Location access denied");
+        setIsGeolocating(false);
+      },
+      { enableHighAccuracy: false, timeout: 10000 }
+    );
+  };
+
+  const hasLocation = latitude !== undefined && longitude !== undefined;
+
+  return (
+    <div>
+      <label className="block text-sm font-medium mb-2">
+        Your Location
+      </label>
+      {hasLocation && (
+        <div className="mb-2 flex items-center gap-2 text-sm">
+          <svg className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <span className="text-gray-700 dark:text-gray-300">{label}</span>
+          <button
+            type="button"
+            onClick={() => onLocationChange(undefined as any, undefined as any, "")}
+            className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            Change
+          </button>
+        </div>
+      )}
+      {!hasLocation && (
+        <>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleGeocode(); } }}
+              placeholder="Zip code or city name..."
+              maxLength={200}
+              disabled={disabled || isGeocoding || isGeolocating}
+              className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 text-sm"
+            />
+            <button
+              type="button"
+              onClick={handleGeocode}
+              disabled={disabled || isGeocoding || isGeolocating || !input.trim()}
+              className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+            >
+              {isGeocoding ? "..." : "Set"}
+            </button>
+            <button
+              type="button"
+              onClick={handleDetect}
+              disabled={disabled || isGeocoding || isGeolocating}
+              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Detect my location"
+            >
+              {isGeolocating ? (
+                <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+              ) : (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              )}
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Search results will be sorted by distance from this location
+          </p>
+        </>
+      )}
+      {error && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/database/migrations/076_add_reference_location_down.sql
+++ b/database/migrations/076_add_reference_location_down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE polls
+    DROP COLUMN IF EXISTS reference_latitude,
+    DROP COLUMN IF EXISTS reference_longitude,
+    DROP COLUMN IF EXISTS reference_location_label;

--- a/database/migrations/076_add_reference_location_up.sql
+++ b/database/migrations/076_add_reference_location_up.sql
@@ -1,0 +1,5 @@
+-- Add reference location columns for proximity-based location search
+ALTER TABLE polls
+    ADD COLUMN IF NOT EXISTS reference_latitude DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS reference_longitude DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS reference_location_label TEXT;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -352,11 +352,14 @@ export interface SearchResult {
 
 const SEARCH_BASE = getApiEndpoint('search');
 
-export async function apiSearchLocations(query: string, refLat?: number, refLon?: number): Promise<SearchResult[]> {
+export async function apiSearchLocations(query: string, refLat?: number, refLon?: number, maxDistance?: number): Promise<SearchResult[]> {
   const params = new URLSearchParams({ q: query });
   if (refLat !== undefined && refLon !== undefined) {
     params.set('lat', String(refLat));
     params.set('lon', String(refLon));
+  }
+  if (maxDistance !== undefined) {
+    params.set('max_distance', String(maxDistance));
   }
   const res = await fetch(`${SEARCH_BASE}/locations?${params}`);
   if (!res.ok) return [];

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -125,6 +125,9 @@ function toPoll(data: any): Poll {
     duration_window: data.duration_window ?? undefined,
     poll_content_type: data.poll_content_type ?? undefined,
     options_metadata: data.options_metadata ?? undefined,
+    reference_latitude: data.reference_latitude ?? undefined,
+    reference_longitude: data.reference_longitude ?? undefined,
+    reference_location_label: data.reference_location_label ?? undefined,
   };
 }
 
@@ -193,6 +196,9 @@ export async function apiCreatePoll(params: {
   duration_window?: any;
   poll_content_type?: string;
   options_metadata?: OptionsMetadata;
+  reference_latitude?: number;
+  reference_longitude?: number;
+  reference_location_label?: string;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',
@@ -341,14 +347,26 @@ export interface SearchResult {
   infoUrl?: string;
   lat?: string;
   lon?: string;
+  distance_miles?: number;
 }
 
 const SEARCH_BASE = getApiEndpoint('search');
 
-export async function apiSearchLocations(query: string): Promise<SearchResult[]> {
+export async function apiSearchLocations(query: string, refLat?: number, refLon?: number): Promise<SearchResult[]> {
   const params = new URLSearchParams({ q: query });
+  if (refLat !== undefined && refLon !== undefined) {
+    params.set('lat', String(refLat));
+    params.set('lon', String(refLon));
+  }
   const res = await fetch(`${SEARCH_BASE}/locations?${params}`);
   if (!res.ok) return [];
+  return res.json();
+}
+
+export async function apiGeocode(query: string): Promise<{ lat: string; lon: string; label: string } | null> {
+  const params = new URLSearchParams({ q: query });
+  const res = await fetch(`${SEARCH_BASE}/geocode?${params}`);
+  if (!res.ok) return null;
   return res.json();
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,6 +46,9 @@ export interface Poll {
   duration_window?: DurationWindow | null;
   poll_content_type?: PollContentType | null;
   options_metadata?: OptionsMetadata | null;
+  reference_latitude?: number | null;
+  reference_longitude?: number | null;
+  reference_location_label?: string | null;
 }
 
 export interface TimeWindow {

--- a/lib/userProfile.ts
+++ b/lib/userProfile.ts
@@ -1,4 +1,11 @@
 const USER_NAME_KEY = 'whoeverwants_user_name';
+const USER_LOCATION_KEY = 'whoeverwants_user_location';
+
+export interface UserLocation {
+  latitude: number;
+  longitude: number;
+  label: string; // City/zip for display, e.g. "San Francisco, CA" or "90210"
+}
 
 export function saveUserName(name: string) {
   if (typeof window === 'undefined') return;
@@ -19,17 +26,38 @@ export function clearUserName() {
   localStorage.removeItem(USER_NAME_KEY);
 }
 
+export function saveUserLocation(location: UserLocation) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(USER_LOCATION_KEY, JSON.stringify(location));
+}
+
+export function getUserLocation(): UserLocation | null {
+  if (typeof window === 'undefined') return null;
+  const stored = localStorage.getItem(USER_LOCATION_KEY);
+  if (!stored) return null;
+  try {
+    return JSON.parse(stored) as UserLocation;
+  } catch {
+    return null;
+  }
+}
+
+export function clearUserLocation() {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(USER_LOCATION_KEY);
+}
+
 export function getUserInitials(name: string | null): string {
   if (!name || !name.trim()) return '?';
-  
+
   const trimmedName = name.trim();
   const words = trimmedName.split(/\s+/).filter(word => word.length > 0);
-  
+
   if (words.length === 0) return '?';
   if (words.length === 1) {
     return words[0][0].toUpperCase();
   }
-  
+
   // Take first letter of first word and first letter of last word
   const firstInitial = words[0][0].toUpperCase();
   const lastInitial = words[words.length - 1][0].toUpperCase();

--- a/server/models.py
+++ b/server/models.py
@@ -55,6 +55,10 @@ class CreatePollRequest(BaseModel):
     poll_content_type: str | None = None
     # Metadata for options (thumbnail URLs, info links) keyed by option label
     options_metadata: dict | None = None
+    # Reference location for proximity-based search
+    reference_latitude: float | None = None
+    reference_longitude: float | None = None
+    reference_location_label: str | None = None
 
 
 class SubmitVoteRequest(BaseModel):
@@ -151,6 +155,9 @@ class PollResponse(BaseModel):
     duration_window: dict | None = None
     poll_content_type: str | None = None
     options_metadata: dict | None = None
+    reference_latitude: float | None = None
+    reference_longitude: float | None = None
+    reference_location_label: str | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -214,6 +214,9 @@ def _row_to_poll(row: dict) -> PollResponse:
         duration_window=row.get("duration_window"),
         poll_content_type=row.get("poll_content_type"),
         options_metadata=row.get("options_metadata"),
+        reference_latitude=row.get("reference_latitude"),
+        reference_longitude=row.get("reference_longitude"),
+        reference_location_label=row.get("reference_location_label"),
     )
 
 
@@ -429,6 +432,8 @@ def create_poll(req: CreatePollRequest):
                                time_preferences_deadline_minutes,
                                day_time_windows, duration_window,
                                poll_content_type, options_metadata,
+                               reference_latitude, reference_longitude,
+                               reference_location_label,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
@@ -444,6 +449,8 @@ def create_poll(req: CreatePollRequest):
                     %(time_preferences_deadline_minutes)s,
                     %(day_time_windows)s::jsonb, %(duration_window)s::jsonb,
                     %(poll_content_type)s, %(options_metadata)s::jsonb,
+                    %(reference_latitude)s, %(reference_longitude)s,
+                    %(reference_location_label)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -478,6 +485,9 @@ def create_poll(req: CreatePollRequest):
                 "duration_window": json.dumps(req.duration_window) if req.duration_window else None,
                 "poll_content_type": req.poll_content_type or "custom",
                 "options_metadata": json.dumps(req.options_metadata) if req.options_metadata else None,
+                "reference_latitude": req.reference_latitude,
+                "reference_longitude": req.reference_longitude,
+                "reference_location_label": req.reference_location_label,
                 "now": now,
             },
         ).fetchone()

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -118,9 +118,6 @@ async def search_locations(
 
     When lat/lon are provided, results are restricted to a bounding box
     derived from max_distance, sorted by proximity, and include distance_miles.
-
-    Handles partial word matching: if "Burger K" returns no results,
-    retries with "Burger" and filters to results containing "K".
     """
     results = await _nominatim_search(q, lat, lon, max_distance)
     return results[:6]

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -28,30 +28,23 @@ def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> floa
     return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
-@router.get("/locations")
-async def search_locations(
-    q: str = Query(..., min_length=2, max_length=100),
-    lat: float | None = Query(None, description="Reference latitude for proximity bias"),
-    lon: float | None = Query(None, description="Reference longitude for proximity bias"),
-    max_distance: float = Query(25, description="Maximum distance in miles (0 = no limit)"),
-):
-    """Search for locations using OpenStreetMap Nominatim.
-
-    When lat/lon are provided, results are restricted to a bounding box
-    derived from max_distance, sorted by proximity, and include distance_miles.
-    """
+async def _nominatim_search(
+    query: str,
+    lat: float | None,
+    lon: float | None,
+    max_distance: float,
+) -> list[dict]:
+    """Run a Nominatim search and return processed results with distance."""
     has_ref = lat is not None and lon is not None
 
     params: dict = {
-        "q": q,
+        "q": query,
         "format": "jsonv2",
         "limit": 20,
         "addressdetails": 1,
     }
 
-    # Restrict search to bounding box around reference location
     if has_ref and max_distance > 0:
-        # 1 degree latitude ≈ 69 miles
         delta = max_distance / 69.0
         params["viewbox"] = f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}"
         params["bounded"] = 1
@@ -91,7 +84,6 @@ async def search_locations(
             distance = round(
                 _haversine_miles(lat, lon, float(item_lat), float(item_lon)), 1
             )
-            # Hard filter: skip results beyond max_distance
             if max_distance > 0 and distance > max_distance:
                 continue
 
@@ -109,9 +101,42 @@ async def search_locations(
             entry["distance_miles"] = distance
         results.append(entry)
 
-    # Sort by distance when reference location provided
     if has_ref:
         results.sort(key=lambda r: r.get("distance_miles", float("inf")))
+
+    return results
+
+
+@router.get("/locations")
+async def search_locations(
+    q: str = Query(..., min_length=2, max_length=100),
+    lat: float | None = Query(None, description="Reference latitude for proximity bias"),
+    lon: float | None = Query(None, description="Reference longitude for proximity bias"),
+    max_distance: float = Query(25, description="Maximum distance in miles (0 = no limit)"),
+):
+    """Search for locations using OpenStreetMap Nominatim.
+
+    When lat/lon are provided, results are restricted to a bounding box
+    derived from max_distance, sorted by proximity, and include distance_miles.
+
+    Handles partial word matching: if "Burger K" returns no results,
+    retries with "Burger" and filters to results containing "K".
+    """
+    results = await _nominatim_search(q, lat, lon, max_distance)
+
+    # Partial word fallback: if no results and query has a trailing
+    # incomplete word, retry with just the complete words and filter
+    if not results and " " in q.strip():
+        complete_words = q.rsplit(" ", 1)[0].strip()
+        partial = q.rsplit(" ", 1)[1].strip().lower()
+        if len(complete_words) >= 2:
+            results = await _nominatim_search(complete_words, lat, lon, max_distance)
+            if partial:
+                # Boost results whose name contains the partial word
+                results.sort(key=lambda r: (
+                    0 if partial in r["label"].lower() else 1,
+                    r.get("distance_miles", float("inf")),
+                ))
 
     return results[:6]
 

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -33,39 +33,68 @@ async def search_locations(
     q: str = Query(..., min_length=2, max_length=100),
     lat: float | None = Query(None, description="Reference latitude for proximity bias"),
     lon: float | None = Query(None, description="Reference longitude for proximity bias"),
+    max_distance: float = Query(25, description="Maximum distance in miles (0 = no limit)"),
 ):
     """Search for locations using OpenStreetMap Nominatim.
 
-    When lat/lon are provided, results are biased toward that area
-    and include a distance_miles field.
+    When lat/lon are provided, results are restricted to a bounding box
+    derived from max_distance, sorted by proximity, and include distance_miles.
     """
+    has_ref = lat is not None and lon is not None
+
     params: dict = {
         "q": q,
         "format": "jsonv2",
-        "limit": 10,
+        "limit": 20,
         "addressdetails": 1,
     }
 
-    # Bias search toward reference location using viewbox
-    if lat is not None and lon is not None:
-        # ~30 mile bounding box (~0.5 degrees)
-        delta = 0.5
+    # Restrict search to bounding box around reference location
+    if has_ref and max_distance > 0:
+        # 1 degree latitude ≈ 69 miles
+        delta = max_distance / 69.0
         params["viewbox"] = f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}"
-        # bounded=0 means prefer but don't restrict to viewbox
-        params["bounded"] = 0
+        params["bounded"] = 1
+
+    headers = {
+        "User-Agent": "WhoeverWants/1.0 (whoeverwants.com)",
+        "Accept-Language": "en",
+    }
 
     resp = await _http_client.get(
         "https://nominatim.openstreetmap.org/search",
         params=params,
-        headers={"User-Agent": "WhoeverWants/1.0 (whoeverwants.com)"},
+        headers=headers,
     )
     resp.raise_for_status()
     data = resp.json()
+
+    # If bounded search returned no results, retry unbounded
+    if not data and has_ref and max_distance > 0:
+        params.pop("bounded", None)
+        params.pop("viewbox", None)
+        params["limit"] = 10
+        resp = await _http_client.get(
+            "https://nominatim.openstreetmap.org/search",
+            params=params,
+            headers=headers,
+        )
+        resp.raise_for_status()
+        data = resp.json()
 
     results = []
     for item in data:
         item_lat = item.get("lat")
         item_lon = item.get("lon")
+        distance = None
+        if has_ref and item_lat and item_lon:
+            distance = round(
+                _haversine_miles(lat, lon, float(item_lat), float(item_lon)), 1
+            )
+            # Hard filter: skip results beyond max_distance
+            if max_distance > 0 and distance > max_distance:
+                continue
+
         entry: dict = {
             "label": item.get("display_name", ""),
             "description": item.get("type", "").replace("_", " ").title(),
@@ -76,14 +105,12 @@ async def search_locations(
                 if item_lat and item_lon else None
             ),
         }
-        if lat is not None and lon is not None and item_lat and item_lon:
-            entry["distance_miles"] = round(
-                _haversine_miles(lat, lon, float(item_lat), float(item_lon)), 1
-            )
+        if distance is not None:
+            entry["distance_miles"] = distance
         results.append(entry)
 
     # Sort by distance when reference location provided
-    if lat is not None and lon is not None:
+    if has_ref:
         results.sort(key=lambda r: r.get("distance_miles", float("inf")))
 
     return results[:6]
@@ -104,7 +131,10 @@ async def geocode(q: str = Query(..., min_length=2, max_length=200)):
             "limit": 1,
             "addressdetails": 1,
         },
-        headers={"User-Agent": "WhoeverWants/1.0 (whoeverwants.com)"},
+        headers={
+            "User-Agent": "WhoeverWants/1.0 (whoeverwants.com)",
+            "Accept-Language": "en",
+        },
     )
     resp.raise_for_status()
     data = resp.json()

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -123,21 +123,6 @@ async def search_locations(
     retries with "Burger" and filters to results containing "K".
     """
     results = await _nominatim_search(q, lat, lon, max_distance)
-
-    # Partial word fallback: if no results and query has a trailing
-    # incomplete word, retry with just the complete words and filter
-    if not results and " " in q.strip():
-        complete_words = q.rsplit(" ", 1)[0].strip()
-        partial = q.rsplit(" ", 1)[1].strip().lower()
-        if len(complete_words) >= 2:
-            results = await _nominatim_search(complete_words, lat, lon, max_distance)
-            if partial:
-                # Boost results whose name contains the partial word
-                results.sort(key=lambda r: (
-                    0 if partial in r["label"].lower() else 1,
-                    r.get("distance_miles", float("inf")),
-                ))
-
     return results[:6]
 
 

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -1,6 +1,7 @@
 """Search/autocomplete endpoints for poll content types."""
 
 import logging
+import math
 import os
 
 import httpx
@@ -16,15 +17,91 @@ RAWG_API_KEY = os.environ.get("RAWG_API_KEY", "")
 _http_client = httpx.AsyncClient(timeout=5.0)
 
 
+def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Calculate the great-circle distance between two points in miles."""
+    R = 3958.8  # Earth radius in miles
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (math.sin(dlat / 2) ** 2
+         + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2))
+         * math.sin(dlon / 2) ** 2)
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
 @router.get("/locations")
-async def search_locations(q: str = Query(..., min_length=2, max_length=100)):
-    """Search for locations using OpenStreetMap Nominatim."""
+async def search_locations(
+    q: str = Query(..., min_length=2, max_length=100),
+    lat: float | None = Query(None, description="Reference latitude for proximity bias"),
+    lon: float | None = Query(None, description="Reference longitude for proximity bias"),
+):
+    """Search for locations using OpenStreetMap Nominatim.
+
+    When lat/lon are provided, results are biased toward that area
+    and include a distance_miles field.
+    """
+    params: dict = {
+        "q": q,
+        "format": "jsonv2",
+        "limit": 10,
+        "addressdetails": 1,
+    }
+
+    # Bias search toward reference location using viewbox
+    if lat is not None and lon is not None:
+        # ~30 mile bounding box (~0.5 degrees)
+        delta = 0.5
+        params["viewbox"] = f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}"
+        # bounded=0 means prefer but don't restrict to viewbox
+        params["bounded"] = 0
+
+    resp = await _http_client.get(
+        "https://nominatim.openstreetmap.org/search",
+        params=params,
+        headers={"User-Agent": "WhoeverWants/1.0 (whoeverwants.com)"},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    results = []
+    for item in data:
+        item_lat = item.get("lat")
+        item_lon = item.get("lon")
+        entry: dict = {
+            "label": item.get("display_name", ""),
+            "description": item.get("type", "").replace("_", " ").title(),
+            "lat": item_lat,
+            "lon": item_lon,
+            "infoUrl": (
+                f"https://www.openstreetmap.org/?mlat={item_lat}&mlon={item_lon}#map=15/{item_lat}/{item_lon}"
+                if item_lat and item_lon else None
+            ),
+        }
+        if lat is not None and lon is not None and item_lat and item_lon:
+            entry["distance_miles"] = round(
+                _haversine_miles(lat, lon, float(item_lat), float(item_lon)), 1
+            )
+        results.append(entry)
+
+    # Sort by distance when reference location provided
+    if lat is not None and lon is not None:
+        results.sort(key=lambda r: r.get("distance_miles", float("inf")))
+
+    return results[:6]
+
+
+@router.get("/geocode")
+async def geocode(q: str = Query(..., min_length=2, max_length=200)):
+    """Geocode an address or zip code to coordinates + label (city/zip).
+
+    Returns the first matching result with lat, lon, and a short label
+    suitable for display (city name or zip code).
+    """
     resp = await _http_client.get(
         "https://nominatim.openstreetmap.org/search",
         params={
             "q": q,
             "format": "jsonv2",
-            "limit": 6,
+            "limit": 1,
             "addressdetails": 1,
         },
         headers={"User-Agent": "WhoeverWants/1.0 (whoeverwants.com)"},
@@ -32,17 +109,32 @@ async def search_locations(q: str = Query(..., min_length=2, max_length=100)):
     resp.raise_for_status()
     data = resp.json()
 
-    return [
-        {
-            "label": item.get("display_name", ""),
-            "description": item.get("type", "").replace("_", " ").title(),
-            "lat": item.get("lat"),
-            "lon": item.get("lon"),
-            "infoUrl": f"https://www.openstreetmap.org/?mlat={item.get('lat')}&mlon={item.get('lon')}#map=15/{item.get('lat')}/{item.get('lon')}"
-            if item.get("lat") and item.get("lon") else None,
-        }
-        for item in data
-    ]
+    if not data:
+        return None
+
+    item = data[0]
+    addr = item.get("address", {})
+    # Build a short label: prefer city/town, fall back to postcode
+    label = (
+        addr.get("city")
+        or addr.get("town")
+        or addr.get("village")
+        or addr.get("hamlet")
+        or addr.get("county")
+    )
+    postcode = addr.get("postcode")
+    state = addr.get("state")
+    # Format: "City, ST" or "City, ST 12345" or just "12345"
+    if label and state:
+        label = f"{label}, {state}"
+    elif postcode:
+        label = postcode
+
+    return {
+        "lat": item.get("lat"),
+        "lon": item.get("lon"),
+        "label": label or item.get("display_name", ""),
+    }
 
 
 @router.get("/movies")


### PR DESCRIPTION
## Summary
- Poll creators can set a reference location (zip code, address, or browser geolocation) that filters/sorts place search results by proximity
- Location persists in localStorage and auto-fills on future polls, editable in profile page
- Search results show distance in miles; configurable radius (default 25 mi) via "Within X mi" bubble
- Autocomplete caches previous results and merges with new API results to handle Nominatim's full-word-only matching (e.g. "Burger K" retains "Burger King" from cached "Burger" results)
- Reference location displayed on poll page as "Near City, State" badge

## Changes
- **New**: `ReferenceLocationInput` component, `/geocode` API endpoint, migration 076 (reference location columns)
- **Modified**: `AutocompleteInput` (caching + location params), `OptionsInput`/`NominationVotingInterface` (prop threading), `create-poll/page.tsx` (location UI), `PollPageClient` (location badge), `profile/page.tsx` (location management), `search.py` (bounded search + distance filtering), `api.ts`/`types.ts`/`models.py`/`polls.py` (reference location fields)

## Test plan
- [ ] Create a location poll, verify reference location auto-fills from saved profile
- [ ] Search for a business name, verify results are nearby and show distance
- [ ] Type "Burger" then "Burger K" — verify Burger King result is retained
- [ ] Change radius via "Within X mi" bubble, verify search results update
- [ ] View poll as voter, verify "Near City, State" badge appears
- [ ] Edit location in profile page, verify it persists

https://claude.ai/code/session_01Pr8GxRAVfZVQsTBY1LiiCH