### PR TITLE
Fix zip code geocoding returning wrong country

### DIFF
--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import os
+import re
 from urllib.parse import urlparse
 
 import httpx
@@ -194,15 +195,16 @@ async def geocode(q: str = Query(..., min_length=2, max_length=200)):
     Returns the first matching result with lat, lon, and a short label
     suitable for display (city name or zip code).
     """
+    q = q.strip()
     params: dict[str, str | int] = {
         "q": q,
         "format": "jsonv2",
         "limit": 1,
         "addressdetails": 1,
     }
-    # Pure numeric queries are zip codes — restrict to US to avoid
+    # Pure numeric queries are US zip codes — restrict to US to avoid
     # matching postal codes in other countries (e.g. 75080 → Pakistan).
-    if q.strip().replace("-", "").isdigit():
+    if re.fullmatch(r"\d{5}(-\d{4})?", q):
         params["countrycodes"] = "us"
     else:
         # Bias (not restrict) toward continental US for non-zip queries

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -194,14 +194,22 @@ async def geocode(q: str = Query(..., min_length=2, max_length=200)):
     Returns the first matching result with lat, lon, and a short label
     suitable for display (city name or zip code).
     """
+    params: dict[str, str | int] = {
+        "q": q,
+        "format": "jsonv2",
+        "limit": 1,
+        "addressdetails": 1,
+    }
+    # Pure numeric queries are zip codes — restrict to US to avoid
+    # matching postal codes in other countries (e.g. 75080 → Pakistan).
+    if q.strip().replace("-", "").isdigit():
+        params["countrycodes"] = "us"
+    else:
+        # Bias (not restrict) toward continental US for non-zip queries
+        params["viewbox"] = "-125.0,49.4,-66.9,25.0"
     resp = await _http_client.get(
         _NOMINATIM_URL,
-        params={
-            "q": q,
-            "format": "jsonv2",
-            "limit": 1,
-            "addressdetails": 1,
-        },
+        params=params,
         headers=_NOMINATIM_HEADERS,
     )
     resp.raise_for_status()


### PR DESCRIPTION
## Summary
- Zip codes like 75080 (Richardson, TX) were resolving to Karachi Division, Pakistan because the Nominatim geocode endpoint had no country filtering
- Pure-numeric queries matching US zip format (`\d{5}(-\d{4})?`) now restrict to US via `countrycodes=us`
- Text queries get a US continental viewbox bias (not hard restriction) so American results are preferred
- Query is stripped once at function entry for consistency

## Test plan
- [ ] Enter zip code `75080` in the "near location" field → should resolve to Richardson, TX area
- [ ] Enter zip code `10001` → should resolve to New York, NY
- [ ] Enter city name `Chicago` → should resolve to Chicago, IL
- [ ] Enter international city `London` → should still work (viewbox is bias, not restriction)

https://claude.ai/code/session_01P3XQvupZf5YQuAk5iYRGGN