### PR TITLE
Fix voted list fade, add category labels, fix restaurant modal

### DIFF
--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import type { OptionMetadataEntry } from "@/lib/types";
 import PlaceDetailModal from "./PlaceDetailModal";
 
@@ -105,25 +105,25 @@ function RestaurantIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "
 
 function PlaceWrapper({
   children,
-  text,
+  address,
   name,
   metadata,
   className,
 }: {
   children: (onOpenModal: () => void) => React.ReactNode;
-  text: string;
+  address: string;
   name: string;
   metadata: OptionMetadataEntry;
   className?: string;
 }) {
   const [modalOpen, setModalOpen] = useState(false);
-  const address = getAddressFromLabel(text, name);
-  const hasCoords = metadata.lat && metadata.lon;
+  const hasCoords = !!(metadata.lat && metadata.lon);
+  const onOpenModal = useCallback(() => { setModalOpen(true); }, []);
 
   return (
     <>
       <div className={className}>
-        {children(() => { if (hasCoords) setModalOpen(true); })}
+        {children(hasCoords ? onOpenModal : () => {})}
       </div>
       {hasCoords && (
         <PlaceDetailModal
@@ -149,7 +149,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
 
     if (layout === "stacked") {
       return (
-        <PlaceWrapper text={text} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
+        <PlaceWrapper address={address} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
           {(onOpenModal) => (
             <>
               <div className="flex justify-center">
@@ -178,7 +178,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
 
     // Default inline layout
     return (
-      <PlaceWrapper text={text} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
+      <PlaceWrapper address={address} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
         {(onOpenModal) => (
           <>
             <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
@@ -209,7 +209,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
 
     if (layout === "stacked") {
       return (
-        <PlaceWrapper text={text} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
+        <PlaceWrapper address={address} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
           {(onOpenModal) => (
             <>
               <div className="flex justify-center">
@@ -238,7 +238,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
 
     // Default inline layout
     return (
-      <PlaceWrapper text={text} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
+      <PlaceWrapper address={address} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
         {(onOpenModal) => (
           <>
             <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -68,10 +68,16 @@ function LocationIcon({ imageUrl, size = "sm" }: { imageUrl?: string; size?: "sm
   );
 }
 
-function PlaceName({ name, hasModal }: { name: string; hasModal: boolean }) {
+function PlaceName({ name, hasModal, onOpenModal }: { name: string; hasModal: boolean; onOpenModal?: () => void }) {
   if (hasModal) {
     return (
-      <span className="font-medium leading-tight underline decoration-2 decoration-blue-400/50 cursor-pointer">
+      <span
+        className="font-medium leading-tight underline decoration-2 decoration-blue-400/50 cursor-pointer"
+        onClick={(e) => {
+          e.stopPropagation();
+          onOpenModal?.();
+        }}
+      >
         {name}
       </span>
     );
@@ -104,7 +110,7 @@ function PlaceWrapper({
   metadata,
   className,
 }: {
-  children: React.ReactNode;
+  children: (onOpenModal: () => void) => React.ReactNode;
   text: string;
   name: string;
   metadata: OptionMetadataEntry;
@@ -116,16 +122,8 @@ function PlaceWrapper({
 
   return (
     <>
-      <div
-        className={`${className}${hasCoords ? " cursor-pointer" : ""}`}
-        onClick={(e) => {
-          if (hasCoords) {
-            e.stopPropagation();
-            setModalOpen(true);
-          }
-        }}
-      >
-        {children}
+      <div className={className}>
+        {children(() => { if (hasCoords) setModalOpen(true); })}
       </div>
       {hasCoords && (
         <PlaceDetailModal
@@ -147,21 +145,32 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     const distance = metadata!.distance_miles;
     const hasCoords = !!(metadata!.lat && metadata!.lon);
 
+    const address = getAddressFromLabel(text, name);
+
     if (layout === "stacked") {
       return (
         <PlaceWrapper text={text} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
-          <div className="flex justify-center">
-            <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
-              <RestaurantIcon imageUrl={metadata!.imageUrl} size="lg" />
-            </span>
-          </div>
-          <div className="line-clamp-2 leading-tight mt-1 text-center">
-            <PlaceName name={name} hasModal={hasCoords} />
-          </div>
-          {distance !== undefined && (
-            <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5 text-center">
-              {formatDistance(distance)}
-            </div>
+          {(onOpenModal) => (
+            <>
+              <div className="flex justify-center">
+                <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
+                  <RestaurantIcon imageUrl={metadata!.imageUrl} size="lg" />
+                </span>
+              </div>
+              <div className="line-clamp-2 leading-tight mt-1 text-center">
+                <PlaceName name={name} hasModal={hasCoords} onOpenModal={onOpenModal} />
+              </div>
+              {address && (
+                <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 leading-tight mt-0.5 text-center">
+                  {address}
+                </div>
+              )}
+              {distance !== undefined && (
+                <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5 text-center">
+                  {formatDistance(distance)}
+                </div>
+              )}
+            </>
           )}
         </PlaceWrapper>
       );
@@ -170,19 +179,23 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     // Default inline layout
     return (
       <PlaceWrapper text={text} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
-        <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
-          <RestaurantIcon imageUrl={metadata!.imageUrl} />
-        </span>
-        <div className="min-w-0 overflow-hidden">
-          <div className="flex items-baseline gap-1.5 flex-wrap">
-            <PlaceName name={name} hasModal={hasCoords} />
-            {distance !== undefined && (
-              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
-                {formatDistance(distance)}
-              </span>
-            )}
-          </div>
-        </div>
+        {(onOpenModal) => (
+          <>
+            <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
+              <RestaurantIcon imageUrl={metadata!.imageUrl} />
+            </span>
+            <div className="min-w-0 overflow-hidden">
+              <div className="flex items-baseline gap-1.5 flex-wrap">
+                <PlaceName name={name} hasModal={hasCoords} onOpenModal={onOpenModal} />
+                {distance !== undefined && (
+                  <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                    {formatDistance(distance)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </>
+        )}
       </PlaceWrapper>
     );
   }
@@ -197,23 +210,27 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     if (layout === "stacked") {
       return (
         <PlaceWrapper text={text} name={name} metadata={metadata!} className={`min-w-0 overflow-hidden ${className}`}>
-          <div className="flex justify-center">
-            <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
-              <LocationIcon imageUrl={metadata!.imageUrl} size="lg" />
-            </span>
-          </div>
-          <div className="line-clamp-2 leading-tight mt-1 text-center">
-            <PlaceName name={name} hasModal={hasCoords} />
-          </div>
-          {address && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 leading-tight mt-0.5 text-center">
-              {address}
-            </div>
-          )}
-          {distance !== undefined && (
-            <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5 text-center">
-              {formatDistance(distance)}
-            </div>
+          {(onOpenModal) => (
+            <>
+              <div className="flex justify-center">
+                <span className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
+                  <LocationIcon imageUrl={metadata!.imageUrl} size="lg" />
+                </span>
+              </div>
+              <div className="line-clamp-2 leading-tight mt-1 text-center">
+                <PlaceName name={name} hasModal={hasCoords} onOpenModal={onOpenModal} />
+              </div>
+              {address && (
+                <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 leading-tight mt-0.5 text-center">
+                  {address}
+                </div>
+              )}
+              {distance !== undefined && (
+                <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5 text-center">
+                  {formatDistance(distance)}
+                </div>
+              )}
+            </>
           )}
         </PlaceWrapper>
       );
@@ -222,24 +239,28 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     // Default inline layout
     return (
       <PlaceWrapper text={text} name={name} metadata={metadata!} className={`flex items-center gap-2 ${className}`}>
-        <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
-          <LocationIcon imageUrl={metadata!.imageUrl} />
-        </span>
-        <div className="min-w-0 overflow-hidden">
-          <div className="flex items-baseline gap-1.5 flex-wrap">
-            <PlaceName name={name} hasModal={hasCoords} />
-            {distance !== undefined && (
-              <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
-                {formatDistance(distance)}
-              </span>
-            )}
-          </div>
-          {address && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
-              {address}
+        {(onOpenModal) => (
+          <>
+            <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center">
+              <LocationIcon imageUrl={metadata!.imageUrl} />
+            </span>
+            <div className="min-w-0 overflow-hidden">
+              <div className="flex items-baseline gap-1.5 flex-wrap">
+                <PlaceName name={name} hasModal={hasCoords} onOpenModal={onOpenModal} />
+                {distance !== undefined && (
+                  <span className="text-xs text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                    {formatDistance(distance)}
+                  </span>
+                )}
+              </div>
+              {address && (
+                <div className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+                  {address}
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          </>
+        )}
       </PlaceWrapper>
     );
   }

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Poll, PollResults } from "@/lib/types";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
+import { getBuiltInType } from "@/components/TypeFieldInput";
 
 const POLL_TYPE_SYMBOLS: Record<string, string> = {
   yes_no: '☐',
@@ -18,6 +19,15 @@ const CLOSED_YES_NO_SYMBOL = '🏆';
 function getPollSymbol(pollType: string, isClosed: boolean): string {
   if (pollType === 'yes_no' && isClosed) return CLOSED_YES_NO_SYMBOL;
   return POLL_TYPE_SYMBOLS[pollType] || '☰';
+}
+
+function getCategoryDisplay(poll: Poll): { label: string; icon: string } | null {
+  const category = poll.category;
+  if (!category || category === 'custom') return null;
+  const builtIn = getBuiltInType(category);
+  if (builtIn) return { label: builtIn.label, icon: builtIn.icon };
+  // Custom category string — capitalize first letter
+  return { label: category.charAt(0).toUpperCase() + category.slice(1), icon: '' };
 }
 
 function relativeTime(dateStr: string): string {
@@ -365,13 +375,20 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
-                        {poll.response_deadline && (
-                          <span className="text-xs text-gray-500 dark:text-gray-400">
-                            <ClientOnly fallback={<>Loading...</>}>
-                              <SimpleCountdown deadline={poll.response_deadline} />
-                            </ClientOnly>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
+                          {poll.response_deadline && (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                              <ClientOnly fallback={<>Loading...</>}>
+                                <SimpleCountdown deadline={poll.response_deadline} />
+                              </ClientOnly>
+                            </span>
+                          )}
+                        </div>
+                        {getCategoryDisplay(poll) && (
+                          <span className="text-xs text-gray-400 dark:text-gray-500">
+                            {getCategoryDisplay(poll)!.label} {getCategoryDisplay(poll)!.icon}
                           </span>
                         )}
                       </div>
@@ -486,31 +503,38 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </svg>
                         </div>
                       )}
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
-                        {poll.response_deadline && (
-                          <span className="text-xs text-gray-500 dark:text-gray-400">
-                            <ClientOnly fallback={<>Closed</>}>
-                              <>Closed {(() => {
-                                const deadline = new Date(poll.response_deadline);
-                                const now = new Date();
-                                const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
+                          {poll.response_deadline && (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                              <ClientOnly fallback={<>Closed</>}>
+                                <>Closed {(() => {
+                                  const deadline = new Date(poll.response_deadline);
+                                  const now = new Date();
+                                  const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
 
-                                if (hoursAgo <= 24) {
-                                  return deadline.toLocaleTimeString("en-US", {
-                                    hour: "numeric",
-                                    minute: "2-digit",
-                                    hour12: true
-                                  });
-                                } else {
-                                  return deadline.toLocaleDateString("en-US", {
-                                    month: "numeric",
-                                    day: "numeric",
-                                    year: "2-digit"
-                                  });
-                                }
-                              })()}</>
-                            </ClientOnly>
+                                  if (hoursAgo <= 24) {
+                                    return deadline.toLocaleTimeString("en-US", {
+                                      hour: "numeric",
+                                      minute: "2-digit",
+                                      hour12: true
+                                    });
+                                  } else {
+                                    return deadline.toLocaleDateString("en-US", {
+                                      month: "numeric",
+                                      day: "numeric",
+                                      year: "2-digit"
+                                    });
+                                  }
+                                })()}</>
+                              </ClientOnly>
+                            </span>
+                          )}
+                        </div>
+                        {getCategoryDisplay(poll) && (
+                          <span className="text-xs text-gray-400 dark:text-gray-500">
+                            {getCategoryDisplay(poll)!.label} {getCategoryDisplay(poll)!.icon}
                           </span>
                         )}
                       </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -282,7 +282,8 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               const prevPoll = index > 0 ? openPolls[index - 1] : null;
               const isPrevVoted = prevPoll ? (votedPollIds.has(prevPoll.id) || abstainedPollIds.has(prevPoll.id)) : false;
               const isFirstVoted = hasVotedOrAbstained && !isPrevVoted;
-              
+              const categoryDisplay = getCategoryDisplay(poll);
+
               const handleTouchStart = (e: React.TouchEvent) => {
                 isLongPress.current = false;
                 isScrolling.current = false;
@@ -386,9 +387,9 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                             </span>
                           )}
                         </div>
-                        {getCategoryDisplay(poll) && (
+                        {categoryDisplay && (
                           <span className="text-xs text-gray-400 dark:text-gray-500">
-                            {getCategoryDisplay(poll)!.label} {getCategoryDisplay(poll)!.icon}
+                            {categoryDisplay.label} {categoryDisplay.icon}
                           </span>
                         )}
                       </div>
@@ -417,6 +418,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
           </div>
           <div>
               {closedPolls.map((poll, index) => {
+                const categoryDisplay = getCategoryDisplay(poll);
                 const handleTouchStart = (e: React.TouchEvent) => {
                   isLongPress.current = false;
                   isScrolling.current = false;
@@ -532,9 +534,9 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                             </span>
                           )}
                         </div>
-                        {getCategoryDisplay(poll) && (
+                        {categoryDisplay && (
                           <span className="text-xs text-gray-400 dark:text-gray-500">
-                            {getCategoryDisplay(poll)!.label} {getCategoryDisplay(poll)!.icon}
+                            {categoryDisplay.label} {categoryDisplay.icon}
                           </span>
                         )}
                       </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -355,7 +355,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       onTouchStart={handleTouchStart}
                       onTouchEnd={handleTouchEnd}
                       onTouchMove={handleTouchMove}
-                      className={`px-1 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : hasVotedOrAbstained ? 'opacity-60' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                      className={`px-1 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
                     >
                       {navigatingPollId === poll.id && (
                         <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Remove opacity fade from already-voted polls in main list (the section header is sufficient)
- Show poll category label + icon (e.g. "Restaurant 🍽️") in upper right of each poll list item
- Fix restaurant two-option voting: only tapping the underlined name opens the detail modal (not the entire button)
- Show address in restaurant stacked layout (two-option view), between name and distance

## Test plan
- [ ] Verify voted polls in main list are no longer faded
- [ ] Verify category labels appear in upper right for restaurant/location/movie polls
- [ ] On a two-option restaurant poll, verify tapping the option button selects it without opening the modal
- [ ] On a two-option restaurant poll, verify tapping the underlined restaurant name opens the detail modal
- [ ] Verify address appears below restaurant name in two-option view

https://claude.ai/code/session_01VpDh868No4XtxBbzd4jxmn