### PR TITLE
Rename poll_content_type to category, fix form spacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -885,7 +885,45 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 
 - **Auto-created polls share the parent's `creator_secret`**, but the browser only stores secrets for polls it created directly. When navigating to an auto-created follow-up poll (e.g., preferences poll from a nomination poll), the browser must propagate the parent's secret to the child. Do this both on navigation (in the close handler) and on page load (check `poll.follow_up_to` and propagate if the parent's secret is known).
 - **Use `recordPollCreation()` from `lib/browserPollAccess.ts`** instead of calling `storeCreatorSecret()` + `addAccessiblePollId()` separately. The higher-level function already does both.
-- **Poll data snapshots (fork/duplicate/follow-up)** are passed between pages via localStorage. When adding new poll fields, update all snapshot construction sites: `FollowUpModal.tsx`, `DuplicateButton.tsx`, and `ForkButton.tsx`. Extract a shared object to avoid drift.
+- **Poll data snapshots (fork/duplicate/follow-up)** are passed between pages via localStorage. When adding new poll fields, update `buildPollSnapshot()` in `lib/pollCreator.ts` — it's used by `FollowUpModal.tsx`, `DuplicateButton.tsx`, and `ForkButton.tsx`.
+
+### Textarea Sizing & Inline-Block Gaps
+
+- **`<textarea>` defaults to `display: inline-block`** in most browsers, which causes a descender-space gap below it (based on parent `line-height`). Always add `display: block` (Tailwind `block` class) to textareas to eliminate this phantom spacing.
+- **The `rows` HTML attribute overrides CSS height** — browsers use `rows` to compute an intrinsic size that takes priority over `min-height` and can fight `height`. To control textarea height with CSS, omit `rows` and use `height`/`style.height` directly.
+- **Auto-grow textareas must reset to a fixed height, not `'auto'`** before reading `scrollHeight`. Resetting to `'auto'` lets the browser expand to its default intrinsic size (often taller than one line), causing the textarea to jump on first keystroke and never shrink back. Reset to the base height (e.g., `el.style.height = '42px'`) so `scrollHeight` only exceeds it when content actually overflows.
+- **`text-sm` on inputs/textareas causes height mismatches** — a `text-sm` input renders ~38px while a default-size input renders ~42px with the same `py-2` padding. When fields appear in a `space-y-*` form, the shorter field makes the gap below it appear larger. Use consistent font sizes across form fields.
+
+### Taking Render Screenshots (Claude Code Cloud)
+
+To visually verify UI changes from the Claude Code cloud environment:
+
+1. **Take screenshot on the droplet** using Playwright (installed in the repo's `node_modules`):
+   ```bash
+   bash scripts/remote.sh "cd /root/whoeverwants && node -e \"
+   const { chromium } = require('playwright');
+   (async () => {
+     const browser = await chromium.launch();
+     const page = await browser.newPage({ viewport: { width: 430, height: 932 } });
+     await page.goto('http://localhost:<dev-port>/path');
+     await page.waitForLoadState('networkidle');
+     await page.waitForTimeout(2000);
+     await page.screenshot({ path: '/tmp/screenshot.png' });
+     await browser.close();
+   })();
+   \"" /root 30
+   ```
+2. **Transfer via base64** and view with the Read tool:
+   ```bash
+   bash scripts/remote.sh "base64 /tmp/screenshot.png" | base64 -d > /tmp/screenshot.png
+   ```
+   Then use the Read tool on `/tmp/screenshot.png` — it renders images natively.
+3. **Share with the user** by copying to a dev server's `public/` directory:
+   ```bash
+   bash scripts/remote.sh "cp /tmp/screenshot.png /root/dev-servers/<slug>/public/image.png"
+   ```
+   The image is then accessible at `https://<slug>.dev.whoeverwants.com/image.png`.
+4. **Measure DOM spacing programmatically** using `page.evaluate()` with `getBoundingClientRect()` — but be aware that `getBoundingClientRect()` may not account for `inline-block` descender gaps. Cross-check by annotating screenshots with Pillow (`python3-pil` on the droplet).
 
 ### CI/GitHub Actions Pitfalls
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1149,7 +1149,7 @@ function CreatePollContent() {
               onChange={(e) => {
                 setDetails(e.target.value);
                 const el = e.target;
-                el.style.height = 'auto';
+                el.style.height = '42px';
                 const maxH = 5 * 20 + 16; // 5 lines + padding
                 el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
                 el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1155,8 +1155,7 @@ function CreatePollContent() {
                 el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
               }}
               disabled={isLoading}
-              rows={1}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden min-h-[42px]"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden h-[42px]"
               placeholder="Add more context or instructions..."
             />
           </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1156,7 +1156,7 @@ function CreatePollContent() {
               }}
               disabled={isLoading}
               rows={1}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden min-h-[42px]"
               placeholder="Add more context or instructions..."
             />
           </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1155,7 +1155,7 @@ function CreatePollContent() {
                 el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
               }}
               disabled={isLoading}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden h-[42px]"
+              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden h-[42px]"
               placeholder="Add more context or instructions..."
             />
           </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -21,6 +21,10 @@ import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
 import ReferenceLocationInput from "@/components/ReferenceLocationInput";
 export const dynamic = 'force-dynamic';
 
+// Matches the rendered height of a single-line <input> with py-2 padding.
+// Used for the Details textarea initial height and auto-grow reset.
+const SINGLE_LINE_INPUT_HEIGHT = 42;
+
 function CreatePollContent() {
   const { prefetch } = useAppPrefetch();
   const router = useRouter();
@@ -1149,13 +1153,14 @@ function CreatePollContent() {
               onChange={(e) => {
                 setDetails(e.target.value);
                 const el = e.target;
-                el.style.height = '42px';
+                el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
                 const maxH = 5 * 20 + 16; // 5 lines + padding
                 el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
                 el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
               }}
               disabled={isLoading}
-              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden h-[42px]"
+              style={{ height: SINGLE_LINE_INPUT_HEIGHT }}
+              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
               placeholder="Add more context or instructions..."
             />
           </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -68,7 +68,7 @@ function CreatePollContent() {
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
-  const [pollContentType, setPollContentType] = useState<string>('custom');
+  const [category, setCategory] = useState<string>('custom');
   const [optionsMetadata, setOptionsMetadata] = useState<OptionsMetadata>({});
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
@@ -260,7 +260,7 @@ function CreatePollContent() {
       const filledOptions = options.filter(opt => opt.trim() !== '');
 
       // Check for options that exceed character limit (relaxed for autocomplete types)
-      const maxOptionLength = pollContentType === 'custom' ? 35 : 200;
+      const maxOptionLength = category === 'custom' ? 35 : 200;
       const longOptions = filledOptions.filter(opt => opt.length > maxOptionLength);
       if (longOptions.length > 0) {
         return `Poll options must be ${maxOptionLength} characters or less.`;
@@ -443,8 +443,8 @@ function CreatePollContent() {
           } else if (forkData.total_votes) {
             setAutoCloseAfter(forkData.total_votes);
           }
-          if (forkData.poll_content_type) {
-            setPollContentType(forkData.poll_content_type);
+          if (forkData.category) {
+            setCategory(forkData.category);
           }
           if (forkData.options_metadata) {
             setOptionsMetadata(forkData.options_metadata);
@@ -528,8 +528,8 @@ function CreatePollContent() {
           } else if (duplicateData.total_votes) {
             setAutoCloseAfter(duplicateData.total_votes);
           }
-          if (duplicateData.poll_content_type) {
-            setPollContentType(duplicateData.poll_content_type);
+          if (duplicateData.category) {
+            setCategory(duplicateData.category);
           }
           if (duplicateData.options_metadata) {
             setOptionsMetadata(duplicateData.options_metadata);
@@ -879,9 +879,9 @@ function CreatePollContent() {
         pollData.fork_of = forkOf;
       }
 
-      // Add content type for nomination and ranked_choice polls
-      if ((dbPollType === 'nomination' || dbPollType === 'ranked_choice') && pollContentType !== 'custom') {
-        pollData.poll_content_type = pollContentType;
+      // Add category for nomination and ranked_choice polls
+      if ((dbPollType === 'nomination' || dbPollType === 'ranked_choice') && category !== 'custom') {
+        pollData.category = category;
       }
 
       // Add reference location if set
@@ -1161,22 +1161,22 @@ function CreatePollContent() {
             />
           </div>
 
-          {/* Content type selector for suggestion and poll types */}
+          {/* Category selector for suggestion and poll types */}
           {pollType !== 'participation' && (
             <div>
-              <label htmlFor="contentType" className="block text-sm font-medium mb-2">
-                Type
+              <label htmlFor="category" className="block text-sm font-medium mb-2">
+                Category
               </label>
               <TypeFieldInput
-                value={pollContentType}
-                onChange={setPollContentType}
+                value={category}
+                onChange={setCategory}
                 disabled={isLoading}
               />
             </div>
           )}
 
           {/* Reference location for location polls */}
-          {(pollContentType === 'location' || (pollType === 'participation' && locationMode !== 'none')) && (
+          {(category === 'location' || (pollType === 'participation' && locationMode !== 'none')) && (
             <ReferenceLocationInput
               latitude={refLatitude}
               longitude={refLongitude}
@@ -1244,7 +1244,7 @@ function CreatePollContent() {
               setOptions={setOptions}
               isLoading={isLoading}
               pollType="poll"
-              contentType={pollContentType}
+              category={category}
               optionsMetadata={optionsMetadata}
               onMetadataChange={setOptionsMetadata}
               referenceLatitude={refLatitude}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1120,7 +1120,7 @@ function CreatePollContent() {
           </div>
 
           <div className="-mt-4">
-            <label htmlFor="title" className="block text-sm font-medium mb-2">
+            <label htmlFor="title" className="block text-sm font-medium mb-1">
               Title
             </label>
             <input
@@ -1139,7 +1139,7 @@ function CreatePollContent() {
 
           {/* Optional details field */}
           <div>
-            <label htmlFor="details" className="block text-sm font-medium mb-2">
+            <label htmlFor="details" className="block text-sm font-medium mb-1">
               Details{' '}
               <span className="text-gray-500 font-normal">(optional)</span>
             </label>
@@ -1164,7 +1164,7 @@ function CreatePollContent() {
           {/* Category selector for suggestion and poll types */}
           {pollType !== 'participation' && (
             <div>
-              <label htmlFor="category" className="block text-sm font-medium mb-2">
+              <label htmlFor="category" className="block text-sm font-medium mb-1">
                 Category
               </label>
               <TypeFieldInput
@@ -1255,7 +1255,7 @@ function CreatePollContent() {
           )}
 
           <div>
-            <label htmlFor="deadline" className="block text-sm font-medium mb-2">
+            <label htmlFor="deadline" className="block text-sm font-medium mb-1">
               Response Deadline
             </label>
             <select
@@ -1275,7 +1275,7 @@ function CreatePollContent() {
 
           {deadlineOption === "custom" && (
             <div>
-              <label className="block text-sm font-medium mb-2">
+              <label className="block text-sm font-medium mb-1">
                 Custom Deadline<span className="text-gray-500 font-normal">{getCustomDeadlineDisplay()}</span>
               </label>
               <div className="flex justify-between gap-2">
@@ -1316,7 +1316,7 @@ function CreatePollContent() {
 
           {/* Auto-close after N responses */}
           <div>
-            <label className="block text-sm font-medium mb-2">Auto-close</label>
+            <label className="block text-sm font-medium mb-1">Auto-close</label>
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-600 dark:text-gray-400">After</span>
               <input
@@ -1388,7 +1388,7 @@ function CreatePollContent() {
           )}
 
           <div>
-            <label htmlFor="creatorName" className="block text-sm font-medium mb-2">
+            <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
               Your Name (optional)
             </label>
             <input

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1156,7 +1156,7 @@ function CreatePollContent() {
               }}
               disabled={isLoading}
               rows={1}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none text-sm overflow-hidden"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
               placeholder="Add more context or instructions..."
             />
           </div>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1520,7 +1520,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   </div>
 
                   <div className="mb-4">
-                    <label htmlFor="voterName" className="block text-sm font-medium mb-2">
+                    <label htmlFor="voterName" className="block text-sm font-medium mb-1">
                       Your Name (optional)
                     </label>
                     <input
@@ -1709,7 +1709,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   )}
 
                   <div className="mb-4">
-                    <label htmlFor="voterName" className="block text-sm font-medium mb-2">
+                    <label htmlFor="voterName" className="block text-sm font-medium mb-1">
                       Your Name <span className="text-gray-500 font-normal">(optional)</span>
                     </label>
                     <input
@@ -1984,7 +1984,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   </div>
 
                   <div className="mt-4">
-                    <label htmlFor="voterNameRanked" className="block text-sm font-medium mb-2">
+                    <label htmlFor="voterNameRanked" className="block text-sm font-medium mb-1">
                       Your Name (optional)
                     </label>
                     <input

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -115,7 +115,7 @@ export default function ProfilePage() {
     <div className="poll-content">
       {/* Name Input Section */}
       <div className="mb-6">
-        <label htmlFor="name" className="block text-sm font-medium mb-2">
+        <label htmlFor="name" className="block text-sm font-medium mb-1">
           Your Name
         </label>
         <input
@@ -135,7 +135,7 @@ export default function ProfilePage() {
 
       {/* Location Section */}
       <div className="mb-6">
-        <label htmlFor="location" className="block text-sm font-medium mb-2">
+        <label htmlFor="location" className="block text-sm font-medium mb-1">
           Your Location
         </label>
         {savedLocation && (

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -2,14 +2,14 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { apiSearchLocations, apiSearchMovies, apiSearchVideoGames, type SearchResult } from "@/lib/api";
-import type { PollContentType } from "@/lib/types";
+import type { PollCategory } from "@/lib/types";
 import { formatDistance } from "./OptionLabel";
 
 interface AutocompleteInputProps {
   value: string;
   onChange: (value: string) => void;
   onSelect?: (result: SearchResult) => void;
-  contentType: Exclude<PollContentType, 'custom'>;
+  category: Exclude<PollCategory, 'custom'>;
   disabled?: boolean;
   placeholder?: string;
   maxLength?: number;
@@ -24,7 +24,7 @@ export default function AutocompleteInput({
   value,
   onChange,
   onSelect,
-  contentType,
+  category,
   disabled = false,
   placeholder,
   maxLength = 35,
@@ -53,9 +53,9 @@ export default function AutocompleteInput({
     }
     try {
       let results: SearchResult[];
-      if (contentType === 'location') {
+      if (category === 'location') {
         results = await apiSearchLocations(query, referenceLatitude, referenceLongitude, searchRadius);
-      } else if (contentType === 'video_game') {
+      } else if (category === 'video_game') {
         results = await apiSearchVideoGames(query);
       } else {
         results = await apiSearchMovies(query);
@@ -85,7 +85,7 @@ export default function AutocompleteInput({
     } catch {
       // On error, keep existing suggestions
     }
-  }, [contentType, referenceLatitude, referenceLongitude, searchRadius]);
+  }, [category, referenceLatitude, referenceLongitude, searchRadius]);
 
   const handleChange = (newValue: string) => {
     onChange(newValue);
@@ -214,9 +214,9 @@ export default function AutocompleteInput({
             </li>
           ))}
           <li className="px-3 py-1.5 text-[10px] text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700">
-            {contentType === 'movie'
+            {category === 'movie'
               ? 'Data from TMDB. Not endorsed by TMDB.'
-              : contentType === 'video_game'
+              : category === 'video_game'
                 ? 'Data from RAWG Video Games Database'
                 : 'Data \u00A9 OpenStreetMap contributors'}
           </li>

--- a/components/DuplicateButton.tsx
+++ b/components/DuplicateButton.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Poll } from "@/lib/types";
+import { buildPollSnapshot } from "@/lib/pollCreator";
 import { debugLog } from "@/lib/debugLogger";
 
 interface DuplicateButtonProps {
@@ -12,20 +13,7 @@ export default function DuplicateButton({ poll }: DuplicateButtonProps) {
   const router = useRouter();
 
   const handleDuplicate = () => {
-    // Create duplicate data for follow-up with prefilled form data
-    const duplicateData = {
-      title: poll.title,
-      poll_type: poll.poll_type,
-      options: poll.options,
-      response_deadline: poll.response_deadline,
-      creator_name: poll.creator_name,
-      min_participants: poll.min_participants,
-      max_participants: poll.max_participants,
-      auto_close_after: poll.auto_close_after,
-      details: poll.details,
-      category: poll.category,
-      options_metadata: poll.options_metadata,
-    };
+    const duplicateData = buildPollSnapshot(poll);
 
     debugLog.logObject('Duplicate button clicked', { pollId: poll.id, duplicateData }, 'DuplicateButton');
     

--- a/components/DuplicateButton.tsx
+++ b/components/DuplicateButton.tsx
@@ -23,7 +23,7 @@ export default function DuplicateButton({ poll }: DuplicateButtonProps) {
       max_participants: poll.max_participants,
       auto_close_after: poll.auto_close_after,
       details: poll.details,
-      poll_content_type: poll.poll_content_type,
+      category: poll.category,
       options_metadata: poll.options_metadata,
     };
 

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -26,7 +26,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
     max_participants: poll.max_participants,
     auto_close_after: poll.auto_close_after,
     details: poll.details,
-    poll_content_type: poll.poll_content_type,
+    category: poll.category,
     options_metadata: poll.options_metadata,
     total_votes: totalVotes,
   };

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import ModalPortal from "@/components/ModalPortal";
 import { Poll } from "@/lib/types";
+import { buildPollSnapshot } from "@/lib/pollCreator";
 
 interface FollowUpModalProps {
   isOpen: boolean;
@@ -17,17 +18,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
   if (!isOpen) return null;
 
   const pollSnapshot = {
-    title: poll.title,
-    poll_type: poll.poll_type,
-    options: poll.options,
-    response_deadline: poll.response_deadline,
-    creator_name: poll.creator_name,
-    min_participants: poll.min_participants,
-    max_participants: poll.max_participants,
-    auto_close_after: poll.auto_close_after,
-    details: poll.details,
-    category: poll.category,
-    options_metadata: poll.options_metadata,
+    ...buildPollSnapshot(poll),
     total_votes: totalVotes,
   };
 

--- a/components/ForkButton.tsx
+++ b/components/ForkButton.tsx
@@ -24,7 +24,7 @@ export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
       max_participants: poll.max_participants,
       auto_close_after: poll.auto_close_after,
       details: poll.details,
-      poll_content_type: poll.poll_content_type,
+      category: poll.category,
       options_metadata: poll.options_metadata,
     };
 

--- a/components/ForkButton.tsx
+++ b/components/ForkButton.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Poll } from "@/lib/types";
+import { buildPollSnapshot } from "@/lib/pollCreator";
 import { debugLog } from "@/lib/debugLogger";
 
 interface ForkButtonProps {
@@ -13,20 +14,7 @@ export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
   const router = useRouter();
 
   const handleFork = () => {
-    // Store poll data in localStorage for the create-poll form to access
-    const forkData = {
-      title: poll.title,
-      poll_type: poll.poll_type,
-      options: poll.options,
-      response_deadline: poll.response_deadline,
-      creator_name: poll.creator_name,
-      min_participants: poll.min_participants,
-      max_participants: poll.max_participants,
-      auto_close_after: poll.auto_close_after,
-      details: poll.details,
-      category: poll.category,
-      options_metadata: poll.options_metadata,
-    };
+    const forkData = buildPollSnapshot(poll);
 
     debugLog.logObject('Fork button clicked', { pollId: poll.id, forkData }, 'ForkButton');
     

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -343,7 +343,7 @@ export default function NominationVotingInterface({
 
         {/* Add new nominations using shared component */}
         <div className={filteredExistingNominations.length > 0 ? "mt-3 pt-3 border-t border-gray-200 dark:border-gray-600" : ""}>
-          {poll.poll_content_type === 'location' && poll.reference_latitude && (
+          {poll.category === 'location' && poll.reference_latitude && (
             <div className="mb-2 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
               <span>Search within</span>
               <select
@@ -363,7 +363,7 @@ export default function NominationVotingInterface({
             isLoading={isSubmitting}
             pollType="nomination"
             label={isEditingVote ? "Add new suggestions:" : "Add new suggestions:"}
-            contentType={poll.poll_content_type || 'custom'}
+            category={poll.category || 'custom'}
             optionsMetadata={nominationMetadata}
             onMetadataChange={onNominationMetadataChange}
             referenceLatitude={poll.reference_latitude}

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef } from "react";
-import type { PollContentType, OptionsMetadata } from "@/lib/types";
+import type { PollCategory, OptionsMetadata } from "@/lib/types";
 import type { SearchResult } from "@/lib/api";
 import AutocompleteInput from "@/components/AutocompleteInput";
 
@@ -14,7 +14,7 @@ interface OptionsInputProps {
   pollType?: 'poll' | 'nomination';
   label?: React.ReactNode;
   placeholder?: string;
-  contentType?: PollContentType;
+  category?: PollCategory;
   optionsMetadata?: OptionsMetadata;
   onMetadataChange?: (metadata: OptionsMetadata) => void;
   referenceLatitude?: number;
@@ -29,7 +29,7 @@ export default function OptionsInput({
   pollType = 'poll',
   label,
   placeholder,
-  contentType = 'custom',
+  category = 'custom',
   optionsMetadata,
   onMetadataChange,
   referenceLatitude,
@@ -111,17 +111,17 @@ export default function OptionsInput({
     const filledOptions = options.filter(opt => opt.trim() !== '');
     const isLastField = index === options.length - 1;
 
-    if (contentType === 'location') {
+    if (category === 'location') {
       if (isLastField) {
         return filledOptions.length === 0 ? "Search for a location..." : "Add another location...";
       }
       return `Location ${index + 1}`;
-    } else if (contentType === 'movie') {
+    } else if (category === 'movie') {
       if (isLastField) {
         return filledOptions.length === 0 ? "Search for a movie..." : "Add another movie...";
       }
       return `Movie ${index + 1}`;
-    } else if (contentType === 'video_game') {
+    } else if (category === 'video_game') {
       if (isLastField) {
         return filledOptions.length === 0 ? "Search for a video game..." : "Add another video game...";
       }
@@ -139,7 +139,7 @@ export default function OptionsInput({
     }
   };
 
-  const useAutocomplete = contentType === 'location' || contentType === 'movie' || contentType === 'video_game';
+  const useAutocomplete = category === 'location' || category === 'movie' || category === 'video_game';
   const inputClassName = (isDuplicate: boolean) =>
     `flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
       isDuplicate
@@ -172,7 +172,7 @@ export default function OptionsInput({
                     value={option}
                     onChange={(value) => updateOption(index, value)}
                     onSelect={handleSelect}
-                    contentType={contentType as Exclude<PollContentType, 'custom'>}
+                    category={category as Exclude<PollCategory, 'custom'>}
                     disabled={isLoading}
                     maxLength={100}
                     placeholder={getPlaceholder(index)}

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -150,7 +150,7 @@ export default function OptionsInput({
   return (
     <div>
       {label && (
-        <label className="block text-sm font-medium mb-2">
+        <label className="block text-sm font-medium mb-1">
           {label}
         </label>
       )}

--- a/components/ParticipationConditions.tsx
+++ b/components/ParticipationConditions.tsx
@@ -143,7 +143,7 @@ export default function ParticipationConditions({
       {/* Duration */}
       {onDurationMinChange && onDurationMaxChange && onDurationMinEnabledChange && onDurationMaxEnabledChange && (
         <div>
-          <label className="block text-sm font-medium mb-2">
+          <label className="block text-sm font-medium mb-1">
             Duration (hours)
           </label>
           <MinMaxCounter

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -113,7 +113,7 @@ export default function ReferenceLocationInput({
 
   return (
     <div>
-      <label className="block text-sm font-medium mb-2">
+      <label className="block text-sm font-medium mb-1">
         Your Location
       </label>
       {hasLocation && (

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -162,7 +162,7 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
           onKeyDown={handleKeyDown}
           disabled={disabled}
           placeholder="Enter built-in or custom category"
-          className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm ${
+          className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed ${
             builtIn && !isOpen ? "pl-9" : ""
           } ${
             !isOpen && isCustomValue ? "pr-24" : !isOpen && value !== "custom" ? "pr-8" : ""

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -161,7 +161,7 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder="Enter built-in or custom type"
+          placeholder="Enter built-in or custom category"
           className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm ${
             builtIn && !isOpen ? "pl-9" : ""
           } ${

--- a/components/VoteOnItModal.tsx
+++ b/components/VoteOnItModal.tsx
@@ -98,7 +98,7 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, nominations, 
           </h3>
 
           <div className="mb-4">
-            <label htmlFor="vote-deadline" className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
+            <label htmlFor="vote-deadline" className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
               Response Deadline
             </label>
             <select

--- a/database/migrations/079_rename_poll_content_type_to_category_down.sql
+++ b/database/migrations/079_rename_poll_content_type_to_category_down.sql
@@ -1,0 +1,2 @@
+-- Revert: rename category column back to poll_content_type
+ALTER TABLE polls RENAME COLUMN category TO poll_content_type;

--- a/database/migrations/079_rename_poll_content_type_to_category_up.sql
+++ b/database/migrations/079_rename_poll_content_type_to_category_up.sql
@@ -1,0 +1,2 @@
+-- Rename poll_content_type column to category
+ALTER TABLE polls RENAME COLUMN poll_content_type TO category;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -123,7 +123,7 @@ function toPoll(data: any): Poll {
     time_preferences_deadline_minutes: data.time_preferences_deadline_minutes ?? undefined,
     day_time_windows: data.day_time_windows ?? undefined,
     duration_window: data.duration_window ?? undefined,
-    poll_content_type: data.poll_content_type ?? undefined,
+    category: data.category ?? undefined,
     options_metadata: data.options_metadata ?? undefined,
     reference_latitude: data.reference_latitude ?? undefined,
     reference_longitude: data.reference_longitude ?? undefined,
@@ -194,7 +194,7 @@ export async function apiCreatePoll(params: {
   time_preferences_deadline_minutes?: number;
   day_time_windows?: any[];
   duration_window?: any;
-  poll_content_type?: string;
+  category?: string;
   options_metadata?: OptionsMetadata;
   reference_latitude?: number;
   reference_longitude?: number;

--- a/lib/pollCreator.ts
+++ b/lib/pollCreator.ts
@@ -1,5 +1,7 @@
 // Utility functions for managing poll creator information in localStorage
 
+import type { Poll } from '@/lib/types';
+
 const POLL_CREATOR_STORAGE_KEY = 'poll_creator_data';
 const CLEANUP_INTERVAL_DAYS = 30; // Clean up polls older than 30 days
 
@@ -73,6 +75,24 @@ export function cleanupOldPolls(): void {
     localStorage.setItem(POLL_CREATOR_STORAGE_KEY, JSON.stringify(filteredData));
     console.log(`Cleaned up ${pollData.length - filteredData.length} old poll records`);
   }
+}
+
+// Build a snapshot of poll fields used for fork/duplicate/follow-up forms.
+// Centralized here to avoid drift when fields are added or renamed.
+export function buildPollSnapshot(poll: Poll) {
+  return {
+    title: poll.title,
+    poll_type: poll.poll_type,
+    options: poll.options,
+    response_deadline: poll.response_deadline,
+    creator_name: poll.creator_name,
+    min_participants: poll.min_participants,
+    max_participants: poll.max_participants,
+    auto_close_after: poll.auto_close_after,
+    details: poll.details,
+    category: poll.category,
+    options_metadata: poll.options_metadata,
+  };
 }
 
 // Initialize cleanup on module load (only in browser)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 // Core type definitions for WhoeverWants
 // Extracted from lib/supabase.ts during Phase 3 cleanup
 
-export type PollContentType = string;
+export type PollCategory = string;
 
 export type OptionMetadataEntry = {
   imageUrl?: string;
@@ -53,7 +53,7 @@ export interface Poll {
   time_preferences_deadline_minutes?: number | null;
   day_time_windows?: DayTimeWindow[] | null;
   duration_window?: DurationWindow | null;
-  poll_content_type?: PollContentType | null;
+  category?: PollCategory | null;
   options_metadata?: OptionsMetadata | null;
   reference_latitude?: number | null;
   reference_longitude?: number | null;

--- a/server/models.py
+++ b/server/models.py
@@ -51,8 +51,8 @@ class CreatePollRequest(BaseModel):
     # Time windows for participation polls
     day_time_windows: list[dict] | None = None
     duration_window: dict | None = None
-    # Content type for autocomplete (nomination/ranked_choice polls)
-    poll_content_type: str | None = None
+    # Category for autocomplete (nomination/ranked_choice polls)
+    category: str | None = None
     # Metadata for options (thumbnail URLs, info links) keyed by option label
     options_metadata: dict | None = None
     # Reference location for proximity-based search
@@ -153,7 +153,7 @@ class PollResponse(BaseModel):
     time_preferences_deadline_minutes: int | None = None
     day_time_windows: list[dict] | None = None
     duration_window: dict | None = None
-    poll_content_type: str | None = None
+    category: str | None = None
     options_metadata: dict | None = None
     reference_latitude: float | None = None
     reference_longitude: float | None = None

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -244,7 +244,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         time_preferences_deadline_minutes=row.get("time_preferences_deadline_minutes"),
         day_time_windows=row.get("day_time_windows"),
         duration_window=row.get("duration_window"),
-        poll_content_type=row.get("poll_content_type"),
+        category=row.get("category"),
         options_metadata=row.get("options_metadata"),
         reference_latitude=row.get("reference_latitude"),
         reference_longitude=row.get("reference_longitude"),
@@ -471,7 +471,7 @@ def create_poll(req: CreatePollRequest):
                                time_suggestions_deadline_minutes,
                                time_preferences_deadline_minutes,
                                day_time_windows, duration_window,
-                               poll_content_type, options_metadata,
+                               category, options_metadata,
                                reference_latitude, reference_longitude,
                                reference_location_label,
                                created_at, updated_at)
@@ -488,7 +488,7 @@ def create_poll(req: CreatePollRequest):
                     %(time_suggestions_deadline_minutes)s,
                     %(time_preferences_deadline_minutes)s,
                     %(day_time_windows)s::jsonb, %(duration_window)s::jsonb,
-                    %(poll_content_type)s, %(options_metadata)s::jsonb,
+                    %(category)s, %(options_metadata)s::jsonb,
                     %(reference_latitude)s, %(reference_longitude)s,
                     %(reference_location_label)s,
                     %(now)s, %(now)s)
@@ -523,7 +523,7 @@ def create_poll(req: CreatePollRequest):
                 "time_preferences_deadline_minutes": req.time_preferences_deadline_minutes,
                 "day_time_windows": json.dumps(req.day_time_windows) if req.day_time_windows else None,
                 "duration_window": json.dumps(req.duration_window) if req.duration_window else None,
-                "poll_content_type": req.poll_content_type or "custom",
+                "category": req.category or "custom",
                 "options_metadata": json.dumps(req.options_metadata) if req.options_metadata else None,
                 "reference_latitude": req.reference_latitude,
                 "reference_longitude": req.reference_longitude,
@@ -542,11 +542,11 @@ def create_poll(req: CreatePollRequest):
                 """
                 INSERT INTO polls (title, poll_type, is_closed, follow_up_to,
                                    creator_secret, creator_name,
-                                   poll_content_type,
+                                   category,
                                    created_at, updated_at)
                 VALUES (%(title)s, 'ranked_choice', true, %(parent_id)s,
                         %(creator_secret)s, %(creator_name)s,
-                        %(poll_content_type)s,
+                        %(category)s,
                         %(now)s, %(now)s)
                 """,
                 {
@@ -554,7 +554,7 @@ def create_poll(req: CreatePollRequest):
                     "parent_id": parent_id,
                     "creator_secret": req.creator_secret,
                     "creator_name": req.creator_name,
-                    "poll_content_type": req.poll_content_type or "custom",
+                    "category": req.category or "custom",
                     "now": now,
                 },
             )

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -1,4 +1,4 @@
-"""Search/autocomplete endpoints for poll content types."""
+"""Search/autocomplete endpoints for poll categories."""
 
 import logging
 import math


### PR DESCRIPTION
## Summary
- Rename `poll_content_type` to `category` across the full stack: DB migration 079, Python models/API, TypeScript types, React components, and UI label ("Type" → "Category")
- Fix inconsistent vertical spacing in the poll creation form caused by textarea `inline-block` descender gap, `rows=1` overriding CSS height, and `text-sm` on some inputs
- Reduce label-to-field spacing from `mb-2` to `mb-1` across all form labels
- Fix Details textarea auto-grow jumping on first keystroke and not shrinking
- Extract shared `buildPollSnapshot()` utility to eliminate duplicated poll snapshot objects in FollowUpModal, DuplicateButton, and ForkButton
- Extract `SINGLE_LINE_INPUT_HEIGHT` constant for textarea height
- Document textarea sizing pitfalls and render screenshot workflow in CLAUDE.md

## Test plan
- [ ] Create a poll — verify "Category" label appears, field works for built-in and custom values
- [ ] Fork/duplicate/follow-up a poll with a category set — verify category carries over
- [ ] Verify form field spacing is visually consistent (equal gaps between all fields)
- [ ] Type in Details field — verify it doesn't jump to two lines prematurely, and shrinks when text is deleted
- [ ] Verify nomination polls with location/movie/video_game category still show autocomplete

https://claude.ai/code/session_01UMXbx3NTD7Aa3fFYQisvyg