### PR TITLE
Move poll type symbols to right side of cards

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -6,6 +6,20 @@ import { Poll } from "@/lib/types";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
 
+const POLL_TYPE_SYMBOLS: Record<string, string> = {
+  yes_no: '☐',
+  nomination: '💡',
+  ranked_choice: '🗳️',
+  participation: '🙋',
+};
+
+const CLOSED_YES_NO_SYMBOL = '🏆';
+
+function getPollSymbol(pollType: string, isClosed: boolean): string {
+  if (pollType === 'yes_no' && isClosed) return CLOSED_YES_NO_SYMBOL;
+  return POLL_TYPE_SYMBOLS[pollType] || '☰';
+}
+
 // Simple countdown component
 const SimpleCountdown = ({ deadline }: { deadline: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -299,7 +313,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         </h3>
                       </div>
                       <div className="flex-shrink-0 text-base">
-                        {poll.poll_type === 'yes_no' ? '☐' : poll.poll_type === 'nomination' ? '💡' : poll.poll_type === 'ranked_choice' ? '🗳️' : poll.poll_type === 'participation' ? '🙋' : '☰'}
+                        {getPollSymbol(poll.poll_type, false)}
                       </div>
                     </div>
                     {poll.response_deadline && (
@@ -423,7 +437,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         </h3>
                       </div>
                       <div className="flex-shrink-0 text-base">
-                        {poll.poll_type === 'yes_no' ? '🏆' : poll.poll_type === 'nomination' ? '💡' : poll.poll_type === 'ranked_choice' ? '🗳️' : poll.poll_type === 'participation' ? '🙋' : '☰'}
+                        {getPollSymbol(poll.poll_type, true)}
                       </div>
                     </div>
                     {poll.response_deadline && (

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -303,7 +303,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       </div>
                     </div>
                     {poll.response_deadline && (
-                      <div className="text-right mt-1 mr-0 text-xs text-gray-500 dark:text-gray-400">
+                      <div className="text-right mt-1 mr-7 text-xs text-gray-500 dark:text-gray-400">
                         <ClientOnly fallback={<>Loading...</>}>
                           <SimpleCountdown deadline={poll.response_deadline} />
                         </ClientOnly>
@@ -427,7 +427,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       </div>
                     </div>
                     {poll.response_deadline && (
-                      <div className="text-right -mt-1 mr-0">
+                      <div className="text-right -mt-1 mr-7">
                         <span className="text-xs text-gray-500 dark:text-gray-400">
                           Closed {(() => {
                             const deadline = new Date(poll.response_deadline);

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -270,15 +270,12 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               return (
                 <React.Fragment key={poll.id}>
                   {isFirstVoted && (
-                    <div className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-0.5 mb-2 ml-7">
+                    <div className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-0.5 mb-2">
                       Already Voted
                     </div>
                   )}
                   <div key={poll.id}>
                     <div className="flex items-center gap-1.5">
-                      <div className="flex-shrink-0 text-base">
-                        {poll.poll_type === 'yes_no' ? '☐' : poll.poll_type === 'nomination' ? '💡' : poll.poll_type === 'ranked_choice' ? '🗳️' : poll.poll_type === 'participation' ? '🙋' : '☰'}
-                      </div>
                       <div
                         onClick={() => {
                           setNavigatingPollId(poll.id);
@@ -301,6 +298,9 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           {poll.title}
                         </h3>
                       </div>
+                      <div className="flex-shrink-0 text-base">
+                        {poll.poll_type === 'yes_no' ? '☐' : poll.poll_type === 'nomination' ? '💡' : poll.poll_type === 'ranked_choice' ? '🗳️' : poll.poll_type === 'participation' ? '🙋' : '☰'}
+                      </div>
                     </div>
                     {poll.response_deadline && (
                       <div className="text-right mt-1 mr-0 text-xs text-gray-500 dark:text-gray-400">
@@ -321,7 +321,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {closedPolls.length > 0 && (
         <div className="mb-3">
           {openPolls.length > 0 && (
-            <div className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-0.5 mb-2 ml-7">
+            <div className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-0.5 mb-2">
               Closed
             </div>
           )}
@@ -400,9 +400,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                 return (
                   <div key={poll.id}>
                     <div className="flex items-center gap-1.5">
-                      <div className="flex-shrink-0 text-base">
-                        {poll.poll_type === 'yes_no' ? '🏆' : poll.poll_type === 'nomination' ? '💡' : poll.poll_type === 'ranked_choice' ? '🗳️' : poll.poll_type === 'participation' ? '🙋' : '☰'}
-                      </div>
                       <div
                         onClick={() => {
                           setNavigatingPollId(poll.id);
@@ -424,6 +421,9 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                           {poll.title}
                         </h3>
+                      </div>
+                      <div className="flex-shrink-0 text-base">
+                        {poll.poll_type === 'yes_no' ? '🏆' : poll.poll_type === 'nomination' ? '💡' : poll.poll_type === 'ranked_choice' ? '🗳️' : poll.poll_type === 'participation' ? '🙋' : '☰'}
                       </div>
                     </div>
                     {poll.response_deadline && (

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1119,7 +1119,21 @@ def get_accessible_polls(req: AccessiblePollsRequest):
         return []
     with get_db() as conn:
         rows = conn.execute(
-            "SELECT * FROM polls WHERE id = ANY(%(poll_ids)s) AND (is_sub_poll = false OR is_sub_poll IS NULL) ORDER BY created_at DESC",
+            """SELECT * FROM polls
+               WHERE id = ANY(%(poll_ids)s)
+                 AND (is_sub_poll = false OR is_sub_poll IS NULL)
+                 AND NOT (
+                   poll_type = 'nomination'
+                   AND auto_create_preferences = true
+                   AND is_closed = true
+                   AND EXISTS (
+                     SELECT 1 FROM polls p2
+                     WHERE p2.follow_up_to = polls.id
+                       AND p2.poll_type = 'ranked_choice'
+                       AND p2.options IS NOT NULL
+                   )
+                 )
+               ORDER BY created_at DESC""",
             {"poll_ids": req.poll_ids},
         ).fetchall()
     return [_row_to_poll(r) for r in rows]


### PR DESCRIPTION
## Summary
- Move poll type emoji symbols from the left side to the right side of each poll card in the main list
- Align countdown/closed date text with the right edge of the card (not the symbol)
- Hide closed suggestion (nomination) polls from the main list when their preferences (ranked-choice) follow-up has been activated
- Extract duplicated emoji mapping into a reusable `getPollSymbol` helper

## Test plan
- [ ] Verify poll type symbols appear on the right side of cards for all poll types
- [ ] Verify countdown and closed date text aligns with the card's right edge
- [ ] Create a nomination poll with auto-create preferences, close it, and verify it disappears from the main list once the preferences poll activates
- [ ] Verify the preferences follow-up poll appears in the main list via poll discovery

https://claude.ai/code/session_01FLUKBnPaEgxMbyEpAgKnYX