### PR TITLE
Fix restaurant poll: modal click target & address display

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1934,7 +1934,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                           {twoOptionDisplayOrder.map((option: string) => (
                             <button
                               key={option}
-                              onClick={() => {
+                              onClick={(e) => {
+                                // Don't trigger vote when clicking the restaurant/place name (opens detail modal instead)
+                                if ((e.target as HTMLElement).closest?.('[data-place-name]')) return;
                                 const other = pollOptions.find((o: string) => o !== option)!;
                                 handleRankingChange([option, other]);
                                 setIsAbstaining(false);

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -72,6 +72,7 @@ function PlaceName({ name, hasModal, onOpenModal }: { name: string; hasModal: bo
   if (hasModal) {
     return (
       <span
+        data-place-name
         className="font-medium leading-tight underline decoration-2 decoration-blue-400/50 cursor-pointer"
         onClick={(e) => {
           e.stopPropagation();
@@ -145,7 +146,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     const distance = metadata!.distance_miles;
     const hasCoords = !!(metadata!.lat && metadata!.lon);
 
-    const address = getAddressFromLabel(text, name);
+    const address = metadata!.address || getAddressFromLabel(text, name);
 
     if (layout === "stacked") {
       return (
@@ -193,6 +194,11 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
                   </span>
                 )}
               </div>
+              {address && (
+                <div className="text-xs text-gray-500 dark:text-gray-400 truncate leading-tight mt-0.5">
+                  {address}
+                </div>
+              )}
             </div>
           </>
         )}
@@ -203,7 +209,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
   // Location entry
   if (isLocationEntry(metadata)) {
     const name = getLocationName(text, metadata!);
-    const address = getAddressFromLabel(text, name);
+    const address = metadata!.address || getAddressFromLabel(text, name);
     const distance = metadata!.distance_miles;
     const hasCoords = !!(metadata!.lat && metadata!.lon);
 

--- a/components/OptionLabel.tsx
+++ b/components/OptionLabel.tsx
@@ -146,7 +146,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
     const distance = metadata!.distance_miles;
     const hasCoords = !!(metadata!.lat && metadata!.lon);
 
-    const address = metadata!.address || getAddressFromLabel(text, name);
+    const address = metadata!.address ?? getAddressFromLabel(text, name);
 
     if (layout === "stacked") {
       return (
@@ -209,7 +209,7 @@ export default function OptionLabel({ text, metadata, className = "", layout = "
   // Location entry
   if (isLocationEntry(metadata)) {
     const name = getLocationName(text, metadata!);
-    const address = metadata!.address || getAddressFromLabel(text, name);
+    const address = metadata!.address ?? getAddressFromLabel(text, name);
     const distance = metadata!.distance_miles;
     const hasCoords = !!(metadata!.lat && metadata!.lon);
 

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -88,6 +88,7 @@ export default function OptionsInput({
     if (result.imageUrl) entry.imageUrl = result.imageUrl;
     if (result.infoUrl) entry.infoUrl = result.infoUrl;
     if (result.name) entry.name = result.name;
+    if (result.address) entry.address = result.address;
     if (result.distance_miles !== undefined) entry.distance_miles = result.distance_miles;
     if (result.lat) entry.lat = result.lat;
     if (result.lon) entry.lon = result.lon;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -349,6 +349,7 @@ export async function apiGetAccessiblePolls(pollIds: string[]): Promise<Poll[]> 
 export interface SearchResult {
   label: string;
   name?: string;
+  address?: string;
   description?: string;
   imageUrl?: string;
   infoUrl?: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ export type OptionMetadataEntry = {
   imageUrl?: string;
   infoUrl?: string;
   name?: string;
+  address?: string;
   distance_miles?: number;
   lat?: string;
   lon?: string;

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -153,9 +153,15 @@ async def _nominatim_search(
         extratags = item.get("extratags") or {}
         image_url = _favicon_url(_extract_website(extratags))
 
+        # Build address from display_name minus the place name
+        display_name = item.get("display_name", "")
+        place_name = item.get("name") or ""
+        loc_address = display_name[len(place_name) + 2:] if display_name.startswith(place_name + ", ") else ""
+
         entry: dict = {
-            "label": item.get("display_name", ""),
-            "name": item.get("name") or "",
+            "label": display_name,
+            "name": place_name,
+            "address": loc_address or None,
             "description": item.get("type", "").replace("_", " ").title(),
             "lat": item.get("lat"),
             "lon": item.get("lon"),
@@ -397,6 +403,7 @@ async def search_restaurants(
         entry: dict = {
             "label": label,
             "name": name,
+            "address": address or None,
             "description": cuisine,
             "imageUrl": image_url,
             "infoUrl": (

--- a/server/routers/search.py
+++ b/server/routers/search.py
@@ -153,7 +153,6 @@ async def _nominatim_search(
         extratags = item.get("extratags") or {}
         image_url = _favicon_url(_extract_website(extratags))
 
-        # Build address from display_name minus the place name
         display_name = item.get("display_name", "")
         place_name = item.get("name") or ""
         loc_address = display_name[len(place_name) + 2:] if display_name.startswith(place_name + ", ") else ""


### PR DESCRIPTION
## Summary
- Only the underlined restaurant name opens the place detail modal now (not the entire option card)
- Address is shown between the restaurant name and distance in both stacked and inline layouts
- Added explicit `address` field to search API responses and metadata types for reliable address display

## Test plan
- [ ] Create a restaurant poll with 2 options — verify tapping the card area selects the option without opening the modal
- [ ] Verify tapping the underlined restaurant name opens the place detail modal without selecting the option
- [ ] Verify address appears below the restaurant name in the two-option voting UI
- [ ] Verify address appears in inline restaurant labels (ranked choice with 3+ options)

https://claude.ai/code/session_01XjBBa7NuNXZqXZecRdKDPv