### PR TITLE
Merge suggestion and preferences poll forms

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1455,7 +1455,7 @@ function CreatePollContent() {
                 placeholder="Enter your title..."
                 required
               />
-              {!isAutoTitle && (
+              {!isAutoTitle && category !== 'yes_no' && (
                 <button
                   type="button"
                   onClick={() => setIsAutoTitle(true)}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -152,10 +152,11 @@ function CreatePollContent() {
       const shorten = isLocationLikeCategory(category) ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
       if (filled.length === 0) {
-        // Suggestion mode (no options) — generate title like old nomination
+        // Suggestion mode (no options) — use category name as title
         const prefix = category === 'location' ? 'Place'
           : builtIn?.label || (category !== 'custom' ? category : '');
-        return addIcon((prefix || 'Quick Poll') + '?');
+        if (prefix) return addIcon(prefix + '?');
+        return '';
       }
       return addIcon(buildFromOptions(filled, 'Quick Vote'));
     }

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -106,6 +106,9 @@ function CreatePollContent() {
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
 
+  const hasNoOptions = options.filter(o => o.trim()).length === 0;
+  const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && hasNoOptions;
+
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
     const builtIn = getBuiltInType(category);
@@ -1295,7 +1298,7 @@ function CreatePollContent() {
                 searchRadius={searchRadius}
                 label={<>Options{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
               />
-              {options.filter(o => o.trim()).length === 0 && (
+              {hasNoOptions && (
                 <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
                   If no options are given, suggestions will be asked for.
                 </p>
@@ -1397,7 +1400,7 @@ function CreatePollContent() {
           </div>
 
           {/* Auto-create preferences poll checkbox - shown when no options provided (suggestion mode) */}
-          {pollType === 'poll' && category !== 'yes_no' && options.filter(o => o.trim()).length === 0 && (
+          {isSuggestionMode && (
             <div className="space-y-2">
               <label className="flex items-center gap-2 cursor-pointer">
                 <input

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1153,7 +1153,7 @@ function CreatePollContent() {
           // Do nothing - all submission is handled by button onClick
         }} className="space-y-4">
           <div className="flex justify-center">
-            <div className="relative w-36 bg-gray-100 dark:bg-gray-800 rounded-full p-0.5 mb-1">
+            <div className="relative w-36 bg-gray-100 dark:bg-gray-800 rounded-full p-0.5 -mb-2">
               <div
                 className={`absolute top-0.5 bottom-0.5 rounded-full shadow-sm ${
                   hasLoadedPollType ? 'transition-all duration-200 ease-in-out' : ''

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -53,7 +53,7 @@ function CreatePollContent() {
   const [voteFromNomination, setVoteFromNomination] = useState<string | null>(null);
 
   const [title, setTitle] = useState("");
-  const [pollType, setPollType] = useState<'poll' | 'nomination' | 'participation'>('nomination');
+  const [pollType, setPollType] = useState<'poll' | 'participation'>('poll');
   const [options, setOptions] = useState<string[]>(['']);
   const [minParticipants, setMinParticipants] = useState<number | null>(1);
   const [maxParticipants, setMaxParticipants] = useState<number | null>(null);
@@ -145,15 +145,18 @@ function CreatePollContent() {
 
     const addIcon = (base: string) => icon ? `${base} ${icon}` : base;
 
-    if (pollType === 'nomination') {
-      const prefix = category === 'location' ? 'Place'
-        : builtIn?.label || (category !== 'custom' ? category : '');
-      return addIcon((prefix || 'Quick Poll') + '?');
-    }
-
     if (pollType === 'poll') {
+      if (category === 'yes_no') {
+        return 'Quick Vote 👍';
+      }
       const shorten = isLocationLikeCategory(category) ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
+      if (filled.length === 0) {
+        // Suggestion mode (no options) — generate title like old nomination
+        const prefix = category === 'location' ? 'Place'
+          : builtIn?.label || (category !== 'custom' ? category : '');
+        return addIcon((prefix || 'Quick Poll') + '?');
+      }
       return addIcon(buildFromOptions(filled, 'Quick Vote'));
     }
 
@@ -196,7 +199,7 @@ function CreatePollContent() {
   }, []);
 
   // Save poll type preference separately (persists across submissions)
-  const savePollTypePreference = useCallback((type: 'poll' | 'nomination' | 'participation') => {
+  const savePollTypePreference = useCallback((type: 'poll' | 'participation') => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('pollTypePreference', type);
     }
@@ -250,8 +253,8 @@ function CreatePollContent() {
   const loadPollTypePreference = () => {
     if (typeof window !== 'undefined') {
       const savedPollType = localStorage.getItem('pollTypePreference');
-      if (savedPollType && (savedPollType === 'poll' || savedPollType === 'nomination' || savedPollType === 'participation')) {
-        setPollType(savedPollType as 'poll' | 'nomination' | 'participation');
+      if (savedPollType && (savedPollType === 'poll' || savedPollType === 'participation')) {
+        setPollType(savedPollType as 'poll' | 'participation');
       }
       // Delay enabling transitions to avoid animation on initial load
       setTimeout(() => {
@@ -317,14 +320,14 @@ function CreatePollContent() {
 
   // Determine poll type based on form selection and options
   const getPollType = (): 'yes_no' | 'ranked_choice' | 'nomination' | 'participation' => {
-    if (pollType === 'nomination') {
-      return 'nomination';
-    }
     if (pollType === 'participation') {
       return 'participation';
     }
+    if (category === 'yes_no') {
+      return 'yes_no';
+    }
     const filledOptions = options.filter(opt => opt.trim() !== '');
-    return filledOptions.length === 0 ? 'yes_no' : 'ranked_choice';
+    return filledOptions.length === 0 ? 'nomination' : 'ranked_choice';
   };
 
 
@@ -354,9 +357,9 @@ function CreatePollContent() {
 
     const dbPollType = getPollType();
 
-    // Options validation only applies to ranked_choice (poll tab) — nomination
+    // Options validation only applies to ranked_choice — yes_no, nomination,
     // and participation polls don't use the options array.
-    if (dbPollType !== 'nomination' && dbPollType !== 'participation') {
+    if (dbPollType === 'ranked_choice') {
       const filledOptions = options.filter(opt => opt.trim() !== '');
 
       // Check for options that exceed character limit (relaxed for autocomplete types)
@@ -384,7 +387,7 @@ function CreatePollContent() {
       }
 
       if (filledOptions.length === 1) {
-        return "Add at least one more option for a ranked choice poll, or leave all options blank for a yes/no poll.";
+        return "Add at least one more option, or leave all options blank to ask for suggestions.";
       }
 
       const uniqueOptions = new Set(filledOptions.map(opt => opt.trim()));
@@ -499,7 +502,7 @@ function CreatePollContent() {
             setPollType('poll');
             setOptions(forkData.options);
           } else if (forkData.poll_type === 'nomination') {
-            setPollType('nomination');
+            setPollType('poll');
             setOptions(['']);
           } else if (forkData.poll_type === 'participation') {
             setPollType('participation');
@@ -585,7 +588,7 @@ function CreatePollContent() {
             setPollType('poll');
             setOptions(duplicateData.options || ['']);
           } else if (duplicateData.poll_type === 'nomination') {
-            setPollType('nomination');
+            setPollType('poll');
             setOptions(['']);
           } else if (duplicateData.poll_type === 'participation') {
             setPollType('participation');
@@ -713,7 +716,7 @@ function CreatePollContent() {
         title !== originalPollData.title ||
         JSON.stringify(options) !== JSON.stringify(originalPollData.options || []) ||
         creatorName !== (originalPollData.creator_name || "") ||
-        pollType !== 'poll'; // Nomination polls are always considered changed
+        category !== (originalPollData.category || 'custom');
 
       setHasFormChanged(hasChanged);
     }
@@ -1150,35 +1153,21 @@ function CreatePollContent() {
           // Do nothing - all submission is handled by button onClick
         }} className="space-y-4">
           <div className="flex justify-center">
-            <div className="relative w-48 bg-gray-100 dark:bg-gray-800 rounded-full p-0.5 mb-1">
+            <div className="relative w-36 bg-gray-100 dark:bg-gray-800 rounded-full p-0.5 mb-1">
               <div
                 className={`absolute top-0.5 bottom-0.5 rounded-full shadow-sm ${
                   hasLoadedPollType ? 'transition-all duration-200 ease-in-out' : ''
                 } ${
-                  pollType === 'nomination'
-                    ? 'bg-blue-100 dark:bg-blue-700/50'
-                    : pollType === 'poll'
+                  pollType === 'poll'
                     ? 'bg-green-100 dark:bg-green-700/50'
                     : 'bg-purple-100 dark:bg-purple-700/50'
                 }`}
                 style={{
-                  width: 'calc(33.333% - 4px)',
-                  left: pollType === 'nomination' ? '2px' : pollType === 'poll' ? 'calc(33.333% + 1px)' : 'calc(66.666% - 0px)'
+                  width: 'calc(50% - 3px)',
+                  left: pollType === 'poll' ? '2px' : 'calc(50% + 1px)'
                 }}
               />
               <div className="relative flex w-full">
-                <button
-                  type="button"
-                  onClick={() => setPollType('nomination')}
-                  disabled={isLoading}
-                  className={`flex-1 py-1 text-xl rounded-md transition-colors duration-200 ${
-                    pollType === 'nomination'
-                      ? 'text-gray-900 dark:text-white'
-                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
-                  } disabled:opacity-50 disabled:cursor-not-allowed`}
-                >
-                  💡
-                </button>
                 <button
                   type="button"
                   onClick={() => setPollType('poll')}
@@ -1283,21 +1272,28 @@ function CreatePollContent() {
             </div>
           )}
 
-          {/* Options field for poll type (ranked choice / yes-no) */}
-          {pollType !== 'nomination' && pollType !== 'participation' && (
-            <OptionsInput
-              options={options}
-              setOptions={setOptions}
-              isLoading={isLoading}
-              pollType="poll"
-              category={category}
-              optionsMetadata={optionsMetadata}
-              onMetadataChange={setOptionsMetadata}
-              referenceLatitude={refLatitude}
-              referenceLongitude={refLongitude}
-              searchRadius={searchRadius}
-              label={<>Options{' '}<span className="text-gray-500 font-normal">(blank for yes/no)</span></>}
-            />
+          {/* Options field for poll type (ranked choice / suggestions) */}
+          {pollType === 'poll' && category !== 'yes_no' && (
+            <>
+              <OptionsInput
+                options={options}
+                setOptions={setOptions}
+                isLoading={isLoading}
+                pollType="poll"
+                category={category}
+                optionsMetadata={optionsMetadata}
+                onMetadataChange={setOptionsMetadata}
+                referenceLatitude={refLatitude}
+                referenceLongitude={refLongitude}
+                searchRadius={searchRadius}
+                label={<>Options{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
+              />
+              {options.filter(o => o.trim()).length === 0 && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+                  If no options are given, suggestions will be asked for.
+                </p>
+              )}
+            </>
           )}
 
           <div>
@@ -1393,8 +1389,8 @@ function CreatePollContent() {
             </div>
           </div>
 
-          {/* Auto-create preferences poll checkbox - nomination polls only */}
-          {pollType === 'nomination' && (
+          {/* Auto-create preferences poll checkbox - shown when no options provided (suggestion mode) */}
+          {pollType === 'poll' && category !== 'yes_no' && options.filter(o => o.trim()).length === 0 && (
             <div className="space-y-2">
               <label className="flex items-center gap-2 cursor-pointer">
                 <input

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -147,7 +147,7 @@ function CreatePollContent() {
 
     if (pollType === 'poll') {
       if (category === 'yes_no') {
-        return 'Quick Vote 👍';
+        return '';
       }
       const shorten = isLocationLikeCategory(category) ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
@@ -1204,7 +1204,13 @@ function CreatePollContent() {
               </label>
               <TypeFieldInput
                 value={category}
-                onChange={setCategory}
+                onChange={(val) => {
+                  setCategory(val);
+                  if (val === 'yes_no') {
+                    setIsAutoTitle(false);
+                    setTitle('');
+                  }
+                }}
                 disabled={isLoading}
               />
             </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -82,7 +82,7 @@ export default function Template({ children }: AppTemplateProps) {
   const [leftElement, setLeftElement] = useState<React.ReactNode>(getInitialLeftElement());
   const [rightElement, setRightElement] = useState<React.ReactNode>(<div className="w-6 h-6" />);
   const [pollPageTitle, setPollPageTitle] = useState('');
-  const [createPollType, setCreatePollType] = useState<'nomination' | 'poll' | 'participation'>('nomination');
+  const [createPollType, setCreatePollType] = useState<'poll' | 'participation'>('poll');
 
   // Determine page-specific header content based on pathname
   useEffect(() => {
@@ -494,7 +494,7 @@ export default function Template({ children }: AppTemplateProps) {
                       className="text-blue-600 dark:text-blue-400"
                       style={{ fontFamily: "'M PLUS 1 Code', monospace" }}
                     >
-                      {createPollType === 'nomination' ? 'Suggestions' : createPollType === 'poll' ? 'Preferences' : 'Participation'}
+                      {createPollType === 'poll' ? 'Preferences' : 'Participation'}
                     </span>
                   </h1>
                 </div>

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -9,6 +9,7 @@ export interface BuiltInType {
 }
 
 const BUILT_IN_TYPES: BuiltInType[] = [
+  { value: "yes_no", label: "Yes / No", icon: "👍" },
   { value: "location", label: "Location", icon: "📍" },
   { value: "restaurant", label: "Restaurant", icon: "🍽️" },
   { value: "movie", label: "Movie", icon: "🎬" },
@@ -24,9 +25,9 @@ export function isLocationLikeCategory(category: string): boolean {
   return category === 'location' || category === 'restaurant';
 }
 
-/** Categories that use autocomplete search (any built-in type). */
+/** Categories that use autocomplete search (any built-in type except yes_no). */
 export function isAutocompleteCategory(category: string): boolean {
-  return BUILT_IN_TYPES.some((t) => t.value === category);
+  return category !== 'yes_no' && BUILT_IN_TYPES.some((t) => t.value === category);
 }
 
 interface TypeFieldInputProps {

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -172,7 +172,7 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder="Enter built-in or custom category"
+          placeholder="Built-in or custom category"
           className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed ${
             builtIn && !isOpen ? "pl-9" : ""
           } ${

--- a/tests/e2e/pages/CreatePollPage.ts
+++ b/tests/e2e/pages/CreatePollPage.ts
@@ -20,8 +20,8 @@ export class CreatePollPage extends BasePage {
 
   get pollTypeToggle() {
     return {
-      poll: this.page.locator('button:has-text("Poll")').first(),
-      nomination: this.page.locator('button:has-text("Nomination/Suggestions")').first()
+      poll: this.page.locator('button:has-text("🗳️")').first(),
+      participation: this.page.locator('button:has-text("🙋")').first()
     };
   }
 
@@ -80,21 +80,11 @@ export class CreatePollPage extends BasePage {
     await this.titleInput.fill(title);
   }
 
-  async selectPollType(type: 'poll' | 'nomination') {
-    // Only click if we need to change the type
-    // Since nomination is the default, only click if switching to poll or if explicitly selecting nomination
+  async selectPollType(type: 'poll' | 'participation') {
     if (type === 'poll') {
       await this.pollTypeToggle.poll.click();
-    } else if (type === 'nomination') {
-      // Check if nomination button exists and is not already selected
-      // If it doesn't exist or page hasn't loaded, it might already be selected by default
-      const nominationButton = this.pollTypeToggle.nomination;
-      const exists = await nominationButton.count() > 0;
-      if (exists) {
-        // Only click if button exists and we can interact with it
-        await nominationButton.click();
-      }
-      // If button doesn't exist, assume nomination is already selected (default)
+    } else if (type === 'participation') {
+      await this.pollTypeToggle.participation.click();
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove the nomination (💡) tab — consolidate to 2 tabs: Poll (🗳️) and Participation (🙋)
- Add "Yes / No" (👍) as the first built-in category — hides options input, no auto-title
- When no options are provided in the poll tab, create a nomination/suggestions poll with auto-create preferences checkbox (default checked) and an info message
- Extract `hasNoOptions` and `isSuggestionMode` derived variables for cleaner JSX conditions

## Test plan
- [ ] Select Yes/No category → options input hidden, no auto-title, title regen button hidden
- [ ] Select a category (e.g. Restaurant) with no options → info message shown, auto-create preferences checkbox shown and checked
- [ ] Fill in 2+ options → ranked choice poll created, no suggestion message
- [ ] Switch between Poll and Participation tabs → correct fields shown
- [ ] Fork/duplicate a nomination poll → loads into poll tab correctly
- [ ] Fork/duplicate a ranked_choice poll → loads with options
- [ ] Custom category with text and no options → title auto-generates as "text?"