### PR TITLE
Improve location display and add uncontested poll support

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -54,7 +54,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [isAbstaining, setIsAbstaining] = useState(false);
   const [nominationChoices, setNominationChoices] = useState<string[]>([]);
   const [nominationMetadata, setNominationMetadata] = useState<OptionsMetadata>({});
-  const [optionsMetadataLocal, setOptionsMetadataLocal] = useState<OptionsMetadata | null>(optionsMetadataLocal ?? null);
+  const [optionsMetadataLocal, setOptionsMetadataLocal] = useState<OptionsMetadata | null>(poll.options_metadata ?? null);
   const [existingNominations, setExistingNominations] = useState<string[]>([]);
   const [justCancelledAbstain, setJustCancelledAbstain] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1940,13 +1940,13 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                                 setIsAbstaining(false);
                               }}
                               disabled={isSubmitting}
-                              className={`flex-1 py-3 px-4 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                              className={`flex-1 min-w-0 py-3 px-3 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                                 rankedChoices[0] === option
                                   ? 'bg-blue-200 dark:bg-blue-800 text-blue-900 dark:text-blue-100 border-2 border-blue-400 dark:border-blue-600 active:bg-blue-300 dark:active:bg-blue-700'
                                   : 'bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 text-blue-800 dark:text-blue-200 border-2 border-transparent active:bg-blue-300 dark:active:bg-blue-700'
                               }`}
                             >
-                              <OptionLabel text={option} metadata={optionsMetadataLocal?.[option]} />
+                              <OptionLabel text={option} metadata={optionsMetadataLocal?.[option]} layout="stacked" />
                             </button>
                           ))}
                         </div>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -55,6 +55,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [nominationChoices, setNominationChoices] = useState<string[]>([]);
   const [nominationMetadata, setNominationMetadata] = useState<OptionsMetadata>({});
   const [optionsMetadataLocal, setOptionsMetadataLocal] = useState<OptionsMetadata | null>(poll.options_metadata ?? null);
+
+  // Sync local metadata when poll prop changes (e.g., navigating between polls)
+  useEffect(() => {
+    setOptionsMetadataLocal(poll.options_metadata ?? null);
+  }, [poll.id]); // eslint-disable-line react-hooks/exhaustive-deps
   const [existingNominations, setExistingNominations] = useState<string[]>([]);
   const [justCancelledAbstain, setJustCancelledAbstain] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -598,7 +598,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           setPollClosed(true);
           apiFindDuplicatePoll(poll.title, poll.id)
             .then((followUp) => {
-              if (followUp && !followUp.is_closed) {
+              if (followUp && (!followUp.is_closed || followUp.close_reason === 'uncontested')) {
                 const shortId = followUp.short_id || followUp.id;
                 router.push(`/p/${shortId}`);
               }
@@ -758,7 +758,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         if (poll.poll_type === 'nomination' && poll.auto_create_preferences) {
           try {
             const followUp = await apiFindDuplicatePoll(poll.title, poll.id);
-            if (followUp && !followUp.is_closed) {
+            if (followUp && (!followUp.is_closed || followUp.close_reason === 'uncontested')) {
               if (creatorSecret) recordPollCreation(followUp.id, creatorSecret);
               const shortId = followUp.short_id || followUp.id;
               router.push(`/p/${shortId}`);

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1816,7 +1816,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       <div className="space-y-2">
                         {[1, 2, 3].map((num) => (
                           <div key={num} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded animate-pulse">
-                            <div className="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded-full flex items-center justify-center text-sm font-medium mr-3">
+                            <div className="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded-full flex items-center justify-center text-sm font-medium mr-2">
                               <svg className="animate-spin h-3 w-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
@@ -1837,7 +1837,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                           </div>
                         ) : pollOptions.length === 2 ? (
                           <div className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded">
-                            <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
+                            <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
                               ✓
                             </span>
                             <OptionLabel text={rankedChoices[0]} metadata={optionsMetadataLocal?.[rankedChoices[0]]} />
@@ -1845,7 +1845,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                         ) : (
                           rankedChoices.map((choice, index) => (
                             <div key={index} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded">
-                              <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
+                              <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
                                 {index + 1}
                               </span>
                               <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -54,6 +54,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [isAbstaining, setIsAbstaining] = useState(false);
   const [nominationChoices, setNominationChoices] = useState<string[]>([]);
   const [nominationMetadata, setNominationMetadata] = useState<OptionsMetadata>({});
+  const [optionsMetadataLocal, setOptionsMetadataLocal] = useState<OptionsMetadata | null>(optionsMetadataLocal ?? null);
   const [existingNominations, setExistingNominations] = useState<string[]>([]);
   const [justCancelledAbstain, setJustCancelledAbstain] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -1088,10 +1089,15 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
       setHasVoted(true);
       setUserVoteId(voteId ?? null);
-      
+
+      // Merge submitted metadata into local state so it's available immediately
+      if (nominationMetadata && Object.keys(nominationMetadata).length > 0) {
+        setOptionsMetadataLocal(prev => ({ ...prev, ...nominationMetadata }));
+      }
+
       // Trigger voter list refresh immediately
       setVoterListRefresh(prev => prev + 1);
-      
+
       // Refresh nomination list for nomination polls with a small delay to ensure DB update is complete
       if (poll.poll_type === 'nomination') {
         // Add a small delay to ensure the database update is fully committed
@@ -1269,7 +1275,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               </div>
             ) : pollResults ? (
               <>
-                <PollResultsDisplay results={pollResults} isPollClosed={isPollClosed} userVoteData={userVoteData} optionsMetadata={poll.options_metadata} />
+                <PollResultsDisplay results={pollResults} isPollClosed={isPollClosed} userVoteData={userVoteData} optionsMetadata={optionsMetadataLocal} />
                 {pollResults.time_slot_rounds && pollResults.time_slot_rounds.length > 0 && (
                   <div className="mt-4">
                     <TimeSlotRoundsDisplay
@@ -1828,7 +1834,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
                               ✓
                             </span>
-                            <OptionLabel text={rankedChoices[0]} metadata={poll.options_metadata?.[rankedChoices[0]]} />
+                            <OptionLabel text={rankedChoices[0]} metadata={optionsMetadataLocal?.[rankedChoices[0]]} />
                           </div>
                         ) : (
                           rankedChoices.map((choice, index) => (
@@ -1836,7 +1842,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                               <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
                                 {index + 1}
                               </span>
-                              <OptionLabel text={choice} metadata={poll.options_metadata?.[choice]} />
+                              <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
                             </div>
                           ))
                         )}
@@ -1930,7 +1936,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                                   : 'bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 text-blue-800 dark:text-blue-200 border-2 border-transparent active:bg-blue-300 dark:active:bg-blue-700'
                               }`}
                             >
-                              <OptionLabel text={option} metadata={poll.options_metadata?.[option]} />
+                              <OptionLabel text={option} metadata={optionsMetadataLocal?.[option]} />
                             </button>
                           ))}
                         </div>
@@ -1949,7 +1955,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             disabled={isSubmitting || isAbstaining}
                             storageKey={pollId ? `poll-ranking-${pollId}` : undefined}
                             initialRanking={isEditingVote && userVoteData?.ranked_choices ? userVoteData.ranked_choices : undefined}
-                            optionsMetadata={poll.options_metadata}
+                            optionsMetadata={optionsMetadataLocal}
                           />
                         )}
                       </>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1836,19 +1836,23 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             <span className="font-medium text-yellow-800 dark:text-yellow-200">Abstained</span>
                           </div>
                         ) : pollOptions.length === 2 ? (
-                          <div className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded">
-                            <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
+                          <div className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0">
+                            <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
                               ✓
                             </span>
-                            <OptionLabel text={rankedChoices[0]} metadata={optionsMetadataLocal?.[rankedChoices[0]]} />
+                            <div className="min-w-0 overflow-hidden">
+                              <OptionLabel text={rankedChoices[0]} metadata={optionsMetadataLocal?.[rankedChoices[0]]} />
+                            </div>
                           </div>
                         ) : (
                           rankedChoices.map((choice, index) => (
-                            <div key={index} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded">
-                              <span className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
+                            <div key={index} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0">
+                              <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
                                 {index + 1}
                               </span>
-                              <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
+                              <div className="min-w-0 overflow-hidden">
+                                <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
+                              </div>
                             </div>
                           ))
                         )}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1768,6 +1768,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               autoCreatePreferences={poll.auto_create_preferences}
               nominationMetadata={nominationMetadata}
               onNominationMetadataChange={setNominationMetadata}
+              optionsMetadata={optionsMetadataLocal}
             />
           ) : (
             <div>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1409,7 +1409,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             ? 'bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700'
                             : 'bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700'
                       }`}>
-                        <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold mr-3 ${
+                        <span className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-bold mr-3 ${
                           userVoteData?.is_abstain || isAbstaining
                             ? 'bg-yellow-600 text-white'
                             : userVoteData?.yes_no_choice === 'yes'
@@ -1607,7 +1607,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                               ? 'bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700'
                               : 'bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700'
                         }`}>
-                          <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold mr-3 ${
+                          <span className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-bold mr-3 ${
                             userVoteData?.is_abstain || isAbstaining
                               ? 'bg-yellow-600 text-white'
                               : userVoteData?.yes_no_choice === 'yes'
@@ -1831,7 +1831,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       <div className="space-y-2">
                         {userVoteData?.is_abstain || isAbstaining ? (
                           <div className="flex items-center p-3 bg-yellow-50 dark:bg-yellow-900 border border-yellow-200 dark:border-yellow-700 rounded-lg">
-                            <span className="w-8 h-8 bg-yellow-600 text-white rounded-full flex items-center justify-center text-sm font-bold mr-3">
+                            <span className="w-8 h-8 flex-shrink-0 bg-yellow-600 text-white rounded-full flex items-center justify-center text-sm font-bold mr-3">
                             </span>
                             <span className="font-medium text-yellow-800 dark:text-yellow-200">Abstained</span>
                           </div>

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { apiSearchLocations, apiSearchMovies, apiSearchVideoGames, type SearchResult } from "@/lib/api";
 import type { PollContentType } from "@/lib/types";
+import { formatDistance } from "./OptionLabel";
 
 interface AutocompleteInputProps {
   value: string;
@@ -182,7 +183,7 @@ export default function AutocompleteInput({
                       </span>
                       {result.distance_miles !== undefined && (
                         <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap flex-shrink-0">
-                          {result.distance_miles < 0.1 ? '<0.1' : result.distance_miles} mi
+                          {formatDistance(result.distance_miles)}
                         </span>
                       )}
                     </div>
@@ -203,7 +204,7 @@ export default function AutocompleteInput({
                       )}
                       {result.distance_miles !== undefined && (
                         <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
-                          {result.distance_miles < 0.1 ? '<0.1' : result.distance_miles} mi
+                          {formatDistance(result.distance_miles)}
                         </span>
                       )}
                     </div>

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -172,21 +172,41 @@ export default function AutocompleteInput({
                 />
               )}
               <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                  {result.label}
-                </div>
-                <div className="flex items-center gap-2">
-                  {result.description && (
-                    <span className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
-                      {result.description}
-                    </span>
-                  )}
-                  {result.distance_miles !== undefined && (
-                    <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
-                      {result.distance_miles < 0.1 ? '<0.1' : result.distance_miles} mi
-                    </span>
-                  )}
-                </div>
+                {result.name ? (
+                  <>
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                        {result.name}
+                      </span>
+                      {result.distance_miles !== undefined && (
+                        <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap flex-shrink-0">
+                          {result.distance_miles < 0.1 ? '<0.1' : result.distance_miles} mi
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                      {result.label.startsWith(result.name + ', ') ? result.label.slice(result.name.length + 2) : result.label}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {result.label}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {result.description && (
+                        <span className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
+                          {result.description}
+                        </span>
+                      )}
+                      {result.distance_miles !== undefined && (
+                        <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                          {result.distance_miles < 0.1 ? '<0.1' : result.distance_miles} mi
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
               </div>
             </li>
           ))}

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -168,7 +168,9 @@ export default function AutocompleteInput({
                 <img
                   src={result.imageUrl}
                   alt=""
-                  className="w-8 h-12 object-cover rounded flex-shrink-0 mt-0.5"
+                  className={`object-cover rounded flex-shrink-0 mt-0.5 ${
+                    result.name ? 'w-5 h-5' : 'w-8 h-12'
+                  }`}
                 />
               )}
               <div className="min-w-0 flex-1">

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -411,7 +411,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center space-x-4 min-w-0 flex-1">
                       {/* Position number */}
-                      <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                      <div className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-bold ${
                         isUserPreference 
                           ? 'bg-blue-500 text-white dark:bg-blue-600 dark:text-white' 
                           : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-200'

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -349,6 +349,9 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
       ) : (
         <div className="text-center mb-4">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{currentRound.title}</h3>
+          {results.total_votes === 0 && results.winner && results.winner !== 'tie' && (
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Uncontested</p>
+          )}
         </div>
       )}
 
@@ -444,36 +447,30 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                       </div>
                     </div>
 
-                    {/* Vote count and percentage */}
-                    <div className="text-right flex-shrink-0">
-                      {results.total_votes === 0 && currentRound.candidates.length === 1 ? (
-                        <div className="text-sm font-medium text-green-700 dark:text-green-300">
-                          Uncontested
+                    {/* Vote count and percentage - hidden for uncontested polls */}
+                    {!(results.total_votes === 0 && currentRound.candidates.length === 1) && (
+                      <div className="text-right flex-shrink-0">
+                        <div className={`text-lg font-bold ${
+                          isTiedCandidate
+                            ? 'text-green-800 dark:text-green-200'
+                            : candidate.isEliminated && !isTiedCandidate
+                            ? 'text-red-700 dark:text-red-300'
+                            : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                            ? 'text-green-800 dark:text-green-200'
+                            : 'text-gray-900 dark:text-white'
+                        }`}>
+                          {candidate.percentage}%
                         </div>
-                      ) : (
-                        <>
-                          <div className={`text-lg font-bold ${
-                            isTiedCandidate
-                              ? 'text-green-800 dark:text-green-200'
-                              : candidate.isEliminated && !isTiedCandidate
-                              ? 'text-red-700 dark:text-red-300'
-                              : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
-                              ? 'text-green-800 dark:text-green-200'
-                              : 'text-gray-900 dark:text-white'
-                          }`}>
-                            {candidate.percentage}%
-                          </div>
-                          <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center justify-end gap-1">
-                            {candidate.donatedVotes && candidate.donatedVotes > 0 && (
-                              <span className="bg-blue-500 text-white text-xs px-2 py-0.5 rounded-full font-medium">
-                                +{candidate.donatedVotes}
-                              </span>
-                            )}
-                            <span>{candidate.votes} vote{candidate.votes !== 1 ? 's' : ''}</span>
-                          </div>
-                        </>
-                      )}
-                    </div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center justify-end gap-1">
+                          {candidate.donatedVotes && candidate.donatedVotes > 0 && (
+                            <span className="bg-blue-500 text-white text-xs px-2 py-0.5 rounded-full font-medium">
+                              +{candidate.donatedVotes}
+                            </span>
+                          )}
+                          <span>{candidate.votes} vote{candidate.votes !== 1 ? 's' : ''}</span>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
 

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -405,8 +405,8 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                     ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600' 
                     : 'bg-white dark:bg-gray-700'
                 }`}>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center space-x-4 min-w-0 flex-1">
                       {/* Position number */}
                       <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
                         isUserPreference 
@@ -445,7 +445,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                     </div>
 
                     {/* Vote count and percentage */}
-                    <div className="text-right">
+                    <div className="text-right flex-shrink-0">
                       <div className={`text-lg font-bold ${
                         isTiedCandidate
                           ? 'text-green-800 dark:text-green-200'

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -417,8 +417,12 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                       </div>
                       
                       {/* Candidate name */}
-                      <div>
-                        <div className={`leading-tight line-clamp-2 ${
+                      <div className="min-w-0 overflow-hidden">
+                        <div className={`leading-tight ${
+                          optionsMetadata?.[candidate.name]?.name || optionsMetadata?.[candidate.name]?.infoUrl?.includes('openstreetmap.org')
+                            ? 'overflow-hidden'
+                            : 'line-clamp-2'
+                        } ${
                           isTiedCandidate
                             ? 'text-green-900 dark:text-green-100 font-bold'
                             : candidate.isEliminated && !isTiedCandidate

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -409,7 +409,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                     : 'bg-white dark:bg-gray-700'
                 }`}>
                   <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center space-x-4 min-w-0 flex-1">
+                    <div className="flex items-center space-x-2 min-w-0 flex-1">
                       {/* Position number */}
                       <div className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-bold ${
                         isUserPreference 

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { PollResults, RankedChoiceRound, OptionsMetadata } from "@/lib/types";
 import { apiGetVotes, ApiRankedChoiceRound } from "@/lib/api";
-import OptionLabel from "./OptionLabel";
+import OptionLabel, { isLocationEntry } from "./OptionLabel";
 
 interface CompactRankedChoiceResultsProps {
   results: PollResults;
@@ -422,7 +422,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                       {/* Candidate name */}
                       <div className="min-w-0 overflow-hidden">
                         <div className={`leading-tight ${
-                          optionsMetadata?.[candidate.name]?.name || optionsMetadata?.[candidate.name]?.infoUrl?.includes('openstreetmap.org')
+                          isLocationEntry(optionsMetadata?.[candidate.name])
                             ? 'overflow-hidden'
                             : 'line-clamp-2'
                         } ${

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -184,7 +184,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
               return {
                 name: round.option_name,
                 votes: round.vote_count,
-                percentage: Math.round((round.vote_count / results.total_votes) * 100),
+                percentage: results.total_votes > 0 ? Math.round((round.vote_count / results.total_votes) * 100) : 0,
                 previousVotes: roundNum > 1 ? previousVotes : undefined,
                 donatedVotes: donatedVotes > 0 ? donatedVotes : undefined,
                 isEliminated: isEliminated,
@@ -446,25 +446,33 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
 
                     {/* Vote count and percentage */}
                     <div className="text-right flex-shrink-0">
-                      <div className={`text-lg font-bold ${
-                        isTiedCandidate
-                          ? 'text-green-800 dark:text-green-200'
-                          : candidate.isEliminated && !isTiedCandidate
-                          ? 'text-red-700 dark:text-red-300'
-                          : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
-                          ? 'text-green-800 dark:text-green-200'
-                          : 'text-gray-900 dark:text-white'
-                      }`}>
-                        {candidate.percentage}%
-                      </div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center justify-end gap-1">
-                        {candidate.donatedVotes && candidate.donatedVotes > 0 && (
-                          <span className="bg-blue-500 text-white text-xs px-2 py-0.5 rounded-full font-medium">
-                            +{candidate.donatedVotes}
-                          </span>
-                        )}
-                        <span>{candidate.votes} vote{candidate.votes !== 1 ? 's' : ''}</span>
-                      </div>
+                      {results.total_votes === 0 && currentRound.candidates.length === 1 ? (
+                        <div className="text-sm font-medium text-green-700 dark:text-green-300">
+                          Uncontested
+                        </div>
+                      ) : (
+                        <>
+                          <div className={`text-lg font-bold ${
+                            isTiedCandidate
+                              ? 'text-green-800 dark:text-green-200'
+                              : candidate.isEliminated && !isTiedCandidate
+                              ? 'text-red-700 dark:text-red-300'
+                              : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                              ? 'text-green-800 dark:text-green-200'
+                              : 'text-gray-900 dark:text-white'
+                          }`}>
+                            {candidate.percentage}%
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center justify-end gap-1">
+                            {candidate.donatedVotes && candidate.donatedVotes > 0 && (
+                              <span className="bg-blue-500 text-white text-xs px-2 py-0.5 rounded-full font-medium">
+                                +{candidate.donatedVotes}
+                              </span>
+                            )}
+                            <span>{candidate.votes} vote{candidate.votes !== 1 ? 's' : ''}</span>
+                          </div>
+                        </>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -310,24 +310,31 @@ export default function NominationVotingInterface({
               {filteredExistingNominations.map((nomination, index) => {
                 const isSelected = nominationChoices.includes(nomination);
                 return (
-                  <button
+                  <div
                     key={index}
-                    onClick={() => {
-                      if (isSelected) {
-                        removeNomination(nomination);
-                      } else {
-                        addExistingNomination(nomination);
-                      }
-                    }}
-                    disabled={isSubmitting}
-                    className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed ${
+                    className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all ${
                       isSelected
-                        ? 'bg-green-100 hover:bg-green-200 dark:bg-green-900/30 dark:hover:bg-green-900/40 active:bg-green-300 dark:active:bg-green-900/50 text-green-900 dark:text-green-100 font-medium border border-green-300 dark:border-green-700'
-                        : 'bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-700 active:bg-gray-100 dark:active:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
+                        ? 'bg-green-100 dark:bg-green-900/30 text-green-900 dark:text-green-100 font-medium border border-green-300 dark:border-green-700'
+                        : 'bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
                     }`}
                   >
-                    <OptionLabel text={nomination} metadata={optionsMetadata?.[nomination]} />
-                  </button>
+                    <div className="min-w-0 flex-1">
+                      <OptionLabel text={nomination} metadata={optionsMetadata?.[nomination]} />
+                    </div>
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      disabled={isSubmitting}
+                      onChange={() => {
+                        if (isSelected) {
+                          removeNomination(nomination);
+                        } else {
+                          addExistingNomination(nomination);
+                        }
+                      }}
+                      className="w-5 h-5 flex-shrink-0 rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
+                  </div>
                 );
               })}
             </div>

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -42,6 +42,7 @@ interface NominationVotingInterfaceProps {
   autoCreatePreferences?: boolean;
   nominationMetadata?: OptionsMetadata;
   onNominationMetadataChange?: (metadata: OptionsMetadata) => void;
+  optionsMetadata?: OptionsMetadata | null;
 }
 
 export default function NominationVotingInterface({
@@ -75,6 +76,7 @@ export default function NominationVotingInterface({
   autoCreatePreferences,
   nominationMetadata,
   onNominationMetadataChange,
+  optionsMetadata,
 }: NominationVotingInterfaceProps) {
   const [newNominations, setNewNominations] = useState<string[]>([""]);
   const [filteredExistingNominations, setFilteredExistingNominations] = useState<string[]>([]);
@@ -214,7 +216,7 @@ export default function NominationVotingInterface({
               showEditButton={!isPollClosed}
               onEditClick={() => setIsEditingVote(true)}
               isEditDisabled={isLoadingVoteData}
-              optionsMetadata={poll.options_metadata}
+              optionsMetadata={optionsMetadata}
             />
           ) : (
             <div className="flex items-center justify-between">
@@ -324,7 +326,7 @@ export default function NominationVotingInterface({
                         : 'bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-700 active:bg-gray-100 dark:active:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
                     }`}
                   >
-                    <OptionLabel text={nomination} metadata={poll.options_metadata?.[nomination]} />
+                    <OptionLabel text={nomination} metadata={optionsMetadata?.[nomination]} />
                   </button>
                 );
               })}

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -46,6 +46,9 @@ export default function NominationsList({
     a.option.localeCompare(b.option)
   );
 
+  // Check if any nomination has location metadata for layout switching
+  const hasLocationMetadata = nominations.some(n => optionsMetadata?.[n.option]?.name);
+
   return (
     <div className={className}>
       <div className="flex items-center justify-between mb-3">
@@ -73,28 +76,32 @@ export default function NominationsList({
         </div>
       </div>
 
-      <div className="flex flex-wrap justify-center gap-2">
+      <div className={`flex flex-wrap justify-center gap-2 ${hasLocationMetadata ? 'flex-col items-stretch' : ''}`}>
         {sortedNominations.map((nomination, index) => {
           const isUserNomination = userNominations.includes(nomination.option);
+          const meta = optionsMetadata?.[nomination.option];
+          const isLocation = !!meta?.name;
 
           return (
             <div
               key={index}
-              className={`inline-flex items-center rounded-full overflow-hidden ${
+              className={`inline-flex items-center overflow-hidden ${
+                isLocation ? 'rounded-xl' : 'rounded-full'
+              } ${
                 isUserNomination
                   ? 'bg-blue-100 dark:bg-blue-900/30'
                   : 'bg-gray-100 dark:bg-gray-700'
               }`}
             >
-              <span className={`px-3 py-1 text-sm font-medium ${
+              <span className={`px-3 py-1.5 text-sm font-medium min-w-0 flex-1 ${
                 isUserNomination
                   ? 'text-blue-900 dark:text-blue-100'
                   : 'text-gray-900 dark:text-gray-100'
               }`}>
-                <OptionLabel text={nomination.option} metadata={optionsMetadata?.[nomination.option]} />
+                <OptionLabel text={nomination.option} metadata={meta} />
               </span>
               {showVoteCounts && (
-                <span className={`px-2.5 py-1 text-sm font-bold ${
+                <span className={`px-2.5 self-stretch flex items-center text-sm font-bold ${
                   isUserNomination
                     ? 'bg-blue-500 text-white'
                     : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -47,7 +47,10 @@ export default function NominationsList({
   );
 
   // Check if any nomination has location metadata for layout switching
-  const hasLocationMetadata = nominations.some(n => optionsMetadata?.[n.option]?.name);
+  const isLocationPoll = nominations.some(n => {
+    const meta = optionsMetadata?.[n.option];
+    return meta?.name || meta?.infoUrl?.includes("openstreetmap.org");
+  });
 
   return (
     <div className={className}>
@@ -76,11 +79,11 @@ export default function NominationsList({
         </div>
       </div>
 
-      <div className={`flex flex-wrap justify-center gap-2 ${hasLocationMetadata ? 'flex-col items-stretch' : ''}`}>
+      <div className={`flex flex-wrap justify-center gap-2 ${isLocationPoll ? 'flex-col items-stretch' : ''}`}>
         {sortedNominations.map((nomination, index) => {
           const isUserNomination = userNominations.includes(nomination.option);
           const meta = optionsMetadata?.[nomination.option];
-          const isLocation = !!meta?.name;
+          const isLocation = !!(meta?.name || meta?.infoUrl?.includes("openstreetmap.org"));
 
           return (
             <div

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { OptionsMetadata } from "@/lib/types";
-import OptionLabel from "./OptionLabel";
+import OptionLabel, { isLocationEntry } from "./OptionLabel";
 
 interface Nomination {
   option: string;
@@ -46,11 +46,7 @@ export default function NominationsList({
     a.option.localeCompare(b.option)
   );
 
-  // Check if any nomination has location metadata for layout switching
-  const isLocationPoll = nominations.some(n => {
-    const meta = optionsMetadata?.[n.option];
-    return meta?.name || meta?.infoUrl?.includes("openstreetmap.org");
-  });
+  const isLocationPoll = nominations.some(n => isLocationEntry(optionsMetadata?.[n.option]));
 
   return (
     <div className={className}>

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -79,43 +79,77 @@ export default function NominationsList({
         </div>
       </div>
 
-      <div className={`flex flex-wrap justify-center gap-2 ${isLocationPoll ? 'flex-col items-stretch' : ''}`}>
-        {sortedNominations.map((nomination, index) => {
-          const isUserNomination = userNominations.includes(nomination.option);
-          const meta = optionsMetadata?.[nomination.option];
-          const isLocation = !!(meta?.name || meta?.infoUrl?.includes("openstreetmap.org"));
+      {isLocationPoll ? (
+        <div className="space-y-2 overflow-hidden">
+          {sortedNominations.map((nomination, index) => {
+            const isUserNomination = userNominations.includes(nomination.option);
+            const meta = optionsMetadata?.[nomination.option];
 
-          return (
-            <div
-              key={index}
-              className={`flex items-center overflow-hidden ${
-                isLocation ? 'rounded-xl' : 'rounded-full'
-              } ${
-                isUserNomination
-                  ? 'bg-blue-100 dark:bg-blue-900/30'
-                  : 'bg-gray-100 dark:bg-gray-700'
-              }`}
-            >
-              <div className={`px-3 py-1.5 text-sm font-medium min-w-0 flex-1 overflow-hidden ${
-                isUserNomination
-                  ? 'text-blue-900 dark:text-blue-100'
-                  : 'text-gray-900 dark:text-gray-100'
-              }`}>
-                <OptionLabel text={nomination.option} metadata={meta} />
-              </div>
-              {showVoteCounts && (
-                <span className={`px-2.5 self-stretch flex items-center text-sm font-bold ${
+            return (
+              <div
+                key={index}
+                className={`flex items-center rounded-xl overflow-hidden ${
                   isUserNomination
-                    ? 'bg-blue-500 text-white'
-                    : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'
+                    ? 'bg-blue-100 dark:bg-blue-900/30'
+                    : 'bg-gray-100 dark:bg-gray-700'
+                }`}
+              >
+                <div className={`min-w-0 flex-1 px-3 py-1.5 text-sm font-medium overflow-hidden ${
+                  isUserNomination
+                    ? 'text-blue-900 dark:text-blue-100'
+                    : 'text-gray-900 dark:text-gray-100'
                 }`}>
-                  {nomination.count}
-                </span>
-              )}
-            </div>
-          );
-        })}
-      </div>
+                  <OptionLabel text={nomination.option} metadata={meta} />
+                </div>
+                {showVoteCounts && (
+                  <span className={`px-2.5 self-stretch flex items-center text-sm font-bold flex-shrink-0 ${
+                    isUserNomination
+                      ? 'bg-blue-500 text-white'
+                      : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'
+                  }`}>
+                    {nomination.count}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="flex flex-wrap justify-center gap-2">
+          {sortedNominations.map((nomination, index) => {
+            const isUserNomination = userNominations.includes(nomination.option);
+            const meta = optionsMetadata?.[nomination.option];
+
+            return (
+              <div
+                key={index}
+                className={`inline-flex items-center rounded-full overflow-hidden ${
+                  isUserNomination
+                    ? 'bg-blue-100 dark:bg-blue-900/30'
+                    : 'bg-gray-100 dark:bg-gray-700'
+                }`}
+              >
+                <div className={`px-3 py-1 text-sm font-medium ${
+                  isUserNomination
+                    ? 'text-blue-900 dark:text-blue-100'
+                    : 'text-gray-900 dark:text-gray-100'
+                }`}>
+                  <OptionLabel text={nomination.option} metadata={meta} />
+                </div>
+                {showVoteCounts && (
+                  <span className={`px-2.5 py-1 text-sm font-bold ${
+                    isUserNomination
+                      ? 'bg-blue-500 text-white'
+                      : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'
+                  }`}>
+                    {nomination.count}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -96,13 +96,13 @@ export default function NominationsList({
                   : 'bg-gray-100 dark:bg-gray-700'
               }`}
             >
-              <span className={`px-3 py-1.5 text-sm font-medium min-w-0 flex-1 overflow-hidden ${
+              <div className={`px-3 py-1.5 text-sm font-medium min-w-0 flex-1 overflow-hidden ${
                 isUserNomination
                   ? 'text-blue-900 dark:text-blue-100'
                   : 'text-gray-900 dark:text-gray-100'
               }`}>
                 <OptionLabel text={nomination.option} metadata={meta} />
-              </span>
+              </div>
               {showVoteCounts && (
                 <span className={`px-2.5 self-stretch flex items-center text-sm font-bold ${
                   isUserNomination

--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -88,7 +88,7 @@ export default function NominationsList({
           return (
             <div
               key={index}
-              className={`inline-flex items-center overflow-hidden ${
+              className={`flex items-center overflow-hidden ${
                 isLocation ? 'rounded-xl' : 'rounded-full'
               } ${
                 isUserNomination
@@ -96,7 +96,7 @@ export default function NominationsList({
                   : 'bg-gray-100 dark:bg-gray-700'
               }`}
             >
-              <span className={`px-3 py-1.5 text-sm font-medium min-w-0 flex-1 ${
+              <span className={`px-3 py-1.5 text-sm font-medium min-w-0 flex-1 overflow-hidden ${
                 isUserNomination
                   ? 'text-blue-900 dark:text-blue-100'
                   : 'text-gray-900 dark:text-gray-100'

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -67,9 +67,9 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     );
 
     const content = (
-      <span className={`inline-flex items-start gap-2 ${className}`}>
+      <span className={`flex items-start gap-2 overflow-hidden ${className}`}>
         {icon}
-        <span className="min-w-0">
+        <span className="min-w-0 overflow-hidden">
           <span className="flex items-baseline gap-1.5 flex-wrap">
             <span className="font-medium leading-tight">{name}</span>
             {distance !== undefined && (

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -17,7 +17,7 @@ function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
 }
 
 /** Detect if metadata represents a location (has OSM infoUrl or name). */
-function isLocationEntry(metadata: OptionMetadataEntry | null | undefined): boolean {
+export function isLocationEntry(metadata: OptionMetadataEntry | null | undefined): boolean {
   if (!metadata) return false;
   if (metadata.name) return true;
   return !!metadata.infoUrl?.includes("openstreetmap.org");

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -16,33 +16,16 @@ function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
   );
 }
 
-/** Icon wrapped in a clickable link with a visible border. */
-function LinkedIcon({ href, children }: { href: string; children: React.ReactNode }) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={(e) => e.stopPropagation()}
-      className="flex-shrink-0 w-7 h-7 flex items-center justify-center rounded border border-blue-300 dark:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/40 transition-colors"
-    >
-      {children}
-    </a>
-  );
-}
-
 /** Detect if metadata represents a location (has OSM infoUrl or name). */
 function isLocationEntry(metadata: OptionMetadataEntry | null | undefined): boolean {
   if (!metadata) return false;
   if (metadata.name) return true;
-  // Legacy entries: only have infoUrl pointing to OpenStreetMap
   return !!metadata.infoUrl?.includes("openstreetmap.org");
 }
 
 /** Extract the place name from metadata or parse from Nominatim display_name. */
 function getLocationName(text: string, metadata: OptionMetadataEntry): string {
   if (metadata.name) return metadata.name;
-  // Parse from Nominatim display_name: "Name, Street, City, ..."
   const commaIdx = text.indexOf(", ");
   return commaIdx >= 0 ? text.slice(0, commaIdx) : text;
 }
@@ -68,7 +51,7 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     const address = getAddressFromLabel(text, name);
     const distance = metadata!.distance_miles;
 
-    const iconContent = metadata!.imageUrl ? (
+    const icon = metadata!.imageUrl ? (
       <img
         src={metadata!.imageUrl}
         alt=""
@@ -81,18 +64,26 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
       </span>
     );
 
-    const icon = metadata!.infoUrl ? (
-      <LinkedIcon href={metadata!.infoUrl}>{iconContent}</LinkedIcon>
+    const nameEl = metadata!.infoUrl ? (
+      <a
+        href={metadata!.infoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="font-medium leading-tight underline decoration-blue-400/50 hover:decoration-blue-500"
+      >
+        {name}
+      </a>
     ) : (
-      <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">{iconContent}</span>
+      <span className="font-medium leading-tight">{name}</span>
     );
 
     return (
       <div className={`flex items-center gap-2 ${className}`}>
-        {icon}
+        <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">{icon}</span>
         <div className="min-w-0 overflow-hidden">
           <div className="flex items-baseline gap-1.5 flex-wrap">
-            <span className="font-medium leading-tight">{name}</span>
+            {nameEl}
             {distance !== undefined && (
               <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
                 {formatDistance(distance)}
@@ -127,16 +118,16 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
   if (metadata.infoUrl) {
     return (
       <span className={`inline-flex items-center gap-1.5 ${className}`}>
-        {imageEl && <LinkedIcon href={metadata.infoUrl}>{imageEl}</LinkedIcon>}
-        {!imageEl && (
-          <LinkedIcon href={metadata.infoUrl}>
-            <svg className="w-4 h-4 text-blue-500" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
-              <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
-            </svg>
-          </LinkedIcon>
-        )}
-        <span>{text}</span>
+        {imageEl && <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">{imageEl}</span>}
+        <a
+          href={metadata.infoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="underline decoration-blue-400/50 hover:decoration-blue-500"
+        >
+          {text}
+        </a>
       </span>
     );
   }

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -38,11 +38,22 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     const address = getAddressFromLabel(text, metadata.name);
     const distance = metadata.distance_miles;
 
+    const icon = metadata.imageUrl ? (
+      <img
+        src={metadata.imageUrl}
+        alt=""
+        className="w-5 h-5 rounded flex-shrink-0 mt-0.5"
+        loading="lazy"
+      />
+    ) : (
+      <span className="text-blue-500 dark:text-blue-400 flex-shrink-0 mt-0.5">
+        <MapPinIcon className="w-4 h-4" />
+      </span>
+    );
+
     const content = (
       <span className={`inline-flex items-start gap-2 ${className}`}>
-        <span className="text-blue-500 dark:text-blue-400 flex-shrink-0 mt-0.5">
-          <MapPinIcon className="w-4 h-4" />
-        </span>
+        {icon}
         <span className="min-w-0">
           <span className="flex items-baseline gap-1.5 flex-wrap">
             <span className="font-medium leading-tight">{metadata.name}</span>

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -40,7 +40,7 @@ function getAddressFromLabel(label: string, name: string): string {
   return commaIdx >= 0 ? label.slice(commaIdx + 2) : "";
 }
 
-function formatDistance(miles: number): string {
+export function formatDistance(miles: number): string {
   if (miles < 0.1) return "<0.1 mi";
   if (miles < 10) return `${miles.toFixed(1)} mi`;
   return `${Math.round(miles)} mi`;

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -1,17 +1,82 @@
 "use client";
 
-interface OptionMetadata {
-  imageUrl?: string;
-  infoUrl?: string;
-}
+import type { OptionMetadataEntry } from "@/lib/types";
 
 interface OptionLabelProps {
   text: string;
-  metadata?: OptionMetadata | null;
+  metadata?: OptionMetadataEntry | null;
   className?: string;
 }
 
+function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <path fillRule="evenodd" clipRule="evenodd" d="M12 2C7.58 2 4 5.58 4 10c0 5.25 7.13 11.38 7.43 11.63a1 1 0 001.14 0C12.87 21.38 20 15.25 20 10c0-4.42-3.58-8-8-8zm0 11a3 3 0 110-6 3 3 0 010 6z" />
+    </svg>
+  );
+}
+
+function getAddressFromLabel(label: string, name: string): string {
+  // Remove the name prefix from the full label to get just the address
+  if (label.startsWith(name + ", ")) {
+    return label.slice(name.length + 2);
+  }
+  // If name isn't at the start, return everything after first comma
+  const commaIdx = label.indexOf(", ");
+  return commaIdx >= 0 ? label.slice(commaIdx + 2) : label;
+}
+
+function formatDistance(miles: number): string {
+  if (miles < 0.1) return "<0.1 mi";
+  if (miles < 10) return `${miles.toFixed(1)} mi`;
+  return `${Math.round(miles)} mi`;
+}
+
 export default function OptionLabel({ text, metadata, className = "" }: OptionLabelProps) {
+  // Location with rich metadata: two-line display
+  if (metadata?.name) {
+    const address = getAddressFromLabel(text, metadata.name);
+    const distance = metadata.distance_miles;
+
+    const content = (
+      <span className={`inline-flex items-start gap-2 ${className}`}>
+        <span className="text-blue-500 dark:text-blue-400 flex-shrink-0 mt-0.5">
+          <MapPinIcon className="w-4 h-4" />
+        </span>
+        <span className="min-w-0">
+          <span className="flex items-baseline gap-1.5 flex-wrap">
+            <span className="font-medium leading-tight">{metadata.name}</span>
+            {distance !== undefined && (
+              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                {formatDistance(distance)}
+              </span>
+            )}
+          </span>
+          <span className="block text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+            {address}
+          </span>
+        </span>
+      </span>
+    );
+
+    if (metadata.infoUrl) {
+      return (
+        <a
+          href={metadata.infoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="hover:underline"
+        >
+          {content}
+        </a>
+      );
+    }
+
+    return content;
+  }
+
+  // Non-location or no rich metadata: original behavior
   if (!metadata || (!metadata.imageUrl && !metadata.infoUrl)) {
     return <span className={className}>{text}</span>;
   }

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRef, useCallback } from "react";
 import type { OptionMetadataEntry } from "@/lib/types";
 
 interface OptionLabelProps {
@@ -9,61 +8,26 @@ interface OptionLabelProps {
   className?: string;
 }
 
-const LONG_PRESS_MS = 500;
-
-/** Wrapper that opens a URL on long press instead of tap. */
-function LongPressLink({
-  href,
-  className,
-  children,
-}: {
-  href: string;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const firedRef = useRef(false);
-
-  const start = useCallback(() => {
-    firedRef.current = false;
-    timerRef.current = setTimeout(() => {
-      firedRef.current = true;
-      window.open(href, "_blank", "noopener,noreferrer");
-    }, LONG_PRESS_MS);
-  }, [href]);
-
-  const cancel = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-
-  return (
-    <div
-      className={className}
-      onMouseDown={start}
-      onMouseUp={cancel}
-      onMouseLeave={cancel}
-      onTouchStart={start}
-      onTouchEnd={cancel}
-      onTouchCancel={cancel}
-      onClick={(e) => {
-        e.stopPropagation();
-        // Prevent any parent tap handlers from firing after long press
-        if (firedRef.current) e.preventDefault();
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
 function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
       <path fillRule="evenodd" clipRule="evenodd" d="M12 2C7.58 2 4 5.58 4 10c0 5.25 7.13 11.38 7.43 11.63a1 1 0 001.14 0C12.87 21.38 20 15.25 20 10c0-4.42-3.58-8-8-8zm0 11a3 3 0 110-6 3 3 0 010 6z" />
     </svg>
+  );
+}
+
+/** Icon wrapped in a clickable link with a visible border. */
+function LinkedIcon({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="flex-shrink-0 rounded border border-blue-300 dark:border-blue-500 p-0.5 hover:bg-blue-50 dark:hover:bg-blue-900/40 transition-colors"
+    >
+      {children}
+    </a>
   );
 }
 
@@ -104,52 +68,43 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     const address = getAddressFromLabel(text, name);
     const distance = metadata!.distance_miles;
 
-    const icon = metadata!.imageUrl ? (
+    const iconContent = metadata!.imageUrl ? (
       <img
         src={metadata!.imageUrl}
         alt=""
-        className="w-5 h-5 rounded flex-shrink-0"
+        className="w-5 h-5 rounded"
         loading="lazy"
       />
     ) : (
-      <span className="text-blue-500 dark:text-blue-400 flex-shrink-0">
+      <span className="text-blue-500 dark:text-blue-400">
         <MapPinIcon className="w-4 h-4" />
       </span>
     );
 
-    const inner = (
-      <>
-        <div className="flex items-baseline gap-1.5 flex-wrap">
-          <span className="font-medium leading-tight">{name}</span>
-          {distance !== undefined && (
-            <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
-              {formatDistance(distance)}
-            </span>
-          )}
-        </div>
-        {address && (
-          <div className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
-            {address}
-          </div>
-        )}
-      </>
-    );
-
-    const wrapper = metadata!.infoUrl ? (
-      <LongPressLink
-        href={metadata!.infoUrl}
-        className="min-w-0 overflow-hidden block cursor-default"
-      >
-        {inner}
-      </LongPressLink>
+    const icon = metadata!.infoUrl ? (
+      <LinkedIcon href={metadata!.infoUrl}>{iconContent}</LinkedIcon>
     ) : (
-      <div className="min-w-0 overflow-hidden">{inner}</div>
+      <span className="flex-shrink-0">{iconContent}</span>
     );
 
     return (
       <div className={`flex items-center gap-2 ${className}`}>
         {icon}
-        {wrapper}
+        <div className="min-w-0 overflow-hidden">
+          <div className="flex items-baseline gap-1.5 flex-wrap">
+            <span className="font-medium leading-tight">{name}</span>
+            {distance !== undefined && (
+              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                {formatDistance(distance)}
+              </span>
+            )}
+          </div>
+          {address && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+              {address}
+            </div>
+          )}
+        </div>
       </div>
     );
   }
@@ -159,34 +114,37 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     return <span className={className}>{text}</span>;
   }
 
-  const content = (
-    <>
-      {metadata.imageUrl && (
-        <img
-          src={metadata.imageUrl}
-          alt=""
-          className="w-5 h-7 object-cover rounded flex-shrink-0"
-          loading="lazy"
-        />
-      )}
-      <span>{text}</span>
-    </>
-  );
+  // Typed option with image and/or link (movies, video games, etc.)
+  const imageEl = metadata.imageUrl ? (
+    <img
+      src={metadata.imageUrl}
+      alt=""
+      className="w-5 h-7 object-cover rounded"
+      loading="lazy"
+    />
+  ) : null;
 
   if (metadata.infoUrl) {
     return (
-      <LongPressLink
-        href={metadata.infoUrl}
-        className={`inline-flex items-center gap-1.5 text-blue-600 dark:text-blue-400 cursor-default ${className}`}
-      >
-        {content}
-      </LongPressLink>
+      <span className={`inline-flex items-center gap-1.5 ${className}`}>
+        {imageEl && <LinkedIcon href={metadata.infoUrl}>{imageEl}</LinkedIcon>}
+        {!imageEl && (
+          <LinkedIcon href={metadata.infoUrl}>
+            <svg className="w-4 h-4 text-blue-500" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+              <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+            </svg>
+          </LinkedIcon>
+        )}
+        <span>{text}</span>
+      </span>
     );
   }
 
   return (
     <span className={`inline-flex items-center gap-1.5 ${className}`}>
-      {content}
+      {imageEl && <span className="flex-shrink-0">{imageEl}</span>}
+      <span>{text}</span>
     </span>
   );
 }

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -1,11 +1,62 @@
 "use client";
 
+import { useRef, useCallback } from "react";
 import type { OptionMetadataEntry } from "@/lib/types";
 
 interface OptionLabelProps {
   text: string;
   metadata?: OptionMetadataEntry | null;
   className?: string;
+}
+
+const LONG_PRESS_MS = 500;
+
+/** Wrapper that opens a URL on long press instead of tap. */
+function LongPressLink({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = useRef(false);
+
+  const start = useCallback(() => {
+    firedRef.current = false;
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true;
+      window.open(href, "_blank", "noopener,noreferrer");
+    }, LONG_PRESS_MS);
+  }, [href]);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  return (
+    <div
+      className={className}
+      onMouseDown={start}
+      onMouseUp={cancel}
+      onMouseLeave={cancel}
+      onTouchStart={start}
+      onTouchEnd={cancel}
+      onTouchCancel={cancel}
+      onClick={(e) => {
+        e.stopPropagation();
+        // Prevent any parent tap handlers from firing after long press
+        if (firedRef.current) e.preventDefault();
+      }}
+    >
+      {children}
+    </div>
+  );
 }
 
 function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
@@ -85,15 +136,12 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     );
 
     const wrapper = metadata!.infoUrl ? (
-      <a
+      <LongPressLink
         href={metadata!.infoUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={(e) => e.stopPropagation()}
-        className="min-w-0 overflow-hidden block hover:underline"
+        className="min-w-0 overflow-hidden block cursor-default"
       >
         {inner}
-      </a>
+      </LongPressLink>
     ) : (
       <div className="min-w-0 overflow-hidden">{inner}</div>
     );
@@ -127,15 +175,12 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
 
   if (metadata.infoUrl) {
     return (
-      <a
+      <LongPressLink
         href={metadata.infoUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={(e) => e.stopPropagation()}
-        className={`inline-flex items-center gap-1.5 text-blue-600 dark:text-blue-400 hover:underline ${className}`}
+        className={`inline-flex items-center gap-1.5 text-blue-600 dark:text-blue-400 cursor-default ${className}`}
       >
         {content}
-      </a>
+      </LongPressLink>
     );
   }
 

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -24,7 +24,7 @@ function LinkedIcon({ href, children }: { href: string; children: React.ReactNod
       target="_blank"
       rel="noopener noreferrer"
       onClick={(e) => e.stopPropagation()}
-      className="flex-shrink-0 rounded border border-blue-300 dark:border-blue-500 p-0.5 hover:bg-blue-50 dark:hover:bg-blue-900/40 transition-colors"
+      className="flex-shrink-0 w-7 h-7 flex items-center justify-center rounded border border-blue-300 dark:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/40 transition-colors"
     >
       {children}
     </a>
@@ -84,7 +84,7 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     const icon = metadata!.infoUrl ? (
       <LinkedIcon href={metadata!.infoUrl}>{iconContent}</LinkedIcon>
     ) : (
-      <span className="flex-shrink-0">{iconContent}</span>
+      <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">{iconContent}</span>
     );
 
     return (
@@ -143,7 +143,7 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
 
   return (
     <span className={`inline-flex items-center gap-1.5 ${className}`}>
-      {imageEl && <span className="flex-shrink-0">{imageEl}</span>}
+      {imageEl && <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">{imageEl}</span>}
       <span>{text}</span>
     </span>
   );

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -16,14 +16,28 @@ function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
   );
 }
 
+/** Detect if metadata represents a location (has OSM infoUrl or name). */
+function isLocationEntry(metadata: OptionMetadataEntry | null | undefined): boolean {
+  if (!metadata) return false;
+  if (metadata.name) return true;
+  // Legacy entries: only have infoUrl pointing to OpenStreetMap
+  return !!metadata.infoUrl?.includes("openstreetmap.org");
+}
+
+/** Extract the place name from metadata or parse from Nominatim display_name. */
+function getLocationName(text: string, metadata: OptionMetadataEntry): string {
+  if (metadata.name) return metadata.name;
+  // Parse from Nominatim display_name: "Name, Street, City, ..."
+  const commaIdx = text.indexOf(", ");
+  return commaIdx >= 0 ? text.slice(0, commaIdx) : text;
+}
+
 function getAddressFromLabel(label: string, name: string): string {
-  // Remove the name prefix from the full label to get just the address
   if (label.startsWith(name + ", ")) {
     return label.slice(name.length + 2);
   }
-  // If name isn't at the start, return everything after first comma
   const commaIdx = label.indexOf(", ");
-  return commaIdx >= 0 ? label.slice(commaIdx + 2) : label;
+  return commaIdx >= 0 ? label.slice(commaIdx + 2) : "";
 }
 
 function formatDistance(miles: number): string {
@@ -33,14 +47,15 @@ function formatDistance(miles: number): string {
 }
 
 export default function OptionLabel({ text, metadata, className = "" }: OptionLabelProps) {
-  // Location with rich metadata: two-line display
-  if (metadata?.name) {
-    const address = getAddressFromLabel(text, metadata.name);
-    const distance = metadata.distance_miles;
+  // Location entry: two-line display with icon
+  if (isLocationEntry(metadata)) {
+    const name = getLocationName(text, metadata!);
+    const address = getAddressFromLabel(text, name);
+    const distance = metadata!.distance_miles;
 
-    const icon = metadata.imageUrl ? (
+    const icon = metadata!.imageUrl ? (
       <img
-        src={metadata.imageUrl}
+        src={metadata!.imageUrl}
         alt=""
         className="w-5 h-5 rounded flex-shrink-0 mt-0.5"
         loading="lazy"
@@ -56,24 +71,26 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
         {icon}
         <span className="min-w-0">
           <span className="flex items-baseline gap-1.5 flex-wrap">
-            <span className="font-medium leading-tight">{metadata.name}</span>
+            <span className="font-medium leading-tight">{name}</span>
             {distance !== undefined && (
               <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
                 {formatDistance(distance)}
               </span>
             )}
           </span>
-          <span className="block text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
-            {address}
-          </span>
+          {address && (
+            <span className="block text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+              {address}
+            </span>
+          )}
         </span>
       </span>
     );
 
-    if (metadata.infoUrl) {
+    if (metadata!.infoUrl) {
       return (
         <a
-          href={metadata.infoUrl}
+          href={metadata!.infoUrl}
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}
@@ -87,7 +104,7 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     return content;
   }
 
-  // Non-location or no rich metadata: original behavior
+  // Non-location or no metadata: original behavior
   if (!metadata || (!metadata.imageUrl && !metadata.infoUrl)) {
     return <span className={className}>{text}</span>;
   }

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -66,42 +66,44 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
       </span>
     );
 
-    const content = (
-      <span className={`flex items-start gap-2 overflow-hidden ${className}`}>
-        {icon}
-        <span className="min-w-0 overflow-hidden">
-          <span className="flex items-baseline gap-1.5 flex-wrap">
-            <span className="font-medium leading-tight">{name}</span>
-            {distance !== undefined && (
-              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
-                {formatDistance(distance)}
-              </span>
-            )}
-          </span>
-          {address && (
-            <span className="block text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
-              {address}
+    const inner = (
+      <>
+        <div className="flex items-baseline gap-1.5 flex-wrap">
+          <span className="font-medium leading-tight">{name}</span>
+          {distance !== undefined && (
+            <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+              {formatDistance(distance)}
             </span>
           )}
-        </span>
-      </span>
+        </div>
+        {address && (
+          <div className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+            {address}
+          </div>
+        )}
+      </>
     );
 
-    if (metadata!.infoUrl) {
-      return (
-        <a
-          href={metadata!.infoUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          className="hover:underline"
-        >
-          {content}
-        </a>
-      );
-    }
+    const wrapper = metadata!.infoUrl ? (
+      <a
+        href={metadata!.infoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="min-w-0 overflow-hidden block hover:underline"
+      >
+        {inner}
+      </a>
+    ) : (
+      <div className="min-w-0 overflow-hidden">{inner}</div>
+    );
 
-    return content;
+    return (
+      <div className={`flex items-start gap-2 ${className}`}>
+        {icon}
+        {wrapper}
+      </div>
+    );
   }
 
   // Non-location or no metadata: original behavior

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -46,13 +46,15 @@ function formatDistance(miles: number): string {
   return `${Math.round(miles)} mi`;
 }
 
-function LocationIcon({ imageUrl }: { imageUrl?: string }) {
+function LocationIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "sm" | "lg" }) {
+  const imgClass = size === "lg" ? "w-10 h-10 rounded" : "w-5 h-5 rounded";
+  const pinClass = size === "lg" ? "w-8 h-8" : "w-4 h-4";
   if (imageUrl) {
-    return <img src={imageUrl} alt="" className="w-5 h-5 rounded" loading="lazy" />;
+    return <img src={imageUrl} alt="" className={imgClass} loading="lazy" />;
   }
   return (
     <span className="text-blue-500 dark:text-blue-400">
-      <MapPinIcon className="w-4 h-4" />
+      <MapPinIcon className={pinClass} />
     </span>
   );
 }
@@ -84,22 +86,22 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     if (layout === "stacked") {
       return (
         <div className={`min-w-0 overflow-hidden ${className}`}>
-          <div className="flex items-center gap-1.5">
-            <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center">
-              <LocationIcon imageUrl={metadata!.imageUrl} />
+          <div className="flex justify-center">
+            <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
+              <LocationIcon imageUrl={metadata!.imageUrl} size="lg" />
             </span>
-            {distance !== undefined && (
-              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
-                {formatDistance(distance)}
-              </span>
-            )}
           </div>
-          <div className="line-clamp-2 leading-tight mt-0.5">
+          <div className="line-clamp-2 leading-tight mt-1 text-center">
             <LocationName name={name} infoUrl={metadata!.infoUrl} />
           </div>
           {address && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 leading-tight mt-0.5">
+            <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 leading-tight mt-0.5 text-center">
               {address}
+            </div>
+          )}
+          {distance !== undefined && (
+            <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5 text-center">
+              {formatDistance(distance)}
             </div>
           )}
         </div>

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -6,6 +6,8 @@ interface OptionLabelProps {
   text: string;
   metadata?: OptionMetadataEntry | null;
   className?: string;
+  /** "inline" (default): icon left, text right. "stacked": icon+distance top, name, address vertically. */
+  layout?: "inline" | "stacked";
 }
 
 function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
@@ -44,29 +46,22 @@ function formatDistance(miles: number): string {
   return `${Math.round(miles)} mi`;
 }
 
-export default function OptionLabel({ text, metadata, className = "" }: OptionLabelProps) {
-  // Location entry: two-line display with icon
-  if (isLocationEntry(metadata)) {
-    const name = getLocationName(text, metadata!);
-    const address = getAddressFromLabel(text, name);
-    const distance = metadata!.distance_miles;
+function LocationIcon({ imageUrl }: { imageUrl?: string }) {
+  if (imageUrl) {
+    return <img src={imageUrl} alt="" className="w-5 h-5 rounded" loading="lazy" />;
+  }
+  return (
+    <span className="text-blue-500 dark:text-blue-400">
+      <MapPinIcon className="w-4 h-4" />
+    </span>
+  );
+}
 
-    const icon = metadata!.imageUrl ? (
-      <img
-        src={metadata!.imageUrl}
-        alt=""
-        className="w-5 h-5 rounded"
-        loading="lazy"
-      />
-    ) : (
-      <span className="text-blue-500 dark:text-blue-400">
-        <MapPinIcon className="w-4 h-4" />
-      </span>
-    );
-
-    const nameEl = metadata!.infoUrl ? (
+function LocationName({ name, infoUrl }: { name: string; infoUrl?: string }) {
+  if (infoUrl) {
+    return (
       <a
-        href={metadata!.infoUrl}
+        href={infoUrl}
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
@@ -74,16 +69,52 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
       >
         {name}
       </a>
-    ) : (
-      <span className="font-medium leading-tight">{name}</span>
     );
+  }
+  return <span className="font-medium leading-tight">{name}</span>;
+}
 
+export default function OptionLabel({ text, metadata, className = "", layout = "inline" }: OptionLabelProps) {
+  // Location entry
+  if (isLocationEntry(metadata)) {
+    const name = getLocationName(text, metadata!);
+    const address = getAddressFromLabel(text, name);
+    const distance = metadata!.distance_miles;
+
+    if (layout === "stacked") {
+      return (
+        <div className={`min-w-0 overflow-hidden ${className}`}>
+          <div className="flex items-center gap-1.5">
+            <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center">
+              <LocationIcon imageUrl={metadata!.imageUrl} />
+            </span>
+            {distance !== undefined && (
+              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                {formatDistance(distance)}
+              </span>
+            )}
+          </div>
+          <div className="line-clamp-2 leading-tight mt-0.5">
+            <LocationName name={name} infoUrl={metadata!.infoUrl} />
+          </div>
+          {address && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 leading-tight mt-0.5">
+              {address}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // Default inline layout
     return (
       <div className={`flex items-center gap-2 ${className}`}>
-        <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">{icon}</span>
+        <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
+          <LocationIcon imageUrl={metadata!.imageUrl} />
+        </span>
         <div className="min-w-0 overflow-hidden">
           <div className="flex items-baseline gap-1.5 flex-wrap">
-            {nameEl}
+            <LocationName name={name} infoUrl={metadata!.infoUrl} />
             {distance !== undefined && (
               <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
                 {formatDistance(distance)}

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -57,11 +57,11 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
       <img
         src={metadata!.imageUrl}
         alt=""
-        className="w-5 h-5 rounded flex-shrink-0 mt-0.5"
+        className="w-5 h-5 rounded flex-shrink-0"
         loading="lazy"
       />
     ) : (
-      <span className="text-blue-500 dark:text-blue-400 flex-shrink-0 mt-0.5">
+      <span className="text-blue-500 dark:text-blue-400 flex-shrink-0">
         <MapPinIcon className="w-4 h-4" />
       </span>
     );
@@ -99,7 +99,7 @@ export default function OptionLabel({ text, metadata, className = "" }: OptionLa
     );
 
     return (
-      <div className={`flex items-start gap-2 ${className}`}>
+      <div className={`flex items-center gap-2 ${className}`}>
         {icon}
         {wrapper}
       </div>

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -82,10 +82,15 @@ export default function OptionsInput({
   };
 
   const handleSelect = (result: SearchResult) => {
-    if (!onMetadataChange || (!result.imageUrl && !result.infoUrl)) return;
-    const entry: { imageUrl?: string; infoUrl?: string } = {};
+    if (!onMetadataChange) return;
+    const entry: Record<string, unknown> = {};
     if (result.imageUrl) entry.imageUrl = result.imageUrl;
     if (result.infoUrl) entry.infoUrl = result.infoUrl;
+    if (result.name) entry.name = result.name;
+    if (result.distance_miles !== undefined) entry.distance_miles = result.distance_miles;
+    if (result.lat) entry.lat = result.lat;
+    if (result.lon) entry.lon = result.lon;
+    if (Object.keys(entry).length === 0) return;
     onMetadataChange({ ...optionsMetadata, [result.label]: entry });
   };
 

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -604,7 +604,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             <div className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
               {rankNumber}
             </div>
-            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="font-medium leading-tight line-clamp-2" />
+            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="font-medium leading-tight overflow-hidden" />
           </div>
           <div className="w-6 h-6 flex flex-col items-center justify-center ml-2">
             <div className="w-4 h-0.5 bg-gray-600 mb-1"></div>
@@ -980,7 +980,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       ? 'text-gray-500 dark:text-gray-400'
                       : 'text-gray-900 dark:text-white'
                   }`}>
-                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="font-medium leading-tight line-clamp-2" />
+                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="font-medium leading-tight overflow-hidden" />
                   </div>
                   
                   {/* Right drag handle with grabbable region */}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -601,10 +601,10 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       >
         <div className="flex items-center justify-between h-full">
           <div className="flex items-center text-gray-900 dark:text-white">
-            <div className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
+            <div className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
               {rankNumber}
             </div>
-            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="font-medium leading-tight overflow-hidden" />
+            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="min-w-0 overflow-hidden" />
           </div>
           <div className="w-6 h-6 flex flex-col items-center justify-center ml-2">
             <div className="w-4 h-0.5 bg-gray-600 mb-1"></div>
@@ -975,12 +975,12 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                   </div>
                   
                   {/* Center content - not grabbable */}
-                  <div className={`flex-1 flex items-center px-12 ${
+                  <div className={`flex-1 flex items-center pl-11 pr-12 ${
                     disabled
                       ? 'text-gray-500 dark:text-gray-400'
                       : 'text-gray-900 dark:text-white'
                   }`}>
-                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="font-medium leading-tight overflow-hidden" />
+                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />
                   </div>
                   
                   {/* Right drag handle with grabbable region */}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { ClientOnlyDragDrop } from './ClientOnly';
 import type { OptionsMetadata } from '@/lib/types';
-import OptionLabel from './OptionLabel';
+import OptionLabel, { isLocationEntry } from './OptionLabel';
 
 interface RankableOption {
   id: string;
@@ -99,8 +99,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     noPreference: 0
   });
 
-  // Configuration
-  const itemHeight = 56;
+  // Configuration — taller items for location entries (two-line layout)
+  const hasLocationOptions = optionsMetadata && Object.values(optionsMetadata).some(m => isLocationEntry(m));
+  const itemHeight = hasLocationOptions ? 72 : 56;
   const gapSize = 8;
   const totalItemHeight = itemHeight + gapSize;
 

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -601,7 +601,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       >
         <div className="flex items-center justify-between h-full">
           <div className="flex items-center text-gray-900 dark:text-white">
-            <div className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
+            <div className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-3">
               {rankNumber}
             </div>
             <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="font-medium leading-tight overflow-hidden" />
@@ -961,7 +961,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                     {/* Visual number circle - positioned within the grabbable area */}
                     <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center">
                       <div 
-                        className={`w-6 h-6 rounded-full flex items-center justify-center text-sm font-medium ${
+                        className={`w-6 h-6 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-medium ${
                           disabled 
                             ? 'bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400' 
                             : listType === 'main'

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -601,8 +601,8 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         style={getDraggedItemStyle()}
       >
         <div className="flex items-center justify-between h-full">
-          <div className="flex items-center text-gray-900 dark:text-white">
-            <div className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
+          <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
+            <div className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-1">
               {rankNumber}
             </div>
             <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="min-w-0 overflow-hidden" />
@@ -976,7 +976,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                   </div>
                   
                   {/* Center content - not grabbable */}
-                  <div className={`flex-1 flex items-center pl-11 pr-12 ${
+                  <div className={`flex-1 flex items-center pl-9 pr-12 min-w-0 ${
                     disabled
                       ? 'text-gray-500 dark:text-gray-400'
                       : 'text-gray-900 dark:text-white'

--- a/database/migrations/077_add_uncontested_close_reason_down.sql
+++ b/database/migrations/077_add_uncontested_close_reason_down.sql
@@ -1,0 +1,4 @@
+-- Revert close_reason check constraint
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_close_reason_check;
+ALTER TABLE polls ADD CONSTRAINT polls_close_reason_check
+  CHECK (close_reason IS NULL OR close_reason IN ('manual', 'deadline', 'max_capacity'));

--- a/database/migrations/077_add_uncontested_close_reason_up.sql
+++ b/database/migrations/077_add_uncontested_close_reason_up.sql
@@ -1,0 +1,4 @@
+-- Add 'uncontested' to close_reason check constraint
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_close_reason_check;
+ALTER TABLE polls ADD CONSTRAINT polls_close_reason_check
+  CHECK (close_reason IS NULL OR close_reason IN ('manual', 'deadline', 'max_capacity', 'uncontested'));

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -342,6 +342,7 @@ export async function apiGetAccessiblePolls(pollIds: string[]): Promise<Poll[]> 
 
 export interface SearchResult {
   label: string;
+  name?: string;
   description?: string;
   imageUrl?: string;
   infoUrl?: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,7 +25,7 @@ export interface Poll {
   creator_secret?: string;
   creator_name?: string;
   is_closed?: boolean;
-  close_reason?: 'manual' | 'deadline' | 'max_capacity';
+  close_reason?: 'manual' | 'deadline' | 'max_capacity' | 'uncontested';
   follow_up_to?: string;
   fork_of?: string;
   min_participants?: number;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,7 +3,16 @@
 
 export type PollContentType = 'custom' | 'location' | 'movie' | 'video_game';
 
-export type OptionsMetadata = Record<string, { imageUrl?: string; infoUrl?: string }>;
+export type OptionMetadataEntry = {
+  imageUrl?: string;
+  infoUrl?: string;
+  name?: string;
+  distance_miles?: number;
+  lat?: string;
+  lon?: string;
+};
+
+export type OptionsMetadata = Record<string, OptionMetadataEntry>;
 
 export interface Poll {
   id: string;

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -115,9 +115,7 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
                 seen.add(lower)
                 all_nominations.append(nom.strip())
 
-    if len(all_nominations) < 2:
-        # Not enough nominations to create a meaningful ranked choice poll.
-        # Leave the reserved poll closed.
+    if len(all_nominations) == 0:
         return
 
     # Find the reserved placeholder poll
@@ -137,13 +135,47 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
     if not reserved:
         return  # No reserved poll found (shouldn't happen)
 
-    # Calculate deadline from now
-    from datetime import timedelta
-    deadline = now + timedelta(minutes=deadline_minutes)
-
     # Propagate options_metadata from parent for matching nominations
     parent_metadata = parent_row.get("options_metadata") or {}
     child_metadata = {nom: parent_metadata[nom] for nom in all_nominations if nom in parent_metadata} or None
+
+    if len(all_nominations) == 1:
+        # Single nomination: activate as already closed with uncontested winner
+        conn.execute(
+            """
+            UPDATE polls
+            SET options = %(options)s::jsonb,
+                is_closed = true,
+                close_reason = 'uncontested',
+                updated_at = %(now)s,
+                options_metadata = %(options_metadata)s::jsonb,
+                is_sub_poll = COALESCE(%(is_sub_poll)s, is_sub_poll),
+                sub_poll_role = COALESCE(%(sub_poll_role)s, sub_poll_role),
+                parent_participation_poll_id = COALESCE(%(parent_id)s, parent_participation_poll_id)
+            WHERE id = %(reserved_id)s
+            """,
+            {
+                "options": json.dumps(all_nominations),
+                "now": now,
+                "reserved_id": str(reserved["id"]),
+                "options_metadata": json.dumps(child_metadata) if child_metadata else None,
+                "is_sub_poll": parent_row.get("is_sub_poll") or None,
+                "sub_poll_role": None,
+                "parent_id": str(parent_row["parent_participation_poll_id"]) if parent_row.get("parent_participation_poll_id") else None,
+            },
+        )
+        # Resolve winner to parent if this is a sub-poll
+        reserved_poll = conn.execute(
+            "SELECT * FROM polls WHERE id = %(id)s",
+            {"id": str(reserved["id"])},
+        ).fetchone()
+        if reserved_poll and reserved_poll.get("sub_poll_role"):
+            _resolve_sub_poll_winner(conn, dict(reserved_poll))
+        return
+
+    # 2+ nominations: activate as open ranked choice poll
+    from datetime import timedelta
+    deadline = now + timedelta(minutes=deadline_minutes)
 
     # Activate the reserved poll (propagate sub-poll metadata if present)
     conn.execute(
@@ -373,11 +405,19 @@ def _resolve_sub_poll_winner(conn, poll_row: dict) -> None:
     if raw_options:
         poll_options = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
 
-    if not poll_options or not votes:
+    if not poll_options:
         return
 
-    result = calculate_ranked_choice_winner([dict(v) for v in votes], poll_options)
-    if result.winner:
+    # Uncontested: single option wins automatically without votes
+    if len(poll_options) == 1 and poll_row.get("close_reason") == "uncontested":
+        winner = poll_options[0]
+    elif not votes:
+        return
+    else:
+        result = calculate_ranked_choice_winner([dict(v) for v in votes], poll_options)
+        winner = result.winner
+
+    if winner:
         conn.execute(
             f"UPDATE polls SET {resolved_column} = %(winner)s, updated_at = %(now)s WHERE id = %(parent_id)s",
             {
@@ -856,6 +896,30 @@ def get_results(poll_id: str):
         poll_options = None
         if raw_options:
             poll_options = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
+
+        # Uncontested: single option wins automatically
+        if poll.get("close_reason") == "uncontested" and poll_options and len(poll_options) == 1:
+            return PollResultsResponse(
+                poll_id=str(poll["id"]),
+                title=poll["title"],
+                poll_type=poll_type,
+                created_at=poll["created_at"].isoformat() if isinstance(poll["created_at"], datetime) else str(poll["created_at"]),
+                response_deadline=poll["response_deadline"].isoformat() if poll.get("response_deadline") else None,
+                options=poll_options,
+                total_votes=0,
+                min_participants=poll.get("min_participants"),
+                max_participants=poll.get("max_participants"),
+                winner=poll_options[0],
+                ranked_choice_winner=poll_options[0],
+                ranked_choice_rounds=[RankedChoiceRoundResponse(
+                    round_number=1,
+                    option_name=poll_options[0],
+                    vote_count=0,
+                    is_eliminated=False,
+                    borda_score=0.0,
+                    tie_broken_by_borda=False,
+                )],
+            )
 
         result = calculate_ranked_choice_winner(votes, poll_options or [])
 

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -89,6 +89,7 @@ async def _nominatim_search(
 
         entry: dict = {
             "label": item.get("display_name", ""),
+            "name": item.get("name") or "",
             "description": item.get("type", "").replace("_", " ").title(),
             "lat": item_lat,
             "lon": item_lon,

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import os
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Query
@@ -42,6 +43,7 @@ async def _nominatim_search(
         "format": "jsonv2",
         "limit": 20,
         "addressdetails": 1,
+        "extratags": 1,
     }
 
     if has_ref and max_distance > 0:
@@ -87,12 +89,25 @@ async def _nominatim_search(
             if max_distance > 0 and distance > max_distance:
                 continue
 
+        # Extract website from extratags for favicon
+        extratags = item.get("extratags") or {}
+        website = extratags.get("website") or extratags.get("contact:website") or ""
+        image_url = None
+        if website:
+            try:
+                domain = urlparse(website).netloc or urlparse(website).path.split("/")[0]
+                if domain:
+                    image_url = f"https://www.google.com/s2/favicons?domain={domain}&sz=32"
+            except Exception:
+                pass
+
         entry: dict = {
             "label": item.get("display_name", ""),
             "name": item.get("name") or "",
             "description": item.get("type", "").replace("_", " ").title(),
             "lat": item_lat,
             "lon": item_lon,
+            "imageUrl": image_url,
             "infoUrl": (
                 f"https://www.openstreetmap.org/?mlat={item_lat}&mlon={item_lon}#map=15/{item_lat}/{item_lon}"
                 if item_lat and item_lon else None


### PR DESCRIPTION
## Summary
- **Location display overhaul**: OptionLabel now renders locations as two-line layout (name + distance on first line, truncated address on second) with favicon icons from Nominatim extratags, used consistently across suggestions, ranked choice options, result cards, and vote confirmations
- **Uncontested poll support**: Single-nomination preferences polls immediately resolve as "uncontested" winner instead of silently failing — shows "Uncontested" subtitle under Final Result header with no vote stats
- **UI improvements**: Suggestion seconding uses checkboxes instead of full-row tap targets; place names are underlined links (not icons); 2-option preference polls use stacked layout with large centered icon; ranking number circles no longer compress in flex layouts
- **Code quality**: Extracted shared `isLocationEntry`, `formatDistance`, `LocationIcon`, `LocationName` from OptionLabel and reuse across NominationsList, CompactRankedChoiceResults, AutocompleteInput, and RankableOptions

## Test plan
- [ ] Create a location suggestion poll, add suggestions, verify two-line layout with icons
- [ ] Close suggestion poll with auto-preferences enabled — verify preferences poll is created
- [ ] Test single-nomination → uncontested flow: verify immediate close with "Uncontested" label
- [ ] Test 2-option preference poll: verify stacked layout with large centered icons
- [ ] Test ranked choice reordering: verify locations show two-line layout, addresses truncate
- [ ] Verify ranking circles stay round (not squished) across all views
- [ ] Test suggestion seconding with checkboxes
- [ ] Verify place name links open in new tab

https://claude.ai/code/session_01L54H1ZveZqvpKgMETinHAy