### PR TITLE
Fix inconsistent search result selection

### DIFF
--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -171,12 +171,13 @@ export default function AutocompleteInput({
                 <img
                   src={result.imageUrl}
                   alt=""
-                  className={`object-cover rounded flex-shrink-0 mt-0.5 ${
+                  draggable={false}
+                  className={`object-cover rounded flex-shrink-0 mt-0.5 pointer-events-none ${
                     result.name ? 'w-5 h-5' : 'w-8 h-12'
                   }`}
                 />
               )}
-              <div className="min-w-0 flex-1">
+              <div className="min-w-0 flex-1 pointer-events-none select-none">
                 {result.name ? (
                   <>
                     <div className="flex items-baseline gap-1.5">


### PR DESCRIPTION
## Summary
- Fix inconsistent click handling on autocomplete search result items (restaurants, locations, etc.)
- Clicking the left side / text area of a result sometimes failed to trigger selection because browser-native image drag and text selection gestures intercepted the `mousedown` event before it bubbled to the `<li>` handler
- Added `draggable={false}` and `pointer-events-none` to the favicon image, and `pointer-events-none select-none` to the text container, so all mouse events go directly to the `<li>`

## Test plan
- [ ] Search for restaurants in poll creation
- [ ] Click on the left side (text/icon area) of search results — should reliably select
- [ ] Click on the right side (blank area) of search results — should still work as before
- [ ] Verify keyboard navigation (arrow keys + Enter) still works

https://claude.ai/code/session_01Q3hH5UEBy4wEw15i6c65uY