### PR TITLE
Reorder poll form fields and auto-generate titles

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -125,19 +125,23 @@ function CreatePollContent() {
       else if (filled.length === 1) base = filled[0];
       else {
         const limit = 40 - (icon ? icon.length + 1 : 0);
+        const joinWithOr = (items: string[]) => {
+          if (items.length === 2) return `${items[0]} or ${items[1]}?`;
+          return `${items.slice(0, -1).join(', ')}, or ${items[items.length - 1]}?`;
+        };
         const buildTitle = (items: string[]) => {
           const included = [items[0]];
           for (let i = 1; i < items.length; i++) {
             const isLast = i === items.length - 1;
             const candidate = isLast
-              ? `${included.join(', ')} or ${items[i]}?`
-              : `${[...included, items[i]].join(', ')} or ...?`;
+              ? joinWithOr([...included, items[i]])
+              : `${[...included, items[i]].join(', ')}, or ...?`;
             if (candidate.length > limit && included.length >= 2) break;
             included.push(items[i]);
           }
           const allFit = included.length === items.length;
           const text = allFit
-            ? `${included.slice(0, -1).join(', ')} or ${included[included.length - 1]}?`
+            ? joinWithOr(included)
             : `${included.join(', ')}, or ...?`;
           return { text, allFit };
         };

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -92,6 +92,13 @@ function CreatePollContent() {
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
 
+  // Acronymize multi-word options: "Call of Duty" → "CoD", "Halo" stays "Halo"
+  const acronymize = (text: string) => {
+    const words = text.split(/\s+/);
+    if (words.length <= 1) return text;
+    return words.map(w => w[0].toUpperCase()).join('');
+  };
+
   // Strip parenthesized suffixes and colon suffixes from option text for titles
   const shortenOption = (text: string) => text.split(/[:(]/)[0].trim();
 
@@ -118,20 +125,30 @@ function CreatePollContent() {
       else if (filled.length === 1) base = filled[0];
       else {
         const limit = 40 - (icon ? icon.length + 1 : 0);
-        // Include as many options as fit within the limit
-        const included = [filled[0]];
-        for (let i = 1; i < filled.length; i++) {
-          const isLast = i === filled.length - 1;
-          const candidate = isLast
-            ? `${included.join(', ')} or ${filled[i]}?`
-            : `${[...included, filled[i]].join(', ')} or ...?`;
-          if (candidate.length > limit && included.length >= 2) break;
-          included.push(filled[i]);
-        }
-        if (included.length === filled.length) {
-          base = `${included.slice(0, -1).join(', ')} or ${included[included.length - 1]}?`;
+        const buildTitle = (items: string[]) => {
+          const included = [items[0]];
+          for (let i = 1; i < items.length; i++) {
+            const isLast = i === items.length - 1;
+            const candidate = isLast
+              ? `${included.join(', ')} or ${items[i]}?`
+              : `${[...included, items[i]].join(', ')} or ...?`;
+            if (candidate.length > limit && included.length >= 2) break;
+            included.push(items[i]);
+          }
+          const allFit = included.length === items.length;
+          const text = allFit
+            ? `${included.slice(0, -1).join(', ')} or ${included[included.length - 1]}?`
+            : `${included.join(', ')}, or ...?`;
+          return { text, allFit };
+        };
+        // Try full names first
+        const full = buildTitle(filled);
+        if (full.allFit) {
+          base = full.text;
         } else {
-          base = `${included.join(', ')}, or ...?`;
+          // Retry with acronyms for multi-word options
+          const abbreviated = filled.map(acronymize);
+          base = buildTitle(abbreviated).text;
         }
       }
       return icon ? `${icon} ${base}` : base;

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -101,6 +101,8 @@ function CreatePollContent() {
 
   // Strip parenthesized suffixes and colon suffixes from option text for titles
   const shortenOption = (text: string) => text.split(/[:(]/)[0].trim();
+  // For locations, take just the name (first comma segment) then apply shortenOption
+  const shortenLocation = (text: string) => shortenOption(text.split(',')[0].trim());
 
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
@@ -152,16 +154,17 @@ function CreatePollContent() {
     }
 
     if (pollType === 'poll') {
-      const filled = options.filter(o => o.trim()).map(shortenOption);
+      const shorten = category === 'location' ? shortenLocation : shortenOption;
+      const filled = options.filter(o => o.trim()).map(shorten);
       return addIcon(buildFromOptions(filled, 'Quick Vote'));
     }
 
     // participation
     if (locationMode === 'set' && locationValue.trim()) {
-      return `Who's going to ${shortenOption(locationValue)}?`;
+      return `Who's going to ${shortenLocation(locationValue)}?`;
     }
     if (locationMode === 'preferences') {
-      const filled = locationOptions.filter(o => o.trim()).map(shortenOption);
+      const filled = locationOptions.filter(o => o.trim()).map(shortenLocation);
       if (filled.length > 0) return addIcon(buildFromOptions(filled, "Who's in?"));
     }
     return "Who's in?";

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -116,8 +116,7 @@ function CreatePollContent() {
       let base: string;
       if (filled.length === 0) base = 'Quick Vote';
       else if (filled.length === 1) base = filled[0];
-      else if (filled.length === 2) base = `${filled[0]} or ${filled[1]}?`;
-      else base = `${filled[0]}, ${filled[1]}, or ...?`;
+      else base = `${filled.slice(0, -1).join(', ')} or ${filled[filled.length - 1]}?`;
       return icon ? `${icon} ${base}` : base;
     }
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -92,6 +92,9 @@ function CreatePollContent() {
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
 
+  // Strip parenthesized suffixes and colon suffixes from option text for titles
+  const shortenOption = (text: string) => text.split(/[:(]/)[0].trim();
+
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
     const builtIn = getBuiltInType(category);
@@ -109,7 +112,7 @@ function CreatePollContent() {
     }
 
     if (pollType === 'poll') {
-      const filled = options.filter(o => o.trim());
+      const filled = options.filter(o => o.trim()).map(shortenOption);
       let base: string;
       if (filled.length === 0) base = 'Quick Vote';
       else if (filled.length === 1) base = filled[0];
@@ -120,7 +123,7 @@ function CreatePollContent() {
 
     // participation
     if (locationMode === 'set' && locationValue.trim()) {
-      return `Who's going to ${locationValue.trim()}?`;
+      return `Who's going to ${shortenOption(locationValue)}?`;
     }
     return "Who's in?";
   }, [pollType, category, options, locationMode, locationValue]);

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -25,6 +25,18 @@ export const dynamic = 'force-dynamic';
 // Used for the Details textarea initial height and auto-grow reset.
 const SINGLE_LINE_INPUT_HEIGHT = 42;
 
+// Acronymize multi-word options: "Call of Duty" → "CoD", "Halo" stays "Halo"
+function acronymize(text: string) {
+  const words = text.split(/\s+/);
+  if (words.length <= 1) return text;
+  return words.map(w => w[0].toUpperCase()).join('');
+}
+
+// Strip parenthesized suffixes and colon suffixes from option text for titles
+function shortenOption(text: string) { return text.split(/[:(]/)[0].trim(); }
+// For locations, take just the name (first comma segment) then apply shortenOption
+function shortenLocation(text: string) { return shortenOption(text.split(',')[0].trim()); }
+
 function CreatePollContent() {
   const { prefetch } = useAppPrefetch();
   const router = useRouter();
@@ -92,18 +104,6 @@ function CreatePollContent() {
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
 
-  // Acronymize multi-word options: "Call of Duty" → "CoD", "Halo" stays "Halo"
-  const acronymize = (text: string) => {
-    const words = text.split(/\s+/);
-    if (words.length <= 1) return text;
-    return words.map(w => w[0].toUpperCase()).join('');
-  };
-
-  // Strip parenthesized suffixes and colon suffixes from option text for titles
-  const shortenOption = (text: string) => text.split(/[:(]/)[0].trim();
-  // For locations, take just the name (first comma segment) then apply shortenOption
-  const shortenLocation = (text: string) => shortenOption(text.split(',')[0].trim());
-
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
     const builtIn = getBuiltInType(category);
@@ -144,12 +144,9 @@ function CreatePollContent() {
     const addIcon = (base: string) => icon ? `${icon} ${base}` : base;
 
     if (pollType === 'nomination') {
-      const nominationLabels: Record<string, string> = {
-        location: 'Place',
-        movie: 'Movie',
-        video_game: 'Video Game',
-      };
-      const prefix = nominationLabels[category] || (category !== 'custom' ? category : '');
+      // Use "Place" instead of "Location" for nomination polls
+      const prefix = category === 'location' ? 'Place'
+        : builtIn?.label || (category !== 'custom' ? category : '');
       return addIcon(prefix ? `${prefix} Suggestions` : 'Suggestions');
     }
 
@@ -699,7 +696,7 @@ function CreatePollContent() {
     if (isClient) {
       saveFormState();
     }
-  }, [title, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, duplicateOf, forkOf, isClient, saveFormState, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
+  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, duplicateOf, forkOf, isClient, saveFormState, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
 
   // Track form changes for fork validation
   useEffect(() => {
@@ -1497,7 +1494,7 @@ function CreatePollContent() {
               value={creatorName}
               onChange={(e) => setCreatorName(e.target.value)}
               disabled={isLoading}
-              maxLength={100}
+              maxLength={50}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
               placeholder="Enter your name..."
             />

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -116,7 +116,24 @@ function CreatePollContent() {
       let base: string;
       if (filled.length === 0) base = 'Quick Vote';
       else if (filled.length === 1) base = filled[0];
-      else base = `${filled.slice(0, -1).join(', ')} or ${filled[filled.length - 1]}?`;
+      else {
+        const limit = 100 - (icon ? icon.length + 1 : 0);
+        // Include as many options as fit within the limit
+        const included = [filled[0]];
+        for (let i = 1; i < filled.length; i++) {
+          const isLast = i === filled.length - 1;
+          const candidate = isLast
+            ? `${included.join(', ')} or ${filled[i]}?`
+            : `${[...included, filled[i]].join(', ')} or ...?`;
+          if (candidate.length > limit && included.length >= 2) break;
+          included.push(filled[i]);
+        }
+        if (included.length === filled.length) {
+          base = `${included.slice(0, -1).join(', ')} or ${included[included.length - 1]}?`;
+        } else {
+          base = `${included.join(', ')}, or ...?`;
+        }
+      }
       return icon ? `${icon} ${base}` : base;
     }
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -209,6 +209,7 @@ function CreatePollContent() {
         customTime,
         creatorName,
         isAutoTitle,
+        category,
         minParticipants,
         maxParticipants,
         maxEnabled,
@@ -220,7 +221,7 @@ function CreatePollContent() {
       };
       localStorage.setItem('pollFormState', JSON.stringify(formState));
     }
-  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
+  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
 
   // Get default date/time values (client-side only to avoid hydration mismatch)
   const getDefaultDateTime = () => {
@@ -269,6 +270,7 @@ function CreatePollContent() {
           setCustomDate(formState.customDate || '');
           setCustomTime(formState.customTime || '');
           setCreatorName(formState.creatorName || '');
+          if (formState.category) setCategory(formState.category);
 
           // Restore participation poll conditions
           if (formState.minParticipants !== undefined) setMinParticipants(formState.minParticipants);
@@ -697,7 +699,7 @@ function CreatePollContent() {
     if (isClient) {
       saveFormState();
     }
-  }, [title, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, duplicateOf, forkOf, isClient, saveFormState, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
+  }, [title, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, duplicateOf, forkOf, isClient, saveFormState, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
 
   // Track form changes for fork validation
   useEffect(() => {

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -148,7 +148,14 @@ function CreatePollContent() {
         } else {
           // Retry with acronyms for multi-word options
           const abbreviated = filled.map(acronymize);
-          base = buildTitle(abbreviated).text;
+          const abbrev = buildTitle(abbreviated);
+          if (abbrev.allFit) {
+            base = abbrev.text;
+          } else {
+            // Fall back to "Which {category}?"
+            const catLabel = builtIn?.label || (category !== 'custom' ? category : 'one');
+            base = `Which ${catLabel}?`;
+          }
         }
       }
       return icon ? `${icon} ${base}` : base;

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -95,7 +95,7 @@ function CreatePollContent() {
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
     const builtIn = getBuiltInType(category);
-    const categoryLabel = builtIn?.label || '';
+    const icon = builtIn?.icon || '';
 
     if (pollType === 'nomination') {
       const nominationLabels: Record<string, string> = {
@@ -104,17 +104,18 @@ function CreatePollContent() {
         video_game: 'Video Game',
       };
       const prefix = nominationLabels[category] || (category !== 'custom' ? category : '');
-      return prefix ? `${prefix} Suggestions` : 'Suggestions';
+      const base = prefix ? `${prefix} Suggestions` : 'Suggestions';
+      return icon ? `${icon} ${base}` : base;
     }
 
     if (pollType === 'poll') {
       const filled = options.filter(o => o.trim());
-      if (filled.length === 0) return categoryLabel ? `${categoryLabel} Vote` : 'Quick Vote';
-      const optionsPart =
-        filled.length === 1 ? filled[0] :
-        filled.length === 2 ? `${filled[0]} or ${filled[1]}?` :
-        `${filled[0]}, ${filled[1]}, or ...?`;
-      return categoryLabel ? `${categoryLabel}: ${optionsPart}` : optionsPart;
+      let base: string;
+      if (filled.length === 0) base = 'Quick Vote';
+      else if (filled.length === 1) base = filled[0];
+      else if (filled.length === 2) base = `${filled[0]} or ${filled[1]}?`;
+      else base = `${filled[0]}, ${filled[1]}, or ...?`;
+      return icon ? `${icon} ${base}` : base;
     }
 
     // participation

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -117,7 +117,7 @@ function CreatePollContent() {
       if (filled.length === 0) base = 'Quick Vote';
       else if (filled.length === 1) base = filled[0];
       else {
-        const limit = 100 - (icon ? icon.length + 1 : 0);
+        const limit = 40 - (icon ? icon.length + 1 : 0);
         // Include as many options as fit within the limit
         const included = [filled[0]];
         for (let i = 1; i < filled.length; i++) {

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -66,6 +66,7 @@ function CreatePollContent() {
   const [creatorName, setCreatorName] = useState<string>("");
   const [originalPollData, setOriginalPollData] = useState<any>(null);
   const [hasFormChanged, setHasFormChanged] = useState(false);
+  const [isAutoTitle, setIsAutoTitle] = useState(true);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
   const [autoCreatePreferences, setAutoCreatePreferences] = useState(true);
@@ -90,6 +91,41 @@ function CreatePollContent() {
   const [refLongitude, setRefLongitude] = useState<number | undefined>(undefined);
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
+
+  // Generate a title from the current form state
+  const generateTitle = useCallback(() => {
+    if (pollType === 'nomination') {
+      const labels: Record<string, string> = {
+        location: 'Place',
+        movie: 'Movie',
+        video_game: 'Video Game',
+      };
+      const prefix = labels[category] || (category !== 'custom' ? category : '');
+      return prefix ? `${prefix} Suggestions` : 'Suggestions';
+    }
+
+    if (pollType === 'poll') {
+      const filled = options.filter(o => o.trim());
+      if (filled.length === 0) return 'Quick Vote';
+      if (filled.length === 1) return filled[0];
+      if (filled.length === 2) return `${filled[0]} or ${filled[1]}?`;
+      return `${filled[0]}, ${filled[1]}, or ...?`;
+    }
+
+    // participation
+    if (locationMode === 'set' && locationValue.trim()) {
+      return `Who's going to ${locationValue.trim()}?`;
+    }
+    return "Who's in?";
+  }, [pollType, category, options, locationMode, locationValue]);
+
+  // Auto-update title when form fields change (if user hasn't manually edited)
+  useEffect(() => {
+    if (isAutoTitle) {
+      const generated = generateTitle();
+      setTitle(generated.slice(0, 50));
+    }
+  }, [isAutoTitle, generateTitle]);
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -121,6 +157,7 @@ function CreatePollContent() {
         customDate,
         customTime,
         creatorName,
+        isAutoTitle,
         minParticipants,
         maxParticipants,
         maxEnabled,
@@ -132,7 +169,7 @@ function CreatePollContent() {
       };
       localStorage.setItem('pollFormState', JSON.stringify(formState));
     }
-  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
+  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
 
   // Get default date/time values (client-side only to avoid hydration mismatch)
   const getDefaultDateTime = () => {
@@ -174,6 +211,7 @@ function CreatePollContent() {
         try {
           const formState = JSON.parse(saved);
           setTitle(formState.title || '');
+          if (formState.isAutoTitle === false) setIsAutoTitle(false);
           setDetails(formState.details || '');
           setOptions(formState.options || ['']);
           setDeadlineOption(formState.deadlineOption || '10min');
@@ -395,6 +433,7 @@ function CreatePollContent() {
 
           // Auto-fill form with fork data
           setTitle(forkData.title || "");
+          if (forkData.title) setIsAutoTitle(false);
           setDetails(forkData.details || "");
 
           // Set poll type and options based on forked poll
@@ -480,6 +519,7 @@ function CreatePollContent() {
 
           // Auto-fill form with duplicate data
           setTitle(duplicateData.title || "");
+          if (duplicateData.title) setIsAutoTitle(false);
           setDetails(duplicateData.details || "");
 
           // Set poll type based on duplicated poll
@@ -570,6 +610,7 @@ function CreatePollContent() {
 
           // Auto-fill form with preference poll type and nominated options
           setTitle(voteData.title || "");
+          if (voteData.title) setIsAutoTitle(false);
           setPollType('poll'); // Set to preference poll
           setOptions(voteData.options && voteData.options.length > 0 ? voteData.options : ['']);
 
@@ -605,7 +646,7 @@ function CreatePollContent() {
     if (isClient) {
       saveFormState();
     }
-  }, [title, options, deadlineOption, customDate, customTime, creatorName, duplicateOf, forkOf, isClient, saveFormState, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
+  }, [title, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, duplicateOf, forkOf, isClient, saveFormState, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
 
   // Track form changes for fork validation
   useEffect(() => {
@@ -1338,18 +1379,35 @@ function CreatePollContent() {
             <label htmlFor="title" className="block text-sm font-medium mb-1">
               Title
             </label>
-            <input
-              type="text"
-              id="title"
-              ref={titleInputRef}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              disabled={isLoading}
-              maxLength={50}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              placeholder="Enter your title..."
-              required
-            />
+            <div className="relative">
+              <input
+                type="text"
+                id="title"
+                ref={titleInputRef}
+                value={title}
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                  setIsAutoTitle(false);
+                }}
+                disabled={isLoading}
+                maxLength={50}
+                className="w-full px-3 py-2 pr-9 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                placeholder="Enter your title..."
+                required
+              />
+              {!isAutoTitle && (
+                <button
+                  type="button"
+                  onClick={() => setIsAutoTitle(true)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                  title="Auto-generate title"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182" />
+                  </svg>
+                </button>
+              )}
+            </div>
           </div>
 
           {/* Optional details field */}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
 import type { OptionsMetadata } from "@/lib/types";
-import TypeFieldInput from "@/components/TypeFieldInput";
+import TypeFieldInput, { getBuiltInType } from "@/components/TypeFieldInput";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -94,22 +94,27 @@ function CreatePollContent() {
 
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
+    const builtIn = getBuiltInType(category);
+    const categoryLabel = builtIn?.label || '';
+
     if (pollType === 'nomination') {
-      const labels: Record<string, string> = {
+      const nominationLabels: Record<string, string> = {
         location: 'Place',
         movie: 'Movie',
         video_game: 'Video Game',
       };
-      const prefix = labels[category] || (category !== 'custom' ? category : '');
+      const prefix = nominationLabels[category] || (category !== 'custom' ? category : '');
       return prefix ? `${prefix} Suggestions` : 'Suggestions';
     }
 
     if (pollType === 'poll') {
       const filled = options.filter(o => o.trim());
-      if (filled.length === 0) return 'Quick Vote';
-      if (filled.length === 1) return filled[0];
-      if (filled.length === 2) return `${filled[0]} or ${filled[1]}?`;
-      return `${filled[0]}, ${filled[1]}, or ...?`;
+      if (filled.length === 0) return categoryLabel ? `${categoryLabel} Vote` : 'Quick Vote';
+      const optionsPart =
+        filled.length === 1 ? filled[0] :
+        filled.length === 2 ? `${filled[0]} or ${filled[1]}?` :
+        `${filled[0]}, ${filled[1]}, or ...?`;
+      return categoryLabel ? `${categoryLabel}: ${optionsPart}` : optionsPart;
     }
 
     // participation

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1070,12 +1070,7 @@ function CreatePollContent() {
               <div className="relative flex w-full">
                 <button
                   type="button"
-                  onClick={() => {
-                    if (titleInputRef.current) {
-                      titleInputRef.current.focus();
-                    }
-                    setPollType('nomination');
-                  }}
+                  onClick={() => setPollType('nomination')}
                   disabled={isLoading}
                   className={`flex-1 py-1 text-xl rounded-md transition-colors duration-200 ${
                     pollType === 'nomination'
@@ -1087,12 +1082,7 @@ function CreatePollContent() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => {
-                    if (titleInputRef.current) {
-                      titleInputRef.current.focus();
-                    }
-                    setPollType('poll');
-                  }}
+                  onClick={() => setPollType('poll')}
                   disabled={isLoading}
                   className={`flex-1 py-1 text-xl rounded-md transition-colors duration-200 ${
                     pollType === 'poll'
@@ -1104,12 +1094,7 @@ function CreatePollContent() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => {
-                    if (titleInputRef.current) {
-                      titleInputRef.current.focus();
-                    }
-                    setPollType('participation');
-                  }}
+                  onClick={() => setPollType('participation')}
                   disabled={isLoading}
                   className={`flex-1 py-1 text-xl rounded-md transition-colors duration-200 ${
                     pollType === 'participation'
@@ -1121,48 +1106,6 @@ function CreatePollContent() {
                 </button>
               </div>
             </div>
-          </div>
-
-          <div className="-mt-4">
-            <label htmlFor="title" className="block text-sm font-medium mb-1">
-              Title
-            </label>
-            <input
-              type="text"
-              id="title"
-              ref={titleInputRef}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              disabled={isLoading}
-              maxLength={50}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              placeholder="Enter your title..."
-              required
-            />
-          </div>
-
-          {/* Optional details field */}
-          <div>
-            <label htmlFor="details" className="block text-sm font-medium mb-1">
-              Details{' '}
-              <span className="text-gray-500 font-normal">(optional)</span>
-            </label>
-            <textarea
-              id="details"
-              value={details}
-              onChange={(e) => {
-                setDetails(e.target.value);
-                const el = e.target;
-                el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
-                const maxH = 5 * 20 + 16; // 5 lines + padding
-                el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
-                el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
-              }}
-              disabled={isLoading}
-              style={{ height: SINGLE_LINE_INPUT_HEIGHT }}
-              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
-              placeholder="Add more context or instructions..."
-            />
           </div>
 
           {/* Category selector for suggestion and poll types */}
@@ -1390,6 +1333,48 @@ function CreatePollContent() {
               )}
             </div>
           )}
+
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium mb-1">
+              Title
+            </label>
+            <input
+              type="text"
+              id="title"
+              ref={titleInputRef}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              disabled={isLoading}
+              maxLength={50}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              placeholder="Enter your title..."
+              required
+            />
+          </div>
+
+          {/* Optional details field */}
+          <div>
+            <label htmlFor="details" className="block text-sm font-medium mb-1">
+              Details{' '}
+              <span className="text-gray-500 font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="details"
+              value={details}
+              onChange={(e) => {
+                setDetails(e.target.value);
+                const el = e.target;
+                el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
+                const maxH = 5 * 20 + 16; // 5 lines + padding
+                el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
+                el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
+              }}
+              disabled={isLoading}
+              style={{ height: SINGLE_LINE_INPUT_HEIGHT }}
+              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
+              placeholder="Add more context or instructions..."
+            />
+          </div>
 
           <div>
             <label htmlFor="creatorName" className="block text-sm font-medium mb-1">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -106,6 +106,40 @@ function CreatePollContent() {
   const generateTitle = useCallback(() => {
     const builtIn = getBuiltInType(category);
     const icon = builtIn?.icon || '';
+    const limit = 40 - (icon ? icon.length + 1 : 0);
+    const catLabel = builtIn?.label || (category !== 'custom' ? category : 'one');
+
+    const joinWithOr = (items: string[]) => {
+      if (items.length === 2) return `${items[0]} or ${items[1]}?`;
+      return `${items.slice(0, -1).join(', ')}, or ${items[items.length - 1]}?`;
+    };
+    const buildTitle = (items: string[]) => {
+      const included = [items[0]];
+      for (let i = 1; i < items.length; i++) {
+        const isLast = i === items.length - 1;
+        const candidate = isLast
+          ? joinWithOr([...included, items[i]])
+          : `${[...included, items[i]].join(', ')}, or ...?`;
+        if (candidate.length > limit && included.length >= 2) break;
+        included.push(items[i]);
+      }
+      const allFit = included.length === items.length;
+      const text = allFit
+        ? joinWithOr(included)
+        : `${included.join(', ')}, or ...?`;
+      return { text, allFit };
+    };
+    const buildFromOptions = (filled: string[], fallback: string) => {
+      if (filled.length === 0) return fallback;
+      if (filled.length === 1) return filled[0];
+      const full = buildTitle(filled);
+      if (full.allFit) return full.text;
+      const abbrev = buildTitle(filled.map(acronymize));
+      if (abbrev.allFit) return abbrev.text;
+      return `Which ${catLabel}?`;
+    };
+
+    const addIcon = (base: string) => icon ? `${icon} ${base}` : base;
 
     if (pollType === 'nomination') {
       const nominationLabels: Record<string, string> = {
@@ -114,63 +148,24 @@ function CreatePollContent() {
         video_game: 'Video Game',
       };
       const prefix = nominationLabels[category] || (category !== 'custom' ? category : '');
-      const base = prefix ? `${prefix} Suggestions` : 'Suggestions';
-      return icon ? `${icon} ${base}` : base;
+      return addIcon(prefix ? `${prefix} Suggestions` : 'Suggestions');
     }
 
     if (pollType === 'poll') {
       const filled = options.filter(o => o.trim()).map(shortenOption);
-      let base: string;
-      if (filled.length === 0) base = 'Quick Vote';
-      else if (filled.length === 1) base = filled[0];
-      else {
-        const limit = 40 - (icon ? icon.length + 1 : 0);
-        const joinWithOr = (items: string[]) => {
-          if (items.length === 2) return `${items[0]} or ${items[1]}?`;
-          return `${items.slice(0, -1).join(', ')}, or ${items[items.length - 1]}?`;
-        };
-        const buildTitle = (items: string[]) => {
-          const included = [items[0]];
-          for (let i = 1; i < items.length; i++) {
-            const isLast = i === items.length - 1;
-            const candidate = isLast
-              ? joinWithOr([...included, items[i]])
-              : `${[...included, items[i]].join(', ')}, or ...?`;
-            if (candidate.length > limit && included.length >= 2) break;
-            included.push(items[i]);
-          }
-          const allFit = included.length === items.length;
-          const text = allFit
-            ? joinWithOr(included)
-            : `${included.join(', ')}, or ...?`;
-          return { text, allFit };
-        };
-        // Try full names first
-        const full = buildTitle(filled);
-        if (full.allFit) {
-          base = full.text;
-        } else {
-          // Retry with acronyms for multi-word options
-          const abbreviated = filled.map(acronymize);
-          const abbrev = buildTitle(abbreviated);
-          if (abbrev.allFit) {
-            base = abbrev.text;
-          } else {
-            // Fall back to "Which {category}?"
-            const catLabel = builtIn?.label || (category !== 'custom' ? category : 'one');
-            base = `Which ${catLabel}?`;
-          }
-        }
-      }
-      return icon ? `${icon} ${base}` : base;
+      return addIcon(buildFromOptions(filled, 'Quick Vote'));
     }
 
     // participation
     if (locationMode === 'set' && locationValue.trim()) {
       return `Who's going to ${shortenOption(locationValue)}?`;
     }
+    if (locationMode === 'preferences') {
+      const filled = locationOptions.filter(o => o.trim()).map(shortenOption);
+      if (filled.length > 0) return addIcon(buildFromOptions(filled, "Who's in?"));
+    }
     return "Who's in?";
-  }, [pollType, category, options, locationMode, locationValue]);
+  }, [pollType, category, options, locationMode, locationValue, locationOptions]);
 
   // Auto-update title when form fields change (if user hasn't manually edited)
   useEffect(() => {

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -132,7 +132,7 @@ function CreatePollContent() {
   useEffect(() => {
     if (isAutoTitle) {
       const generated = generateTitle();
-      setTitle(generated.slice(0, 50));
+      setTitle(generated.slice(0, 100));
     }
   }, [isAutoTitle, generateTitle]);
 
@@ -287,8 +287,8 @@ function CreatePollContent() {
       return "Please enter a title.";
     }
     
-    if (title.length > 50) {
-      return "Title must be 50 characters or less.";
+    if (title.length > 100) {
+      return "Title must be 100 characters or less.";
     }
 
     // Check custom deadline if selected
@@ -1399,7 +1399,7 @@ function CreatePollContent() {
                   setIsAutoTitle(false);
                 }}
                 disabled={isLoading}
-                maxLength={50}
+                maxLength={100}
                 className="w-full px-3 py-2 pr-9 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
                 placeholder="Enter your title..."
                 required
@@ -1453,7 +1453,7 @@ function CreatePollContent() {
               value={creatorName}
               onChange={(e) => setCreatorName(e.target.value)}
               disabled={isLoading}
-              maxLength={50}
+              maxLength={100}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
               placeholder="Enter your name..."
             />

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -138,7 +138,52 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     return <span className={className}>{text}</span>;
   }
 
+  // Extract name without parenthesized suffix (e.g. "Inception (2010)" → "Inception")
+  const displayName = text.replace(/\s*\(.*\)\s*$/, '').trim() || text;
+  const yearMatch = text.match(/\((\d{4})\)/);
+  const year = yearMatch ? yearMatch[1] : null;
+
   // Typed option with image and/or link (movies, video games, etc.)
+  if (layout === "stacked") {
+    const nameEl = metadata.infoUrl ? (
+      <a
+        href={metadata.infoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="font-medium leading-tight underline decoration-2 decoration-blue-400/50 hover:decoration-blue-500"
+      >
+        {displayName}
+      </a>
+    ) : (
+      <span className="font-medium leading-tight">{displayName}</span>
+    );
+
+    return (
+      <div className={`min-w-0 overflow-hidden ${className}`}>
+        {metadata.imageUrl && (
+          <div className="flex justify-center">
+            <img
+              src={metadata.imageUrl}
+              alt=""
+              className="w-12 h-16 object-cover rounded"
+              loading="lazy"
+            />
+          </div>
+        )}
+        <div className="line-clamp-2 leading-tight mt-1 text-center">
+          {nameEl}
+        </div>
+        {year && (
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 text-center">
+            {year}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Default inline layout
   const imageEl = metadata.imageUrl ? (
     <img
       src={metadata.imageUrl}

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -138,13 +138,11 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     return <span className={className}>{text}</span>;
   }
 
-  // Extract name without parenthesized suffix (e.g. "Inception (2010)" → "Inception")
-  const displayName = text.replace(/\s*\(.*\)\s*$/, '').trim() || text;
-  const yearMatch = text.match(/\((\d{4})\)/);
-  const year = yearMatch ? yearMatch[1] : null;
-
-  // Typed option with image and/or link (movies, video games, etc.)
+  // Stacked layout for movies, video games, etc.
   if (layout === "stacked") {
+    const displayName = text.replace(/\s*\(.*\)\s*$/, '').trim() || text;
+    const yearMatch = text.match(/\((\d{4})\)/);
+    const year = yearMatch ? yearMatch[1] : null;
     const nameEl = metadata.infoUrl ? (
       <a
         href={metadata.infoUrl}

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -107,7 +107,6 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
     onChange(type.value);
     setEditText(null);
     closeDropdown();
-    inputRef.current?.blur();
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {


### PR DESCRIPTION
## Summary
- Move title and description fields to the bottom of the poll creation form, right before the name field
- Auto-generate poll titles from form state (type, category, options, location) as users fill in the form
- Editing the title disables auto-generation; a recycle button re-enables it
- Add stacked layout (poster/cover art on top) for movie and video game options in 2-option ballots
- Fix category dropdown selection being overwritten by stale blur handler
- Persist category in localStorage form state

## Auto-title generation
- **Nomination**: `📍 Place Suggestions`, `🎬 Movie Suggestions`, `Suggestions`
- **Poll**: `📍 Burger King or Chili's?`, `🎬 Inception or Matrix?`, `Quick Vote`
- **Participation**: `Who's going to Burger King?`, `Who's in?`
- Truncation cascade: full names → acronyms (CoD, BotW) → `Which {category}?`
- Locations stripped to name only (no address), options stripped at `(` and `:`
- Oxford comma for 3+ items

## Test plan
- [ ] Create polls of each type and verify auto-title updates as fields change
- [ ] Edit the title manually, confirm recycle button appears and re-enables auto-gen
- [ ] Navigate away from create form and back — verify category and title persist
- [ ] Select a category from dropdown — verify it sticks
- [ ] Create a 2-option movie/video game poll and verify stacked poster layout
- [ ] Create a 2-option location poll and verify stacked layout with logos

https://claude.ai/code/session_01VPWpSdFKu6RDjVEFdDvLhp