### PR TITLE
Fix poll divider header and compact name display

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -76,6 +76,8 @@ function CreatePollContent() {
   const isSubmittingRef = useRef(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [creatorName, setCreatorName] = useState<string>("");
+  const [isEditingName, setIsEditingName] = useState(false);
+  const nameInputRef = useRef<HTMLInputElement>(null);
   const [originalPollData, setOriginalPollData] = useState<any>(null);
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const [isAutoTitle, setIsAutoTitle] = useState(true);
@@ -1487,16 +1489,40 @@ function CreatePollContent() {
             <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
               Your Name (optional)
             </label>
-            <input
-              type="text"
-              id="creatorName"
-              value={creatorName}
-              onChange={(e) => setCreatorName(e.target.value)}
-              disabled={isLoading}
-              maxLength={50}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              placeholder="Enter your name..."
-            />
+            {creatorName.trim() && !isEditingName ? (
+              <div className="flex items-center gap-2 text-sm">
+                <svg className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                </svg>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsEditingName(true);
+                    setTimeout(() => nameInputRef.current?.focus(), 0);
+                  }}
+                  className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+                >
+                  {creatorName.trim()}
+                </button>
+              </div>
+            ) : (
+              <input
+                ref={nameInputRef}
+                type="text"
+                id="creatorName"
+                value={creatorName}
+                onChange={(e) => setCreatorName(e.target.value)}
+                onBlur={() => {
+                  if (creatorName.trim()) {
+                    setIsEditingName(false);
+                  }
+                }}
+                disabled={isLoading}
+                maxLength={50}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                placeholder="Enter your name..."
+              />
+            )}
           </div>
           
           {!isFormValid() && !isLoading && (

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -168,6 +168,13 @@ function CreatePollContent() {
     return "Who's in?";
   }, [pollType, category, options, locationMode, locationValue, locationOptions]);
 
+  // Focus name input when switching to edit mode
+  useEffect(() => {
+    if (isEditingName) {
+      nameInputRef.current?.focus();
+    }
+  }, [isEditingName]);
+
   // Auto-update title when form fields change (if user hasn't manually edited)
   useEffect(() => {
     if (isAutoTitle) {
@@ -1489,40 +1496,40 @@ function CreatePollContent() {
             <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
               Your Name (optional)
             </label>
-            {creatorName.trim() && !isEditingName ? (
-              <div className="flex items-center gap-2 text-sm">
-                <svg className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                </svg>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setIsEditingName(true);
-                    setTimeout(() => nameInputRef.current?.focus(), 0);
+            {(() => {
+              const trimmedName = creatorName.trim();
+              return trimmedName && !isEditingName ? (
+                <div className="flex items-center gap-2 text-sm">
+                  <svg className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                  </svg>
+                  <button
+                    type="button"
+                    onClick={() => setIsEditingName(true)}
+                    className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+                  >
+                    {trimmedName}
+                  </button>
+                </div>
+              ) : (
+                <input
+                  ref={nameInputRef}
+                  type="text"
+                  id="creatorName"
+                  value={creatorName}
+                  onChange={(e) => setCreatorName(e.target.value)}
+                  onBlur={() => {
+                    if (creatorName.trim()) {
+                      setIsEditingName(false);
+                    }
                   }}
-                  className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
-                >
-                  {creatorName.trim()}
-                </button>
-              </div>
-            ) : (
-              <input
-                ref={nameInputRef}
-                type="text"
-                id="creatorName"
-                value={creatorName}
-                onChange={(e) => setCreatorName(e.target.value)}
-                onBlur={() => {
-                  if (creatorName.trim()) {
-                    setIsEditingName(false);
-                  }
-                }}
-                disabled={isLoading}
-                maxLength={50}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                placeholder="Enter your name..."
-              />
-            )}
+                  disabled={isLoading}
+                  maxLength={50}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                  placeholder="Enter your name..."
+                />
+              );
+            })()}
           </div>
           
           {!isFormValid() && !isLoading && (

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -356,11 +356,9 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {/* Closed Polls Section */}
       {closedPolls.length > 0 && (
         <div>
-          {openPolls.length > 0 && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
-              Closed
-            </div>
-          )}
+          <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
+            Closed
+          </div>
           <div>
               {closedPolls.map((poll, index) => {
                 const handleTouchStart = (e: React.TouchEvent) => {


### PR DESCRIPTION
## Summary
- **Always show "Closed" divider header** above closed polls section, even when there are no open polls
- **Compact name display on create form**: when a user already has a saved name, show it as a clickable compact display (person icon + name) matching the location field pattern, instead of a full text input. Clicking reverts to editable input; blurring collapses back.

## Test plan
- [ ] Open main page with only closed polls — verify "Closed" header appears
- [ ] Open main page with both open and closed polls — verify "Closed" header still appears
- [ ] Go to create poll with no saved name — verify blank input shows as before
- [ ] Go to create poll with a saved name — verify compact display with person icon
- [ ] Click the compact name — verify it switches to editable input and auto-focuses
- [ ] Edit name and click away — verify it collapses back to compact display
- [ ] Clear name and click away — verify empty input stays visible

https://claude.ai/code/session_018ZfmwrXAyYUwUa4i6iJg1h