### PR TITLE
Validate poll time slots and improve day picker

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -424,10 +424,10 @@ function CreatePollContent() {
     }
 
     // Participation poll: must have days selected, and every day needs a time slot
-    if (dbPollType === 'participation' && dayTimeWindows.length === 0) {
-      return "Please select at least one day.";
-    }
-    if (dbPollType === 'participation' && dayTimeWindows.length > 0) {
+    if (dbPollType === 'participation') {
+      if (dayTimeWindows.length === 0) {
+        return "Please select at least one day.";
+      }
       const emptyDays = dayTimeWindows.filter(dtw => dtw.windows.length === 0);
       if (emptyDays.length > 0) {
         return "Every selected day must have at least one time slot. Add time slots or remove empty days.";

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -423,6 +423,14 @@ function CreatePollContent() {
       }
     }
 
+    // Participation poll: every selected day must have at least one time slot
+    if (dbPollType === 'participation' && dayTimeWindows.length > 0) {
+      const emptyDays = dayTimeWindows.filter(dtw => dtw.windows.length === 0);
+      if (emptyDays.length > 0) {
+        return "Every selected day must have at least one time slot. Add time slots or remove empty days.";
+      }
+    }
+
     return null;
   };
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -423,7 +423,10 @@ function CreatePollContent() {
       }
     }
 
-    // Participation poll: every selected day must have at least one time slot
+    // Participation poll: must have days selected, and every day needs a time slot
+    if (dbPollType === 'participation' && dayTimeWindows.length === 0) {
+      return "Please select at least one day.";
+    }
     if (dbPollType === 'participation' && dayTimeWindows.length > 0) {
       const emptyDays = dayTimeWindows.filter(dtw => dtw.windows.length === 0);
       if (emptyDays.length > 0) {

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,7 +85,7 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+    <div className={`flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
       {/* Left: Day display */}
       <div className="min-w-[100px]">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -87,7 +87,7 @@ export default function DayTimeWindowsInput({
   return (
     <div className={`flex items-start gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
       {/* Left: Day display */}
-      <div className="min-w-[100px] pt-1">
+      <div className="min-w-[100px]">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {formatDayDisplay(day)}
         </div>

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,7 +85,7 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+    <div className={`flex items-start gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
       {/* Left: Day display */}
       <div className="min-w-[100px]">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -91,11 +91,6 @@ export default function DayTimeWindowsInput({
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {formatDayDisplay(day)}
         </div>
-        {windows.length === 0 && !pollWindows && (
-          <div className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
-            Add a time slot
-          </div>
-        )}
       </div>
 
       {/* Right: Time windows */}
@@ -155,7 +150,7 @@ export default function DayTimeWindowsInput({
             type="button"
             onClick={handleAddWindow}
             disabled={disabled}
-            className="w-[168px] py-1.5 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full text-sm font-medium hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-center"
+            className={`w-[168px] py-1.5 rounded-full text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-center ${windows.length === 0 ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 border border-amber-400 dark:border-amber-500 hover:bg-amber-200 dark:hover:bg-amber-900/60' : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'}`}
           >
             + Time
           </button>

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,9 +85,9 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex items-start gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+    <div className={`flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
       {/* Left: Day display */}
-      <div className="min-w-[100px]">
+      <div className="min-w-[100px] self-start">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {formatDayDisplay(day)}
         </div>

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,12 +85,17 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+    <div className={`flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
       {/* Left: Day display */}
       <div className="min-w-[100px]">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {formatDayDisplay(day)}
         </div>
+        {windows.length === 0 && !pollWindows && (
+          <div className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
+            Add a time slot
+          </div>
+        )}
       </div>
 
       {/* Right: Time windows */}

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,7 +85,7 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex items-start gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+    <div className={`flex items-start gap-3 px-1.5 py-0.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
       {/* Left: Day display */}
       <div className="min-w-[100px]">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,21 +85,21 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
-      {/* Left: Day display */}
-      <div className="min-w-[100px]">
+    <div className={`flex flex-col gap-1.5 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+      {/* Top: Day display */}
+      <div className="flex items-center gap-1">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {formatDayDisplay(day)}
         </div>
         {windows.length === 0 && !pollWindows && (
-          <div className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
-            Add a time slot
+          <div className="text-xs text-amber-600 dark:text-amber-400">
+            — Add a time slot
           </div>
         )}
       </div>
 
-      {/* Right: Time windows */}
-      <div className="flex-1 flex flex-wrap gap-2 items-center justify-end">
+      {/* Bottom: Time windows */}
+      <div className="flex flex-wrap gap-2 items-center">
         {windows.map((window, index) => (
           <div
             key={index}

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,7 +85,7 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex items-start gap-3 px-1.5 py-0.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+    <div className={`flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
       {/* Left: Day display */}
       <div className="min-w-[100px]">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -37,6 +37,24 @@ function formatDayDisplay(dateStr: string): string {
   return `${weekday}, ${month} ${day}`;
 }
 
+function getRelativeDay(dateStr: string): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const target = new Date(dateStr + 'T00:00:00');
+  const diffMs = target.getTime() - today.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Tomorrow';
+  if (diffDays < 14) return `${diffDays} days away`;
+  const weeks = Math.floor(diffDays / 7);
+  if (weeks < 8) return `${weeks} week${weeks === 1 ? '' : 's'} away`;
+  const months = Math.floor(diffDays / 30.44);
+  if (months < 24) return `${months} month${months === 1 ? '' : 's'} away`;
+  const years = Math.floor(diffDays / 365.25);
+  return `${years} year${years === 1 ? '' : 's'} away`;
+}
+
 export default function DayTimeWindowsInput({
   day,
   windows,
@@ -85,11 +103,14 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+    <div className="flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
       {/* Left: Day display */}
       <div className="min-w-[100px] self-start">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {formatDayDisplay(day)}
+        </div>
+        <div className="text-xs text-blue-500 dark:text-blue-400">
+          {getRelativeDay(day)}
         </div>
       </div>
 

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -85,21 +85,21 @@ export default function DayTimeWindowsInput({
   };
 
   return (
-    <div className={`flex flex-col gap-1.5 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
-      {/* Top: Day display */}
-      <div className="flex items-center gap-1">
+    <div className={`flex items-start gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border ${windows.length === 0 && !pollWindows ? 'border-amber-400 dark:border-amber-500' : 'border-gray-200 dark:border-gray-700'}`}>
+      {/* Left: Day display */}
+      <div className="min-w-[100px] pt-1">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {formatDayDisplay(day)}
         </div>
         {windows.length === 0 && !pollWindows && (
-          <div className="text-xs text-amber-600 dark:text-amber-400">
-            — Add a time slot
+          <div className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
+            Add a time slot
           </div>
         )}
       </div>
 
-      {/* Bottom: Time windows */}
-      <div className="flex flex-wrap gap-2 items-center">
+      {/* Right: Time windows */}
+      <div className="flex-1 flex flex-wrap gap-2 items-center justify-end">
         {windows.map((window, index) => (
           <div
             key={index}

--- a/components/DaysSelector.tsx
+++ b/components/DaysSelector.tsx
@@ -186,31 +186,34 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
     const year = currentMonth.getFullYear();
     const month = currentMonth.getMonth();
 
-    // Get first day of month
     const firstDay = new Date(year, month, 1);
-    const lastDay = new Date(year, month + 1, 0);
-
-    // Get day of week for first day (0 = Sunday)
     const firstDayOfWeek = firstDay.getDay();
 
-    // Get total days in month
-    const daysInMonth = lastDay.getDate();
+    const days: { dateStr: string; isCurrentMonth: boolean }[] = [];
+    const TOTAL_CELLS = 35; // 5 rows × 7 cols
 
-    // Create array of all days
-    const days: (string | null)[] = [];
-
-    // Add empty cells for days before month starts
-    for (let i = 0; i < firstDayOfWeek; i++) {
-      days.push(null);
+    // Fill leading days from previous month
+    for (let i = firstDayOfWeek - 1; i >= 0; i--) {
+      const date = new Date(year, month, -i);
+      days.push({ dateStr: dateToString(date), isCurrentMonth: false });
     }
 
-    // Add all days of the month
+    // Add all days of the current month
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
     for (let day = 1; day <= daysInMonth; day++) {
       const date = new Date(year, month, day);
-      days.push(dateToString(date));
+      days.push({ dateStr: dateToString(date), isCurrentMonth: true });
     }
 
-    return days;
+    // Fill trailing days from next month
+    let nextDay = 1;
+    while (days.length < TOTAL_CELLS) {
+      const date = new Date(year, month + 1, nextDay++);
+      days.push({ dateStr: dateToString(date), isCurrentMonth: false });
+    }
+
+    // If we have more than 35 (month spans 6 rows), truncate to 35
+    return days.slice(0, TOTAL_CELLS);
   };
 
   const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -308,20 +311,16 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
 
                   {/* Calendar days */}
                   <div className="grid grid-cols-7 gap-1">
-                    {calendarDays.map((dateStr, index) => {
-                      if (dateStr === null) {
-                        return <div key={`empty-${index}`} className="aspect-square" />;
-                      }
-
+                    {calendarDays.map(({ dateStr, isCurrentMonth }, index) => {
                       const isPast = isPastDate(dateStr);
                       const isAllowed = !allowedDays || allowedDays.includes(dateStr);
-                      const isDisabled = isPast || !isAllowed;
+                      const isDisabled = isPast || !isAllowed || !isCurrentMonth;
                       const isSelected = tempSelectedDays.includes(dateStr);
                       const isToday = dateStr === getTodayDate();
 
                       return (
                         <button
-                          key={dateStr}
+                          key={`${dateStr}-${index}`}
                           type="button"
                           onClick={() => !isDisabled && handleToggleDay(dateStr)}
                           disabled={isDisabled}
@@ -329,9 +328,11 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                           data-testid={`calendar-day-${dateStr}`}
                           className={`
                             aspect-square rounded-md text-sm flex items-center justify-center
-                            ${isDisabled
-                              ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-                              : 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
+                            ${!isCurrentMonth
+                              ? 'text-gray-300 dark:text-gray-600 cursor-default'
+                              : isDisabled
+                                ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                                : 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
                             }
                             ${isSelected
                               ? 'bg-blue-500 text-white hover:bg-blue-600'

--- a/components/DaysSelector.tsx
+++ b/components/DaysSelector.tsx
@@ -14,7 +14,10 @@ interface DaysSelectorProps {
 
 export default function DaysSelector({ selectedDays, onChange, disabled = false, isOpen, onOpenChange, allowedDays, hideButton = false }: DaysSelectorProps) {
   const [tempSelectedDays, setTempSelectedDays] = useState<string[]>(selectedDays);
-  const [currentMonth, setCurrentMonth] = useState(new Date());
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
   const modalContentRef = useRef<HTMLDivElement>(null);
 
   const handleToggleDay = (date: string) => {
@@ -66,7 +69,8 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
       onChange(validDays);
     }
     setTempSelectedDays(validDays);
-    setCurrentMonth(new Date());
+    const now = new Date();
+    setCurrentMonth(new Date(now.getFullYear(), now.getMonth(), 1));
 
     const body = document.body;
     const html = document.documentElement;
@@ -174,7 +178,8 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
   };
 
   const goToToday = () => {
-    setCurrentMonth(new Date());
+    const now = new Date();
+    setCurrentMonth(new Date(now.getFullYear(), now.getMonth(), 1));
   };
 
   const renderCalendar = () => {

--- a/components/DaysSelector.tsx
+++ b/components/DaysSelector.tsx
@@ -314,7 +314,7 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                     {calendarDays.map(({ dateStr, isCurrentMonth }, index) => {
                       const isPast = isPastDate(dateStr);
                       const isAllowed = !allowedDays || allowedDays.includes(dateStr);
-                      const isDisabled = isPast || !isAllowed || !isCurrentMonth;
+                      const isDisabled = isPast || !isAllowed;
                       const isSelected = tempSelectedDays.includes(dateStr);
                       const isToday = dateStr === getTodayDate();
 
@@ -328,10 +328,10 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                           data-testid={`calendar-day-${dateStr}`}
                           className={`
                             aspect-square rounded-md text-sm flex items-center justify-center
-                            ${!isCurrentMonth
-                              ? 'text-gray-300 dark:text-gray-600 cursor-default'
-                              : isDisabled
-                                ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                            ${isDisabled
+                              ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                              : !isCurrentMonth
+                                ? 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
                                 : 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
                             }
                             ${isSelected
@@ -351,17 +351,11 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                   </div>
                 </div>
 
-                {/* Selected count or warning */}
-                <div className="my-2 text-sm text-center">
-                  {tempSelectedDays.length > 0 ? (
-                    <div className="text-gray-600 dark:text-gray-400">
-                      {tempSelectedDays.length} day{tempSelectedDays.length !== 1 ? 's' : ''} selected
-                    </div>
-                  ) : (
-                    <div className="text-orange-600 dark:text-orange-400">
-                      Please select at least one day
-                    </div>
-                  )}
+                {/* Selected count */}
+                <div className="my-2 text-sm text-center text-gray-600 dark:text-gray-400">
+                  {tempSelectedDays.length > 0
+                    ? `${tempSelectedDays.length} day${tempSelectedDays.length !== 1 ? 's' : ''} selected`
+                    : 'No days selected'}
                 </div>
 
                 <div className="flex gap-2 pt-2">
@@ -375,8 +369,7 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                   <button
                     type="button"
                     onClick={handleApply}
-                    disabled={tempSelectedDays.length === 0}
-                    className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-blue-600"
+                    className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
                   >
                     Apply
                   </button>

--- a/components/DaysSelector.tsx
+++ b/components/DaysSelector.tsx
@@ -154,13 +154,6 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
     return `${year}-${month}-${day}`;
   };
 
-  const isPastDate = (dateStr: string) => {
-    const date = new Date(dateStr + 'T00:00:00');
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return date < today;
-  };
-
   const goToPreviousMonth = () => {
     setCurrentMonth(prev => {
       const newMonth = new Date(prev);
@@ -311,12 +304,14 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
 
                   {/* Calendar days */}
                   <div className="grid grid-cols-7 gap-1">
-                    {calendarDays.map(({ dateStr, isCurrentMonth }, index) => {
-                      const isPast = isPastDate(dateStr);
+                    {(() => {
+                      const todayStr = getTodayDate();
+                      return calendarDays.map(({ dateStr, isCurrentMonth }, index) => {
+                      const isPast = dateStr < todayStr;
                       const isAllowed = !allowedDays || allowedDays.includes(dateStr);
                       const isDisabled = isPast || !isAllowed;
                       const isSelected = tempSelectedDays.includes(dateStr);
-                      const isToday = dateStr === getTodayDate();
+                      const isToday = dateStr === todayStr;
 
                       return (
                         <button
@@ -347,7 +342,8 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                           {new Date(dateStr + 'T00:00:00').getDate()}
                         </button>
                       );
-                    })}
+                    });
+                    })()}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- **Form validation**: Participation polls require at least one day selected, and every day must have at least one time slot
- **Day picker fixes**: Fix month navigation skipping months on the 31st (March → May instead of April); calendar now always shows 5 rows with overflow days from adjacent months visible and selectable
- **UI improvements**: Reduced day panel padding by 50%, top-aligned day labels, added relative date labels ("Today", "Tomorrow", "3 days away"), amber-highlighted "+ Time" button on empty days
- **Perf**: Hoisted `getTodayDate()` out of 35-cell calendar render loop, removed redundant `isPastDate()` Date allocations

## Test plan
- [ ] Create a participation poll — verify "Please select at least one day" error when no days selected
- [ ] Add days but leave one without time slots — verify "Every selected day must have at least one time slot" error
- [ ] Open day picker on the 31st of a month — verify next/prev month navigation works correctly
- [ ] Verify overflow days from adjacent months are visible and selectable in the calendar
- [ ] Verify day picker can be closed with no days selected (Apply button always enabled)
- [ ] Check relative date labels appear correctly (Today, Tomorrow, X days/weeks/months away)

https://claude.ai/code/session_01YEURJn8gGAy5qAYHWiBdqU