### PR TITLE
Fix closed poll fade and nomination poll titles

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -144,10 +144,9 @@ function CreatePollContent() {
     const addIcon = (base: string) => icon ? `${base} ${icon}` : base;
 
     if (pollType === 'nomination') {
-      // Use "Place" instead of "Location" for nomination polls
       const prefix = category === 'location' ? 'Place'
         : builtIn?.label || (category !== 'custom' ? category : '');
-      return addIcon(prefix ? `${prefix} Suggestions` : 'Suggestions');
+      return addIcon(prefix || 'Quick Poll');
     }
 
     if (pollType === 'poll') {

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -146,7 +146,7 @@ function CreatePollContent() {
     if (pollType === 'nomination') {
       const prefix = category === 'location' ? 'Place'
         : builtIn?.label || (category !== 'custom' ? category : '');
-      return addIcon(prefix || 'Quick Poll');
+      return addIcon((prefix || 'Quick Poll') + '?');
     }
 
     if (pollType === 'poll') {

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -363,10 +363,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
           )}
           <div>
               {closedPolls.map((poll, index) => {
-                const isVoted = votedPollIds.has(poll.id);
-                const isAbstained = abstainedPollIds.has(poll.id);
-                const hasVotedOrAbstained = isVoted || isAbstained;
-                
                 const handleTouchStart = (e: React.TouchEvent) => {
                   isLongPress.current = false;
                   isScrolling.current = false;

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -443,7 +443,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`px-1 py-2.5 opacity-60 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-1 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Remove opacity fade from closed polls on the main page so they display at full visual weight
- Remove poll type descriptor ("Suggestions") from auto-generated nomination poll titles (e.g. "Restaurant Suggestions" → "Restaurant?")
- Clean up dead variables left over from the opacity removal

## Test plan
- [ ] Verify closed polls on the home page are no longer faded
- [ ] Create a nomination poll and verify the auto-title uses just the category + question mark (e.g. "Restaurant? 🍽️")
- [ ] Verify custom-category nomination polls get "Quick Poll?" as default title

https://claude.ai/code/session_01D8Axuco6hocWspLtnsjH4B