### PR TITLE
Searchable type field with custom type support

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -4,7 +4,8 @@ import { useState, useRef, useEffect, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
-import type { PollContentType, OptionsMetadata } from "@/lib/types";
+import type { OptionsMetadata } from "@/lib/types";
+import TypeFieldInput from "@/components/TypeFieldInput";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -67,7 +68,7 @@ function CreatePollContent() {
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
-  const [pollContentType, setPollContentType] = useState<PollContentType>('custom');
+  const [pollContentType, setPollContentType] = useState<string>('custom');
   const [optionsMetadata, setOptionsMetadata] = useState<OptionsMetadata>({});
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
@@ -1166,18 +1167,11 @@ function CreatePollContent() {
               <label htmlFor="contentType" className="block text-sm font-medium mb-2">
                 Type
               </label>
-              <select
-                id="contentType"
+              <TypeFieldInput
                 value={pollContentType}
-                onChange={(e) => setPollContentType(e.target.value as PollContentType)}
+                onChange={setPollContentType}
                 disabled={isLoading}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <option value="custom">Custom</option>
-                <option value="location">Location</option>
-                <option value="movie">Movie</option>
-                <option value="video_game">Video Game</option>
-              </select>
+              />
             </div>
           )}
 

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -47,7 +47,7 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
       )
     : BUILT_IN_TYPES;
 
-  // Close dropdown on outside click
+  // Close dropdown on outside click or focus loss
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -58,6 +58,14 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  function handleBlur(e: React.FocusEvent) {
+    // If focus moves outside the container, close dropdown
+    if (containerRef.current && !containerRef.current.contains(e.relatedTarget as Node)) {
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    }
+  }
 
   // Scroll highlighted item into view
   useEffect(() => {
@@ -151,11 +159,14 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
           value={inputText}
           onChange={(e) => handleInputChange(e.target.value)}
           onFocus={handleFocus}
+          onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           disabled={disabled}
           placeholder="Enter built-in or custom type"
           className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm ${
             builtIn && !isOpen ? "pl-9" : ""
+          } ${
+            !isOpen && isCustomValue ? "pr-24" : !isOpen && value !== "custom" ? "pr-8" : ""
           }`}
         />
         {/* Custom badge */}

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -8,22 +8,11 @@ export interface BuiltInType {
   icon: string;
 }
 
+// Only types with actual search/autocomplete backends
 const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "location", label: "Location", icon: "📍" },
   { value: "movie", label: "Movie", icon: "🎬" },
   { value: "video_game", label: "Video Game", icon: "🎮" },
-  { value: "food", label: "Food", icon: "🍕" },
-  { value: "restaurant", label: "Restaurant", icon: "🍽️" },
-  { value: "music", label: "Music", icon: "🎵" },
-  { value: "book", label: "Book", icon: "📚" },
-  { value: "tv_show", label: "TV Show", icon: "📺" },
-  { value: "sport", label: "Sport", icon: "⚽" },
-  { value: "activity", label: "Activity", icon: "🎯" },
-  { value: "travel", label: "Travel", icon: "✈️" },
-  { value: "gift", label: "Gift", icon: "🎁" },
-  { value: "drink", label: "Drink", icon: "🍹" },
-  { value: "board_game", label: "Board Game", icon: "🎲" },
-  { value: "date", label: "Date", icon: "📅" },
 ];
 
 export function getBuiltInType(value: string): BuiltInType | undefined {

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -31,20 +31,19 @@ interface TypeFieldInputProps {
 
 export default function TypeFieldInput({ value, onChange, disabled = false }: TypeFieldInputProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [searchText, setSearchText] = useState("");
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  // Derive display text from current value
   const builtIn = getBuiltInType(value);
-  const displayText = builtIn ? builtIn.label : (value === "custom" ? "" : value);
+  // What shows in the input: built-in label, custom text, or empty
+  const inputText = builtIn ? builtIn.label : (value === "custom" ? "" : value);
 
-  // Filter types based on search text
-  const filteredTypes = searchText
+  // Filter types based on current input text
+  const filteredTypes = inputText
     ? BUILT_IN_TYPES.filter((t) =>
-        t.label.toLowerCase().includes(searchText.toLowerCase())
+        t.label.toLowerCase().includes(inputText.toLowerCase())
       )
     : BUILT_IN_TYPES;
 
@@ -53,7 +52,6 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
     function handleClickOutside(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
-        setSearchText("");
         setHighlightedIndex(-1);
       }
     }
@@ -73,39 +71,34 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
 
   function handleFocus() {
     setIsOpen(true);
-    setSearchText("");
     setHighlightedIndex(-1);
+    // If it's a built-in type, clear so user can type fresh or see all options
+    if (builtIn) {
+      onChange("custom");
+    }
   }
 
   function handleInputChange(text: string) {
-    setSearchText(text);
+    // Check if it exactly matches a built-in type label
+    const match = BUILT_IN_TYPES.find(
+      (t) => t.label.toLowerCase() === text.toLowerCase()
+    );
+    if (match) {
+      onChange(match.value);
+    } else if (text.trim() === "") {
+      onChange("custom");
+    } else {
+      onChange(text);
+    }
     setHighlightedIndex(-1);
     if (!isOpen) setIsOpen(true);
   }
 
   function selectType(type: BuiltInType) {
     onChange(type.value);
-    setSearchText("");
     setIsOpen(false);
     setHighlightedIndex(-1);
     inputRef.current?.blur();
-  }
-
-  function handleBlurCommit() {
-    // Called when dropdown closes — commit typed text as custom type
-    const trimmed = searchText.trim();
-    if (trimmed) {
-      // Check if it matches a built-in type label
-      const match = BUILT_IN_TYPES.find(
-        (t) => t.label.toLowerCase() === trimmed.toLowerCase()
-      );
-      if (match) {
-        onChange(match.value);
-      } else {
-        onChange(trimmed);
-      }
-    }
-    setSearchText("");
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -130,28 +123,16 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
       if (highlightedIndex >= 0 && highlightedIndex < filteredTypes.length) {
         selectType(filteredTypes[highlightedIndex]);
       } else {
-        // Commit the search text as-is
-        handleBlurCommit();
+        // Just close — value is already committed live
         setIsOpen(false);
         inputRef.current?.blur();
       }
     } else if (e.key === "Escape") {
       setIsOpen(false);
-      setSearchText("");
       setHighlightedIndex(-1);
       inputRef.current?.blur();
     }
   }
-
-  // When dropdown closes (not via selection), commit any typed text
-  const prevIsOpen = useRef(isOpen);
-  useEffect(() => {
-    if (prevIsOpen.current && !isOpen) {
-      handleBlurCommit();
-    }
-    prevIsOpen.current = isOpen;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
 
   const isCustomValue = value && value !== "custom" && !builtIn;
 
@@ -167,12 +148,12 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
         <input
           ref={inputRef}
           type="text"
-          value={isOpen ? searchText : displayText}
+          value={inputText}
           onChange={(e) => handleInputChange(e.target.value)}
           onFocus={handleFocus}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder={isOpen ? "Search or type custom..." : "Select a type (optional)"}
+          placeholder="Enter built-in or custom type"
           className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm ${
             builtIn && !isOpen ? "pl-9" : ""
           }`}
@@ -190,7 +171,6 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
             onClick={(e) => {
               e.stopPropagation();
               onChange("custom");
-              setSearchText("");
               inputRef.current?.focus();
             }}
             className={`absolute top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-sm ${
@@ -203,40 +183,34 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
       </div>
 
       {/* Dropdown list */}
-      {isOpen && (
+      {isOpen && filteredTypes.length > 0 && (
         <div
           ref={listRef}
           className="absolute z-50 mt-1 w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-48 overflow-y-auto"
         >
-          {filteredTypes.length > 0 ? (
-            filteredTypes.map((type, index) => (
-              <button
-                key={type.value}
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault(); // Prevent blur before click registers
-                  selectType(type);
-                }}
-                onMouseEnter={() => setHighlightedIndex(index)}
-                className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 ${
-                  highlightedIndex === index
-                    ? "bg-blue-50 dark:bg-blue-900/30"
-                    : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
-                } ${
-                  value === type.value
-                    ? "text-blue-600 dark:text-blue-400 font-medium"
-                    : "text-gray-900 dark:text-white"
-                }`}
-              >
-                <span className="text-base">{type.icon}</span>
-                <span>{type.label}</span>
-              </button>
-            ))
-          ) : (
-            <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
-              No matches — press Enter to use &ldquo;{searchText}&rdquo;
-            </div>
-          )}
+          {filteredTypes.map((type, index) => (
+            <button
+              key={type.value}
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault(); // Prevent blur before click registers
+                selectType(type);
+              }}
+              onMouseEnter={() => setHighlightedIndex(index)}
+              className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 ${
+                highlightedIndex === index
+                  ? "bg-blue-50 dark:bg-blue-900/30"
+                  : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              } ${
+                value === type.value
+                  ? "text-blue-600 dark:text-blue-400 font-medium"
+                  : "text-gray-900 dark:text-white"
+              }`}
+            >
+              <span className="text-base">{type.icon}</span>
+              <span>{type.label}</span>
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+export interface BuiltInType {
+  value: string;
+  label: string;
+  icon: string;
+}
+
+const BUILT_IN_TYPES: BuiltInType[] = [
+  { value: "location", label: "Location", icon: "📍" },
+  { value: "movie", label: "Movie", icon: "🎬" },
+  { value: "video_game", label: "Video Game", icon: "🎮" },
+  { value: "food", label: "Food", icon: "🍕" },
+  { value: "restaurant", label: "Restaurant", icon: "🍽️" },
+  { value: "music", label: "Music", icon: "🎵" },
+  { value: "book", label: "Book", icon: "📚" },
+  { value: "tv_show", label: "TV Show", icon: "📺" },
+  { value: "sport", label: "Sport", icon: "⚽" },
+  { value: "activity", label: "Activity", icon: "🎯" },
+  { value: "travel", label: "Travel", icon: "✈️" },
+  { value: "gift", label: "Gift", icon: "🎁" },
+  { value: "drink", label: "Drink", icon: "🍹" },
+  { value: "board_game", label: "Board Game", icon: "🎲" },
+  { value: "date", label: "Date", icon: "📅" },
+];
+
+export function getBuiltInType(value: string): BuiltInType | undefined {
+  return BUILT_IN_TYPES.find((t) => t.value === value);
+}
+
+export function isBuiltInType(value: string): boolean {
+  return BUILT_IN_TYPES.some((t) => t.value === value);
+}
+
+interface TypeFieldInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export default function TypeFieldInput({ value, onChange, disabled = false }: TypeFieldInputProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchText, setSearchText] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Derive display text from current value
+  const builtIn = getBuiltInType(value);
+  const displayText = builtIn ? builtIn.label : (value === "custom" ? "" : value);
+
+  // Filter types based on search text
+  const filteredTypes = searchText
+    ? BUILT_IN_TYPES.filter((t) =>
+        t.label.toLowerCase().includes(searchText.toLowerCase())
+      )
+    : BUILT_IN_TYPES;
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setSearchText("");
+        setHighlightedIndex(-1);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const items = listRef.current.children;
+      if (items[highlightedIndex]) {
+        (items[highlightedIndex] as HTMLElement).scrollIntoView({ block: "nearest" });
+      }
+    }
+  }, [highlightedIndex]);
+
+  function handleFocus() {
+    setIsOpen(true);
+    setSearchText("");
+    setHighlightedIndex(-1);
+  }
+
+  function handleInputChange(text: string) {
+    setSearchText(text);
+    setHighlightedIndex(-1);
+    if (!isOpen) setIsOpen(true);
+  }
+
+  function selectType(type: BuiltInType) {
+    onChange(type.value);
+    setSearchText("");
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+    inputRef.current?.blur();
+  }
+
+  function handleBlurCommit() {
+    // Called when dropdown closes — commit typed text as custom type
+    const trimmed = searchText.trim();
+    if (trimmed) {
+      // Check if it matches a built-in type label
+      const match = BUILT_IN_TYPES.find(
+        (t) => t.label.toLowerCase() === trimmed.toLowerCase()
+      );
+      if (match) {
+        onChange(match.value);
+      } else {
+        onChange(trimmed);
+      }
+    }
+    setSearchText("");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (!isOpen) {
+      if (e.key === "ArrowDown" || e.key === "Enter") {
+        setIsOpen(true);
+        e.preventDefault();
+      }
+      return;
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < filteredTypes.length - 1 ? prev + 1 : prev
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : -1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < filteredTypes.length) {
+        selectType(filteredTypes[highlightedIndex]);
+      } else {
+        // Commit the search text as-is
+        handleBlurCommit();
+        setIsOpen(false);
+        inputRef.current?.blur();
+      }
+    } else if (e.key === "Escape") {
+      setIsOpen(false);
+      setSearchText("");
+      setHighlightedIndex(-1);
+      inputRef.current?.blur();
+    }
+  }
+
+  // When dropdown closes (not via selection), commit any typed text
+  const prevIsOpen = useRef(isOpen);
+  useEffect(() => {
+    if (prevIsOpen.current && !isOpen) {
+      handleBlurCommit();
+    }
+    prevIsOpen.current = isOpen;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  const isCustomValue = value && value !== "custom" && !builtIn;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="relative">
+        {/* Icon prefix for built-in types */}
+        {builtIn && !isOpen && (
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-base pointer-events-none">
+            {builtIn.icon}
+          </span>
+        )}
+        <input
+          ref={inputRef}
+          type="text"
+          value={isOpen ? searchText : displayText}
+          onChange={(e) => handleInputChange(e.target.value)}
+          onFocus={handleFocus}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder={isOpen ? "Search or type custom..." : "Select a type (optional)"}
+          className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm ${
+            builtIn && !isOpen ? "pl-9" : ""
+          }`}
+        />
+        {/* Custom badge */}
+        {isCustomValue && !isOpen && (
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] font-medium bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 px-1.5 py-0.5 rounded-full">
+            Custom
+          </span>
+        )}
+        {/* Clear button when a value is set and not open */}
+        {value !== "custom" && !isOpen && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onChange("custom");
+              setSearchText("");
+              inputRef.current?.focus();
+            }}
+            className={`absolute top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-sm ${
+              isCustomValue ? "right-[4.5rem]" : "right-3"
+            }`}
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Dropdown list */}
+      {isOpen && (
+        <div
+          ref={listRef}
+          className="absolute z-50 mt-1 w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-48 overflow-y-auto"
+        >
+          {filteredTypes.length > 0 ? (
+            filteredTypes.map((type, index) => (
+              <button
+                key={type.value}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault(); // Prevent blur before click registers
+                  selectType(type);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 ${
+                  highlightedIndex === index
+                    ? "bg-blue-50 dark:bg-blue-900/30"
+                    : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                } ${
+                  value === type.value
+                    ? "text-blue-600 dark:text-blue-400 font-medium"
+                    : "text-gray-900 dark:text-white"
+                }`}
+              >
+                <span className="text-base">{type.icon}</span>
+                <span>{type.label}</span>
+              </button>
+            ))
+          ) : (
+            <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+              No matches — press Enter to use &ldquo;{searchText}&rdquo;
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -169,13 +169,13 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
             !isOpen && isCustomValue ? "pr-24" : !isOpen && value !== "custom" ? "pr-8" : ""
           }`}
         />
-        {/* Custom badge */}
+        {/* Custom badge — left of the clear button */}
         {isCustomValue && !isOpen && (
-          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] font-medium bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 px-1.5 py-0.5 rounded-full">
+          <span className="absolute right-8 top-1/2 -translate-y-1/2 text-[10px] font-medium bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 px-1.5 py-0.5 rounded-full">
             Custom
           </span>
         )}
-        {/* Clear button when a value is set and not open */}
+        {/* Clear button — rightmost */}
         {value !== "custom" && !isOpen && (
           <button
             type="button"
@@ -184,9 +184,7 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
               onChange("custom");
               inputRef.current?.focus();
             }}
-            className={`absolute top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-sm ${
-              isCustomValue ? "right-[4.5rem]" : "right-3"
-            }`}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-sm"
           >
             ✕
           </button>

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -8,7 +8,6 @@ export interface BuiltInType {
   icon: string;
 }
 
-// Only types with actual search/autocomplete backends
 const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "location", label: "Location", icon: "📍" },
   { value: "movie", label: "Movie", icon: "🎬" },
@@ -19,10 +18,6 @@ export function getBuiltInType(value: string): BuiltInType | undefined {
   return BUILT_IN_TYPES.find((t) => t.value === value);
 }
 
-export function isBuiltInType(value: string): boolean {
-  return BUILT_IN_TYPES.some((t) => t.value === value);
-}
-
 interface TypeFieldInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -31,43 +26,38 @@ interface TypeFieldInputProps {
 
 export default function TypeFieldInput({ value, onChange, disabled = false }: TypeFieldInputProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [editText, setEditText] = useState<string | null>(null);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
   const builtIn = getBuiltInType(value);
-  // What shows in the input: built-in label, custom text, or empty
-  const inputText = builtIn ? builtIn.label : (value === "custom" ? "" : value);
+  // When editing, show local edit text; otherwise show the committed value
+  const inputText = editText !== null ? editText : (builtIn ? builtIn.label : (value === "custom" ? "" : value));
 
-  // Filter types based on current input text
-  const filteredTypes = inputText
+  const filterText = editText !== null ? editText : "";
+  const filteredTypes = filterText
     ? BUILT_IN_TYPES.filter((t) =>
-        t.label.toLowerCase().includes(inputText.toLowerCase())
+        t.label.toLowerCase().includes(filterText.toLowerCase())
       )
     : BUILT_IN_TYPES;
 
-  // Close dropdown on outside click or focus loss
+  function closeDropdown() {
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+  }
+
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-        setHighlightedIndex(-1);
+        closeDropdown();
       }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  function handleBlur(e: React.FocusEvent) {
-    // If focus moves outside the container, close dropdown
-    if (containerRef.current && !containerRef.current.contains(e.relatedTarget as Node)) {
-      setIsOpen(false);
-      setHighlightedIndex(-1);
-    }
-  }
-
-  // Scroll highlighted item into view
   useEffect(() => {
     if (highlightedIndex >= 0 && listRef.current) {
       const items = listRef.current.children;
@@ -80,32 +70,43 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
   function handleFocus() {
     setIsOpen(true);
     setHighlightedIndex(-1);
-    // If it's a built-in type, clear so user can type fresh or see all options
-    if (builtIn) {
-      onChange("custom");
+    setEditText("");
+  }
+
+  function commitAndClose() {
+    if (editText !== null) {
+      const trimmed = editText.trim();
+      const match = BUILT_IN_TYPES.find(
+        (t) => t.label.toLowerCase() === trimmed.toLowerCase()
+      );
+      if (match) {
+        onChange(match.value);
+      } else if (trimmed) {
+        onChange(trimmed);
+      } else {
+        onChange("custom");
+      }
+      setEditText(null);
+    }
+    closeDropdown();
+  }
+
+  function handleBlur(e: React.FocusEvent) {
+    if (containerRef.current && !containerRef.current.contains(e.relatedTarget as Node)) {
+      commitAndClose();
     }
   }
 
   function handleInputChange(text: string) {
-    // Check if it exactly matches a built-in type label
-    const match = BUILT_IN_TYPES.find(
-      (t) => t.label.toLowerCase() === text.toLowerCase()
-    );
-    if (match) {
-      onChange(match.value);
-    } else if (text.trim() === "") {
-      onChange("custom");
-    } else {
-      onChange(text);
-    }
+    setEditText(text);
     setHighlightedIndex(-1);
     if (!isOpen) setIsOpen(true);
   }
 
   function selectType(type: BuiltInType) {
     onChange(type.value);
-    setIsOpen(false);
-    setHighlightedIndex(-1);
+    setEditText(null);
+    closeDropdown();
     inputRef.current?.blur();
   }
 
@@ -131,23 +132,21 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
       if (highlightedIndex >= 0 && highlightedIndex < filteredTypes.length) {
         selectType(filteredTypes[highlightedIndex]);
       } else {
-        // Just close — value is already committed live
-        setIsOpen(false);
+        commitAndClose();
         inputRef.current?.blur();
       }
     } else if (e.key === "Escape") {
-      setIsOpen(false);
-      setHighlightedIndex(-1);
+      setEditText(null);
+      closeDropdown();
       inputRef.current?.blur();
     }
   }
 
-  const isCustomValue = value && value !== "custom" && !builtIn;
+  const isCustomValue = value !== "" && value !== "custom" && !builtIn;
 
   return (
     <div ref={containerRef} className="relative">
       <div className="relative">
-        {/* Icon prefix for built-in types */}
         {builtIn && !isOpen && (
           <span className="absolute left-3 top-1/2 -translate-y-1/2 text-base pointer-events-none">
             {builtIn.icon}
@@ -169,13 +168,11 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
             !isOpen && isCustomValue ? "pr-24" : !isOpen && value !== "custom" ? "pr-8" : ""
           }`}
         />
-        {/* Custom badge — left of the clear button */}
         {isCustomValue && !isOpen && (
           <span className="absolute right-8 top-1/2 -translate-y-1/2 text-[10px] font-medium bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 px-1.5 py-0.5 rounded-full">
             Custom
           </span>
         )}
-        {/* Clear button — rightmost */}
         {value !== "custom" && !isOpen && (
           <button
             type="button"
@@ -191,7 +188,6 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
         )}
       </div>
 
-      {/* Dropdown list */}
       {isOpen && filteredTypes.length > 0 && (
         <div
           ref={listRef}
@@ -202,7 +198,7 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
               key={type.value}
               type="button"
               onMouseDown={(e) => {
-                e.preventDefault(); // Prevent blur before click registers
+                e.preventDefault();
                 selectType(type);
               }}
               onMouseEnter={() => setHighlightedIndex(index)}

--- a/database/migrations/078_allow_custom_content_types_down.sql
+++ b/database/migrations/078_allow_custom_content_types_down.sql
@@ -1,0 +1,7 @@
+-- Restore poll_content_type check constraint
+-- Note: any rows with custom values will need to be updated to 'custom' first
+UPDATE polls SET poll_content_type = 'custom'
+  WHERE poll_content_type NOT IN ('custom', 'location', 'movie', 'video_game');
+ALTER TABLE polls ALTER COLUMN poll_content_type TYPE VARCHAR(20);
+ALTER TABLE polls ADD CONSTRAINT polls_poll_content_type_check
+    CHECK (poll_content_type IN ('custom', 'location', 'movie', 'video_game'));

--- a/database/migrations/078_allow_custom_content_types_up.sql
+++ b/database/migrations/078_allow_custom_content_types_up.sql
@@ -1,0 +1,3 @@
+-- Allow arbitrary poll_content_type values (not just built-in types)
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_content_type_check;
+ALTER TABLE polls ALTER COLUMN poll_content_type TYPE VARCHAR(50);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 // Core type definitions for WhoeverWants
 // Extracted from lib/supabase.ts during Phase 3 cleanup
 
-export type PollContentType = 'custom' | 'location' | 'movie' | 'video_game';
+export type PollContentType = string;
 
 export type OptionMetadataEntry = {
   imageUrl?: string;


### PR DESCRIPTION
## Summary
- Replace the poll content type dropdown with a searchable text input
- Built-in types (Location, Movie, Video Game) show with icons and provide autocomplete for poll options
- Users can type any custom type, which shows a "Custom" badge
- DB migration removes CHECK constraint to allow arbitrary content type strings

## Test plan
- [ ] Select a built-in type (Location/Movie/Video Game) and verify icon appears
- [ ] Type a custom type, click away, verify "Custom" badge and clear button show
- [ ] Verify keyboard navigation (arrow keys, Enter, Escape) works in dropdown
- [ ] Verify clearing with ✕ button resets the field
- [ ] Fork/duplicate a poll with a content type and verify it carries over

https://claude.ai/code/session_017LBbzuPwSZrba7UCSbBeNu