### PR TITLE
Redesign polls list layout

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -141,7 +141,7 @@ function CreatePollContent() {
       return `Which ${catLabel}?`;
     };
 
-    const addIcon = (base: string) => icon ? `${icon} ${base}` : base;
+    const addIcon = (base: string) => icon ? `${base} ${icon}` : base;
 
     if (pollType === 'nomination') {
       // Use "Place" instead of "Location" for nomination polls

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -538,7 +538,7 @@ export default function Template({ children }: AppTemplateProps) {
       {/* Scroll-aware bottom bar - rendered via portal outside scaled container */}
       {isMounted && createPortal(
         <div
-          className={`fixed left-0 right-0 bottom-0 backdrop-blur-lg bg-white/50 dark:bg-black/50 shadow-lg z-50 ${
+          className={`fixed left-0 right-0 bottom-0 z-50 border-t border-gray-300 dark:border-gray-600 bg-gray-200/95 dark:bg-gray-800/95 backdrop-blur-sm ${
             showBottomBar ? '' : 'pointer-events-none'
           }`}
           style={{
@@ -548,48 +548,48 @@ export default function Template({ children }: AppTemplateProps) {
             willChange: 'transform',
           }}
         >
-        <div className="max-w-4xl mx-auto px-4 py-2 flex items-center justify-center">
-          <div className="flex items-center justify-center gap-12">
-            {/* Home button */}
-            <button 
-              onClick={pathname === '/' ? undefined : () => window.location.href = '/'}
-              className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${
-                pathname === '/' 
-                  ? 'bg-blue-100 dark:bg-blue-900/30 cursor-default' 
-                  : 'hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer'
-              }`}
-              aria-label="Go to home"
-              disabled={pathname === '/'}
-            >
-              <svg className={`w-7 h-7 ${
-                pathname === '/' 
-                  ? 'text-blue-600 dark:text-blue-400' 
-                  : 'text-gray-400 dark:text-gray-500'
-              }`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-              </svg>
-            </button>
-            
-            {/* Profile button - larger direct size */}
-            <button
-              onClick={isProfilePage ? undefined : () => router.push('/profile')}
-              className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${
-                isProfilePage 
-                  ? 'bg-blue-100 dark:bg-blue-900/30 cursor-default' 
-                  : 'hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer'
-              }`}
-              aria-label="Profile"
-              disabled={isProfilePage}
-            >
-              <svg className={`w-7 h-7 ${
-                isProfilePage 
-                  ? 'text-blue-600 dark:text-blue-400' 
-                  : 'text-gray-400 dark:text-gray-500'
-              }`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-              </svg>
-            </button>
-          </div>
+        <div className="flex items-center justify-evenly py-1.5">
+          {/* Home button */}
+          <button
+            onClick={pathname === '/' ? undefined : () => window.location.href = '/'}
+            className="flex flex-col items-center gap-0.5 min-w-[64px] cursor-pointer"
+            aria-label="Go to home"
+            disabled={pathname === '/'}
+          >
+            <svg className={`w-6 h-6 ${
+              pathname === '/'
+                ? 'text-blue-600 dark:text-blue-400'
+                : 'text-gray-500 dark:text-gray-400'
+            }`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            <span className={`text-[10px] font-medium ${
+              pathname === '/'
+                ? 'text-blue-600 dark:text-blue-400'
+                : 'text-gray-500 dark:text-gray-400'
+            }`}>Home</span>
+          </button>
+
+          {/* Profile button */}
+          <button
+            onClick={isProfilePage ? undefined : () => router.push('/profile')}
+            className="flex flex-col items-center gap-0.5 min-w-[64px] cursor-pointer"
+            aria-label="Profile"
+            disabled={isProfilePage}
+          >
+            <svg className={`w-6 h-6 ${
+              isProfilePage
+                ? 'text-blue-600 dark:text-blue-400'
+                : 'text-gray-500 dark:text-gray-400'
+            }`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+            <span className={`text-[10px] font-medium ${
+              isProfilePage
+                ? 'text-blue-600 dark:text-blue-400'
+                : 'text-gray-500 dark:text-gray-400'
+            }`}>Account</span>
+          </button>
         </div>
         </div>,
         document.getElementById('bottom-bar-portal')!

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -529,7 +529,7 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? 'px-0 sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-2 pb-6' : 'py-6'} ${pathname === '/' ? 'text-red-600' : ''}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-2 pb-6' : 'py-6'}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -461,8 +461,8 @@ export default function Template({ children }: AppTemplateProps) {
         className="flex-1 overflow-auto safari-scroll-container"
         style={{
           paddingTop: '0',
-          paddingLeft: 'max(0.5rem, env(safe-area-inset-left))',
-          paddingRight: 'max(0.5rem, env(safe-area-inset-right))',
+          paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
+          paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
           paddingBottom: '1rem',
         }}>
         <div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -529,7 +529,7 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? 'px-2' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-2 pb-6' : 'py-6'} ${pathname === '/' ? 'text-red-600' : ''}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? 'px-0 sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-2 pb-6' : 'py-6'} ${pathname === '/' ? 'text-red-600' : ''}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -520,7 +520,7 @@ export default function Template({ children }: AppTemplateProps) {
                       className="text-2xl font-bold mb-1 cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                       onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
                     >Whoever Wants</h1>
-                    <div className="h-7 flex items-center justify-center mb-4" id="home-phrase-content">
+                    <div className="h-7 flex items-center justify-center mb-2" id="home-phrase-content">
                       {/* Blue phrase will be injected here */}
                     </div>
                   </div>
@@ -529,7 +529,7 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-2 pb-6' : 'py-6'}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-1 pb-6' : 'py-6'}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -520,7 +520,7 @@ export default function Template({ children }: AppTemplateProps) {
                       className="text-2xl font-bold mb-1 cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                       onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
                     >Whoever Wants</h1>
-                    <div className="h-7 flex items-center justify-center mb-2" id="home-phrase-content">
+                    <div className="h-7 flex items-center justify-center mb-1" id="home-phrase-content">
                       {/* Blue phrase will be injected here */}
                     </div>
                   </div>
@@ -529,7 +529,7 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-1 pb-6' : 'py-6'}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -461,8 +461,8 @@ export default function Template({ children }: AppTemplateProps) {
         className="flex-1 overflow-auto safari-scroll-container"
         style={{
           paddingTop: '0',
-          paddingLeft: 'max(1rem, env(safe-area-inset-left))',
-          paddingRight: 'max(1rem, env(safe-area-inset-right))',
+          paddingLeft: 'max(0.5rem, env(safe-area-inset-left))',
+          paddingRight: 'max(0.5rem, env(safe-area-inset-right))',
           paddingBottom: '1rem',
         }}>
         <div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -15,9 +15,20 @@ const POLL_TYPE_SYMBOLS: Record<string, string> = {
 
 const CLOSED_YES_NO_SYMBOL = '🏆';
 
+const POLL_TYPE_LABELS: Record<string, string> = {
+  yes_no: 'Poll',
+  nomination: 'Suggestions',
+  ranked_choice: 'Preferences',
+  participation: 'Participation',
+};
+
 function getPollSymbol(pollType: string, isClosed: boolean): string {
   if (pollType === 'yes_no' && isClosed) return CLOSED_YES_NO_SYMBOL;
   return POLL_TYPE_SYMBOLS[pollType] || '☰';
+}
+
+function getPollTypeLabel(pollType: string): string {
+  return POLL_TYPE_LABELS[pollType] || pollType;
 }
 
 // Simple countdown component
@@ -297,7 +308,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`flex items-center gap-1.5 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
@@ -307,21 +318,20 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                          {poll.title}
-                        </h3>
-                        {poll.response_deadline && (
-                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                            <ClientOnly fallback={<>Loading...</>}>
-                              <SimpleCountdown deadline={poll.response_deadline} />
-                            </ClientOnly>
-                          </div>
-                        )}
+                      <div className="flex justify-end items-center gap-1 mb-0.5">
+                        <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
+                        <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
                       </div>
-                      <div className="flex-shrink-0 text-base">
-                        {getPollSymbol(poll.poll_type, false)}
-                      </div>
+                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                        {poll.title}
+                      </h3>
+                      {poll.response_deadline && (
+                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          <ClientOnly fallback={<>Loading...</>}>
+                            <SimpleCountdown deadline={poll.response_deadline} />
+                          </ClientOnly>
+                        </div>
+                      )}
                     </div>
                   </div>
                 </React.Fragment>
@@ -421,7 +431,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`flex items-center gap-1.5 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : 'opacity-60'} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : 'opacity-60'} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
@@ -431,36 +441,36 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                          {poll.title}
-                        </h3>
-                        {poll.response_deadline && (
-                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                            Closed {(() => {
-                              const deadline = new Date(poll.response_deadline);
-                              const now = new Date();
-                              const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
-
-                              if (hoursAgo <= 24) {
-                                return deadline.toLocaleTimeString("en-US", {
-                                  hour: "numeric",
-                                  minute: "2-digit",
-                                  hour12: true
-                                });
-                              } else {
-                                return deadline.toLocaleDateString("en-US", {
-                                  month: "numeric",
-                                  day: "numeric",
-                                  year: "2-digit"
-                                });
-                              }
-                            })()}
-                          </div>
-                        )}
+                      <div className="flex justify-end items-center gap-1 mb-0.5">
+                        <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
+                        <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
                       </div>
-                      <div className="flex-shrink-0 text-base">
-                        {getPollSymbol(poll.poll_type, true)}
+                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                        {poll.title}
+                      </h3>
+                      {poll.response_deadline && (
+                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          Closed {(() => {
+                            const deadline = new Date(poll.response_deadline);
+                            const now = new Date();
+                            const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+
+                            if (hoursAgo <= 24) {
+                              return deadline.toLocaleTimeString("en-US", {
+                                hour: "numeric",
+                                minute: "2-digit",
+                                hour12: true
+                              });
+                            } else {
+                              return deadline.toLocaleDateString("en-US", {
+                                month: "numeric",
+                                day: "numeric",
+                                year: "2-digit"
+                              });
+                            }
+                          })()}
+                        </div>
+                      )}
                       </div>
                     </div>
                   </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -308,7 +308,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`flex items-start gap-2 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
@@ -318,19 +318,19 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <span className="w-6 flex-shrink-0 text-center text-sm mt-0.5">{getPollSymbol(poll.poll_type, false)}</span>
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                          {poll.title}
-                        </h3>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
                         {poll.response_deadline && (
-                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
                             <ClientOnly fallback={<>Loading...</>}>
                               <SimpleCountdown deadline={poll.response_deadline} />
                             </ClientOnly>
-                          </div>
+                          </span>
                         )}
                       </div>
+                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                        {poll.title}
+                      </h3>
                     </div>
                   </div>
                 </React.Fragment>
@@ -430,7 +430,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`flex items-start gap-2 px-3 py-2.5 opacity-60 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-3 py-2.5 opacity-60 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
@@ -440,35 +440,35 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <span className="w-6 flex-shrink-0 text-center text-sm mt-0.5">{getPollSymbol(poll.poll_type, true)}</span>
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                          {poll.title}
-                        </h3>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
                         {poll.response_deadline && (
-                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
                             Closed {(() => {
-                            const deadline = new Date(poll.response_deadline);
-                            const now = new Date();
-                            const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+                              const deadline = new Date(poll.response_deadline);
+                              const now = new Date();
+                              const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
 
-                            if (hoursAgo <= 24) {
-                              return deadline.toLocaleTimeString("en-US", {
-                                hour: "numeric",
-                                minute: "2-digit",
-                                hour12: true
-                              });
-                            } else {
-                              return deadline.toLocaleDateString("en-US", {
-                                month: "numeric",
-                                day: "numeric",
-                                year: "2-digit"
-                              });
-                            }
-                          })()}
-                        </div>
-                      )}
+                              if (hoursAgo <= 24) {
+                                return deadline.toLocaleTimeString("en-US", {
+                                  hour: "numeric",
+                                  minute: "2-digit",
+                                  hour12: true
+                                });
+                              } else {
+                                return deadline.toLocaleDateString("en-US", {
+                                  month: "numeric",
+                                  day: "numeric",
+                                  year: "2-digit"
+                                });
+                              }
+                            })()}
+                          </span>
+                        )}
                       </div>
+                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                        {poll.title}
+                      </h3>
                     </div>
                   </div>
               );

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -430,7 +430,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`flex items-start gap-2 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : 'opacity-60'} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`flex items-start gap-2 px-3 py-2.5 opacity-60 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -213,11 +213,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   }
 
   return (
-    <div className="border-t border-b border-gray-200 dark:border-gray-700">
+    <div>
       {/* Open Polls Section */}
       {openPolls.length > 0 && (
         <div>
-          <div className="divide-y divide-gray-200 dark:divide-gray-700">
+          <div>
             {openPolls.map((poll, index) => {
               const isVoted = votedPollIds.has(poll.id);
               const isAbstained = abstainedPollIds.has(poll.id);
@@ -295,11 +295,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               return (
                 <React.Fragment key={poll.id}>
                   {isFirstVoted && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-3 py-1.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-3 bg-gray-50 dark:bg-gray-800/30">
                       Already Voted
                     </div>
                   )}
-                  <div key={poll.id}>
+                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-3">
                     <div
                       onClick={() => {
                         setNavigatingPollId(poll.id);
@@ -308,7 +308,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-1 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
@@ -344,11 +344,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {closedPolls.length > 0 && (
         <div>
           {openPolls.length > 0 && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-3 py-1.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30">
+            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-3 bg-gray-50 dark:bg-gray-800/30">
               Closed
             </div>
           )}
-          <div className="divide-y divide-gray-200 dark:divide-gray-700">
+          <div>
               {closedPolls.map((poll, index) => {
                 const isVoted = votedPollIds.has(poll.id);
                 const isAbstained = abstainedPollIds.has(poll.id);
@@ -421,7 +421,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                 };
 
                 return (
-                  <div key={poll.id}>
+                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-3">
                     <div
                       onClick={() => {
                         setNavigatingPollId(poll.id);
@@ -430,7 +430,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`px-3 py-2.5 opacity-60 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-1 py-2.5 opacity-60 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -202,11 +202,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   }
 
   return (
-    <div>
+    <div className="border-t border-b border-gray-200 dark:border-gray-700">
       {/* Open Polls Section */}
       {openPolls.length > 0 && (
-        <div className="mb-3">
-          <div className="space-y-1">
+        <div>
+          <div className="divide-y divide-gray-200 dark:divide-gray-700">
             {openPolls.map((poll, index) => {
               const isVoted = votedPollIds.has(poll.id);
               const isAbstained = abstainedPollIds.has(poll.id);
@@ -284,45 +284,45 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               return (
                 <React.Fragment key={poll.id}>
                   {isFirstVoted && (
-                    <div className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-0.5 mb-2">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-3 py-1.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30">
                       Already Voted
                     </div>
                   )}
                   <div key={poll.id}>
-                    <div className="flex items-center gap-1.5">
-                      <div
-                        onClick={() => {
-                          setNavigatingPollId(poll.id);
-                          router.push(`/p/${poll.short_id || poll.id}`);
-                        }}
-                        onTouchStart={handleTouchStart}
-                        onTouchEnd={handleTouchEnd}
-                        onTouchMove={handleTouchMove}
-                        className={`flex-1 ${pressedPollId === poll.id ? '' : hasVotedOrAbstained ? 'bg-gray-100 dark:bg-gray-800/50 opacity-75' : 'bg-white dark:bg-gray-800'} border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 active:scale-95 active:shadow-sm active:border-blue-400 dark:active:border-blue-500 ${pressedPollId === poll.id ? 'scale-95 !shadow-md !border-blue-500 dark:!border-blue-400 !bg-blue-100 dark:!bg-blue-900/40 opacity-100' : ''} transition-all cursor-pointer select-none relative`}
-                      >
-                        {navigatingPollId === poll.id && (
-                          <div className="absolute inset-0 bg-white/80 dark:bg-gray-800/80 flex items-center justify-center rounded-lg">
-                            <svg className="animate-spin h-6 w-6 text-blue-600 dark:text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                            </svg>
-                          </div>
-                        )}
-                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+                    <div
+                      onClick={() => {
+                        setNavigatingPollId(poll.id);
+                        router.push(`/p/${poll.short_id || poll.id}`);
+                      }}
+                      onTouchStart={handleTouchStart}
+                      onTouchEnd={handleTouchEnd}
+                      onTouchMove={handleTouchMove}
+                      className={`flex items-center gap-1.5 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                    >
+                      {navigatingPollId === poll.id && (
+                        <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
+                          <svg className="animate-spin h-6 w-6 text-blue-600 dark:text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                          </svg>
+                        </div>
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                           {poll.title}
                         </h3>
+                        {poll.response_deadline && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                            <ClientOnly fallback={<>Loading...</>}>
+                              <SimpleCountdown deadline={poll.response_deadline} />
+                            </ClientOnly>
+                          </div>
+                        )}
                       </div>
                       <div className="flex-shrink-0 text-base">
                         {getPollSymbol(poll.poll_type, false)}
                       </div>
                     </div>
-                    {poll.response_deadline && (
-                      <div className="text-right mt-1 mr-7 text-xs text-gray-500 dark:text-gray-400">
-                        <ClientOnly fallback={<>Loading...</>}>
-                          <SimpleCountdown deadline={poll.response_deadline} />
-                        </ClientOnly>
-                      </div>
-                    )}
                   </div>
                 </React.Fragment>
               );
@@ -333,13 +333,13 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
 
       {/* Closed Polls Section */}
       {closedPolls.length > 0 && (
-        <div className="mb-3">
+        <div>
           {openPolls.length > 0 && (
-            <div className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-0.5 mb-2">
+            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-3 py-1.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30">
               Closed
             </div>
           )}
-          <div className="space-y-1">
+          <div className="divide-y divide-gray-200 dark:divide-gray-700">
               {closedPolls.map((poll, index) => {
                 const isVoted = votedPollIds.has(poll.id);
                 const isAbstained = abstainedPollIds.has(poll.id);
@@ -413,60 +413,56 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
 
                 return (
                   <div key={poll.id}>
-                    <div className="flex items-center gap-1.5">
-                      <div
-                        onClick={() => {
-                          setNavigatingPollId(poll.id);
-                          router.push(`/p/${poll.short_id || poll.id}`);
-                        }}
-                        onTouchStart={handleTouchStart}
-                        onTouchEnd={handleTouchEnd}
-                        onTouchMove={handleTouchMove}
-                        className={`flex-1 ${pressedPollId === poll.id ? '' : 'bg-gray-100 dark:bg-gray-800/50'} border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm hover:shadow-md hover:border-blue-300 dark:hover:border-blue-600 active:scale-95 active:shadow-sm active:border-blue-400 dark:active:border-blue-500 ${pressedPollId === poll.id ? 'scale-95 !shadow-md !border-blue-500 dark:!border-blue-400 !bg-blue-100 dark:!bg-blue-900/40 opacity-100' : 'opacity-75'} transition-all cursor-pointer select-none relative`}
-                      >
-                        {navigatingPollId === poll.id && (
-                          <div className="absolute inset-0 bg-gray-100/90 dark:bg-gray-800/90 flex items-center justify-center rounded-lg">
-                            <svg className="animate-spin h-6 w-6 text-blue-600 dark:text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                            </svg>
-                          </div>
-                        )}
-                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+                    <div
+                      onClick={() => {
+                        setNavigatingPollId(poll.id);
+                        router.push(`/p/${poll.short_id || poll.id}`);
+                      }}
+                      onTouchStart={handleTouchStart}
+                      onTouchEnd={handleTouchEnd}
+                      onTouchMove={handleTouchMove}
+                      className={`flex items-center gap-1.5 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : 'opacity-60'} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                    >
+                      {navigatingPollId === poll.id && (
+                        <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
+                          <svg className="animate-spin h-6 w-6 text-blue-600 dark:text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                          </svg>
+                        </div>
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                           {poll.title}
                         </h3>
+                        {poll.response_deadline && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                            Closed {(() => {
+                              const deadline = new Date(poll.response_deadline);
+                              const now = new Date();
+                              const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+
+                              if (hoursAgo <= 24) {
+                                return deadline.toLocaleTimeString("en-US", {
+                                  hour: "numeric",
+                                  minute: "2-digit",
+                                  hour12: true
+                                });
+                              } else {
+                                return deadline.toLocaleDateString("en-US", {
+                                  month: "numeric",
+                                  day: "numeric",
+                                  year: "2-digit"
+                                });
+                              }
+                            })()}
+                          </div>
+                        )}
                       </div>
                       <div className="flex-shrink-0 text-base">
                         {getPollSymbol(poll.poll_type, true)}
                       </div>
                     </div>
-                    {poll.response_deadline && (
-                      <div className="text-right -mt-1 mr-7">
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
-                          Closed {(() => {
-                            const deadline = new Date(poll.response_deadline);
-                            const now = new Date();
-                            const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
-
-                            if (hoursAgo <= 24) {
-                              // Within 24 hours, show only time
-                              return deadline.toLocaleTimeString("en-US", {
-                                hour: "numeric",
-                                minute: "2-digit",
-                                hour12: true
-                              });
-                            } else {
-                              // More than 24 hours ago, show only date
-                              return deadline.toLocaleDateString("en-US", {
-                                month: "numeric",
-                                day: "numeric",
-                                year: "2-digit"
-                              });
-                            }
-                          })()}
-                        </span>
-                      </div>
-                    )}
                   </div>
               );
             })}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -15,20 +15,9 @@ const POLL_TYPE_SYMBOLS: Record<string, string> = {
 
 const CLOSED_YES_NO_SYMBOL = '🏆';
 
-const POLL_TYPE_LABELS: Record<string, string> = {
-  yes_no: 'Poll',
-  nomination: 'Suggestions',
-  ranked_choice: 'Preferences',
-  participation: 'Participation',
-};
-
 function getPollSymbol(pollType: string, isClosed: boolean): string {
   if (pollType === 'yes_no' && isClosed) return CLOSED_YES_NO_SYMBOL;
   return POLL_TYPE_SYMBOLS[pollType] || '☰';
-}
-
-function getPollTypeLabel(pollType: string): string {
-  return POLL_TYPE_LABELS[pollType] || pollType;
 }
 
 function relativeTime(dateStr: string): string {

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -326,7 +326,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         {poll.title}
                       </h3>
                       {poll.response_deadline && (
-                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                        <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                           <ClientOnly fallback={<>Loading...</>}>
                             <SimpleCountdown deadline={poll.response_deadline} />
                           </ClientOnly>
@@ -449,7 +449,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         {poll.title}
                       </h3>
                       {poll.response_deadline && (
-                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                        <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                           Closed {(() => {
                             const deadline = new Date(poll.response_deadline);
                             const now = new Date();
@@ -471,7 +471,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           })()}
                         </div>
                       )}
-                      </div>
                     </div>
                   </div>
               );

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -295,11 +295,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               return (
                 <React.Fragment key={poll.id}>
                   {isFirstVoted && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-2 bg-gray-50 dark:bg-gray-800/30">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
                       Already Voted
                     </div>
                   )}
-                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-2">
+                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-1.5">
                     <div
                       onClick={() => {
                         setNavigatingPollId(poll.id);
@@ -344,7 +344,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {closedPolls.length > 0 && (
         <div>
           {openPolls.length > 0 && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-2 bg-gray-50 dark:bg-gray-800/30">
+            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
               Closed
             </div>
           )}
@@ -421,7 +421,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                 };
 
                 return (
-                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-2">
+                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-1.5">
                     <div
                       onClick={() => {
                         setNavigatingPollId(poll.id);

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -322,10 +322,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                           {poll.title}
                         </h3>
-                        <div className="flex-shrink-0 flex items-center gap-1 mt-0.5">
-                          <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
-                          <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
-                        </div>
+                        <span className="flex-shrink-0 text-sm mt-0.5">{getPollSymbol(poll.poll_type, false)}</span>
                       </div>
                       {poll.response_deadline && (
                         <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">
@@ -447,10 +444,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                           {poll.title}
                         </h3>
-                        <div className="flex-shrink-0 flex items-center gap-1 mt-0.5">
-                          <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
-                          <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
-                        </div>
+                        <span className="flex-shrink-0 text-sm mt-0.5">{getPollSymbol(poll.poll_type, true)}</span>
                       </div>
                       {poll.response_deadline && (
                         <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -31,6 +31,25 @@ function getPollTypeLabel(pollType: string): string {
   return POLL_TYPE_LABELS[pollType] || pollType;
 }
 
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
 // Simple countdown component
 const SimpleCountdown = ({ deadline }: { deadline: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -331,6 +350,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                         {poll.title}
                       </h3>
+                      <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                        <ClientOnly fallback={null}>
+                          <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
+                        </ClientOnly>
+                      </div>
                     </div>
                   </div>
                 </React.Fragment>
@@ -469,6 +493,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                         {poll.title}
                       </h3>
+                      <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                        <ClientOnly fallback={null}>
+                          <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
+                        </ClientOnly>
+                      </div>
                     </div>
                   </div>
               );

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -350,7 +350,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                         {poll.title}
                       </h3>
-                      <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                      <div className="text-xs text-gray-400 dark:text-gray-500">
                         <ClientOnly fallback={null}>
                           <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
                         </ClientOnly>
@@ -493,7 +493,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                         {poll.title}
                       </h3>
-                      <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                      <div className="text-xs text-gray-400 dark:text-gray-500">
                         <ClientOnly fallback={null}>
                           <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
                         </ClientOnly>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -295,11 +295,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               return (
                 <React.Fragment key={poll.id}>
                   {isFirstVoted && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-3 bg-gray-50 dark:bg-gray-800/30">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-2 bg-gray-50 dark:bg-gray-800/30">
                       Already Voted
                     </div>
                   )}
-                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-3">
+                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-2">
                     <div
                       onClick={() => {
                         setNavigatingPollId(poll.id);
@@ -344,7 +344,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {closedPolls.length > 0 && (
         <div>
           {openPolls.length > 0 && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-3 bg-gray-50 dark:bg-gray-800/30">
+            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-2 bg-gray-50 dark:bg-gray-800/30">
               Closed
             </div>
           )}
@@ -421,7 +421,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                 };
 
                 return (
-                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-3">
+                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-2">
                     <div
                       onClick={() => {
                         setNavigatingPollId(poll.id);

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -318,13 +318,15 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex justify-end items-center gap-1 mb-0.5">
-                        <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
-                        <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
+                      <div className="flex items-start justify-between gap-2">
+                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                          {poll.title}
+                        </h3>
+                        <div className="flex-shrink-0 flex items-center gap-1 mt-0.5">
+                          <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
+                          <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
+                        </div>
                       </div>
-                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                        {poll.title}
-                      </h3>
                       {poll.response_deadline && (
                         <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                           <ClientOnly fallback={<>Loading...</>}>
@@ -441,13 +443,15 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex justify-end items-center gap-1 mb-0.5">
-                        <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
-                        <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
+                      <div className="flex items-start justify-between gap-2">
+                        <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                          {poll.title}
+                        </h3>
+                        <div className="flex-shrink-0 flex items-center gap-1 mt-0.5">
+                          <span className="text-xs text-gray-400 dark:text-gray-500">{getPollTypeLabel(poll.poll_type)}</span>
+                          <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
+                        </div>
                       </div>
-                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                        {poll.title}
-                      </h3>
                       {poll.response_deadline && (
                         <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                           Closed {(() => {

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -308,7 +308,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`flex items-start gap-2 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
@@ -318,19 +318,19 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-start justify-between gap-2">
+                      <span className="w-6 flex-shrink-0 text-center text-sm mt-0.5">{getPollSymbol(poll.poll_type, false)}</span>
+                      <div className="flex-1 min-w-0">
                         <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                           {poll.title}
                         </h3>
-                        <span className="flex-shrink-0 text-sm mt-0.5">{getPollSymbol(poll.poll_type, false)}</span>
+                        {poll.response_deadline && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                            <ClientOnly fallback={<>Loading...</>}>
+                              <SimpleCountdown deadline={poll.response_deadline} />
+                            </ClientOnly>
+                          </div>
+                        )}
                       </div>
-                      {poll.response_deadline && (
-                        <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                          <ClientOnly fallback={<>Loading...</>}>
-                            <SimpleCountdown deadline={poll.response_deadline} />
-                          </ClientOnly>
-                        </div>
-                      )}
                     </div>
                   </div>
                 </React.Fragment>
@@ -430,7 +430,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : 'opacity-60'} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`flex items-start gap-2 px-3 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : 'opacity-60'} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
@@ -440,15 +440,14 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-start justify-between gap-2">
+                      <span className="w-6 flex-shrink-0 text-center text-sm mt-0.5">{getPollSymbol(poll.poll_type, true)}</span>
+                      <div className="flex-1 min-w-0">
                         <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                           {poll.title}
                         </h3>
-                        <span className="flex-shrink-0 text-sm mt-0.5">{getPollSymbol(poll.poll_type, true)}</span>
-                      </div>
-                      {poll.response_deadline && (
-                        <div className="flex justify-end text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                          Closed {(() => {
+                        {poll.response_deadline && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                            Closed {(() => {
                             const deadline = new Date(poll.response_deadline);
                             const now = new Date();
                             const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
@@ -469,6 +468,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           })()}
                         </div>
                       )}
+                      </div>
                     </div>
                   </div>
               );


### PR DESCRIPTION
## Summary
- Replace card-style poll items with flat divider-based layout (edge-to-edge on mobile, padded on desktop)
- Each poll item: line 1 = poll type symbol + countdown/closed time, line 2 = title, line 3 = creator name + relative creation date
- Restyle bottom bar to match iOS tab bar (solid gray background, icon above label text)
- Move category emoji to end of auto-generated poll titles (updated existing titles in prod + dev DBs)
- Reduce spacing between header and poll list
- Fix closed polls staying faded during touch press

## Test plan
- [ ] Verify polls list renders with divider lines instead of cards
- [ ] Verify poll type symbols appear on the top line with countdown/closed time
- [ ] Verify creator name and relative date appear below titles
- [ ] Verify closed polls stay faded during touch interactions
- [ ] Verify bottom bar shows icon + label style
- [ ] Verify layout is edge-to-edge on mobile, padded on desktop
- [ ] Verify new polls get emoji at end of title (not beginning)

https://claude.ai/code/session_019MjqNYs9uYdswzTLT6FaJw