### PR TITLE
Fix restaurant search, add place detail modal with map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -888,6 +888,8 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **`isAutocompleteCategory()`** in `TypeFieldInput.tsx` controls which categories use the autocomplete dropdown (derived from `BUILT_IN_TYPES`).
 - **Search dispatch** is in `AutocompleteInput.tsx: doSearch()` — add a new branch for each category's API endpoint.
 - **Metadata rendering** is in `OptionLabel.tsx` — add detection function (like `isRestaurantEntry()`) and inline/stacked layout branches.
+- **Place detail modal**: Tapping a restaurant/location name opens `PlaceDetailModal` (map embed + metadata). Tapping the address opens an iOS-style action sheet (`AddressActionsModal`) with "Open in Maps" (Apple Maps), "Open in Google Maps", and "Copy Address". Don't use `geo:` URIs on iOS — they're unreliable (may open Google Earth or other random apps). Don't include the business name in maps queries — it triggers a search for multiple branches instead of navigating to the specific address.
+- **`line-clamp-2` breaks flex layouts**: Don't apply `line-clamp-*` to containers with flex children (like `OptionLabel`). The CSS treats flex items as flowing text and truncates unexpectedly. Use `overflow-hidden` instead and let inner components handle their own truncation.
 
 ### API Development Pitfalls
 

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { PollResults, RankedChoiceRound, OptionsMetadata } from "@/lib/types";
 import { apiGetVotes, ApiRankedChoiceRound } from "@/lib/api";
-import OptionLabel, { isLocationEntry } from "./OptionLabel";
+import OptionLabel, { isLocationEntry, isRestaurantEntry } from "./OptionLabel";
 
 interface CompactRankedChoiceResultsProps {
   results: PollResults;
@@ -422,7 +422,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                       {/* Candidate name */}
                       <div className="min-w-0 overflow-hidden">
                         <div className={`leading-tight ${
-                          isLocationEntry(optionsMetadata?.[candidate.name])
+                          isLocationEntry(optionsMetadata?.[candidate.name]) || isRestaurantEntry(optionsMetadata?.[candidate.name])
                             ? 'overflow-hidden'
                             : 'line-clamp-2'
                         } ${

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -161,7 +161,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
           </div>
           <div className="flex items-baseline gap-1.5">
             {metadata!.cuisine && (
-              <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+              <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
                 {metadata!.cuisine}
               </span>
             )}
@@ -170,8 +170,8 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
                 {metadata!.priceLevel}
               </span>
             )}
-            {!metadata!.cuisine && address && (
-              <span className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+            {address && (
+              <span className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight">
                 {address}
               </span>
             )}

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import type { OptionMetadataEntry } from "@/lib/types";
+import PlaceDetailModal from "./PlaceDetailModal";
 
 interface OptionLabelProps {
   text: string;
@@ -39,7 +41,7 @@ function getLocationName(text: string, metadata: OptionMetadataEntry): string {
   return commaIdx >= 0 ? text.slice(0, commaIdx) : text;
 }
 
-function getAddressFromLabel(label: string, name: string): string {
+export function getAddressFromLabel(label: string, name: string): string {
   if (label.startsWith(name + ", ")) {
     return label.slice(name.length + 2);
   }
@@ -66,18 +68,13 @@ function LocationIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "sm
   );
 }
 
-function LocationName({ name, infoUrl }: { name: string; infoUrl?: string }) {
-  if (infoUrl) {
+/** Clickable place name that opens the detail modal. */
+function PlaceName({ name, hasModal }: { name: string; hasModal: boolean }) {
+  if (hasModal) {
     return (
-      <a
-        href={infoUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={(e) => e.stopPropagation()}
-        className="font-medium leading-tight underline decoration-2 decoration-blue-400/50 hover:decoration-blue-500"
-      >
+      <span className="font-medium leading-tight underline decoration-2 decoration-blue-400/50 cursor-pointer">
         {name}
-      </a>
+      </span>
     );
   }
   return <span className="font-medium leading-tight">{name}</span>;
@@ -101,83 +98,95 @@ function RestaurantIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "
   return <span className={textClass}>🍽️</span>;
 }
 
+/** Wrapper that adds modal behavior to place/restaurant entries. */
+function PlaceWrapper({
+  children,
+  text,
+  name,
+  metadata,
+  className,
+}: {
+  children: React.ReactNode;
+  text: string;
+  name: string;
+  metadata: OptionMetadataEntry;
+  className?: string;
+}) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const address = getAddressFromLabel(text, name);
+  const hasCoords = metadata.lat && metadata.lon;
+
+  return (
+    <>
+      <div
+        className={className}
+        onClick={(e) => {
+          if (hasCoords) {
+            e.stopPropagation();
+            setModalOpen(true);
+          }
+        }}
+        style={hasCoords ? { cursor: "pointer" } : undefined}
+      >
+        {children}
+      </div>
+      {hasCoords && (
+        <PlaceDetailModal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          name={name}
+          address={address}
+          metadata={metadata}
+        />
+      )}
+    </>
+  );
+}
+
 export default function OptionLabel({ text, metadata, className = "", layout = "inline" }: OptionLabelProps) {
   // Restaurant entry
   if (isRestaurantEntry(metadata)) {
     const name = metadata!.name || text.split(", ")[0];
-    const address = getAddressFromLabel(text, name);
     const distance = metadata!.distance_miles;
+    const hasCoords = !!(metadata!.lat && metadata!.lon);
 
     if (layout === "stacked") {
       return (
-        <div className={`min-w-0 overflow-hidden ${className}`}>
+        <PlaceWrapper text={text} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
           <div className="flex justify-center">
             <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
               <RestaurantIcon imageUrl={metadata!.imageUrl} size="lg" />
             </span>
           </div>
           <div className="line-clamp-2 leading-tight mt-1 text-center">
-            <LocationName name={name} infoUrl={metadata!.infoUrl} />
+            <PlaceName name={name} hasModal={hasCoords} />
           </div>
-          {metadata!.rating !== undefined && (
-            <div className="text-xs mt-0.5 text-center">
-              <StarRating rating={metadata!.rating} />
-            </div>
-          )}
-          {metadata!.cuisine && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 text-center truncate">
-              {metadata!.cuisine}
-              {metadata!.priceLevel && <span className="ml-1 text-green-600 dark:text-green-400">{metadata!.priceLevel}</span>}
-            </div>
-          )}
           {distance !== undefined && (
             <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5 text-center">
               {formatDistance(distance)}
             </div>
           )}
-        </div>
+        </PlaceWrapper>
       );
     }
 
     // Default inline layout
     return (
-      <div className={`flex items-center gap-2 ${className}`}>
+      <PlaceWrapper text={text} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
         <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
           <RestaurantIcon imageUrl={metadata!.imageUrl} />
         </span>
         <div className="min-w-0 overflow-hidden">
           <div className="flex items-baseline gap-1.5 flex-wrap">
-            <LocationName name={name} infoUrl={metadata!.infoUrl} />
-            {metadata!.rating !== undefined && (
-              <span className="text-xs">
-                <StarRating rating={metadata!.rating} />
-              </span>
-            )}
+            <PlaceName name={name} hasModal={hasCoords} />
             {distance !== undefined && (
               <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
                 {formatDistance(distance)}
               </span>
             )}
           </div>
-          <div className="flex items-baseline gap-1.5">
-            {metadata!.cuisine && (
-              <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                {metadata!.cuisine}
-              </span>
-            )}
-            {metadata!.priceLevel && (
-              <span className="text-xs text-green-600 dark:text-green-400 whitespace-nowrap">
-                {metadata!.priceLevel}
-              </span>
-            )}
-            {address && (
-              <span className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight">
-                {address}
-              </span>
-            )}
-          </div>
         </div>
-      </div>
+      </PlaceWrapper>
     );
   }
 
@@ -186,17 +195,18 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     const name = getLocationName(text, metadata!);
     const address = getAddressFromLabel(text, name);
     const distance = metadata!.distance_miles;
+    const hasCoords = !!(metadata!.lat && metadata!.lon);
 
     if (layout === "stacked") {
       return (
-        <div className={`min-w-0 overflow-hidden ${className}`}>
+        <PlaceWrapper text={text} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
           <div className="flex justify-center">
             <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
               <LocationIcon imageUrl={metadata!.imageUrl} size="lg" />
             </span>
           </div>
           <div className="line-clamp-2 leading-tight mt-1 text-center">
-            <LocationName name={name} infoUrl={metadata!.infoUrl} />
+            <PlaceName name={name} hasModal={hasCoords} />
           </div>
           {address && (
             <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 leading-tight mt-0.5 text-center">
@@ -208,19 +218,19 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
               {formatDistance(distance)}
             </div>
           )}
-        </div>
+        </PlaceWrapper>
       );
     }
 
     // Default inline layout
     return (
-      <div className={`flex items-center gap-2 ${className}`}>
+      <PlaceWrapper text={text} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
         <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
           <LocationIcon imageUrl={metadata!.imageUrl} />
         </span>
         <div className="min-w-0 overflow-hidden">
           <div className="flex items-baseline gap-1.5 flex-wrap">
-            <LocationName name={name} infoUrl={metadata!.infoUrl} />
+            <PlaceName name={name} hasModal={hasCoords} />
             {distance !== undefined && (
               <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
                 {formatDistance(distance)}
@@ -233,7 +243,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
             </div>
           )}
         </div>
-      </div>
+      </PlaceWrapper>
     );
   }
 

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -41,7 +41,7 @@ function getLocationName(text: string, metadata: OptionMetadataEntry): string {
   return commaIdx >= 0 ? text.slice(0, commaIdx) : text;
 }
 
-export function getAddressFromLabel(label: string, name: string): string {
+function getAddressFromLabel(label: string, name: string): string {
   if (label.startsWith(name + ", ")) {
     return label.slice(name.length + 2);
   }
@@ -68,7 +68,6 @@ function LocationIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "sm
   );
 }
 
-/** Clickable place name that opens the detail modal. */
 function PlaceName({ name, hasModal }: { name: string; hasModal: boolean }) {
   if (hasModal) {
     return (
@@ -98,7 +97,6 @@ function RestaurantIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "
   return <span className={textClass}>🍽️</span>;
 }
 
-/** Wrapper that adds modal behavior to place/restaurant entries. */
 function PlaceWrapper({
   children,
   text,
@@ -119,14 +117,13 @@ function PlaceWrapper({
   return (
     <>
       <div
-        className={className}
+        className={`${className}${hasCoords ? " cursor-pointer" : ""}`}
         onClick={(e) => {
           if (hasCoords) {
             e.stopPropagation();
             setModalOpen(true);
           }
         }}
-        style={hasCoords ? { cursor: "pointer" } : undefined}
       >
         {children}
       </div>

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -102,8 +102,18 @@ export default function PlaceDetailModal({
               )}
             </div>
 
-            {/* Address */}
-            {address && (
+            {/* Address — opens native maps app on mobile */}
+            {address && hasCoords && (
+              <a
+                href={`https://maps.apple.com/?ll=${lat},${lon}&q=${encodeURIComponent(name)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block mt-1.5 text-sm text-blue-600 dark:text-blue-400 underline decoration-1 underline-offset-2"
+              >
+                {address}
+              </a>
+            )}
+            {address && !hasCoords && (
               <p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
                 {address}
               </p>

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -105,7 +105,7 @@ export default function PlaceDetailModal({
             {/* Address — opens native maps app on mobile */}
             {address && hasCoords && (
               <a
-                href={`geo:${lat},${lon}?q=${lat},${lon}(${encodeURIComponent(name)})`}
+                href={`geo:0,0?q=${encodeURIComponent(name + ", " + address)}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block mt-1.5 text-sm text-blue-600 dark:text-blue-400 underline decoration-1 underline-offset-2"

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -105,7 +105,7 @@ export default function PlaceDetailModal({
             {/* Address — opens native maps app on mobile */}
             {address && hasCoords && (
               <a
-                href={`geo:0,0?q=${encodeURIComponent(name + ", " + address)}`}
+                href={`https://maps.apple.com/?q=${encodeURIComponent(name + ", " + address)}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block mt-1.5 text-sm text-blue-600 dark:text-blue-400 underline decoration-1 underline-offset-2"

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -119,25 +119,6 @@ export default function PlaceDetailModal({
               </p>
             )}
 
-            {/* Actions */}
-            <div className="flex gap-2 mt-3">
-              {hasCoords && (
-                <a
-                  href={`https://www.google.com/maps/search/?api=1&query=${lat},${lon}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 text-center px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
-                >
-                  Open in Maps
-                </a>
-              )}
-              <button
-                onClick={onClose}
-                className="flex-1 px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg transition-colors"
-              >
-                Close
-              </button>
-            </div>
           </div>
         </div>
       </div>

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect } from "react";
+import ModalPortal from "./ModalPortal";
+import type { OptionMetadataEntry } from "@/lib/types";
+import { formatDistance } from "./OptionLabel";
+
+interface PlaceDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  name: string;
+  address: string;
+  metadata: OptionMetadataEntry;
+}
+
+export default function PlaceDetailModal({
+  isOpen,
+  onClose,
+  name,
+  address,
+  metadata,
+}: PlaceDetailModalProps) {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) onClose();
+    };
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const lat = metadata.lat;
+  const lon = metadata.lon;
+  const hasCoords = lat && lon;
+
+  // OSM embed URL with marker
+  const embedUrl = hasCoords
+    ? `https://www.openstreetmap.org/export/embed.html?bbox=${Number(lon) - 0.005},${Number(lat) - 0.003},${Number(lon) + 0.005},${Number(lat) + 0.003}&layer=mapnik&marker=${lat},${lon}`
+    : null;
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        {/* Backdrop */}
+        <div
+          className="absolute inset-0 bg-black/50 dark:bg-black/70"
+          onClick={onClose}
+        />
+
+        {/* Modal */}
+        <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-sm w-full overflow-hidden">
+          {/* Map preview */}
+          {embedUrl && (
+            <a
+              href={metadata.infoUrl || "#"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block"
+            >
+              <iframe
+                src={embedUrl}
+                className="w-full h-48 border-0 pointer-events-none"
+                loading="lazy"
+                title={`Map of ${name}`}
+              />
+            </a>
+          )}
+
+          {/* Details */}
+          <div className="px-4 py-3">
+            {/* Name + icon */}
+            <div className="flex items-center gap-2.5">
+              {metadata.imageUrl && (
+                <img
+                  src={metadata.imageUrl}
+                  alt=""
+                  className="w-8 h-8 rounded object-cover flex-shrink-0"
+                />
+              )}
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white leading-tight">
+                {name}
+              </h3>
+            </div>
+
+            {/* Metadata row */}
+            <div className="flex items-center gap-2 mt-1.5 text-sm text-gray-500 dark:text-gray-400 flex-wrap">
+              {metadata.cuisine && <span>{metadata.cuisine}</span>}
+              {metadata.cuisine && metadata.distance_miles !== undefined && (
+                <span>·</span>
+              )}
+              {metadata.distance_miles !== undefined && (
+                <span className="text-blue-600 dark:text-blue-400">
+                  {formatDistance(metadata.distance_miles)}
+                </span>
+              )}
+            </div>
+
+            {/* Address */}
+            {address && (
+              <p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+                {address}
+              </p>
+            )}
+
+            {/* Actions */}
+            <div className="flex gap-2 mt-3">
+              {metadata.infoUrl && (
+                <a
+                  href={metadata.infoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 text-center px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  Open in Maps
+                </a>
+              )}
+              <button
+                onClick={onClose}
+                className="flex-1 px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg transition-colors"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -26,7 +26,7 @@ function AddressActionsModal({
 }) {
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen) onClose();
+      if (e.key === "Escape") onClose();
     };
     if (isOpen) {
       document.addEventListener("keydown", handleEscape);
@@ -135,7 +135,6 @@ export default function PlaceDetailModal({
             <iframe
               src={embedUrl}
               className="w-full h-48 border-0"
-              loading="lazy"
               title={`Map of ${name}`}
               style={{ pointerEvents: "none" }}
             />

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import ModalPortal from "./ModalPortal";
 import type { OptionMetadataEntry } from "@/lib/types";
 import { formatDistance } from "./OptionLabel";
@@ -13,6 +13,82 @@ interface PlaceDetailModalProps {
   metadata: OptionMetadataEntry;
 }
 
+function AddressActionsModal({
+  isOpen,
+  onClose,
+  name,
+  address,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  name: string;
+  address: string;
+}) {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) onClose();
+    };
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+    }
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const query = encodeURIComponent(name + ", " + address);
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-[60] flex items-end justify-center p-4 pb-8">
+        <div
+          className="absolute inset-0 bg-black/50 dark:bg-black/70"
+          onClick={onClose}
+        />
+        <div className="relative w-full max-w-sm flex flex-col gap-2">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl overflow-hidden">
+            <a
+              href={`https://maps.apple.com/?q=${query}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={onClose}
+              className="block w-full px-4 py-3 text-center text-blue-600 dark:text-blue-400 font-medium border-b border-gray-200 dark:border-gray-700 active:bg-gray-100 dark:active:bg-gray-700"
+            >
+              Open in Maps
+            </a>
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${query}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={onClose}
+              className="block w-full px-4 py-3 text-center text-blue-600 dark:text-blue-400 font-medium border-b border-gray-200 dark:border-gray-700 active:bg-gray-100 dark:active:bg-gray-700"
+            >
+              Open in Google Maps
+            </a>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(name + ", " + address);
+                onClose();
+              }}
+              className="block w-full px-4 py-3 text-center text-blue-600 dark:text-blue-400 font-medium active:bg-gray-100 dark:active:bg-gray-700"
+            >
+              Copy Address
+            </button>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-full px-4 py-3 bg-white dark:bg-gray-800 rounded-xl shadow-xl text-center text-blue-600 dark:text-blue-400 font-semibold active:bg-gray-100 dark:active:bg-gray-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}
+
 export default function PlaceDetailModal({
   isOpen,
   onClose,
@@ -20,9 +96,11 @@ export default function PlaceDetailModal({
   address,
   metadata,
 }: PlaceDetailModalProps) {
+  const [addressModalOpen, setAddressModalOpen] = useState(false);
+
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen) onClose();
+      if (e.key === "Escape" && isOpen && !addressModalOpen) onClose();
     };
     if (isOpen) {
       document.addEventListener("keydown", handleEscape);
@@ -32,7 +110,7 @@ export default function PlaceDetailModal({
       document.removeEventListener("keydown", handleEscape);
       document.body.style.overflow = "unset";
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, addressModalOpen, onClose]);
 
   if (!isOpen) return null;
 
@@ -40,7 +118,6 @@ export default function PlaceDetailModal({
   const lon = metadata.lon;
   const hasCoords = lat && lon;
 
-  // OSM embed URL with marker
   const embedUrl = hasCoords
     ? `https://www.openstreetmap.org/export/embed.html?bbox=${Number(lon) - 0.005},${Number(lat) - 0.003},${Number(lon) + 0.005},${Number(lat) + 0.003}&layer=mapnik&marker=${lat},${lon}`
     : null;
@@ -48,34 +125,23 @@ export default function PlaceDetailModal({
   return (
     <ModalPortal>
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        {/* Backdrop */}
         <div
           className="absolute inset-0 bg-black/50 dark:bg-black/70"
           onClick={onClose}
         />
 
-        {/* Modal */}
         <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-sm w-full overflow-hidden">
-          {/* Map preview */}
           {embedUrl && (
-            <a
-              href={metadata.infoUrl || "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block"
-            >
-              <iframe
-                src={embedUrl}
-                className="w-full h-48 border-0 pointer-events-none"
-                loading="lazy"
-                title={`Map of ${name}`}
-              />
-            </a>
+            <iframe
+              src={embedUrl}
+              className="w-full h-48 border-0"
+              loading="lazy"
+              title={`Map of ${name}`}
+              style={{ pointerEvents: "none" }}
+            />
           )}
 
-          {/* Details */}
           <div className="px-4 py-3">
-            {/* Name + icon */}
             <div className="flex items-center gap-2.5">
               {metadata.imageUrl && (
                 <img
@@ -89,7 +155,6 @@ export default function PlaceDetailModal({
               </h3>
             </div>
 
-            {/* Metadata row */}
             <div className="flex items-center gap-2 mt-1.5 text-sm text-gray-500 dark:text-gray-400 flex-wrap">
               {metadata.cuisine && <span>{metadata.cuisine}</span>}
               {metadata.cuisine && metadata.distance_miles !== undefined && (
@@ -102,26 +167,27 @@ export default function PlaceDetailModal({
               )}
             </div>
 
-            {/* Address — opens native maps app on mobile */}
-            {address && hasCoords && (
-              <a
-                href={`https://maps.apple.com/?q=${encodeURIComponent(name + ", " + address)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block mt-1.5 text-sm text-blue-600 dark:text-blue-400 underline decoration-1 underline-offset-2"
+            {address && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setAddressModalOpen(true);
+                }}
+                className="block mt-1.5 text-sm text-blue-600 dark:text-blue-400 underline decoration-1 underline-offset-2 text-left"
               >
                 {address}
-              </a>
+              </button>
             )}
-            {address && !hasCoords && (
-              <p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
-                {address}
-              </p>
-            )}
-
           </div>
         </div>
       </div>
+
+      <AddressActionsModal
+        isOpen={addressModalOpen}
+        onClose={() => setAddressModalOpen(false)}
+        name={name}
+        address={address}
+      />
     </ModalPortal>
   );
 }

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -105,7 +105,7 @@ export default function PlaceDetailModal({
             {/* Address — opens native maps app on mobile */}
             {address && hasCoords && (
               <a
-                href={`https://maps.apple.com/?ll=${lat},${lon}&q=${encodeURIComponent(name)}`}
+                href={`https://www.google.com/maps/search/?api=1&query=${lat},${lon}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block mt-1.5 text-sm text-blue-600 dark:text-blue-400 underline decoration-1 underline-offset-2"
@@ -121,9 +121,9 @@ export default function PlaceDetailModal({
 
             {/* Actions */}
             <div className="flex gap-2 mt-3">
-              {metadata.infoUrl && (
+              {hasCoords && (
                 <a
-                  href={metadata.infoUrl}
+                  href={`https://www.google.com/maps/search/?api=1&query=${lat},${lon}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex-1 text-center px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -105,7 +105,7 @@ export default function PlaceDetailModal({
             {/* Address — opens native maps app on mobile */}
             {address && hasCoords && (
               <a
-                href={`https://www.google.com/maps/search/?api=1&query=${lat},${lon}`}
+                href={`geo:${lat},${lon}?q=${lat},${lon}(${encodeURIComponent(name)})`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block mt-1.5 text-sm text-blue-600 dark:text-blue-400 underline decoration-1 underline-offset-2"

--- a/components/PlaceDetailModal.tsx
+++ b/components/PlaceDetailModal.tsx
@@ -38,7 +38,7 @@ function AddressActionsModal({
 
   if (!isOpen) return null;
 
-  const query = encodeURIComponent(name + ", " + address);
+  const query = encodeURIComponent(address);
 
   return (
     <ModalPortal>


### PR DESCRIPTION
## Summary
- **Distance truncation fix**: Restaurant entries in ranked choice results showed "2.1 ..." instead of "2.1 mi" due to `line-clamp-2` being applied to flex layouts
- **Place detail modal**: Tapping a restaurant/location name opens a modal with OSM map preview, name, cuisine, distance, and clickable address
- **Address action sheet**: Tapping the address shows iOS-style options: "Open in Maps" (Apple Maps), "Open in Google Maps", "Copy Address"
- **Cleaner inline display**: Removed cuisine/price from inline labels — details are in the modal

## Test plan
- [ ] Distance shows fully ("2.1 mi") in ranked choice results
- [ ] Tapping restaurant/location name opens place detail modal with map
- [ ] Tapping address in modal opens action sheet with three options
- [ ] "Open in Maps" opens Apple Maps with correct address
- [ ] "Open in Google Maps" opens Google Maps with correct address
- [ ] "Copy Address" copies to clipboard
- [ ] Tapping backdrop dismisses modals
- [ ] Non-location options unaffected

https://claude.ai/code/session_01RtCQkS7bdZv968JquUAYut