### PR TITLE
Batch poll results into accessible polls endpoint

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Poll, PollResults } from "@/lib/types";
 import ClientOnly from "@/components/ClientOnly";
@@ -145,7 +145,16 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const isScrolling = useRef(false);
   const [pressedPollId, setPressedPollId] = useState<string | null>(null);
   const [navigatingPollId, setNavigatingPollId] = useState<string | null>(null);
-  const [winnerTexts, setWinnerTexts] = useState<Record<string, string>>({});
+  const winnerTexts = useMemo(() => {
+    const texts: Record<string, string> = {};
+    for (const poll of closedPolls) {
+      if (poll.results) {
+        const winner = getWinnerText(poll, poll.results);
+        if (winner) texts[poll.id] = winner;
+      }
+    }
+    return texts;
+  }, [closedPolls]);
   
   // Load voted and abstained polls from localStorage
   useEffect(() => {
@@ -235,22 +244,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
     categorizePollsByTime();
   }, [categorizePollsByTime]);
   
-  // Extract winner texts from pre-fetched results on closed polls
-  useEffect(() => {
-    if (closedPolls.length === 0) return;
-
-    const newTexts: Record<string, string> = {};
-    for (const poll of closedPolls) {
-      if (poll.results && !winnerTexts[poll.id]) {
-        const winner = getWinnerText(poll, poll.results);
-        if (winner) newTexts[poll.id] = winner;
-      }
-    }
-    if (Object.keys(newTexts).length > 0) {
-      setWinnerTexts(prev => ({ ...prev, ...newTexts }));
-    }
-  }, [closedPolls]); // eslint-disable-line react-hooks/exhaustive-deps
-
   // Set up timer to check for expired polls every 10 seconds
   useEffect(() => {
     if (typeof window === 'undefined' || polls.length === 0) return;

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Poll, PollResults } from "@/lib/types";
-import { apiGetPollResults } from "@/lib/api";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
 
@@ -147,7 +146,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const [pressedPollId, setPressedPollId] = useState<string | null>(null);
   const [navigatingPollId, setNavigatingPollId] = useState<string | null>(null);
   const [winnerTexts, setWinnerTexts] = useState<Record<string, string>>({});
-  const fetchedPollIds = useRef<Set<string>>(new Set());
   
   // Load voted and abstained polls from localStorage
   useEffect(() => {
@@ -237,35 +235,21 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
     categorizePollsByTime();
   }, [categorizePollsByTime]);
   
-  // Fetch results for closed polls to display winners
+  // Extract winner texts from pre-fetched results on closed polls
   useEffect(() => {
     if (closedPolls.length === 0) return;
 
-    const pollsToFetch = closedPolls.filter(p => !fetchedPollIds.current.has(p.id));
-    if (pollsToFetch.length === 0) return;
-
-    // Mark as fetched immediately to prevent duplicate requests
-    for (const p of pollsToFetch) fetchedPollIds.current.add(p.id);
-
-    Promise.all(
-      pollsToFetch.map(async (poll) => {
-        try {
-          const results = await apiGetPollResults(poll.id);
-          return { id: poll.id, winner: getWinnerText(poll, results) };
-        } catch {
-          return { id: poll.id, winner: null };
-        }
-      })
-    ).then((entries) => {
-      const newTexts: Record<string, string> = {};
-      for (const { id, winner } of entries) {
-        if (winner) newTexts[id] = winner;
+    const newTexts: Record<string, string> = {};
+    for (const poll of closedPolls) {
+      if (poll.results && !winnerTexts[poll.id]) {
+        const winner = getWinnerText(poll, poll.results);
+        if (winner) newTexts[poll.id] = winner;
       }
-      if (Object.keys(newTexts).length > 0) {
-        setWinnerTexts(prev => ({ ...prev, ...newTexts }));
-      }
-    });
-  }, [closedPolls]);
+    }
+    if (Object.keys(newTexts).length > 0) {
+      setWinnerTexts(prev => ({ ...prev, ...newTexts }));
+    }
+  }, [closedPolls]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Set up timer to check for expired polls every 10 seconds
   useEffect(() => {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -333,9 +333,15 @@ export async function apiGetAccessiblePolls(pollIds: string[]): Promise<Poll[]> 
   if (pollIds.length === 0) return [];
   const data: any[] = await apiFetch('/accessible', {
     method: 'POST',
-    body: JSON.stringify({ poll_ids: pollIds }),
+    body: JSON.stringify({ poll_ids: pollIds, include_results: true }),
   });
-  return data.map(toPoll);
+  return data.map(d => {
+    const poll = toPoll(d);
+    if (d.results) {
+      poll.results = toPollResults(d.results);
+    }
+    return poll;
+  });
 }
 
 // --- Search/autocomplete ---

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -62,6 +62,7 @@ export interface Poll {
   reference_latitude?: number | null;
   reference_longitude?: number | null;
   reference_location_label?: string | null;
+  results?: PollResults | null;
 }
 
 export interface TimeWindow {

--- a/server/models.py
+++ b/server/models.py
@@ -99,6 +99,7 @@ class ReopenPollRequest(BaseModel):
 
 class AccessiblePollsRequest(BaseModel):
     poll_ids: list[str]
+    include_results: bool = False
 
 
 class RelatedPollsRequest(BaseModel):
@@ -158,6 +159,7 @@ class PollResponse(BaseModel):
     reference_latitude: float | None = None
     reference_longitude: float | None = None
     reference_location_label: str | None = None
+    results: "PollResultsResponse | None" = None
 
 
 class VoteResponse(BaseModel):
@@ -228,3 +230,7 @@ class RankedChoiceRoundResponse(BaseModel):
     is_eliminated: bool
     borda_score: int | None = None
     tie_broken_by_borda: bool = False
+
+
+# Resolve forward references (PollResponse.results -> PollResultsResponse)
+PollResponse.model_rebuild()

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1,6 +1,9 @@
 """Poll API endpoints."""
 
+import logging
 from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
 
 from fastapi import APIRouter, HTTPException
 
@@ -1145,7 +1148,6 @@ def get_accessible_polls(req: AccessiblePollsRequest):
         if not req.include_results:
             return [_row_to_poll(r) for r in rows]
 
-        # Identify closed polls that need results
         closed_poll_ids = []
         for r in rows:
             is_closed = r.get("is_closed", False)
@@ -1154,7 +1156,6 @@ def get_accessible_polls(req: AccessiblePollsRequest):
             if is_closed or deadline_passed:
                 closed_poll_ids.append(str(r["id"]))
 
-        # Batch-fetch all votes for closed polls in a single query
         votes_by_poll: dict[str, list] = {pid: [] for pid in closed_poll_ids}
         if closed_poll_ids:
             vote_rows = conn.execute(
@@ -1166,7 +1167,6 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                 if pid in votes_by_poll:
                     votes_by_poll[pid].append(v)
 
-    # Build responses with results for closed polls
     results = []
     for r in rows:
         poll_resp = _row_to_poll(r)
@@ -1175,7 +1175,7 @@ def get_accessible_polls(req: AccessiblePollsRequest):
             try:
                 poll_resp.results = _compute_results(dict(r), votes_by_poll[pid])
             except Exception:
-                pass  # If results computation fails, just omit results
+                logger.warning("Failed to compute results for poll %s", pid, exc_info=True)
         results.append(poll_resp)
     return results
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -842,6 +842,11 @@ def get_results(poll_id: str):
             {"poll_id": poll_id},
         ).fetchall()
 
+    return _compute_results(poll, votes)
+
+
+def _compute_results(poll, votes) -> PollResultsResponse:
+    """Compute poll results from a poll row and its votes. Shared by get_results and get_accessible_polls."""
     poll_type = poll["poll_type"]
 
     if poll_type == "yes_no":
@@ -865,7 +870,6 @@ def get_results(poll_id: str):
         )
 
     if poll_type == "nomination":
-        # Parse poll options from JSONB
         import json
         raw_options = poll.get("options")
         poll_options = None
@@ -1117,6 +1121,7 @@ def get_accessible_polls(req: AccessiblePollsRequest):
     """Get polls by a list of IDs (used by frontend to fetch polls the browser has access to)."""
     if not req.poll_ids:
         return []
+    now = datetime.now(timezone.utc)
     with get_db() as conn:
         rows = conn.execute(
             """SELECT * FROM polls
@@ -1136,7 +1141,43 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                ORDER BY created_at DESC""",
             {"poll_ids": req.poll_ids},
         ).fetchall()
-    return [_row_to_poll(r) for r in rows]
+
+        if not req.include_results:
+            return [_row_to_poll(r) for r in rows]
+
+        # Identify closed polls that need results
+        closed_poll_ids = []
+        for r in rows:
+            is_closed = r.get("is_closed", False)
+            deadline = r.get("response_deadline")
+            deadline_passed = deadline and deadline <= now
+            if is_closed or deadline_passed:
+                closed_poll_ids.append(str(r["id"]))
+
+        # Batch-fetch all votes for closed polls in a single query
+        votes_by_poll: dict[str, list] = {pid: [] for pid in closed_poll_ids}
+        if closed_poll_ids:
+            vote_rows = conn.execute(
+                "SELECT * FROM votes WHERE poll_id = ANY(%(poll_ids)s)",
+                {"poll_ids": closed_poll_ids},
+            ).fetchall()
+            for v in vote_rows:
+                pid = str(v["poll_id"])
+                if pid in votes_by_poll:
+                    votes_by_poll[pid].append(v)
+
+    # Build responses with results for closed polls
+    results = []
+    for r in rows:
+        poll_resp = _row_to_poll(r)
+        pid = str(r["id"])
+        if pid in votes_by_poll:
+            try:
+                poll_resp.results = _compute_results(dict(r), votes_by_poll[pid])
+            except Exception:
+                pass  # If results computation fails, just omit results
+        results.append(poll_resp)
+    return results
 
 
 @router.post("/related", response_model=RelatedPollsResponse)


### PR DESCRIPTION
## Summary
- Eliminates N+1 API calls on the home page: previously 1 request for polls + N requests for each closed poll's results, now **1 total request**
- Backend `/accessible` endpoint accepts `include_results=true`, batch-fetches all votes for closed polls in a single SQL query, and returns computed results inline
- Frontend uses `useMemo` to derive winner texts from pre-fetched `poll.results` instead of async-fetching per poll

## Test plan
- [ ] Load home page with mix of open and closed polls — closed polls should show winner badges immediately without waterfall fetches
- [ ] Verify open polls still show countdown timers (no results computed for them)
- [ ] Check browser Network tab confirms single `/accessible` request instead of N+1
- [ ] Verify all poll types show correct winners: yes/no (Yes/No/Tie), ranked choice (winner name), nomination (top option), participation (Happening/Not happening)

https://claude.ai/code/session_011mrhT8NY7CH9NpRxau6H7y