### PR TITLE
Add poll winner tag to closed polls on main page

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -511,45 +511,43 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-start gap-2">
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2">
-                            <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
-                            {poll.response_deadline && (
-                              <span className="text-xs text-gray-500 dark:text-gray-400">
-                                Closed {(() => {
-                                  const deadline = new Date(poll.response_deadline);
-                                  const now = new Date();
-                                  const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
+                        {poll.response_deadline && (
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                            Closed {(() => {
+                              const deadline = new Date(poll.response_deadline);
+                              const now = new Date();
+                              const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
 
-                                  if (hoursAgo <= 24) {
-                                    return deadline.toLocaleTimeString("en-US", {
-                                      hour: "numeric",
-                                      minute: "2-digit",
-                                      hour12: true
-                                    });
-                                  } else {
-                                    return deadline.toLocaleDateString("en-US", {
-                                      month: "numeric",
-                                      day: "numeric",
-                                      year: "2-digit"
-                                    });
-                                  }
-                                })()}
-                              </span>
-                            )}
-                          </div>
-                          <h3 className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1">
-                            {poll.title}
-                          </h3>
-                          <div className="text-xs text-gray-400 dark:text-gray-500">
-                            <ClientOnly fallback={null}>
-                              <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
-                            </ClientOnly>
-                          </div>
+                              if (hoursAgo <= 24) {
+                                return deadline.toLocaleTimeString("en-US", {
+                                  hour: "numeric",
+                                  minute: "2-digit",
+                                  hour12: true
+                                });
+                              } else {
+                                return deadline.toLocaleDateString("en-US", {
+                                  month: "numeric",
+                                  day: "numeric",
+                                  year: "2-digit"
+                                });
+                              }
+                            })()}
+                          </span>
+                        )}
+                      </div>
+                      <h3 className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1">
+                        {poll.title}
+                      </h3>
+                      <div className="flex items-center justify-between">
+                        <div className="text-xs text-gray-400 dark:text-gray-500">
+                          <ClientOnly fallback={null}>
+                            <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
+                          </ClientOnly>
                         </div>
                         {winnerTexts[poll.id] && (
-                          <div className="flex-shrink-0 flex items-center gap-1 max-w-[40%] self-end">
+                          <div className="flex items-center gap-1 max-w-[40%]">
                             <span className="flex-shrink-0 text-xs">👑</span>
                             <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 truncate">
                               {winnerTexts[poll.id]}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -94,6 +94,12 @@ const SimpleCountdown = ({ deadline }: { deadline: string }) => {
   );
 };
 
+function getOptionDisplayName(optionKey: string, poll: Poll): string {
+  const meta = poll.options_metadata?.[optionKey];
+  if (meta?.name) return meta.name;
+  return optionKey;
+}
+
 function getWinnerText(poll: Poll, results: PollResults): string | null {
   switch (poll.poll_type) {
     case 'yes_no':
@@ -102,10 +108,11 @@ function getWinnerText(poll: Poll, results: PollResults): string | null {
       if (results.winner === 'tie') return 'Tie';
       return null;
     case 'ranked_choice':
-      return results.winner || null;
+      if (!results.winner) return null;
+      return getOptionDisplayName(results.winner, poll);
     case 'nomination':
       if (results.nomination_counts && results.nomination_counts.length > 0) {
-        return results.nomination_counts[0].option;
+        return getOptionDisplayName(results.nomination_counts[0].option, poll);
       }
       return null;
     case 'participation':
@@ -504,7 +511,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-start gap-2">
+                      <div className="flex items-center gap-2">
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2">
                             <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
@@ -542,9 +549,10 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </div>
                         </div>
                         {winnerTexts[poll.id] && (
-                          <div className="flex-shrink-0 self-center max-w-[40%]">
-                            <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 truncate max-w-full">
-                              {winnerTexts[poll.id]}
+                          <div className="flex-shrink-0 max-w-[40%]">
+                            <span className="inline-flex items-center gap-0.5 text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 max-w-full">
+                              <span className="flex-shrink-0">👑</span>
+                              <span className="truncate">{winnerTexts[poll.id]}</span>
                             </span>
                           </div>
                         )}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -550,7 +550,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         </div>
                         {winnerTexts[poll.id] && (
                           <div className="flex items-center gap-1 max-w-[40%]">
-                            <span className="flex-shrink-0 text-xs">👑</span>
+                            <span className="flex-shrink-0 text-xs leading-none">👑</span>
                             <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 truncate">
                               {winnerTexts[poll.id]}
                             </span>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -550,7 +550,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         </div>
                         {winnerTexts[poll.id] && (
                           <div className="flex items-center gap-1 max-w-[40%]">
-                            <span className="flex-shrink-0 text-xs leading-none">👑</span>
+                            <span className="flex-shrink-0 text-xs leading-none -mt-px">👑</span>
                             <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200 truncate">
                               {winnerTexts[poll.id]}
                             </span>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -549,7 +549,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </div>
                         </div>
                         {winnerTexts[poll.id] && (
-                          <div className="flex-shrink-0 flex items-center gap-1 max-w-[40%] mt-5">
+                          <div className="flex-shrink-0 flex items-center gap-1 max-w-[40%] self-end">
                             <span className="flex-shrink-0 text-xs">👑</span>
                             <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 truncate">
                               {winnerTexts[poll.id]}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -147,6 +147,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const [pressedPollId, setPressedPollId] = useState<string | null>(null);
   const [navigatingPollId, setNavigatingPollId] = useState<string | null>(null);
   const [winnerTexts, setWinnerTexts] = useState<Record<string, string>>({});
+  const fetchedPollIds = useRef<Set<string>>(new Set());
   
   // Load voted and abstained polls from localStorage
   useEffect(() => {
@@ -240,8 +241,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   useEffect(() => {
     if (closedPolls.length === 0) return;
 
-    const pollsToFetch = closedPolls.filter(p => !winnerTexts[p.id]);
+    const pollsToFetch = closedPolls.filter(p => !fetchedPollIds.current.has(p.id));
     if (pollsToFetch.length === 0) return;
+
+    // Mark as fetched immediately to prevent duplicate requests
+    for (const p of pollsToFetch) fetchedPollIds.current.add(p.id);
 
     let cancelled = false;
 
@@ -249,8 +253,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       pollsToFetch.map(async (poll) => {
         try {
           const results = await apiGetPollResults(poll.id);
-          const winner = getWinnerText(poll, results);
-          return { id: poll.id, winner };
+          return { id: poll.id, winner: getWinnerText(poll, results) };
         } catch {
           return { id: poll.id, winner: null };
         }

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -551,7 +551,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         {winnerTexts[poll.id] && (
                           <div className="flex items-center gap-1 max-w-[40%]">
                             <span className="flex-shrink-0 text-xs leading-none">👑</span>
-                            <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 truncate">
+                            <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200 truncate">
                               {winnerTexts[poll.id]}
                             </span>
                           </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -539,7 +539,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                               </span>
                             )}
                           </div>
-                          <h3 className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white">
+                          <h3 className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1">
                             {poll.title}
                           </h3>
                           <div className="text-xs text-gray-400 dark:text-gray-500">

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -515,25 +515,27 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
                         {poll.response_deadline && (
                           <span className="text-xs text-gray-500 dark:text-gray-400">
-                            Closed {(() => {
-                              const deadline = new Date(poll.response_deadline);
-                              const now = new Date();
-                              const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+                            <ClientOnly fallback={<>Closed</>}>
+                              <>Closed {(() => {
+                                const deadline = new Date(poll.response_deadline);
+                                const now = new Date();
+                                const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
 
-                              if (hoursAgo <= 24) {
-                                return deadline.toLocaleTimeString("en-US", {
-                                  hour: "numeric",
-                                  minute: "2-digit",
-                                  hour12: true
-                                });
-                              } else {
-                                return deadline.toLocaleDateString("en-US", {
-                                  month: "numeric",
-                                  day: "numeric",
-                                  year: "2-digit"
-                                });
-                              }
-                            })()}
+                                if (hoursAgo <= 24) {
+                                  return deadline.toLocaleTimeString("en-US", {
+                                    hour: "numeric",
+                                    minute: "2-digit",
+                                    hour12: true
+                                  });
+                                } else {
+                                  return deadline.toLocaleDateString("en-US", {
+                                    month: "numeric",
+                                    day: "numeric",
+                                    year: "2-digit"
+                                  });
+                                }
+                              })()}</>
+                            </ClientOnly>
                           </span>
                         )}
                       </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -539,7 +539,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                               </span>
                             )}
                           </div>
-                          <h3 className="font-medium text-lg leading-snug line-clamp-2 text-gray-900 dark:text-white">
+                          <h3 className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white">
                             {poll.title}
                           </h3>
                           <div className="text-xs text-gray-400 dark:text-gray-500">

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -511,7 +511,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-start gap-2">
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2">
                             <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
@@ -549,10 +549,10 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </div>
                         </div>
                         {winnerTexts[poll.id] && (
-                          <div className="flex-shrink-0 max-w-[40%]">
-                            <span className="inline-flex items-center gap-0.5 text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 max-w-full">
-                              <span className="flex-shrink-0">👑</span>
-                              <span className="truncate">{winnerTexts[poll.id]}</span>
+                          <div className="flex-shrink-0 flex items-center gap-1 max-w-[40%] mt-5">
+                            <span className="flex-shrink-0 text-xs">👑</span>
+                            <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 truncate">
+                              {winnerTexts[poll.id]}
                             </span>
                           </div>
                         )}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Poll } from "@/lib/types";
+import { Poll, PollResults } from "@/lib/types";
+import { apiGetPollResults } from "@/lib/api";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
 
@@ -93,6 +94,28 @@ const SimpleCountdown = ({ deadline }: { deadline: string }) => {
   );
 };
 
+function getWinnerText(poll: Poll, results: PollResults): string | null {
+  switch (poll.poll_type) {
+    case 'yes_no':
+      if (results.winner === 'yes') return 'Yes';
+      if (results.winner === 'no') return 'No';
+      if (results.winner === 'tie') return 'Tie';
+      return null;
+    case 'ranked_choice':
+      return results.winner || null;
+    case 'nomination':
+      if (results.nomination_counts && results.nomination_counts.length > 0) {
+        return results.nomination_counts[0].option;
+      }
+      return null;
+    case 'participation':
+      if (results.is_happening) return 'Happening';
+      return 'Not happening';
+    default:
+      return null;
+  }
+}
+
 interface PollListProps {
   polls: Poll[];
   showSections?: boolean; // Whether to show "Open Polls" and "Closed Polls" section headers
@@ -116,6 +139,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const isScrolling = useRef(false);
   const [pressedPollId, setPressedPollId] = useState<string | null>(null);
   const [navigatingPollId, setNavigatingPollId] = useState<string | null>(null);
+  const [winnerTexts, setWinnerTexts] = useState<Record<string, string>>({});
   
   // Load voted and abstained polls from localStorage
   useEffect(() => {
@@ -205,6 +229,39 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
     categorizePollsByTime();
   }, [categorizePollsByTime]);
   
+  // Fetch results for closed polls to display winners
+  useEffect(() => {
+    if (closedPolls.length === 0) return;
+
+    const pollsToFetch = closedPolls.filter(p => !winnerTexts[p.id]);
+    if (pollsToFetch.length === 0) return;
+
+    let cancelled = false;
+
+    Promise.all(
+      pollsToFetch.map(async (poll) => {
+        try {
+          const results = await apiGetPollResults(poll.id);
+          const winner = getWinnerText(poll, results);
+          return { id: poll.id, winner };
+        } catch {
+          return { id: poll.id, winner: null };
+        }
+      })
+    ).then((entries) => {
+      if (cancelled) return;
+      const newTexts: Record<string, string> = {};
+      for (const { id, winner } of entries) {
+        if (winner) newTexts[id] = winner;
+      }
+      if (Object.keys(newTexts).length > 0) {
+        setWinnerTexts(prev => ({ ...prev, ...newTexts }));
+      }
+    });
+
+    return () => { cancelled = true; };
+  }, [closedPolls]);
+
   // Set up timer to check for expired polls every 10 seconds
   useEffect(() => {
     if (typeof window === 'undefined' || polls.length === 0) return;
@@ -447,39 +504,50 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
-                        {poll.response_deadline && (
-                          <span className="text-xs text-gray-500 dark:text-gray-400">
-                            Closed {(() => {
-                              const deadline = new Date(poll.response_deadline);
-                              const now = new Date();
-                              const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+                      <div className="flex items-start gap-2">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
+                            {poll.response_deadline && (
+                              <span className="text-xs text-gray-500 dark:text-gray-400">
+                                Closed {(() => {
+                                  const deadline = new Date(poll.response_deadline);
+                                  const now = new Date();
+                                  const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
 
-                              if (hoursAgo <= 24) {
-                                return deadline.toLocaleTimeString("en-US", {
-                                  hour: "numeric",
-                                  minute: "2-digit",
-                                  hour12: true
-                                });
-                              } else {
-                                return deadline.toLocaleDateString("en-US", {
-                                  month: "numeric",
-                                  day: "numeric",
-                                  year: "2-digit"
-                                });
-                              }
-                            })()}
-                          </span>
+                                  if (hoursAgo <= 24) {
+                                    return deadline.toLocaleTimeString("en-US", {
+                                      hour: "numeric",
+                                      minute: "2-digit",
+                                      hour12: true
+                                    });
+                                  } else {
+                                    return deadline.toLocaleDateString("en-US", {
+                                      month: "numeric",
+                                      day: "numeric",
+                                      year: "2-digit"
+                                    });
+                                  }
+                                })()}
+                              </span>
+                            )}
+                          </div>
+                          <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                            {poll.title}
+                          </h3>
+                          <div className="text-xs text-gray-400 dark:text-gray-500">
+                            <ClientOnly fallback={null}>
+                              <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
+                            </ClientOnly>
+                          </div>
+                        </div>
+                        {winnerTexts[poll.id] && (
+                          <div className="flex-shrink-0 self-center max-w-[40%]">
+                            <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 truncate max-w-full">
+                              {winnerTexts[poll.id]}
+                            </span>
+                          </div>
                         )}
-                      </div>
-                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                        {poll.title}
-                      </h3>
-                      <div className="text-xs text-gray-400 dark:text-gray-500">
-                        <ClientOnly fallback={null}>
-                          <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
-                        </ClientOnly>
                       </div>
                     </div>
                   </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -539,7 +539,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                               </span>
                             )}
                           </div>
-                          <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                          <h3 className="font-medium text-lg leading-snug line-clamp-2 text-gray-900 dark:text-white">
                             {poll.title}
                           </h3>
                           <div className="text-xs text-gray-400 dark:text-gray-500">


### PR DESCRIPTION
## Summary
- Closed polls on the main page now show a compact 👑 winner badge at the bottom-right of each poll item
- Fetches results for each closed poll type: Yes/No/Tie, ranked choice winner, top nomination, Happening/Not happening
- For location-based polls, shows just the place name (from options_metadata) instead of the full address
- Fixed closed poll timestamps showing UTC instead of local timezone (wrapped in ClientOnly)
- Tightened title line-height for wrapped titles

## Bug fixes included
- Fixed stale closure in winner fetch effect that caused re-fetching all closed polls every 10 seconds
- Failed fetches are tracked to prevent infinite retry loops

## Test plan
- [ ] Verify closed polls show winner badges with correct text per poll type
- [ ] Verify winner badge is bottom-aligned with crown emoji
- [ ] Verify long winner names truncate properly within 40% width
- [ ] Verify closed timestamps show in local timezone
- [ ] Verify no duplicate API calls in network tab (check 10s+ after page load)

https://claude.ai/code/session_01BSG8WqFop4AatnnSMi7KCH