### PR TITLE
Fix winner badge not appearing on closed polls

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -247,8 +247,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
     // Mark as fetched immediately to prevent duplicate requests
     for (const p of pollsToFetch) fetchedPollIds.current.add(p.id);
 
-    let cancelled = false;
-
     Promise.all(
       pollsToFetch.map(async (poll) => {
         try {
@@ -259,7 +257,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
         }
       })
     ).then((entries) => {
-      if (cancelled) return;
       const newTexts: Record<string, string> = {};
       for (const { id, winner } of entries) {
         if (winner) newTexts[id] = winner;
@@ -268,8 +265,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
         setWinnerTexts(prev => ({ ...prev, ...newTexts }));
       }
     });
-
-    return () => { cancelled = true; };
   }, [closedPolls]);
 
   // Set up timer to check for expired polls every 10 seconds


### PR DESCRIPTION
## Summary
- Fixes the winner badge not appearing on the main page poll list
- The `useEffect` cleanup function cancelled in-flight fetch results whenever `closedPolls` got a new array reference (every re-categorization). Since `fetchedPollIds` ref already prevents duplicate requests, the cancellation just discarded results before they could update state.

## Test plan
- [x] Verified fix on dev server — winner badges now appear on closed polls
- [ ] Confirm no duplicate API calls in network tab after 10s+

https://claude.ai/code/session_01BSG8WqFop4AatnnSMi7KCH