### PR TITLE
Collapse poll creation form fields for compact layout

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -107,6 +107,7 @@ function CreatePollContent() {
   const [refLongitude, setRefLongitude] = useState<number | undefined>(undefined);
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
+  const [showRadiusModal, setShowRadiusModal] = useState(false);
 
   const hasNoOptions = options.filter(o => o.trim()).length === 0;
   const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && hasNoOptions;
@@ -1238,6 +1239,8 @@ function CreatePollContent() {
               }}
               searchRadius={searchRadius}
               onSearchRadiusChange={setSearchRadius}
+              showRadiusModal={showRadiusModal}
+              onShowRadiusModal={setShowRadiusModal}
               disabled={isLoading}
             />
           )}
@@ -1301,7 +1304,20 @@ function CreatePollContent() {
                 referenceLatitude={refLatitude}
                 referenceLongitude={refLongitude}
                 searchRadius={searchRadius}
-                label={<>Options{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
+                label={
+                  <span className="flex items-center justify-between">
+                    <span>Options{' '}<span className="text-gray-500 font-normal">(optional)</span></span>
+                    {refLatitude !== undefined && (
+                      <button
+                        type="button"
+                        onClick={() => setShowRadiusModal(true)}
+                        className="px-2 py-0.5 text-xs font-normal bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 rounded-full hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
+                      >
+                        within {searchRadius} mi
+                      </button>
+                    )}
+                  </span>
+                }
               />
               {hasNoOptions && (
                 <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1438,38 +1438,52 @@ function CreatePollContent() {
           )}
 
           <div>
-            <label htmlFor="title" className="block text-sm font-medium mb-1">
-              Title
-            </label>
-            <div className="relative">
-              <input
-                type="text"
-                id="title"
-                ref={titleInputRef}
-                value={title}
-                onChange={(e) => {
-                  setTitle(e.target.value);
+            {isAutoTitle ? (
+              <button
+                type="button"
+                onClick={() => {
                   setIsAutoTitle(false);
+                  setTitle('');
+                  setTimeout(() => titleInputRef.current?.focus(), 0);
                 }}
-                disabled={isLoading}
-                maxLength={100}
-                className="w-full px-3 py-2 pr-9 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                placeholder="Enter your title..."
-                required
-              />
-              {!isAutoTitle && category !== 'yes_no' && (
-                <button
-                  type="button"
-                  onClick={() => setIsAutoTitle(true)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                  title="Auto-generate title"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182" />
-                  </svg>
-                </button>
-              )}
-            </div>
+                className="block text-sm font-medium text-left"
+              >
+                Title: {title || <span className="text-gray-400 italic font-normal">auto</span>}{' '}
+                <span className="text-gray-500 font-normal">(Tap to Edit)</span>
+              </button>
+            ) : (
+              <>
+                <div className="flex items-center justify-between mb-1">
+                  <label htmlFor="title" className="text-sm font-medium">
+                    Title
+                  </label>
+                  {category !== 'yes_no' && (
+                    <button
+                      type="button"
+                      onClick={() => setIsAutoTitle(true)}
+                      className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    >
+                      Autogen
+                    </button>
+                  )}
+                </div>
+                <input
+                  type="text"
+                  id="title"
+                  ref={titleInputRef}
+                  value={title}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    setIsAutoTitle(false);
+                  }}
+                  disabled={isLoading}
+                  maxLength={100}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                  placeholder="Enter your title..."
+                  required
+                />
+              </>
+            )}
           </div>
 
           {/* Optional details field */}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -37,6 +37,22 @@ function shortenOption(text: string) { return text.split(/[:(]/)[0].trim(); }
 // For locations, take just the name (first comma segment) then apply shortenOption
 function shortenLocation(text: string) { return shortenOption(text.split(',')[0].trim()); }
 
+const BASE_DEADLINE_OPTIONS = [
+  { value: "5min", label: "5 min", minutes: 5 },
+  { value: "10min", label: "10 min", minutes: 10 },
+  { value: "15min", label: "15 min", minutes: 15 },
+  { value: "30min", label: "30 min", minutes: 30 },
+  { value: "1hr", label: "1 hr", minutes: 60 },
+  { value: "2hr", label: "2 hr", minutes: 120 },
+  { value: "4hr", label: "4 hr", minutes: 240 },
+  { value: "custom", label: "Custom", minutes: 0 },
+];
+
+const DEV_DEADLINE_OPTIONS = [
+  { value: "10sec", label: "10 sec", minutes: 1/6 },
+  ...BASE_DEADLINE_OPTIONS,
+];
+
 function CreatePollContent() {
   const { prefetch } = useAppPrefetch();
   const router = useRouter();
@@ -781,24 +797,9 @@ function CreatePollContent() {
   }, [options.length, shouldFocusNewOption]);
 
 
-  const baseDeadlineOptions = [
-    { value: "5min", label: "5 min", minutes: 5 },
-    { value: "10min", label: "10 min", minutes: 10 },
-    { value: "15min", label: "15 min", minutes: 15 },
-    { value: "30min", label: "30 min", minutes: 30 },
-    { value: "1hr", label: "1 hr", minutes: 60 },
-    { value: "2hr", label: "2 hr", minutes: 120 },
-    { value: "4hr", label: "4 hr", minutes: 240 },
-    { value: "custom", label: "Custom", minutes: 0 },
-  ];
-
-  // Add 10-second option for development only
   const deadlineOptions = process.env.NODE_ENV === 'development'
-    ? [
-        { value: "10sec", label: "10 sec", minutes: 1/6 }, // 10 seconds = 1/6 minute
-        ...baseDeadlineOptions
-      ]
-    : baseDeadlineOptions;
+    ? DEV_DEADLINE_OPTIONS
+    : BASE_DEADLINE_OPTIONS;
 
   const calculateDeadline = () => {
     const now = new Date();
@@ -877,6 +878,11 @@ function CreatePollContent() {
     if (displayParts.length === 0) return " (less than 1 min)";
     
     return ` (${displayParts.join(', ')})`;
+  };
+
+  const handleEditName = () => {
+    setIsEditingName(true);
+    setTimeout(() => nameInputRef.current?.focus(), 0);
   };
 
   const handleSubmitClick = (e: React.FormEvent | React.MouseEvent) => {
@@ -1018,7 +1024,7 @@ function CreatePollContent() {
       if (dbPollType === 'nomination' && autoCreatePreferences) {
         pollData.auto_create_preferences = true;
         pollData.auto_preferences_deadline_minutes =
-          baseDeadlineOptions.find(o => o.value === autoPreferencesDeadline)?.minutes || 10;
+          BASE_DEADLINE_OPTIONS.find(o => o.value === autoPreferencesDeadline)?.minutes || 10;
       }
 
       // Add min/max participants for participation polls
@@ -1065,12 +1071,12 @@ function CreatePollContent() {
           } else if (mode === 'preferences') {
             pollData[`${fieldName}_options`] = fieldOptions.filter(o => o.trim() !== '');
             pollData[`${fieldName}_preferences_deadline_minutes`] =
-              baseDeadlineOptions.find(o => o.value === prefDeadline)?.minutes || 10;
+              BASE_DEADLINE_OPTIONS.find(o => o.value === prefDeadline)?.minutes || 10;
           } else if (mode === 'suggestions') {
             pollData[`${fieldName}_suggestions_deadline_minutes`] =
-              baseDeadlineOptions.find(o => o.value === sugDeadline)?.minutes || 10;
+              BASE_DEADLINE_OPTIONS.find(o => o.value === sugDeadline)?.minutes || 10;
             pollData[`${fieldName}_preferences_deadline_minutes`] =
-              baseDeadlineOptions.find(o => o.value === prefDeadline)?.minutes || 10;
+              BASE_DEADLINE_OPTIONS.find(o => o.value === prefDeadline)?.minutes || 10;
           }
         };
         addFieldData('location', locationMode, locationValue, locationOptions, locationSuggestionsDeadline, locationPreferencesDeadline);
@@ -1278,7 +1284,7 @@ function CreatePollContent() {
                 onSuggestionsDeadlineChange={setLocationSuggestionsDeadline}
                 preferencesDeadline={locationPreferencesDeadline}
                 onPreferencesDeadlineChange={setLocationPreferencesDeadline}
-                deadlineOptions={baseDeadlineOptions}
+                deadlineOptions={BASE_DEADLINE_OPTIONS}
                 isLoading={isLoading}
               />
             </div>
@@ -1550,10 +1556,7 @@ function CreatePollContent() {
             ) : creatorName.trim() ? (
               <button
                 type="button"
-                onClick={() => {
-                  setIsEditingName(true);
-                  setTimeout(() => nameInputRef.current?.focus(), 0);
-                }}
+                onClick={handleEditName}
                 className="block text-sm font-medium text-left"
               >
                 Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{creatorName.trim()}</span>
@@ -1561,10 +1564,7 @@ function CreatePollContent() {
             ) : (
               <button
                 type="button"
-                onClick={() => {
-                  setIsEditingName(true);
-                  setTimeout(() => nameInputRef.current?.focus(), 0);
-                }}
+                onClick={handleEditName}
                 className="text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
               >
                 Add Your Name <span className="font-normal">(optional)</span>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -87,6 +87,8 @@ function CreatePollContent() {
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const detailsRef = useRef<HTMLTextAreaElement>(null);
   const [category, setCategory] = useState<string>('custom');
   const [optionsMetadata, setOptionsMetadata] = useState<OptionsMetadata>({});
   // Location/time fields for participation polls
@@ -277,6 +279,7 @@ function CreatePollContent() {
           setTitle(formState.title || '');
           if (formState.isAutoTitle === false) setIsAutoTitle(false);
           setDetails(formState.details || '');
+          if (formState.details) setDetailsOpen(true);
           setOptions(formState.options || ['']);
           setDeadlineOption(formState.deadlineOption || '10min');
           setCustomDate(formState.customDate || '');
@@ -500,6 +503,7 @@ function CreatePollContent() {
           setTitle(forkData.title || "");
           if (forkData.title) setIsAutoTitle(false);
           setDetails(forkData.details || "");
+          if (forkData.details) setDetailsOpen(true);
 
           // Set poll type and options based on forked poll
           if (forkData.poll_type === 'ranked_choice' && forkData.options) {
@@ -586,6 +590,7 @@ function CreatePollContent() {
           setTitle(duplicateData.title || "");
           if (duplicateData.title) setIsAutoTitle(false);
           setDetails(duplicateData.details || "");
+          if (duplicateData.details) setDetailsOpen(true);
 
           // Set poll type based on duplicated poll
           if (duplicateData.poll_type === 'ranked_choice') {
@@ -1469,26 +1474,48 @@ function CreatePollContent() {
 
           {/* Optional details field */}
           <div>
-            <label htmlFor="details" className="block text-sm font-medium mb-1">
-              Details{' '}
-              <span className="text-gray-500 font-normal">(optional)</span>
-            </label>
-            <textarea
-              id="details"
-              value={details}
-              onChange={(e) => {
-                setDetails(e.target.value);
-                const el = e.target;
-                el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
-                const maxH = 5 * 20 + 16; // 5 lines + padding
-                el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
-                el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
-              }}
-              disabled={isLoading}
-              style={{ height: SINGLE_LINE_INPUT_HEIGHT }}
-              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
-              placeholder="Add more context or instructions..."
-            />
+            {detailsOpen ? (
+              <>
+                <label htmlFor="details" className="block text-sm font-medium mb-1">
+                  Details{' '}
+                  <span className="text-gray-500 font-normal">(optional)</span>
+                </label>
+                <textarea
+                  ref={detailsRef}
+                  id="details"
+                  value={details}
+                  onChange={(e) => {
+                    setDetails(e.target.value);
+                    const el = e.target;
+                    el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
+                    const maxH = 5 * 20 + 16; // 5 lines + padding
+                    el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
+                    el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
+                  }}
+                  onBlur={() => {
+                    if (!details.trim()) {
+                      setDetailsOpen(false);
+                      setDetails('');
+                    }
+                  }}
+                  disabled={isLoading}
+                  style={{ height: SINGLE_LINE_INPUT_HEIGHT }}
+                  className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
+                  placeholder="Add more context or instructions..."
+                />
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setDetailsOpen(true);
+                  setTimeout(() => detailsRef.current?.focus(), 0);
+                }}
+                className="text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+              >
+                Add Details <span className="font-normal">(optional)</span>
+              </button>
+            )}
           </div>
 
           <div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -114,8 +114,7 @@ function CreatePollContent() {
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
     const builtIn = getBuiltInType(category);
-    const icon = builtIn?.icon || '';
-    const limit = 40 - (icon ? icon.length + 1 : 0);
+    const limit = 40;
     const catLabel = builtIn?.label || (category !== 'custom' ? category : 'one');
 
     const joinWithOr = (items: string[]) => {
@@ -148,8 +147,6 @@ function CreatePollContent() {
       return `Which ${catLabel}?`;
     };
 
-    const addIcon = (base: string) => icon ? `${base} ${icon}` : base;
-
     if (pollType === 'poll') {
       if (category === 'yes_no') {
         return '';
@@ -160,10 +157,10 @@ function CreatePollContent() {
         // Suggestion mode (no options) — use category name as title
         const prefix = category === 'location' ? 'Place'
           : builtIn?.label || (category !== 'custom' ? category : '');
-        if (prefix) return addIcon(prefix + '?');
+        if (prefix) return prefix + '?';
         return '';
       }
-      return addIcon(buildFromOptions(filled, 'Quick Vote'));
+      return buildFromOptions(filled, 'Quick Vote');
     }
 
     // participation
@@ -172,7 +169,7 @@ function CreatePollContent() {
     }
     if (locationMode === 'preferences') {
       const filled = locationOptions.filter(o => o.trim()).map(shortenLocation);
-      if (filled.length > 0) return addIcon(buildFromOptions(filled, "Who's in?"));
+      if (filled.length > 0) return buildFromOptions(filled, "Who's in?");
     }
     return "Who's in?";
   }, [pollType, category, options, locationMode, locationValue, locationOptions]);

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1533,43 +1533,47 @@ function CreatePollContent() {
           </div>
 
           <div>
-            <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
-              Your Name (optional)
-            </label>
-            {(() => {
-              const trimmedName = creatorName.trim();
-              return trimmedName && !isEditingName ? (
-                <div className="flex items-center gap-2 text-sm">
-                  <svg className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                  </svg>
-                  <button
-                    type="button"
-                    onClick={() => setIsEditingName(true)}
-                    className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
-                  >
-                    {trimmedName}
-                  </button>
-                </div>
-              ) : (
+            {isEditingName ? (
+              <>
+                <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
+                  Your Name <span className="text-gray-500 font-normal">(optional)</span>
+                </label>
                 <input
                   ref={nameInputRef}
                   type="text"
                   id="creatorName"
                   value={creatorName}
                   onChange={(e) => setCreatorName(e.target.value)}
-                  onBlur={() => {
-                    if (creatorName.trim()) {
-                      setIsEditingName(false);
-                    }
-                  }}
+                  onBlur={() => setIsEditingName(false)}}
                   disabled={isLoading}
                   maxLength={50}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
                   placeholder="Enter your name..."
                 />
-              );
-            })()}
+              </>
+            ) : creatorName.trim() ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setIsEditingName(true);
+                  setTimeout(() => nameInputRef.current?.focus(), 0);
+                }}
+                className="block text-sm font-medium text-left"
+              >
+                Your Name: <span className="font-normal">{creatorName.trim()}</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setIsEditingName(true);
+                  setTimeout(() => nameInputRef.current?.focus(), 0);
+                }}
+                className="text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+              >
+                Add Your Name <span className="font-normal">(optional)</span>
+              </button>
+            )}
           </div>
           
           {!isFormValid() && !isLoading && (

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -107,7 +107,6 @@ function CreatePollContent() {
   const [refLongitude, setRefLongitude] = useState<number | undefined>(undefined);
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
-  const [showRadiusModal, setShowRadiusModal] = useState(false);
 
   const hasNoOptions = options.filter(o => o.trim()).length === 0;
   const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && hasNoOptions;
@@ -1239,8 +1238,6 @@ function CreatePollContent() {
               }}
               searchRadius={searchRadius}
               onSearchRadiusChange={setSearchRadius}
-              showRadiusModal={showRadiusModal}
-              onShowRadiusModal={setShowRadiusModal}
               disabled={isLoading}
             />
           )}
@@ -1304,20 +1301,7 @@ function CreatePollContent() {
                 referenceLatitude={refLatitude}
                 referenceLongitude={refLongitude}
                 searchRadius={searchRadius}
-                label={
-                  <span className="flex items-center justify-between">
-                    <span>Options{' '}<span className="text-gray-500 font-normal">(optional)</span></span>
-                    {refLatitude !== undefined && (
-                      <button
-                        type="button"
-                        onClick={() => setShowRadiusModal(true)}
-                        className="px-2 py-0.5 text-xs font-normal bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 rounded-full hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
-                      >
-                        within {searchRadius} mi
-                      </button>
-                    )}
-                  </span>
-                }
+                label={<>Options{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
               />
               {hasNoOptions && (
                 <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1461,9 +1461,9 @@ function CreatePollContent() {
                     <button
                       type="button"
                       onClick={() => setIsAutoTitle(true)}
-                      className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                      className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
                     >
-                      Autogen
+                      Generate
                     </button>
                   )}
                 </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -780,20 +780,20 @@ function CreatePollContent() {
 
 
   const baseDeadlineOptions = [
-    { value: "5min", label: "5 minutes", minutes: 5 },
-    { value: "10min", label: "10 minutes", minutes: 10 },
-    { value: "15min", label: "15 minutes", minutes: 15 },
-    { value: "30min", label: "30 minutes", minutes: 30 },
-    { value: "1hr", label: "1 hour", minutes: 60 },
-    { value: "2hr", label: "2 hours", minutes: 120 },
-    { value: "4hr", label: "4 hours", minutes: 240 },
+    { value: "5min", label: "5 min", minutes: 5 },
+    { value: "10min", label: "10 min", minutes: 10 },
+    { value: "15min", label: "15 min", minutes: 15 },
+    { value: "30min", label: "30 min", minutes: 30 },
+    { value: "1hr", label: "1 hr", minutes: 60 },
+    { value: "2hr", label: "2 hr", minutes: 120 },
+    { value: "4hr", label: "4 hr", minutes: 240 },
     { value: "custom", label: "Custom", minutes: 0 },
   ];
 
   // Add 10-second option for development only
-  const deadlineOptions = process.env.NODE_ENV === 'development' 
+  const deadlineOptions = process.env.NODE_ENV === 'development'
     ? [
-        { value: "10sec", label: "10 seconds (Dev Only)", minutes: 1/6 }, // 10 seconds = 1/6 minute
+        { value: "10sec", label: "10 sec", minutes: 1/6 }, // 10 seconds = 1/6 minute
         ...baseDeadlineOptions
       ]
     : baseDeadlineOptions;

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1306,23 +1306,49 @@ function CreatePollContent() {
             </>
           )}
 
+          {/* Auto-close + Response Deadline */}
           <div>
-            <label htmlFor="deadline" className="block text-sm font-medium mb-1">
-              Response Deadline
-            </label>
-            <select
-              id="deadline"
-              value={deadlineOption}
-              onChange={(e) => setDeadlineOption(e.target.value)}
-              disabled={isLoading}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {deadlineOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {isClient ? getTimeLabel(option.value) : option.label}
-                </option>
-              ))}
-            </select>
+            <label className="block text-sm font-medium mb-1">Close after</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min="1"
+                value={autoCloseAfter ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val, 10) || 1));
+                }}
+                disabled={isLoading}
+                placeholder="—"
+                className="w-16 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
+              />
+              <span className="text-sm text-gray-600 dark:text-gray-400">responses or</span>
+              <select
+                id="deadline"
+                value={deadlineOption}
+                onChange={(e) => setDeadlineOption(e.target.value)}
+                disabled={isLoading}
+                className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+              >
+                {deadlineOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {isClient ? getTimeLabel(option.value) : option.label}
+                  </option>
+                ))}
+              </select>
+              {autoCloseAfter !== null && (
+                <button
+                  type="button"
+                  onClick={() => setAutoCloseAfter(null)}
+                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0"
+                  title="Disable auto-close"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
           </div>
 
           {deadlineOption === "custom" && (
@@ -1365,39 +1391,6 @@ function CreatePollContent() {
               </div>
             </div>
           )}
-
-          {/* Auto-close after N responses */}
-          <div>
-            <label className="block text-sm font-medium mb-1">Auto-close</label>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600 dark:text-gray-400">After</span>
-              <input
-                type="number"
-                min="1"
-                value={autoCloseAfter ?? ''}
-                onChange={(e) => {
-                  const val = e.target.value;
-                  setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val, 10) || 1));
-                }}
-                disabled={isLoading}
-                placeholder="—"
-                className="w-16 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
-              />
-              <span className="text-sm text-gray-600 dark:text-gray-400">responses</span>
-              {autoCloseAfter !== null && (
-                <button
-                  type="button"
-                  onClick={() => setAutoCloseAfter(null)}
-                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 ml-1"
-                  title="Disable auto-close"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              )}
-            </div>
-          </div>
 
           {/* Auto-create preferences poll checkbox - shown when no options provided (suggestion mode) */}
           {isSuggestionMode && (

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1308,8 +1308,8 @@ function CreatePollContent() {
 
           {/* Auto-close + Response Deadline */}
           <div>
-            <label className="block text-sm font-medium mb-1">Close after</label>
-            <div className="flex items-center gap-2">
+            <label className="block text-sm font-medium mb-1">Close After</label>
+            <div className="flex items-center gap-2 min-w-0">
               <input
                 type="number"
                 min="1"
@@ -1320,15 +1320,15 @@ function CreatePollContent() {
                 }}
                 disabled={isLoading}
                 placeholder="—"
-                className="w-16 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
+                className="w-16 shrink-0 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
               />
-              <span className="text-sm text-gray-600 dark:text-gray-400">responses or</span>
+              <span className="text-sm text-gray-600 dark:text-gray-400 shrink-0">votes or</span>
               <select
                 id="deadline"
                 value={deadlineOption}
                 onChange={(e) => setDeadlineOption(e.target.value)}
                 disabled={isLoading}
-                className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                className="min-w-0 flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm truncate"
               >
                 {deadlineOptions.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1544,7 +1544,7 @@ function CreatePollContent() {
                   id="creatorName"
                   value={creatorName}
                   onChange={(e) => setCreatorName(e.target.value)}
-                  onBlur={() => setIsEditingName(false)}}
+                  onBlur={() => setIsEditingName(false)}
                   disabled={isLoading}
                   maxLength={50}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1448,8 +1448,7 @@ function CreatePollContent() {
                 }}
                 className="block text-sm font-medium text-left"
               >
-                Title: {title || <span className="text-gray-400 italic font-normal">auto</span>}{' '}
-                <span className="text-gray-500 font-normal">(Tap to Edit)</span>
+                Title: <span className="text-blue-600 dark:text-blue-400 font-normal">{title || <span className="italic">auto</span>}</span>
               </button>
             ) : (
               <>
@@ -1560,7 +1559,7 @@ function CreatePollContent() {
                 }}
                 className="block text-sm font-medium text-left"
               >
-                Your Name: <span className="font-normal">{creatorName.trim()}</span>
+                Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{creatorName.trim()}</span>
               </button>
             ) : (
               <button

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -136,7 +136,7 @@ export default function ProfilePage() {
       {/* Location Section */}
       <div className="mb-6">
         <label htmlFor="location" className="block text-sm font-medium mb-1">
-          Your Location
+          Reference Location
         </label>
         {savedLocation && (
           <div className="mb-2 flex items-center gap-2">
@@ -183,7 +183,7 @@ export default function ProfilePage() {
           </button>
         </div>
         <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          Used to find nearby places when creating location polls
+          Used as the reference point for calculating distance in location-based polls
         </p>
       </div>
 

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -11,8 +11,6 @@ interface ReferenceLocationInputProps {
   onLocationChange: (lat: number | undefined, lng: number | undefined, label: string) => void;
   searchRadius: number;
   onSearchRadiusChange: (radius: number) => void;
-  showRadiusModal?: boolean;
-  onShowRadiusModal?: (show: boolean) => void;
   disabled?: boolean;
 }
 
@@ -23,17 +21,13 @@ export default function ReferenceLocationInput({
   onLocationChange,
   searchRadius,
   onSearchRadiusChange,
-  showRadiusModal: showRadiusModalProp,
-  onShowRadiusModal,
   disabled = false,
 }: ReferenceLocationInputProps) {
   const [input, setInput] = useState("");
   const [isGeocoding, setIsGeocoding] = useState(false);
   const [isGeolocating, setIsGeolocating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showRadiusModalLocal, setShowRadiusModalLocal] = useState(false);
-  const showRadiusModal = showRadiusModalProp ?? showRadiusModalLocal;
-  const setShowRadiusModal = onShowRadiusModal ?? setShowRadiusModalLocal;
+  const [showRadiusModal, setShowRadiusModal] = useState(false);
   const [radiusInput, setRadiusInput] = useState(String(searchRadius));
   const radiusInputRef = useRef<HTMLInputElement>(null);
 

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -11,6 +11,8 @@ interface ReferenceLocationInputProps {
   onLocationChange: (lat: number | undefined, lng: number | undefined, label: string) => void;
   searchRadius: number;
   onSearchRadiusChange: (radius: number) => void;
+  showRadiusModal?: boolean;
+  onShowRadiusModal?: (show: boolean) => void;
   disabled?: boolean;
 }
 
@@ -21,13 +23,17 @@ export default function ReferenceLocationInput({
   onLocationChange,
   searchRadius,
   onSearchRadiusChange,
+  showRadiusModal: showRadiusModalProp,
+  onShowRadiusModal,
   disabled = false,
 }: ReferenceLocationInputProps) {
   const [input, setInput] = useState("");
   const [isGeocoding, setIsGeocoding] = useState(false);
   const [isGeolocating, setIsGeolocating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showRadiusModal, setShowRadiusModal] = useState(false);
+  const [showRadiusModalLocal, setShowRadiusModalLocal] = useState(false);
+  const showRadiusModal = showRadiusModalProp ?? showRadiusModalLocal;
+  const setShowRadiusModal = onShowRadiusModal ?? setShowRadiusModalLocal;
   const [radiusInput, setRadiusInput] = useState(String(searchRadius));
   const radiusInputRef = useRef<HTMLInputElement>(null);
 
@@ -113,15 +119,9 @@ export default function ReferenceLocationInput({
 
   return (
     <div>
-      <label className="block text-sm font-medium mb-1">
-        Your Location
-      </label>
-      {hasLocation && (
-        <div className="mb-2 flex items-center gap-2 text-sm flex-wrap">
-          <svg className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-          </svg>
+      {hasLocation ? (
+        <div className="flex items-center gap-2 text-sm flex-wrap">
+          <span className="font-medium">Near:</span>
           <button
             type="button"
             onClick={() => onLocationChange(undefined, undefined, "")}
@@ -129,45 +129,12 @@ export default function ReferenceLocationInput({
           >
             {label}
           </button>
-          <div className="flex-1" />
-          <button
-            type="button"
-            onClick={() => setShowRadiusModal(true)}
-            className="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 rounded-full hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
-          >
-            Within {searchRadius} mi
-          </button>
         </div>
-      )}
-      {showRadiusModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowRadiusModal(false)}>
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 w-56" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-sm font-medium mb-3 text-gray-900 dark:text-white">Search Radius</h3>
-            <div className="flex items-center gap-2">
-              <input
-                ref={radiusInputRef}
-                type="number"
-                min="1"
-                max="10000"
-                value={radiusInput}
-                onChange={(e) => setRadiusInput(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') applyRadius(); }}
-                className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
-              />
-              <span className="text-sm text-gray-500 dark:text-gray-400">mi</span>
-            </div>
-            <button
-              type="button"
-              onClick={applyRadius}
-              className="mt-3 w-full py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium"
-            >
-              Apply
-            </button>
-          </div>
-        </div>
-      )}
-      {!hasLocation && (
+      ) : (
         <>
+          <label className="block text-sm font-medium mb-1">
+            Near
+          </label>
           <div className="flex gap-2">
             <input
               type="text"
@@ -207,10 +174,34 @@ export default function ReferenceLocationInput({
               )}
             </button>
           </div>
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-            Search results will be sorted by distance from this location
-          </p>
         </>
+      )}
+      {showRadiusModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowRadiusModal(false)}>
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 w-56" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-medium mb-3 text-gray-900 dark:text-white">Search Radius</h3>
+            <div className="flex items-center gap-2">
+              <input
+                ref={radiusInputRef}
+                type="number"
+                min="1"
+                max="10000"
+                value={radiusInput}
+                onChange={(e) => setRadiusInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') applyRadius(); }}
+                className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white text-sm"
+              />
+              <span className="text-sm text-gray-500 dark:text-gray-400">mi</span>
+            </div>
+            <button
+              type="button"
+              onClick={applyRadius}
+              className="mt-3 w-full py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium"
+            >
+              Apply
+            </button>
+          </div>
+        </div>
       )}
       {error && (
         <p className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</p>

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -120,14 +120,22 @@ export default function ReferenceLocationInput({
   return (
     <div>
       {hasLocation ? (
-        <div className="flex items-center gap-2 text-sm flex-wrap">
-          <span className="font-medium">Near:</span>
+        <div className="flex items-center gap-2 text-sm min-w-0">
+          <span className="font-medium shrink-0">Near:</span>
           <button
             type="button"
             onClick={() => onLocationChange(undefined, undefined, "")}
-            className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+            className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer truncate min-w-0"
+            title={label}
           >
             {label}
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowRadiusModal(true)}
+            className="shrink-0 px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 rounded-full hover:bg-blue-200 dark:hover:bg-blue-900/60 transition-colors"
+          >
+            within {searchRadius} mi
           </button>
         </div>
       ) : (

--- a/components/ReferenceLocationInput.tsx
+++ b/components/ReferenceLocationInput.tsx
@@ -130,6 +130,7 @@ export default function ReferenceLocationInput({
           >
             {label}
           </button>
+          <div className="flex-1" />
           <button
             type="button"
             onClick={() => setShowRadiusModal(true)}


### PR DESCRIPTION
## Summary
- Combine auto-close count and response deadline into single "Close After" line: `[input] votes or [dropdown]`
- Abbreviate deadline dropdown units (min, hr, sec)
- Title field shows inline "Title: [value]" when auto-generated, with "Generate" button to revert from edit mode
- Details field collapses to clickable "Add Details (optional)" when empty
- Name field collapses to inline "Your Name: [value]" or "Add Your Name (optional)" when not editing
- Location field renamed to "Near" with inline display and truncated long addresses
- Profile page clarifies location is "Reference Location" for distance calculation
- Remove emoji icons from auto-generated titles
- Hoist deadline options arrays outside component to avoid per-render re-creation

## Test plan
- [ ] Create polls of each type, verify all fields render correctly
- [ ] Verify title auto-generation works and "Generate" button restores it
- [ ] Verify details field opens/closes on tap/blur
- [ ] Verify name field shows inline when set, opens input on tap
- [ ] Verify auto-close + deadline row stays within bounds on narrow screens
- [ ] Verify location "Near:" line truncates long addresses with radius pill right-aligned
- [ ] Verify fork/duplicate pre-populates fields in expanded state

https://claude.ai/code/session_01S1ywjuWVJF2qDwGEj2aHfd