### PR TITLE
Style Add Details and Your Name as collapsed fields

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1500,7 +1500,7 @@ function CreatePollContent() {
             {detailsOpen ? (
               <>
                 <label htmlFor="details" className="block text-sm font-medium mb-1">
-                  Details{!details.trim() && <>{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
+                  Details{!details.trim() && <>{' '}<span className="font-normal">(optional)</span></>}
                 </label>
                 <textarea
                   ref={detailsRef}
@@ -1528,7 +1528,7 @@ function CreatePollContent() {
               </>
             ) : (
               <div className="text-sm font-medium">
-                Details <span className="text-gray-500 font-normal">(optional)</span>:{' '}
+                Details <span className="font-normal">(optional)</span>:{' '}
                 <button
                   type="button"
                   onClick={() => setDetailsOpen(true)}
@@ -1544,7 +1544,7 @@ function CreatePollContent() {
             {isEditingName ? (
               <>
                 <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
-                  Your Name{!creatorName.trim() && <>{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
+                  Your Name{!creatorName.trim() && <>{' '}<span className="font-normal">(optional)</span></>}
                 </label>
                 <input
                   ref={nameInputRef}
@@ -1569,7 +1569,7 @@ function CreatePollContent() {
               </button>
             ) : (
               <div className="text-sm font-medium">
-                Your Name <span className="text-gray-500 font-normal">(optional)</span>:{' '}
+                Your Name <span className="font-normal">(optional)</span>:{' '}
                 <button
                   type="button"
                   onClick={handleEditName}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1311,13 +1311,8 @@ function CreatePollContent() {
                 referenceLatitude={refLatitude}
                 referenceLongitude={refLongitude}
                 searchRadius={searchRadius}
-                label={<>Options{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
+                label={<>Options <span className="font-normal">(leave blank to ask for suggestions first)</span></>}
               />
-              {hasNoOptions && (
-                <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
-                  If no options are given, suggestions will be asked for.
-                </p>
-              )}
             </>
           )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1527,7 +1527,7 @@ function CreatePollContent() {
                   setDetailsOpen(true);
                   setTimeout(() => detailsRef.current?.focus(), 0);
                 }}
-                className="text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-500 text-left dark:bg-gray-800"
               >
                 Add Details <span className="font-normal">(optional)</span>
               </button>
@@ -1557,7 +1557,7 @@ function CreatePollContent() {
               <button
                 type="button"
                 onClick={handleEditName}
-                className="block text-sm font-medium text-left"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-left hover:border-gray-400 dark:hover:border-gray-500 dark:bg-gray-800"
               >
                 Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{creatorName.trim()}</span>
               </button>
@@ -1565,7 +1565,7 @@ function CreatePollContent() {
               <button
                 type="button"
                 onClick={handleEditName}
-                className="text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-500 text-left dark:bg-gray-800"
               >
                 Add Your Name <span className="font-normal">(optional)</span>
               </button>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1500,8 +1500,7 @@ function CreatePollContent() {
             {detailsOpen ? (
               <>
                 <label htmlFor="details" className="block text-sm font-medium mb-1">
-                  Details{' '}
-                  <span className="text-gray-500 font-normal">(optional)</span>
+                  Details{!details.trim() && <>{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
                 </label>
                 <textarea
                   ref={detailsRef}
@@ -1545,7 +1544,7 @@ function CreatePollContent() {
             {isEditingName ? (
               <>
                 <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
-                  Your Name <span className="text-gray-500 font-normal">(optional)</span>
+                  Your Name{!creatorName.trim() && <>{' '}<span className="text-gray-500 font-normal">(optional)</span></>}
                 </label>
                 <input
                   ref={nameInputRef}
@@ -1569,13 +1568,16 @@ function CreatePollContent() {
                 Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{creatorName.trim()}</span>
               </button>
             ) : (
-              <button
-                type="button"
-                onClick={handleEditName}
-                className="block text-sm font-medium text-left"
-              >
-                Your Name: <span className="text-blue-600 dark:text-blue-400 font-normal italic">add</span>
-              </button>
+              <div className="text-sm font-medium">
+                Your Name <span className="text-gray-500 font-normal">(optional)</span>:{' '}
+                <button
+                  type="button"
+                  onClick={handleEditName}
+                  className="font-normal text-blue-600 dark:text-blue-400"
+                >
+                  Add
+                </button>
+              </div>
             )}
           </div>
           

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1311,7 +1311,7 @@ function CreatePollContent() {
                 referenceLatitude={refLatitude}
                 referenceLongitude={refLongitude}
                 searchRadius={searchRadius}
-                label={<>Options <span className="font-normal">(leave blank to ask for suggestions first)</span></>}
+                label={<>Options <span className="font-normal">(leave blank to ask for suggestions)</span></>}
               />
             </>
           )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -197,6 +197,13 @@ function CreatePollContent() {
     }
   }, [isEditingName]);
 
+  // Focus details textarea when opening
+  useEffect(() => {
+    if (detailsOpen) {
+      detailsRef.current?.focus();
+    }
+  }, [detailsOpen]);
+
   // Auto-update title when form fields change (if user hasn't manually edited)
   useEffect(() => {
     if (isAutoTitle) {
@@ -1523,13 +1530,10 @@ function CreatePollContent() {
             ) : (
               <button
                 type="button"
-                onClick={() => {
-                  setDetailsOpen(true);
-                  setTimeout(() => detailsRef.current?.focus(), 0);
-                }}
+                onClick={() => setDetailsOpen(true)}
                 className="block text-sm font-medium text-left"
               >
-                Details: <span className="text-blue-600 dark:text-blue-400 font-normal italic">add</span>
+                Add Details <span className="font-normal text-gray-500">(optional)</span>
               </button>
             )}
           </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1527,9 +1527,9 @@ function CreatePollContent() {
                   setDetailsOpen(true);
                   setTimeout(() => detailsRef.current?.focus(), 0);
                 }}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-500 text-left dark:bg-gray-800"
+                className="block text-sm font-medium text-left"
               >
-                Add Details <span className="font-normal">(optional)</span>
+                Details: <span className="text-blue-600 dark:text-blue-400 font-normal italic">add</span>
               </button>
             )}
           </div>
@@ -1557,7 +1557,7 @@ function CreatePollContent() {
               <button
                 type="button"
                 onClick={handleEditName}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-left hover:border-gray-400 dark:hover:border-gray-500 dark:bg-gray-800"
+                className="block text-sm font-medium text-left"
               >
                 Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{creatorName.trim()}</span>
               </button>
@@ -1565,9 +1565,9 @@ function CreatePollContent() {
               <button
                 type="button"
                 onClick={handleEditName}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-500 text-left dark:bg-gray-800"
+                className="block text-sm font-medium text-left"
               >
-                Add Your Name <span className="font-normal">(optional)</span>
+                Your Name: <span className="text-blue-600 dark:text-blue-400 font-normal italic">add</span>
               </button>
             )}
           </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1528,13 +1528,16 @@ function CreatePollContent() {
                 />
               </>
             ) : (
-              <button
-                type="button"
-                onClick={() => setDetailsOpen(true)}
-                className="block text-sm font-medium text-left"
-              >
-                <span className="font-normal text-blue-600 dark:text-blue-400">Add Details</span> <span className="font-normal text-gray-500">(optional)</span>
-              </button>
+              <div className="text-sm font-medium">
+                Details <span className="text-gray-500 font-normal">(optional)</span>:{' '}
+                <button
+                  type="button"
+                  onClick={() => setDetailsOpen(true)}
+                  className="font-normal text-blue-600 dark:text-blue-400"
+                >
+                  Add
+                </button>
+              </div>
             )}
           </div>
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1533,7 +1533,7 @@ function CreatePollContent() {
                 onClick={() => setDetailsOpen(true)}
                 className="block text-sm font-medium text-left"
               >
-                Add Details <span className="font-normal text-gray-500">(optional)</span>
+                <span className="font-normal text-blue-600 dark:text-blue-400">Add Details</span> <span className="font-normal text-gray-500">(optional)</span>
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Restyle "Add Details" and "Add Your Name" buttons as collapsed label fields matching the title pattern: `Label (optional): Add` where only "Add" is a blue clickable link
- Hide "(optional)" from labels when the field has content
- Add "(optional)" to the Your Name field header
- Fix details textarea focus by using `useEffect` instead of unreliable `setTimeout`
- Replace "If no options are given..." hint text with inline "(leave blank to ask for suggestions)" in the Options header

## Test plan
- [ ] Verify "Details (optional): Add" appears as collapsed text with blue "Add" link
- [ ] Verify "Your Name (optional): Add" appears the same way
- [ ] Verify clicking "Add" opens the field and focuses it
- [ ] Verify "(optional)" disappears from labels when content is entered
- [ ] Verify Options header shows "(leave blank to ask for suggestions)"

https://claude.ai/code/session_01YWPhqUjEvbZPx2MZQ21tok