### PR TITLE
Improve favicon resolution and link underline visibility

### DIFF
--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -67,7 +67,7 @@ function LocationName({ name, infoUrl }: { name: string; infoUrl?: string }) {
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
-        className="font-medium leading-tight underline decoration-blue-400/50 hover:decoration-blue-500"
+        className="font-medium leading-tight underline decoration-2 decoration-blue-400/50 hover:decoration-blue-500"
       >
         {name}
       </a>
@@ -157,7 +157,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}
-          className="underline decoration-blue-400/50 hover:decoration-blue-500"
+          className="underline decoration-2 decoration-blue-400/50 hover:decoration-blue-500"
         >
           {text}
         </a>

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -97,7 +97,7 @@ async def _nominatim_search(
             try:
                 domain = urlparse(website).netloc or urlparse(website).path.split("/")[0]
                 if domain:
-                    image_url = f"https://www.google.com/s2/favicons?domain={domain}&sz=32"
+                    image_url = f"https://www.google.com/s2/favicons?domain={domain}&sz=128"
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- Increase location favicon size from 32px to 128px for crisp rendering on retina displays (icons render at 40x40 CSS px in stacked layout = 80-120 physical px on 2x/3x screens)
- Make underline thicker (`decoration-2`) on linked option names for both location and generic typed options (movies, video games)

## Test plan
- [ ] Search for a location with a website (e.g. a restaurant chain) and verify the favicon is crisp, not blurry
- [ ] Check the underline on linked option names is visibly thicker than before