### PR TITLE
Add Restaurant category with Yelp Fusion API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,6 +875,24 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Use `bounded=1` with viewbox AND a hard distance cutoff** for proximity searches. Nominatim's viewbox is a bias, not a hard filter — results outside the box can still appear. Always post-filter with `_haversine_miles()` against `max_distance`.
 - **Always set `Accept-Language: en`** in Nominatim requests to avoid foreign-language results.
 - **Reference location is stored per-poll** (`reference_latitude`, `reference_longitude`, `reference_location_label` columns) and per-user in localStorage (`lib/userProfile.ts: UserLocation`). The poll creation page auto-fills from localStorage.
+- **Nominatim rate-limits aggressively (1 req/sec, IP-based).** Never fire parallel Nominatim requests — use a single search covering the area. The restaurant endpoint does one Nominatim call for the whole result set, not one per business. If rate-limited (429), the code silently falls back to Yelp photos.
+- **OSM data completeness varies wildly by region.** NYC has websites for most chain restaurants; suburban/rural areas often have none. The `_restaurant_favicon_cache` compensates: once any location of a chain (e.g., Burger King) has a website in OSM, all locations get that favicon via name-based caching.
+
+### Yelp Fusion API (Restaurant Search)
+
+- **`YELP_API_KEY` in `.env.api` on the droplet.** Free tier: 500 calls/day. If missing, restaurant search falls back to Nominatim with "restaurant" appended to the query.
+- **Yelp search doesn't return business websites** — only the Yelp listing URL. To get favicons, the backend does a single Nominatim search in the area and matches OSM results to Yelp businesses by proximity (<0.5 mi). If no OSM match, falls back to Yelp's business photo (resized to 60x60 via `/ms.jpg` suffix).
+- **Favicon cache is name-based and in-memory** (`_restaurant_favicon_cache` in `search.py`). Bounded to 500 entries with LRU eviction. Persists for the API process lifetime. Populated from OSM `website`, `contact:website`, and `brand:website` extratags.
+- **`sort_by=distance` requires `latitude`/`longitude`** in the Yelp request. Without coordinates, Yelp ignores the sort parameter.
+- **Yelp image URL suffixes control size:** `/o.jpg` = original, `/ms.jpg` = 60x60, `/s.jpg` = 100x100, `/l.jpg` = 600x400. Use `/ms.jpg` for icon-like display.
+
+### Adding New Poll Categories
+
+- **Built-in categories** are defined in `TypeFieldInput.tsx: BUILT_IN_TYPES`. Add new entries there.
+- **`isLocationLikeCategory()`** in `TypeFieldInput.tsx` controls which categories show reference location input and use proximity search. Update it when adding location-aware categories.
+- **`isAutocompleteCategory()`** in `TypeFieldInput.tsx` controls which categories use the autocomplete dropdown (derived from `BUILT_IN_TYPES`).
+- **Search dispatch** is in `AutocompleteInput.tsx: doSearch()` — add a new branch for each category's API endpoint.
+- **Metadata rendering** is in `OptionLabel.tsx` — add detection function (like `isRestaurantEntry()`) and inline/stacked layout branches.
 
 ### API Development Pitfalls
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -151,7 +151,7 @@ function CreatePollContent() {
     }
 
     if (pollType === 'poll') {
-      const shorten = category === 'location' ? shortenLocation : shortenOption;
+      const shorten = (category === 'location' || category === 'restaurant') ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
       return addIcon(buildFromOptions(filled, 'Quick Vote'));
     }
@@ -1214,7 +1214,7 @@ function CreatePollContent() {
           )}
 
           {/* Reference location for location polls */}
-          {(category === 'location' || (pollType === 'participation' && locationMode !== 'none')) && (
+          {(category === 'location' || category === 'restaurant' || (pollType === 'participation' && locationMode !== 'none')) && (
             <ReferenceLocationInput
               latitude={refLatitude}
               longitude={refLongitude}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
 import type { OptionsMetadata } from "@/lib/types";
-import TypeFieldInput, { getBuiltInType } from "@/components/TypeFieldInput";
+import TypeFieldInput, { getBuiltInType, isLocationLikeCategory } from "@/components/TypeFieldInput";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -151,7 +151,7 @@ function CreatePollContent() {
     }
 
     if (pollType === 'poll') {
-      const shorten = (category === 'location' || category === 'restaurant') ? shortenLocation : shortenOption;
+      const shorten = isLocationLikeCategory(category) ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
       return addIcon(buildFromOptions(filled, 'Quick Vote'));
     }
@@ -1214,7 +1214,7 @@ function CreatePollContent() {
           )}
 
           {/* Reference location for location polls */}
-          {(category === 'location' || category === 'restaurant' || (pollType === 'participation' && locationMode !== 'none')) && (
+          {(isLocationLikeCategory(category) || (pollType === 'participation' && locationMode !== 'none')) && (
             <ReferenceLocationInput
               latitude={refLatitude}
               longitude={refLongitude}

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { apiSearchLocations, apiSearchMovies, apiSearchVideoGames, type SearchResult } from "@/lib/api";
+import { apiSearchLocations, apiSearchMovies, apiSearchVideoGames, apiSearchRestaurants, type SearchResult } from "@/lib/api";
 import type { PollCategory } from "@/lib/types";
 import { formatDistance } from "./OptionLabel";
 
@@ -53,7 +53,9 @@ export default function AutocompleteInput({
     }
     try {
       let results: SearchResult[];
-      if (category === 'location') {
+      if (category === 'restaurant') {
+        results = await apiSearchRestaurants(query, referenceLatitude, referenceLongitude, searchRadius);
+      } else if (category === 'location') {
         results = await apiSearchLocations(query, referenceLatitude, referenceLongitude, searchRadius);
       } else if (category === 'video_game') {
         results = await apiSearchVideoGames(query);
@@ -181,15 +183,33 @@ export default function AutocompleteInput({
                       <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
                         {result.name}
                       </span>
+                      {result.rating !== undefined && (
+                        <span className="text-xs text-yellow-600 dark:text-yellow-400 whitespace-nowrap flex-shrink-0">
+                          {'★'.repeat(Math.floor(result.rating))}{result.rating % 1 >= 0.5 ? '½' : ''} {result.rating}
+                        </span>
+                      )}
                       {result.distance_miles !== undefined && (
                         <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap flex-shrink-0">
                           {formatDistance(result.distance_miles)}
                         </span>
                       )}
                     </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                      {result.label.startsWith(result.name + ', ') ? result.label.slice(result.name.length + 2) : result.label}
-                    </div>
+                    {result.cuisine ? (
+                      <div className="flex items-baseline gap-1.5">
+                        <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                          {result.cuisine}
+                        </span>
+                        {result.priceLevel && (
+                          <span className="text-xs text-green-600 dark:text-green-400 whitespace-nowrap flex-shrink-0">
+                            {result.priceLevel}
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                        {result.label.startsWith(result.name + ', ') ? result.label.slice(result.name.length + 2) : result.label}
+                      </div>
+                    )}
                   </>
                 ) : (
                   <>
@@ -214,11 +234,13 @@ export default function AutocompleteInput({
             </li>
           ))}
           <li className="px-3 py-1.5 text-[10px] text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700">
-            {category === 'movie'
-              ? 'Data from TMDB. Not endorsed by TMDB.'
-              : category === 'video_game'
-                ? 'Data from RAWG Video Games Database'
-                : 'Data \u00A9 OpenStreetMap contributors'}
+            {category === 'restaurant'
+              ? 'Powered by Yelp'
+              : category === 'movie'
+                ? 'Data from TMDB. Not endorsed by TMDB.'
+                : category === 'video_game'
+                  ? 'Data from RAWG Video Games Database'
+                  : 'Data \u00A9 OpenStreetMap contributors'}
           </li>
         </ul>
       )}

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { apiSearchLocations, apiSearchMovies, apiSearchVideoGames, apiSearchRestaurants, type SearchResult } from "@/lib/api";
 import type { PollCategory } from "@/lib/types";
-import { formatDistance } from "./OptionLabel";
+import { formatDistance, StarRating } from "./OptionLabel";
 
 interface AutocompleteInputProps {
   value: string;
@@ -184,8 +184,8 @@ export default function AutocompleteInput({
                         {result.name}
                       </span>
                       {result.rating !== undefined && (
-                        <span className="text-xs text-yellow-600 dark:text-yellow-400 whitespace-nowrap flex-shrink-0">
-                          {'★'.repeat(Math.floor(result.rating))}{result.rating % 1 >= 0.5 ? '½' : ''} {result.rating}
+                        <span className="text-xs flex-shrink-0">
+                          <StarRating rating={result.rating} />
                         </span>
                       )}
                       {result.distance_miles !== undefined && (

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, Dispatch, SetStateAction } from "react";
 import PollResultsDisplay from "@/components/PollResults";
 import OptionsInput, { type OptionsMetadata } from "@/components/OptionsInput";
+import { isLocationLikeCategory } from "@/components/TypeFieldInput";
 import NominationsList from "@/components/NominationsList";
 import OptionLabel from "@/components/OptionLabel";
 import PollManagementButtons from "@/components/PollManagementButtons";
@@ -343,7 +344,7 @@ export default function NominationVotingInterface({
 
         {/* Add new nominations using shared component */}
         <div className={filteredExistingNominations.length > 0 ? "mt-3 pt-3 border-t border-gray-200 dark:border-gray-600" : ""}>
-          {(poll.category === 'location' || poll.category === 'restaurant') && poll.reference_latitude && (
+          {isLocationLikeCategory(poll.category || '') && poll.reference_latitude && (
             <div className="mb-2 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
               <span>Search within</span>
               <select

--- a/components/NominationVotingInterface.tsx
+++ b/components/NominationVotingInterface.tsx
@@ -343,7 +343,7 @@ export default function NominationVotingInterface({
 
         {/* Add new nominations using shared component */}
         <div className={filteredExistingNominations.length > 0 ? "mt-3 pt-3 border-t border-gray-200 dark:border-gray-600" : ""}>
-          {poll.category === 'location' && poll.reference_latitude && (
+          {(poll.category === 'location' || poll.category === 'restaurant') && poll.reference_latitude && (
             <div className="mb-2 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
               <span>Search within</span>
               <select

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -83,7 +83,7 @@ function LocationName({ name, infoUrl }: { name: string; infoUrl?: string }) {
   return <span className="font-medium leading-tight">{name}</span>;
 }
 
-function StarRating({ rating }: { rating: number }) {
+export function StarRating({ rating }: { rating: number }) {
   return (
     <span className="text-yellow-500 dark:text-yellow-400 whitespace-nowrap">
       {'★'.repeat(Math.floor(rating))}{rating % 1 >= 0.5 ? '½' : ''}

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -18,9 +18,16 @@ function MapPinIcon({ className = "w-5 h-5" }: { className?: string }) {
   );
 }
 
+/** Detect if metadata represents a restaurant (has rating or cuisine). */
+export function isRestaurantEntry(metadata: OptionMetadataEntry | null | undefined): boolean {
+  if (!metadata) return false;
+  return metadata.rating !== undefined || !!metadata.cuisine;
+}
+
 /** Detect if metadata represents a location (has OSM infoUrl or name). */
 export function isLocationEntry(metadata: OptionMetadataEntry | null | undefined): boolean {
   if (!metadata) return false;
+  if (isRestaurantEntry(metadata)) return false; // restaurants handled separately
   if (metadata.name) return true;
   return !!metadata.infoUrl?.includes("openstreetmap.org");
 }
@@ -76,7 +83,104 @@ function LocationName({ name, infoUrl }: { name: string; infoUrl?: string }) {
   return <span className="font-medium leading-tight">{name}</span>;
 }
 
+function StarRating({ rating }: { rating: number }) {
+  return (
+    <span className="text-yellow-500 dark:text-yellow-400 whitespace-nowrap">
+      {'★'.repeat(Math.floor(rating))}{rating % 1 >= 0.5 ? '½' : ''}
+      <span className="text-xs ml-0.5">{rating}</span>
+    </span>
+  );
+}
+
+function RestaurantIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "sm" | "lg" }) {
+  if (imageUrl) {
+    const imgClass = size === "lg" ? "w-10 h-10 rounded object-cover" : "w-7 h-7 rounded object-cover";
+    return <img src={imageUrl} alt="" className={imgClass} loading="lazy" />;
+  }
+  const textClass = size === "lg" ? "text-2xl" : "text-base";
+  return <span className={textClass}>🍽️</span>;
+}
+
 export default function OptionLabel({ text, metadata, className = "", layout = "inline" }: OptionLabelProps) {
+  // Restaurant entry
+  if (isRestaurantEntry(metadata)) {
+    const name = metadata!.name || text.split(", ")[0];
+    const address = getAddressFromLabel(text, name);
+    const distance = metadata!.distance_miles;
+
+    if (layout === "stacked") {
+      return (
+        <div className={`min-w-0 overflow-hidden ${className}`}>
+          <div className="flex justify-center">
+            <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
+              <RestaurantIcon imageUrl={metadata!.imageUrl} size="lg" />
+            </span>
+          </div>
+          <div className="line-clamp-2 leading-tight mt-1 text-center">
+            <LocationName name={name} infoUrl={metadata!.infoUrl} />
+          </div>
+          {metadata!.rating !== undefined && (
+            <div className="text-xs mt-0.5 text-center">
+              <StarRating rating={metadata!.rating} />
+            </div>
+          )}
+          {metadata!.cuisine && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 text-center truncate">
+              {metadata!.cuisine}
+              {metadata!.priceLevel && <span className="ml-1 text-green-600 dark:text-green-400">{metadata!.priceLevel}</span>}
+            </div>
+          )}
+          {distance !== undefined && (
+            <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5 text-center">
+              {formatDistance(distance)}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // Default inline layout
+    return (
+      <div className={`flex items-center gap-2 ${className}`}>
+        <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
+          <RestaurantIcon imageUrl={metadata!.imageUrl} />
+        </span>
+        <div className="min-w-0 overflow-hidden">
+          <div className="flex items-baseline gap-1.5 flex-wrap">
+            <LocationName name={name} infoUrl={metadata!.infoUrl} />
+            {metadata!.rating !== undefined && (
+              <span className="text-xs">
+                <StarRating rating={metadata!.rating} />
+              </span>
+            )}
+            {distance !== undefined && (
+              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                {formatDistance(distance)}
+              </span>
+            )}
+          </div>
+          <div className="flex items-baseline gap-1.5">
+            {metadata!.cuisine && (
+              <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                {metadata!.cuisine}
+              </span>
+            )}
+            {metadata!.priceLevel && (
+              <span className="text-xs text-green-600 dark:text-green-400 whitespace-nowrap">
+                {metadata!.priceLevel}
+              </span>
+            )}
+            {!metadata!.cuisine && address && (
+              <span className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+                {address}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // Location entry
   if (isLocationEntry(metadata)) {
     const name = getLocationName(text, metadata!);

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import type { PollCategory, OptionsMetadata } from "@/lib/types";
 import type { SearchResult } from "@/lib/api";
 import AutocompleteInput from "@/components/AutocompleteInput";
+import { isAutocompleteCategory } from "@/components/TypeFieldInput";
 
 export type { OptionsMetadata };
 
@@ -148,7 +149,7 @@ export default function OptionsInput({
     }
   };
 
-  const useAutocomplete = category === 'location' || category === 'movie' || category === 'video_game' || category === 'restaurant';
+  const useAutocomplete = isAutocompleteCategory(category);
   const inputClassName = (isDuplicate: boolean) =>
     `flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
       isDuplicate

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -90,6 +90,10 @@ export default function OptionsInput({
     if (result.distance_miles !== undefined) entry.distance_miles = result.distance_miles;
     if (result.lat) entry.lat = result.lat;
     if (result.lon) entry.lon = result.lon;
+    if (result.rating !== undefined) entry.rating = result.rating;
+    if (result.reviewCount !== undefined) entry.reviewCount = result.reviewCount;
+    if (result.cuisine) entry.cuisine = result.cuisine;
+    if (result.priceLevel) entry.priceLevel = result.priceLevel;
     if (Object.keys(entry).length === 0) return;
     onMetadataChange({ ...optionsMetadata, [result.label]: entry });
   };
@@ -126,6 +130,11 @@ export default function OptionsInput({
         return filledOptions.length === 0 ? "Search for a video game..." : "Add another video game...";
       }
       return `Video game ${index + 1}`;
+    } else if (category === 'restaurant') {
+      if (isLastField) {
+        return filledOptions.length === 0 ? "Search for a restaurant..." : "Add another restaurant...";
+      }
+      return `Restaurant ${index + 1}`;
     } else if (pollType === 'nomination') {
       if (isLastField) {
         return filledOptions.length === 0 ? "Add a suggestion" : "Add another suggestion...";
@@ -139,7 +148,7 @@ export default function OptionsInput({
     }
   };
 
-  const useAutocomplete = category === 'location' || category === 'movie' || category === 'video_game';
+  const useAutocomplete = category === 'location' || category === 'movie' || category === 'video_game' || category === 'restaurant';
   const inputClassName = (isDuplicate: boolean) =>
     `flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
       isDuplicate

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -10,6 +10,7 @@ export interface BuiltInType {
 
 const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "location", label: "Location", icon: "📍" },
+  { value: "restaurant", label: "Restaurant", icon: "🍽️" },
   { value: "movie", label: "Movie", icon: "🎬" },
   { value: "video_game", label: "Video Game", icon: "🎮" },
 ];

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -19,6 +19,16 @@ export function getBuiltInType(value: string): BuiltInType | undefined {
   return BUILT_IN_TYPES.find((t) => t.value === value);
 }
 
+/** Categories that use location-based search (proximity, reference location, radius). */
+export function isLocationLikeCategory(category: string): boolean {
+  return category === 'location' || category === 'restaurant';
+}
+
+/** Categories that use autocomplete search (any built-in type). */
+export function isAutocompleteCategory(category: string): boolean {
+  return BUILT_IN_TYPES.some((t) => t.value === category);
+}
+
 interface TypeFieldInputProps {
   value: string;
   onChange: (value: string) => void;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -357,7 +357,7 @@ export interface SearchResult {
 
 const SEARCH_BASE = getApiEndpoint('search');
 
-export async function apiSearchLocations(query: string, refLat?: number, refLon?: number, maxDistance?: number): Promise<SearchResult[]> {
+async function searchWithLocation(endpoint: string, query: string, refLat?: number, refLon?: number, maxDistance?: number): Promise<SearchResult[]> {
   const params = new URLSearchParams({ q: query });
   if (refLat !== undefined && refLon !== undefined) {
     params.set('lat', String(refLat));
@@ -366,9 +366,17 @@ export async function apiSearchLocations(query: string, refLat?: number, refLon?
   if (maxDistance !== undefined) {
     params.set('max_distance', String(maxDistance));
   }
-  const res = await fetch(`${SEARCH_BASE}/locations?${params}`);
+  const res = await fetch(`${SEARCH_BASE}/${endpoint}?${params}`);
   if (!res.ok) return [];
   return res.json();
+}
+
+export function apiSearchLocations(query: string, refLat?: number, refLon?: number, maxDistance?: number): Promise<SearchResult[]> {
+  return searchWithLocation('locations', query, refLat, refLon, maxDistance);
+}
+
+export function apiSearchRestaurants(query: string, refLat?: number, refLon?: number, maxDistance?: number): Promise<SearchResult[]> {
+  return searchWithLocation('restaurants', query, refLat, refLon, maxDistance);
 }
 
 export async function apiGeocode(query: string): Promise<{ lat: string; lon: string; label: string } | null> {
@@ -388,20 +396,6 @@ export async function apiSearchMovies(query: string): Promise<SearchResult[]> {
 export async function apiSearchVideoGames(query: string): Promise<SearchResult[]> {
   const params = new URLSearchParams({ q: query });
   const res = await fetch(`${SEARCH_BASE}/video-games?${params}`);
-  if (!res.ok) return [];
-  return res.json();
-}
-
-export async function apiSearchRestaurants(query: string, refLat?: number, refLon?: number, maxDistance?: number): Promise<SearchResult[]> {
-  const params = new URLSearchParams({ q: query });
-  if (refLat !== undefined && refLon !== undefined) {
-    params.set('lat', String(refLat));
-    params.set('lon', String(refLon));
-  }
-  if (maxDistance !== undefined) {
-    params.set('max_distance', String(maxDistance));
-  }
-  const res = await fetch(`${SEARCH_BASE}/restaurants?${params}`);
   if (!res.ok) return [];
   return res.json();
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -349,6 +349,10 @@ export interface SearchResult {
   lat?: string;
   lon?: string;
   distance_miles?: number;
+  rating?: number;
+  reviewCount?: number;
+  cuisine?: string;
+  priceLevel?: string;
 }
 
 const SEARCH_BASE = getApiEndpoint('search');
@@ -384,6 +388,20 @@ export async function apiSearchMovies(query: string): Promise<SearchResult[]> {
 export async function apiSearchVideoGames(query: string): Promise<SearchResult[]> {
   const params = new URLSearchParams({ q: query });
   const res = await fetch(`${SEARCH_BASE}/video-games?${params}`);
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function apiSearchRestaurants(query: string, refLat?: number, refLon?: number, maxDistance?: number): Promise<SearchResult[]> {
+  const params = new URLSearchParams({ q: query });
+  if (refLat !== undefined && refLon !== undefined) {
+    params.set('lat', String(refLat));
+    params.set('lon', String(refLon));
+  }
+  if (maxDistance !== undefined) {
+    params.set('max_distance', String(maxDistance));
+  }
+  const res = await fetch(`${SEARCH_BASE}/restaurants?${params}`);
   if (!res.ok) return [];
   return res.json();
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,10 @@ export type OptionMetadataEntry = {
   distance_miles?: number;
   lat?: string;
   lon?: string;
+  rating?: number;
+  reviewCount?: number;
+  cuisine?: string;
+  priceLevel?: string;
 };
 
 export type OptionsMetadata = Record<string, OptionMetadataEntry>;

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -18,6 +18,10 @@ YELP_API_KEY = os.environ.get("YELP_API_KEY", "")
 
 _http_client = httpx.AsyncClient(timeout=5.0)
 
+# Cache mapping normalized restaurant name -> favicon URL.
+# When one "Burger King" has a website on OSM, all Burger Kings get the same favicon.
+_restaurant_favicon_cache: dict[str, str] = {}
+
 
 def _favicon_url(website: str) -> str | None:
     """Extract a Google favicon URL from a website URL."""
@@ -91,12 +95,19 @@ async def _find_osm_websites(
                 continue
             item_lat = item.get("lat")
             item_lon = item.get("lon")
-            if item_lat and item_lon:
+            favicon = _favicon_url(website)
+            if item_lat and item_lon and favicon:
                 osm_entries.append({
                     "lat": float(item_lat),
                     "lon": float(item_lon),
-                    "favicon": _favicon_url(website),
+                    "favicon": favicon,
                 })
+                # Cache favicon by normalized name so other locations of the
+                # same chain get the same icon even if OSM doesn't have their
+                # individual website (e.g. one Burger King has bk.com, all do).
+                item_name = (item.get("name") or "").strip().lower()
+                if item_name:
+                    _restaurant_favicon_cache[item_name] = favicon
         return osm_entries
     except Exception:
         return []
@@ -449,10 +460,12 @@ async def search_restaurants(
         name = biz.get("name", "")
         label = f"{name}, {address}" if address else name
 
-        # Prefer favicon from OSM website, fall back to Yelp business photo (small square)
+        # Prefer favicon from OSM website, then name cache, then Yelp photo
         favicon = None
         if biz_lat and biz_lon and osm_entries:
             favicon = _match_osm_favicon(biz_lat, biz_lon, osm_entries)
+        if not favicon:
+            favicon = _restaurant_favicon_cache.get(name.strip().lower())
         yelp_photo = biz.get("image_url") or None
         if yelp_photo and not favicon:
             # Yelp image URLs end with /o.jpg (original). Replace with /ms.jpg

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -384,7 +384,7 @@ async def search_restaurants(
         "term": q,
         "categories": "restaurants,food",
         "limit": 6,
-        "sort_by": "best_match",
+        "sort_by": "distance",
     }
 
     if has_ref:

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -36,31 +36,64 @@ def _favicon_url(website: str) -> str | None:
 async def _find_website_on_osm(name: str, lat: float, lon: float) -> str | None:
     """Search Nominatim for a business by name near coordinates to find its website.
 
-    Uses a tight bounding box (~0.3 miles) around the known coordinates.
+    Tries a bounded search first (~1 mile box), then an unbounded search with
+    distance filtering if the bounded search finds no website.
     Returns the website URL if found, None otherwise.
     """
-    delta = 0.005  # ~0.3 miles
+    headers = {
+        "User-Agent": "WhoeverWants/1.0 (whoeverwants.com)",
+        "Accept-Language": "en",
+    }
+    delta = 0.015  # ~1 mile
+
     try:
+        # Try bounded search first
         resp = await _http_client.get(
             "https://nominatim.openstreetmap.org/search",
             params={
                 "q": name,
                 "format": "jsonv2",
-                "limit": 3,
+                "limit": 5,
                 "extratags": 1,
                 "viewbox": f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}",
                 "bounded": 1,
             },
-            headers={
-                "User-Agent": "WhoeverWants/1.0 (whoeverwants.com)",
-                "Accept-Language": "en",
-            },
+            headers=headers,
         )
         resp.raise_for_status()
-        for item in resp.json():
+        results = resp.json()
+
+        # If bounded search found nothing, try unbounded (biased, not restricted)
+        if not results:
+            resp = await _http_client.get(
+                "https://nominatim.openstreetmap.org/search",
+                params={
+                    "q": name,
+                    "format": "jsonv2",
+                    "limit": 5,
+                    "extratags": 1,
+                    "viewbox": f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}",
+                },
+                headers=headers,
+            )
+            resp.raise_for_status()
+            results = resp.json()
+
+        for item in results:
             extratags = item.get("extratags") or {}
-            website = extratags.get("website") or extratags.get("contact:website")
+            website = (
+                extratags.get("website")
+                or extratags.get("contact:website")
+                or extratags.get("brand:website")
+            )
             if website:
+                # Verify it's reasonably close (within 2 miles)
+                item_lat = item.get("lat")
+                item_lon = item.get("lon")
+                if item_lat and item_lon:
+                    dist = _haversine_miles(lat, lon, float(item_lat), float(item_lon))
+                    if dist > 2.0:
+                        continue
                 return website
     except Exception:
         pass

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -449,11 +449,16 @@ async def search_restaurants(
         name = biz.get("name", "")
         label = f"{name}, {address}" if address else name
 
-        # Prefer favicon from OSM website, fall back to Yelp business photo
+        # Prefer favicon from OSM website, fall back to Yelp business photo (small square)
         favicon = None
         if biz_lat and biz_lon and osm_entries:
             favicon = _match_osm_favicon(biz_lat, biz_lon, osm_entries)
-        image_url = favicon or biz.get("image_url") or None
+        yelp_photo = biz.get("image_url") or None
+        if yelp_photo and not favicon:
+            # Yelp image URLs end with /o.jpg (original). Replace with /ms.jpg
+            # for a 60x60 square thumbnail, or /s.jpg for 100x100.
+            yelp_photo = yelp_photo.replace("/o.jpg", "/ms.jpg")
+        image_url = favicon or yelp_photo
 
         entry: dict = {
             "label": label,

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -1,5 +1,6 @@
 """Search/autocomplete endpoints for poll categories."""
 
+import asyncio
 import logging
 import math
 import os
@@ -17,6 +18,53 @@ RAWG_API_KEY = os.environ.get("RAWG_API_KEY", "")
 YELP_API_KEY = os.environ.get("YELP_API_KEY", "")
 
 _http_client = httpx.AsyncClient(timeout=5.0)
+
+
+def _favicon_url(website: str) -> str | None:
+    """Extract a Google favicon URL from a website URL."""
+    if not website:
+        return None
+    try:
+        domain = urlparse(website).netloc or urlparse(website).path.split("/")[0]
+        if domain:
+            return f"https://www.google.com/s2/favicons?domain={domain}&sz=128"
+    except Exception:
+        pass
+    return None
+
+
+async def _find_website_on_osm(name: str, lat: float, lon: float) -> str | None:
+    """Search Nominatim for a business by name near coordinates to find its website.
+
+    Uses a tight bounding box (~0.3 miles) around the known coordinates.
+    Returns the website URL if found, None otherwise.
+    """
+    delta = 0.005  # ~0.3 miles
+    try:
+        resp = await _http_client.get(
+            "https://nominatim.openstreetmap.org/search",
+            params={
+                "q": name,
+                "format": "jsonv2",
+                "limit": 3,
+                "extratags": 1,
+                "viewbox": f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}",
+                "bounded": 1,
+            },
+            headers={
+                "User-Agent": "WhoeverWants/1.0 (whoeverwants.com)",
+                "Accept-Language": "en",
+            },
+        )
+        resp.raise_for_status()
+        for item in resp.json():
+            extratags = item.get("extratags") or {}
+            website = extratags.get("website") or extratags.get("contact:website")
+            if website:
+                return website
+    except Exception:
+        pass
+    return None
 
 
 def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -93,14 +141,7 @@ async def _nominatim_search(
         # Extract website from extratags for favicon
         extratags = item.get("extratags") or {}
         website = extratags.get("website") or extratags.get("contact:website") or ""
-        image_url = None
-        if website:
-            try:
-                domain = urlparse(website).netloc or urlparse(website).path.split("/")[0]
-                if domain:
-                    image_url = f"https://www.google.com/s2/favicons?domain={domain}&sz=128"
-            except Exception:
-                pass
+        image_url = _favicon_url(website)
 
         entry: dict = {
             "label": item.get("display_name", ""),
@@ -319,8 +360,11 @@ async def search_restaurants(
 
     data = resp.json()
 
-    results = []
-    for biz in data.get("businesses", [])[:6]:
+    businesses = data.get("businesses", [])[:6]
+
+    # Pre-filter and extract coordinates
+    filtered = []
+    for biz in businesses:
         biz_lat = biz.get("coordinates", {}).get("latitude")
         biz_lon = biz.get("coordinates", {}).get("longitude")
 
@@ -330,6 +374,23 @@ async def search_restaurants(
             if max_distance > 0 and distance > max_distance:
                 continue
 
+        filtered.append((biz, biz_lat, biz_lon, distance))
+
+    # Look up websites on OSM in parallel for all results
+    async def _lookup_favicon(name: str, blat: float | None, blon: float | None) -> str | None:
+        if not blat or not blon:
+            return None
+        website = await _find_website_on_osm(name, blat, blon)
+        return _favicon_url(website)
+
+    favicon_tasks = [
+        _lookup_favicon(biz.get("name", ""), blat, blon)
+        for biz, blat, blon, _ in filtered
+    ]
+    favicons = await asyncio.gather(*favicon_tasks)
+
+    results = []
+    for (biz, biz_lat, biz_lon, distance), favicon in zip(filtered, favicons):
         # Build cuisine string from Yelp categories
         categories = biz.get("categories", [])
         cuisine = ", ".join(c.get("title", "") for c in categories[:3])
@@ -346,11 +407,14 @@ async def search_restaurants(
         name = biz.get("name", "")
         label = f"{name}, {address}" if address else name
 
+        # Prefer favicon from OSM website, fall back to Yelp business photo
+        image_url = favicon or biz.get("image_url") or None
+
         entry: dict = {
             "label": label,
             "name": name,
             "description": cuisine or None,
-            "imageUrl": biz.get("image_url") or None,
+            "imageUrl": image_url,
             "infoUrl": biz.get("url") or None,
             "lat": str(biz_lat) if biz_lat else None,
             "lon": str(biz_lon) if biz_lon else None,

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -14,6 +14,7 @@ router = APIRouter(prefix="/api/search", tags=["search"])
 
 TMDB_API_KEY = os.environ.get("TMDB_API_KEY", "")
 RAWG_API_KEY = os.environ.get("RAWG_API_KEY", "")
+YELP_API_KEY = os.environ.get("YELP_API_KEY", "")
 
 _http_client = httpx.AsyncClient(timeout=5.0)
 
@@ -265,4 +266,102 @@ async def search_video_games(q: str = Query(..., min_length=2, max_length=100)):
             "imageUrl": _rawg_crop_image(game.get("background_image")),
             "infoUrl": f"https://rawg.io/games/{slug}" if slug else None,
         })
+    return results
+
+
+@router.get("/restaurants")
+async def search_restaurants(
+    q: str = Query(..., min_length=2, max_length=100),
+    lat: float | None = Query(None, description="Reference latitude for proximity"),
+    lon: float | None = Query(None, description="Reference longitude for proximity"),
+    max_distance: float = Query(25, description="Maximum distance in miles (0 = no limit)"),
+):
+    """Search for restaurants using the Yelp Fusion API.
+
+    Returns up to 6 results with name, cuisine categories, rating, distance,
+    and image. Requires YELP_API_KEY environment variable.
+    Falls back to Nominatim location search filtered to food-related results
+    if no Yelp key is configured.
+    """
+    if not YELP_API_KEY:
+        # Fallback: use Nominatim with food keywords appended
+        results = await _nominatim_search(f"{q} restaurant", lat, lon, max_distance)
+        return results[:6]
+
+    has_ref = lat is not None and lon is not None
+
+    params: dict = {
+        "term": q,
+        "categories": "restaurants,food",
+        "limit": 6,
+        "sort_by": "best_match",
+    }
+
+    if has_ref:
+        params["latitude"] = lat
+        params["longitude"] = lon
+        if max_distance > 0:
+            # Yelp uses meters for radius (max 40000)
+            radius_meters = min(int(max_distance * 1609.34), 40000)
+            params["radius"] = radius_meters
+
+    try:
+        resp = await _http_client.get(
+            "https://api.yelp.com/v3/businesses/search",
+            params=params,
+            headers={"Authorization": f"Bearer {YELP_API_KEY}"},
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError:
+        logger.warning("Yelp API error for query %r, falling back to Nominatim", q)
+        results = await _nominatim_search(f"{q} restaurant", lat, lon, max_distance)
+        return results[:6]
+
+    data = resp.json()
+
+    results = []
+    for biz in data.get("businesses", [])[:6]:
+        biz_lat = biz.get("coordinates", {}).get("latitude")
+        biz_lon = biz.get("coordinates", {}).get("longitude")
+
+        distance = None
+        if has_ref and biz_lat and biz_lon:
+            distance = round(_haversine_miles(lat, lon, biz_lat, biz_lon), 1)
+            if max_distance > 0 and distance > max_distance:
+                continue
+
+        # Build cuisine string from Yelp categories
+        categories = biz.get("categories", [])
+        cuisine = ", ".join(c.get("title", "") for c in categories[:3])
+
+        # Build address label
+        location = biz.get("location", {})
+        address_parts = [
+            location.get("address1", ""),
+            location.get("city", ""),
+            location.get("state", ""),
+        ]
+        address = ", ".join(p for p in address_parts if p)
+
+        name = biz.get("name", "")
+        label = f"{name}, {address}" if address else name
+
+        entry: dict = {
+            "label": label,
+            "name": name,
+            "description": cuisine or None,
+            "imageUrl": biz.get("image_url") or None,
+            "infoUrl": biz.get("url") or None,
+            "lat": str(biz_lat) if biz_lat else None,
+            "lon": str(biz_lon) if biz_lon else None,
+            "rating": biz.get("rating"),
+            "reviewCount": biz.get("review_count"),
+            "cuisine": cuisine or None,
+            "priceLevel": biz.get("price"),
+        }
+        if distance is not None:
+            entry["distance_miles"] = distance
+
+        results.append(entry)
+
     return results

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -18,8 +18,9 @@ YELP_API_KEY = os.environ.get("YELP_API_KEY", "")
 
 _http_client = httpx.AsyncClient(timeout=5.0)
 
-# Cache mapping normalized restaurant name -> favicon URL.
-# When one "Burger King" has a website on OSM, all Burger Kings get the same favicon.
+# LRU-style cache: normalized restaurant name -> favicon URL.
+# Bounded to 500 entries; oldest entries evicted when full.
+_FAVICON_CACHE_MAX = 500
 _restaurant_favicon_cache: dict[str, str] = {}
 
 
@@ -57,7 +58,7 @@ async def _find_osm_websites(
             params={
                 "q": name,
                 "format": "jsonv2",
-                "limit": 20,
+                "limit": 10,
                 "extratags": 1,
                 "viewbox": f"{ref_lon - delta},{ref_lat + delta},{ref_lon + delta},{ref_lat - delta}",
                 "bounded": 1,
@@ -102,11 +103,11 @@ async def _find_osm_websites(
                     "lon": float(item_lon),
                     "favicon": favicon,
                 })
-                # Cache favicon by normalized name so other locations of the
-                # same chain get the same icon even if OSM doesn't have their
-                # individual website (e.g. one Burger King has bk.com, all do).
                 item_name = (item.get("name") or "").strip().lower()
                 if item_name:
+                    if len(_restaurant_favicon_cache) >= _FAVICON_CACHE_MAX:
+                        # Evict oldest entry (first key in insertion order)
+                        _restaurant_favicon_cache.pop(next(iter(_restaurant_favicon_cache)))
                     _restaurant_favicon_cache[item_name] = favicon
         return osm_entries
     except Exception:
@@ -436,10 +437,11 @@ async def search_restaurants(
 
         filtered.append((biz, biz_lat, biz_lon, distance))
 
-    # Single Nominatim search for the query in the area to find websites/favicons.
-    # This avoids per-result lookups that would violate Nominatim's rate limit.
+    # Skip Nominatim if all business names are already in the favicon cache.
     osm_entries: list[dict] = []
-    if has_ref:
+    biz_names = {biz.get("name", "").strip().lower() for biz, *_ in filtered}
+    all_cached = biz_names and all(n in _restaurant_favicon_cache for n in biz_names if n)
+    if has_ref and not all_cached:
         osm_entries = await _find_osm_websites(q, lat, lon, max_distance)
 
     results = []

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -1,6 +1,5 @@
 """Search/autocomplete endpoints for poll categories."""
 
-import asyncio
 import logging
 import math
 import os
@@ -33,29 +32,30 @@ def _favicon_url(website: str) -> str | None:
     return None
 
 
-async def _find_website_on_osm(name: str, lat: float, lon: float) -> str | None:
-    """Search Nominatim for a business by name near coordinates to find its website.
+async def _find_osm_websites(
+    name: str, ref_lat: float, ref_lon: float, max_distance: float,
+) -> list[dict]:
+    """Search Nominatim once for a business name in the area.
 
-    Tries a bounded search first (~1 mile box), then an unbounded search with
-    distance filtering if the bounded search finds no website.
-    Returns the website URL if found, None otherwise.
+    Returns a list of OSM results that have a website, with their coordinates
+    and favicon URL. Uses a single API call covering the whole search area
+    (respects Nominatim's 1 req/sec policy).
     """
     headers = {
         "User-Agent": "WhoeverWants/1.0 (whoeverwants.com)",
         "Accept-Language": "en",
     }
-    delta = 0.015  # ~1 mile
+    delta = max(max_distance / 69.0, 0.02)  # at least ~1.4 miles
 
     try:
-        # Try bounded search first
         resp = await _http_client.get(
             "https://nominatim.openstreetmap.org/search",
             params={
                 "q": name,
                 "format": "jsonv2",
-                "limit": 5,
+                "limit": 20,
                 "extratags": 1,
-                "viewbox": f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}",
+                "viewbox": f"{ref_lon - delta},{ref_lat + delta},{ref_lon + delta},{ref_lat - delta}",
                 "bounded": 1,
             },
             headers=headers,
@@ -63,22 +63,23 @@ async def _find_website_on_osm(name: str, lat: float, lon: float) -> str | None:
         resp.raise_for_status()
         results = resp.json()
 
-        # If bounded search found nothing, try unbounded (biased, not restricted)
+        # If bounded search found nothing, retry unbounded (biased, not restricted)
         if not results:
             resp = await _http_client.get(
                 "https://nominatim.openstreetmap.org/search",
                 params={
                     "q": name,
                     "format": "jsonv2",
-                    "limit": 5,
+                    "limit": 10,
                     "extratags": 1,
-                    "viewbox": f"{lon - delta},{lat + delta},{lon + delta},{lat - delta}",
+                    "viewbox": f"{ref_lon - delta},{ref_lat + delta},{ref_lon + delta},{ref_lat - delta}",
                 },
                 headers=headers,
             )
             resp.raise_for_status()
             results = resp.json()
 
+        osm_entries = []
         for item in results:
             extratags = item.get("extratags") or {}
             website = (
@@ -86,18 +87,33 @@ async def _find_website_on_osm(name: str, lat: float, lon: float) -> str | None:
                 or extratags.get("contact:website")
                 or extratags.get("brand:website")
             )
-            if website:
-                # Verify it's reasonably close (within 2 miles)
-                item_lat = item.get("lat")
-                item_lon = item.get("lon")
-                if item_lat and item_lon:
-                    dist = _haversine_miles(lat, lon, float(item_lat), float(item_lon))
-                    if dist > 2.0:
-                        continue
-                return website
+            if not website:
+                continue
+            item_lat = item.get("lat")
+            item_lon = item.get("lon")
+            if item_lat and item_lon:
+                osm_entries.append({
+                    "lat": float(item_lat),
+                    "lon": float(item_lon),
+                    "favicon": _favicon_url(website),
+                })
+        return osm_entries
     except Exception:
-        pass
-    return None
+        return []
+
+
+def _match_osm_favicon(
+    biz_lat: float, biz_lon: float, osm_entries: list[dict],
+) -> str | None:
+    """Find the closest OSM entry with a favicon within 0.5 miles of a business."""
+    best_favicon = None
+    best_dist = 0.5  # max match distance in miles
+    for entry in osm_entries:
+        dist = _haversine_miles(biz_lat, biz_lon, entry["lat"], entry["lon"])
+        if dist < best_dist:
+            best_dist = dist
+            best_favicon = entry["favicon"]
+    return best_favicon
 
 
 def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -409,21 +425,14 @@ async def search_restaurants(
 
         filtered.append((biz, biz_lat, biz_lon, distance))
 
-    # Look up websites on OSM in parallel for all results
-    async def _lookup_favicon(name: str, blat: float | None, blon: float | None) -> str | None:
-        if not blat or not blon:
-            return None
-        website = await _find_website_on_osm(name, blat, blon)
-        return _favicon_url(website)
-
-    favicon_tasks = [
-        _lookup_favicon(biz.get("name", ""), blat, blon)
-        for biz, blat, blon, _ in filtered
-    ]
-    favicons = await asyncio.gather(*favicon_tasks)
+    # Single Nominatim search for the query in the area to find websites/favicons.
+    # This avoids per-result lookups that would violate Nominatim's rate limit.
+    osm_entries: list[dict] = []
+    if has_ref:
+        osm_entries = await _find_osm_websites(q, lat, lon, max_distance)
 
     results = []
-    for (biz, biz_lat, biz_lon, distance), favicon in zip(filtered, favicons):
+    for biz, biz_lat, biz_lon, distance in filtered:
         # Build cuisine string from Yelp categories
         categories = biz.get("categories", [])
         cuisine = ", ".join(c.get("title", "") for c in categories[:3])
@@ -441,6 +450,9 @@ async def search_restaurants(
         label = f"{name}, {address}" if address else name
 
         # Prefer favicon from OSM website, fall back to Yelp business photo
+        favicon = None
+        if biz_lat and biz_lon and osm_entries:
+            favicon = _match_osm_favicon(biz_lat, biz_lon, osm_entries)
         image_url = favicon or biz.get("image_url") or None
 
         entry: dict = {


### PR DESCRIPTION
## Summary
- Add Restaurant as a built-in poll category (🍽️) with Yelp Fusion API integration for search
- Display star ratings, cuisine type (e.g. Mexican, Italian), price level, and distance in autocomplete dropdown and poll results
- Favicon resolution: OSM website lookup → name-based cache → Yelp 60x60 thumbnail fallback
- In-memory favicon cache (bounded to 500 entries) so all locations of a chain share the same icon

## Details

**Backend** (`server/routers/search.py`):
- New `/api/search/restaurants` endpoint using Yelp Fusion API (`sort_by=distance`)
- Single Nominatim search per request (not per-result) to find business websites for favicons
- `_restaurant_favicon_cache` with LRU eviction — once one Burger King has a favicon, all do
- Skips Nominatim entirely when all result names are already cached
- Graceful fallback to Nominatim if `YELP_API_KEY` is not configured

**Frontend**:
- `StarRating` component exported from `OptionLabel.tsx`, reused in `AutocompleteInput.tsx`
- `isLocationLikeCategory()` and `isAutocompleteCategory()` helpers in `TypeFieldInput.tsx` replace scattered string checks
- `searchWithLocation()` shared helper in `api.ts` deduplicates location/restaurant API calls
- Rich restaurant display in poll results: photo/favicon, star rating, cuisine, price level, distance

**Environment**: `YELP_API_KEY` must be in `.env.api` on the droplet (already configured). Free tier: 500 calls/day.

## Test plan
- [ ] Create a ranked choice poll with Restaurant category, set reference location, search for restaurants
- [ ] Verify star ratings, cuisine, and distance appear in autocomplete dropdown
- [ ] Verify chain restaurants (e.g. Burger King) show favicon icons after first search
- [ ] Verify poll results display restaurant metadata (rating, cuisine, price level)
- [ ] Create a nomination poll with Restaurant category, verify voters can suggest restaurants
- [ ] Test without reference location set — results should still appear (without distance sort)

https://claude.ai/code/session_01GaepKZBMr6Bn8jGpg7CnFd