### PR TITLE
Reorder categories and move rank numbers to static column

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1230,7 +1230,7 @@ function CreatePollContent() {
           {pollType !== 'participation' && (
             <div>
               <label htmlFor="category" className="block text-sm font-medium mb-1">
-                Category
+                Category <span className="text-gray-400 font-normal">(optional)</span>
               </label>
               <TypeFieldInput
                 value={category}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1845,28 +1845,20 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             </div>
                           </div>
                         ) : (
-                          <div className="flex">
-                            {/* Static rank numbers column */}
-                            <div className="flex-shrink-0 flex flex-col" style={{ width: '32px' }}>
-                              {rankedChoices.map((_, index) => (
-                                <div key={index} className="flex items-center justify-center" style={{ height: '40px', marginBottom: index < rankedChoices.length - 1 ? '8px' : '0' }}>
-                                  <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                                    {index + 1}
-                                  </span>
+                          rankedChoices.map((choice, index) => (
+                            <div key={index} className="flex items-center gap-2">
+                              <div className="flex-shrink-0" style={{ width: '32px' }}>
+                                <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                                  {index + 1}
+                                </span>
+                              </div>
+                              <div className="flex-1 flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0">
+                                <div className="min-w-0 overflow-hidden">
+                                  <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
                                 </div>
-                              ))}
+                              </div>
                             </div>
-                            {/* Reorderable items */}
-                            <div className="flex-1 space-y-2">
-                              {rankedChoices.map((choice, index) => (
-                                <div key={index} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0" style={{ height: '40px' }}>
-                                  <div className="min-w-0 overflow-hidden">
-                                    <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
+                          ))
                         )}
                       </div>
                     )}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1845,16 +1845,28 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             </div>
                           </div>
                         ) : (
-                          rankedChoices.map((choice, index) => (
-                            <div key={index} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0">
-                              <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-2">
-                                {index + 1}
-                              </span>
-                              <div className="min-w-0 overflow-hidden">
-                                <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
-                              </div>
+                          <div className="flex">
+                            {/* Static rank numbers column */}
+                            <div className="flex-shrink-0 flex flex-col" style={{ width: '32px' }}>
+                              {rankedChoices.map((_, index) => (
+                                <div key={index} className="flex items-center justify-center" style={{ height: '40px', marginBottom: index < rankedChoices.length - 1 ? '8px' : '0' }}>
+                                  <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                                    {index + 1}
+                                  </span>
+                                </div>
+                              ))}
                             </div>
-                          ))
+                            {/* Reorderable items */}
+                            <div className="flex-1 space-y-2">
+                              {rankedChoices.map((choice, index) => (
+                                <div key={index} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0" style={{ height: '40px' }}>
+                                  <div className="min-w-0 overflow-hidden">
+                                    <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
                         )}
                       </div>
                     )}

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -363,128 +363,147 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
         onTouchMove={roundVisualizations.length > 1 ? handleTouchMove : undefined}
         onTouchEnd={roundVisualizations.length > 1 ? handleTouchEnd : undefined}
       >
-        <div className="space-y-2">
-          {currentRound.candidates.map((candidate, index) => {
-            // Find the highest vote count in the current round
-            const highestVotes = Math.max(...currentRound.candidates.map(c => c.votes));
-            const candidatesWithHighestVotes = currentRound.candidates.filter(c => c.votes === highestVotes);
-            const isTieByVotes = candidatesWithHighestVotes.length > 1;
-            
-            const isTiedCandidate = currentRound.roundNumber === roundVisualizations.length &&
-                                  (results.winner === 'tie' || isTieByVotes) &&
-                                  candidate.votes === highestVotes;
+        <div className="flex">
+          {/* Static position numbers column */}
+          <div className="flex-shrink-0 flex flex-col" style={{ width: '36px' }}>
+            {currentRound.candidates.map((candidate, index) => {
+              const highestVotes = Math.max(...currentRound.candidates.map(c => c.votes));
+              const candidatesWithHighestVotes = currentRound.candidates.filter(c => c.votes === highestVotes);
+              const isTieByVotes = candidatesWithHighestVotes.length > 1;
+              const isTiedCandidate = currentRound.roundNumber === roundVisualizations.length &&
+                                    (results.winner === 'tie' || isTieByVotes) &&
+                                    candidate.votes === highestVotes;
+              const isUserPreference = currentRound.userPreference === candidate.name;
 
-            // Check if we should show Borda explanation after this candidate
-            // Show it only after the LAST eliminated candidate in a tie-breaking round
-            const isLastEliminatedCandidate = candidate.isEliminated && 
-                                            index === currentRound.candidates.length - 1;
-            const hasBordaTieBreaking = isLastEliminatedCandidate && 
-                                      currentRound.eliminatedCandidates.length > 0;
-            
-            // Check if this candidate is the user's preference for this round
-            const isUserPreference = currentRound.userPreference === candidate.name;
-            
-            // Get the ordinal position of this candidate in user's ranking
-            const getUserChoicePosition = () => {
-              if (!isUserPreference || !userVoteData?.ranked_choices) return null;
-              const position = userVoteData.ranked_choices.indexOf(candidate.name) + 1;
-              if (position === 0) return null;
-              
-              // Convert to ordinal (1st, 2nd, 3rd, etc.)
-              const suffix = position === 1 ? 'st' : position === 2 ? 'nd' : position === 3 ? 'rd' : 'th';
-              return `Your ${position}${suffix} choice`;
-            };
-            
-            const userChoiceText = getUserChoicePosition();
-            
-            return (
-              <React.Fragment key={candidate.name}>
-                <div className={`border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 transition-all ${
-                  isTiedCandidate
-                    ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600'
-                    : candidate.isEliminated && !isTiedCandidate
-                    ? 'bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800 opacity-75'
-                    : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
-                    ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600' 
-                    : 'bg-white dark:bg-gray-700'
-                }`}>
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center space-x-2 min-w-0 flex-1">
-                      {/* Position number */}
-                      <div className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-bold ${
-                        isUserPreference 
-                          ? 'bg-blue-500 text-white dark:bg-blue-600 dark:text-white' 
-                          : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-200'
-                      }`}>
-                        {isTiedCandidate ? 'T' : candidate.position}
-                      </div>
-                      
-                      {/* Candidate name */}
-                      <div className="min-w-0 overflow-hidden">
-                        <div className={`leading-tight ${
-                          isLocationEntry(optionsMetadata?.[candidate.name]) || isRestaurantEntry(optionsMetadata?.[candidate.name])
-                            ? 'overflow-hidden'
-                            : 'line-clamp-2'
-                        } ${
-                          isTiedCandidate
-                            ? 'text-green-900 dark:text-green-100 font-bold'
-                            : candidate.isEliminated && !isTiedCandidate
-                            ? 'text-gray-500/60 dark:text-gray-400/60 line-through font-medium'
-                            : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
-                            ? 'text-green-900 dark:text-green-100 font-bold'
-                            : 'text-gray-700/80 dark:text-gray-300/80 font-medium'
-                        }`}>
-                          <OptionLabel text={candidate.name} metadata={optionsMetadata?.[candidate.name]} />
-                        </div>
-                        {/* Show user preference indicator under name */}
-                        {userChoiceText && (
-                          <div className="mt-1">
-                            <span className="inline-block px-2 py-1 bg-blue-500 text-white text-xs font-medium rounded-full">
-                              {userChoiceText}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Vote count and percentage - hidden for uncontested polls */}
-                    {!(results.total_votes === 0 && currentRound.candidates.length === 1) && (
-                      <div className="text-right flex-shrink-0">
-                        <div className={`text-lg font-bold ${
-                          isTiedCandidate
-                            ? 'text-green-800 dark:text-green-200'
-                            : candidate.isEliminated && !isTiedCandidate
-                            ? 'text-red-700 dark:text-red-300'
-                            : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
-                            ? 'text-green-800 dark:text-green-200'
-                            : 'text-gray-900 dark:text-white'
-                        }`}>
-                          {candidate.percentage}%
-                        </div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center justify-end gap-1">
-                          {candidate.donatedVotes && candidate.donatedVotes > 0 && (
-                            <span className="bg-blue-500 text-white text-xs px-2 py-0.5 rounded-full font-medium">
-                              +{candidate.donatedVotes}
-                            </span>
-                          )}
-                          <span>{candidate.votes} vote{candidate.votes !== 1 ? 's' : ''}</span>
-                        </div>
-                      </div>
-                    )}
+              return (
+                <div key={candidate.name} className="flex items-center justify-center" style={{ height: '52px', marginBottom: index < currentRound.candidates.length - 1 ? '8px' : '0' }}>
+                  <div className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-bold ${
+                    isUserPreference
+                      ? 'bg-blue-500 text-white dark:bg-blue-600 dark:text-white'
+                      : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-200'
+                  }`}>
+                    {isTiedCandidate ? 'T' : candidate.position}
                   </div>
                 </div>
+              );
+            })}
+          </div>
 
-                {/* Show Borda count explanation when tie-breaking occurs */}
-                {hasBordaTieBreaking && (
-                  <BordaCountExplanation
-                    pollId={results.poll_id}
-                    roundNumber={currentRound.roundNumber}
-                    roundEntries={currentRound.roundEntries}
-                  />
-                )}
-              </React.Fragment>
-            );
-          })}
+          {/* Candidate rows */}
+          <div className="flex-1 space-y-2">
+            {currentRound.candidates.map((candidate, index) => {
+              // Find the highest vote count in the current round
+              const highestVotes = Math.max(...currentRound.candidates.map(c => c.votes));
+              const candidatesWithHighestVotes = currentRound.candidates.filter(c => c.votes === highestVotes);
+              const isTieByVotes = candidatesWithHighestVotes.length > 1;
+
+              const isTiedCandidate = currentRound.roundNumber === roundVisualizations.length &&
+                                    (results.winner === 'tie' || isTieByVotes) &&
+                                    candidate.votes === highestVotes;
+
+              // Check if we should show Borda explanation after this candidate
+              // Show it only after the LAST eliminated candidate in a tie-breaking round
+              const isLastEliminatedCandidate = candidate.isEliminated &&
+                                              index === currentRound.candidates.length - 1;
+              const hasBordaTieBreaking = isLastEliminatedCandidate &&
+                                        currentRound.eliminatedCandidates.length > 0;
+
+              // Check if this candidate is the user's preference for this round
+              const isUserPreference = currentRound.userPreference === candidate.name;
+
+              // Get the ordinal position of this candidate in user's ranking
+              const getUserChoicePosition = () => {
+                if (!isUserPreference || !userVoteData?.ranked_choices) return null;
+                const position = userVoteData.ranked_choices.indexOf(candidate.name) + 1;
+                if (position === 0) return null;
+
+                // Convert to ordinal (1st, 2nd, 3rd, etc.)
+                const suffix = position === 1 ? 'st' : position === 2 ? 'nd' : position === 3 ? 'rd' : 'th';
+                return `Your ${position}${suffix} choice`;
+              };
+
+              const userChoiceText = getUserChoicePosition();
+
+              return (
+                <React.Fragment key={candidate.name}>
+                  <div className={`border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 transition-all ${
+                    isTiedCandidate
+                      ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600'
+                      : candidate.isEliminated && !isTiedCandidate
+                      ? 'bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800 opacity-75'
+                      : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                      ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600'
+                      : 'bg-white dark:bg-gray-700'
+                  }`}>
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        {/* Candidate name */}
+                        <div className="min-w-0 overflow-hidden">
+                          <div className={`leading-tight ${
+                            isLocationEntry(optionsMetadata?.[candidate.name]) || isRestaurantEntry(optionsMetadata?.[candidate.name])
+                              ? 'overflow-hidden'
+                              : 'line-clamp-2'
+                          } ${
+                            isTiedCandidate
+                              ? 'text-green-900 dark:text-green-100 font-bold'
+                              : candidate.isEliminated && !isTiedCandidate
+                              ? 'text-gray-500/60 dark:text-gray-400/60 line-through font-medium'
+                              : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                              ? 'text-green-900 dark:text-green-100 font-bold'
+                              : 'text-gray-700/80 dark:text-gray-300/80 font-medium'
+                          }`}>
+                            <OptionLabel text={candidate.name} metadata={optionsMetadata?.[candidate.name]} />
+                          </div>
+                          {/* Show user preference indicator under name */}
+                          {userChoiceText && (
+                            <div className="mt-1">
+                              <span className="inline-block px-2 py-1 bg-blue-500 text-white text-xs font-medium rounded-full">
+                                {userChoiceText}
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Vote count and percentage - hidden for uncontested polls */}
+                      {!(results.total_votes === 0 && currentRound.candidates.length === 1) && (
+                        <div className="text-right flex-shrink-0">
+                          <div className={`text-lg font-bold ${
+                            isTiedCandidate
+                              ? 'text-green-800 dark:text-green-200'
+                              : candidate.isEliminated && !isTiedCandidate
+                              ? 'text-red-700 dark:text-red-300'
+                              : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                              ? 'text-green-800 dark:text-green-200'
+                              : 'text-gray-900 dark:text-white'
+                          }`}>
+                            {candidate.percentage}%
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center justify-end gap-1">
+                            {candidate.donatedVotes && candidate.donatedVotes > 0 && (
+                              <span className="bg-blue-500 text-white text-xs px-2 py-0.5 rounded-full font-medium">
+                                +{candidate.donatedVotes}
+                              </span>
+                            )}
+                            <span>{candidate.votes} vote{candidate.votes !== 1 ? 's' : ''}</span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Show Borda count explanation when tie-breaking occurs */}
+                  {hasBordaTieBreaking && (
+                    <BordaCountExplanation
+                      pollId={results.poll_id}
+                      roundNumber={currentRound.roundNumber}
+                      roundEntries={currentRound.roundEntries}
+                    />
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -363,70 +363,51 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
         onTouchMove={roundVisualizations.length > 1 ? handleTouchMove : undefined}
         onTouchEnd={roundVisualizations.length > 1 ? handleTouchEnd : undefined}
       >
-        <div className="flex">
-          {/* Static position numbers column */}
-          <div className="flex-shrink-0 flex flex-col" style={{ width: '36px' }}>
-            {currentRound.candidates.map((candidate, index) => {
-              const highestVotes = Math.max(...currentRound.candidates.map(c => c.votes));
-              const candidatesWithHighestVotes = currentRound.candidates.filter(c => c.votes === highestVotes);
-              const isTieByVotes = candidatesWithHighestVotes.length > 1;
-              const isTiedCandidate = currentRound.roundNumber === roundVisualizations.length &&
-                                    (results.winner === 'tie' || isTieByVotes) &&
-                                    candidate.votes === highestVotes;
-              const isUserPreference = currentRound.userPreference === candidate.name;
+        <div className="space-y-2">
+          {currentRound.candidates.map((candidate, index) => {
+            // Find the highest vote count in the current round
+            const highestVotes = Math.max(...currentRound.candidates.map(c => c.votes));
+            const candidatesWithHighestVotes = currentRound.candidates.filter(c => c.votes === highestVotes);
+            const isTieByVotes = candidatesWithHighestVotes.length > 1;
 
-              return (
-                <div key={candidate.name} className="flex items-center justify-center" style={{ height: '52px', marginBottom: index < currentRound.candidates.length - 1 ? '8px' : '0' }}>
-                  <div className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-bold ${
-                    isUserPreference
-                      ? 'bg-blue-500 text-white dark:bg-blue-600 dark:text-white'
-                      : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-200'
-                  }`}>
-                    {isTiedCandidate ? 'T' : candidate.position}
+            const isTiedCandidate = currentRound.roundNumber === roundVisualizations.length &&
+                                  (results.winner === 'tie' || isTieByVotes) &&
+                                  candidate.votes === highestVotes;
+
+            // Check if we should show Borda explanation after this candidate
+            const isLastEliminatedCandidate = candidate.isEliminated &&
+                                            index === currentRound.candidates.length - 1;
+            const hasBordaTieBreaking = isLastEliminatedCandidate &&
+                                      currentRound.eliminatedCandidates.length > 0;
+
+            const isUserPreference = currentRound.userPreference === candidate.name;
+
+            const getUserChoicePosition = () => {
+              if (!isUserPreference || !userVoteData?.ranked_choices) return null;
+              const position = userVoteData.ranked_choices.indexOf(candidate.name) + 1;
+              if (position === 0) return null;
+              const suffix = position === 1 ? 'st' : position === 2 ? 'nd' : position === 3 ? 'rd' : 'th';
+              return `Your ${position}${suffix} choice`;
+            };
+
+            const userChoiceText = getUserChoicePosition();
+
+            return (
+              <React.Fragment key={candidate.name}>
+                <div className="flex items-center gap-2">
+                  {/* Static position number */}
+                  <div className="flex-shrink-0" style={{ width: '32px' }}>
+                    <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                      isUserPreference
+                        ? 'bg-blue-500 text-white dark:bg-blue-600 dark:text-white'
+                        : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-200'
+                    }`}>
+                      {isTiedCandidate ? 'T' : candidate.position}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-          </div>
 
-          {/* Candidate rows */}
-          <div className="flex-1 space-y-2">
-            {currentRound.candidates.map((candidate, index) => {
-              // Find the highest vote count in the current round
-              const highestVotes = Math.max(...currentRound.candidates.map(c => c.votes));
-              const candidatesWithHighestVotes = currentRound.candidates.filter(c => c.votes === highestVotes);
-              const isTieByVotes = candidatesWithHighestVotes.length > 1;
-
-              const isTiedCandidate = currentRound.roundNumber === roundVisualizations.length &&
-                                    (results.winner === 'tie' || isTieByVotes) &&
-                                    candidate.votes === highestVotes;
-
-              // Check if we should show Borda explanation after this candidate
-              // Show it only after the LAST eliminated candidate in a tie-breaking round
-              const isLastEliminatedCandidate = candidate.isEliminated &&
-                                              index === currentRound.candidates.length - 1;
-              const hasBordaTieBreaking = isLastEliminatedCandidate &&
-                                        currentRound.eliminatedCandidates.length > 0;
-
-              // Check if this candidate is the user's preference for this round
-              const isUserPreference = currentRound.userPreference === candidate.name;
-
-              // Get the ordinal position of this candidate in user's ranking
-              const getUserChoicePosition = () => {
-                if (!isUserPreference || !userVoteData?.ranked_choices) return null;
-                const position = userVoteData.ranked_choices.indexOf(candidate.name) + 1;
-                if (position === 0) return null;
-
-                // Convert to ordinal (1st, 2nd, 3rd, etc.)
-                const suffix = position === 1 ? 'st' : position === 2 ? 'nd' : position === 3 ? 'rd' : 'th';
-                return `Your ${position}${suffix} choice`;
-              };
-
-              const userChoiceText = getUserChoicePosition();
-
-              return (
-                <React.Fragment key={candidate.name}>
-                  <div className={`border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 transition-all ${
+                  {/* Candidate row */}
+                  <div className={`flex-1 border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 transition-all ${
                     isTiedCandidate
                       ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600'
                       : candidate.isEliminated && !isTiedCandidate
@@ -437,7 +418,6 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                   }`}>
                     <div className="flex items-center justify-between gap-2">
                       <div className="min-w-0 flex-1">
-                        {/* Candidate name */}
                         <div className="min-w-0 overflow-hidden">
                           <div className={`leading-tight ${
                             isLocationEntry(optionsMetadata?.[candidate.name]) || isRestaurantEntry(optionsMetadata?.[candidate.name])
@@ -454,7 +434,6 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                           }`}>
                             <OptionLabel text={candidate.name} metadata={optionsMetadata?.[candidate.name]} />
                           </div>
-                          {/* Show user preference indicator under name */}
                           {userChoiceText && (
                             <div className="mt-1">
                               <span className="inline-block px-2 py-1 bg-blue-500 text-white text-xs font-medium rounded-full">
@@ -465,7 +444,6 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                         </div>
                       </div>
 
-                      {/* Vote count and percentage - hidden for uncontested polls */}
                       {!(results.total_votes === 0 && currentRound.candidates.length === 1) && (
                         <div className="text-right flex-shrink-0">
                           <div className={`text-lg font-bold ${
@@ -491,19 +469,18 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                       )}
                     </div>
                   </div>
+                </div>
 
-                  {/* Show Borda count explanation when tie-breaking occurs */}
-                  {hasBordaTieBreaking && (
-                    <BordaCountExplanation
-                      pollId={results.poll_id}
-                      roundNumber={currentRound.roundNumber}
-                      roundEntries={currentRound.roundEntries}
-                    />
-                  )}
-                </React.Fragment>
-              );
-            })}
-          </div>
+                {hasBordaTieBreaking && (
+                  <BordaCountExplanation
+                    pollId={results.poll_id}
+                    roundNumber={currentRound.roundNumber}
+                    roundEntries={currentRound.roundEntries}
+                  />
+                )}
+              </React.Fragment>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -364,13 +364,13 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
         onTouchEnd={roundVisualizations.length > 1 ? handleTouchEnd : undefined}
       >
         <div className="space-y-2">
-          {currentRound.candidates.map((candidate, index) => {
-            // Find the highest vote count in the current round
+          {(() => {
             const highestVotes = Math.max(...currentRound.candidates.map(c => c.votes));
-            const candidatesWithHighestVotes = currentRound.candidates.filter(c => c.votes === highestVotes);
-            const isTieByVotes = candidatesWithHighestVotes.length > 1;
+            const isTieByVotes = currentRound.candidates.filter(c => c.votes === highestVotes).length > 1;
+            const isFinalRound = currentRound.roundNumber === roundVisualizations.length;
 
-            const isTiedCandidate = currentRound.roundNumber === roundVisualizations.length &&
+            return currentRound.candidates.map((candidate, index) => {
+              const isTiedCandidate = isFinalRound &&
                                   (results.winner === 'tie' || isTieByVotes) &&
                                   candidate.votes === highestVotes;
 
@@ -412,7 +412,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                       ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600'
                       : candidate.isEliminated && !isTiedCandidate
                       ? 'bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800 opacity-75'
-                      : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                      : results.winner === candidate.name && isFinalRound
                       ? 'bg-green-100 dark:bg-green-900 border-green-300 dark:border-green-600'
                       : 'bg-white dark:bg-gray-700'
                   }`}>
@@ -428,7 +428,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                               ? 'text-green-900 dark:text-green-100 font-bold'
                               : candidate.isEliminated && !isTiedCandidate
                               ? 'text-gray-500/60 dark:text-gray-400/60 line-through font-medium'
-                              : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                              : results.winner === candidate.name && isFinalRound
                               ? 'text-green-900 dark:text-green-100 font-bold'
                               : 'text-gray-700/80 dark:text-gray-300/80 font-medium'
                           }`}>
@@ -451,7 +451,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                               ? 'text-green-800 dark:text-green-200'
                               : candidate.isEliminated && !isTiedCandidate
                               ? 'text-red-700 dark:text-red-300'
-                              : results.winner === candidate.name && currentRound.roundNumber === roundVisualizations.length
+                              : results.winner === candidate.name && isFinalRound
                               ? 'text-green-800 dark:text-green-200'
                               : 'text-gray-900 dark:text-white'
                           }`}>
@@ -480,7 +480,8 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
                 )}
               </React.Fragment>
             );
-          })}
+          });
+          })()}
         </div>
       </div>
     </div>

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -586,15 +586,6 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     const draggedOption = getDraggedOption();
     if (!draggedOption) return null;
 
-    // Find the current ranking number based on which list it's in
-    let rankNumber = '';
-    const mainIndex = mainList.findIndex(opt => opt.id === draggedOption.id);
-    if (mainIndex !== -1) {
-      rankNumber = (mainIndex + 1).toString();
-    } else {
-      rankNumber = ''; // No ranking for no preference items
-    }
-
     return (
       <div
         className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md p-3 select-none"
@@ -602,9 +593,6 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       >
         <div className="flex items-center justify-between h-full">
           <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
-            <div className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium mr-1">
-              {rankNumber}
-            </div>
             <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="min-w-0 overflow-hidden" />
           </div>
           <div className="w-6 h-6 flex flex-col items-center justify-center ml-2">
@@ -865,6 +853,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     // Use dynamic height from state with smooth transitions
     const dynamicHeight = containerHeights[listType];
     
+    // Calculate how many number slots to show (account for items being dragged in from other list)
+    const numberSlotCount = listType === 'main'
+      ? (dragState.isDragging && dragState.sourceList === 'noPreference' && dragState.targetList === 'main'
+          ? listItems.length + 1
+          : listItems.length)
+      : 0;
+
     return (
       <div className={listType === 'main' ? 'mb-4' : ''}>
         {title && (
@@ -879,141 +874,146 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             )}
           </div>
         )}
-        
-        <div
-          ref={containerRef}
-          className={`p-3 relative transition-all duration-200 ease-out ${
-            listItems.length === 0 
-              ? 'border-2 border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/50 rounded-lg' 
-              : ''
-          }`}
-          style={{
-            height: `${dynamicHeight}px`,
-            minHeight: `${totalItemHeight}px`
-          }}
-          role="listbox"
-          aria-label={listType === 'main' ? 'Ranked choice options' : 'No preference options'}
-          aria-describedby={`${listType}-description`}
-        >
-          {/* Show empty state message if list is empty */}
-          {listItems.length === 0 && (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <div className="text-center">
-                <p className={`text-sm ${
-                  listType === 'noPreference' 
-                    ? 'text-gray-500 dark:text-gray-400 font-medium' 
-                    : 'text-gray-400 dark:text-gray-500'
-                }`}>
-                  {listType === 'main' ? 'Drag items here to rank them' : 'Drag items here to exclude from ranking'}
-                </p>
-              </div>
+
+        <div className="flex">
+          {/* Static rank numbers column - only for main list */}
+          {listType === 'main' && numberSlotCount > 0 && (
+            <div className="flex-shrink-0 relative" style={{ width: '32px', height: `${dynamicHeight}px`, minHeight: `${totalItemHeight}px` }}>
+              {Array.from({ length: numberSlotCount }, (_, i) => (
+                <div
+                  key={i}
+                  className="absolute left-0 right-0 flex items-center justify-center"
+                  style={{ top: `${i * totalItemHeight}px`, height: `${itemHeight}px` }}
+                >
+                  <div className={`w-6 h-6 rounded-full flex items-center justify-center text-sm font-medium ${
+                    disabled
+                      ? 'bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400'
+                      : 'bg-blue-600 text-white'
+                  }`}>
+                    {i + 1}
+                  </div>
+                </div>
+              ))}
             </div>
           )}
-          
-          {/* Render all items in this list */}
-          {listItems.map((option, index) => {
-            // Skip rendering the item in its original position if it's being dragged
-            if (dragState.isDragging && option.id === dragState.draggedId) {
-              return null;
-            }
 
-            // Determine rank number display
-            const rankNumber = listType === 'main' ? (index + 1).toString() : '';
-
-            return (
-              <div
-                key={option.id}
-                ref={el => {
-                  elementRefs.current[option.id] = el;
-                }}
-                className={`
-                  absolute left-0 right-0 rounded-md shadow-sm
-                  ${disabled ? 'cursor-not-allowed bg-gray-200 dark:bg-gray-600' : 'cursor-grab active:cursor-grabbing bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800'}
-                  ${keyboardMode && focusedItemId === option.id ? 'ring-2 ring-blue-500 ring-offset-2' : ''}
-                  border border-gray-300 dark:border-gray-500 p-3 select-none
-                  transition-colors duration-150
-                `}
-                style={{
-                  top: `${option.top}px`,
-                  height: `${itemHeight}px`,
-                  transition: dragState.isDragging ? 'top 0.2s ease' : 'top 0.3s ease',
-                  zIndex: 1
-                }}
-                onKeyDown={!disabled ? (e) => handleKeyDown(e, option.id) : undefined}
-                onContextMenu={(e) => e.preventDefault()}
-                tabIndex={disabled ? -1 : 0}
-                role="option"
-                aria-selected={keyboardMode && focusedItemId === option.id}
-                aria-label={`${option.text}, ${listType === 'main' ? `ranked ${index + 1}` : 'no preference'}`}
-                aria-describedby={`${option.id}-instructions`}
-              >
-                <div className="flex items-center justify-between h-full relative">
-                  {/* Left drag handle with grabbable region */}
-                  <div 
-                    className="absolute -left-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
-                    style={{
-                      width: 'calc(20% + 0.75rem)',
-                      touchAction: 'none',
-                      zIndex: 2
-                    }}
-                    onPointerDown={!disabled ? (e) => handlePointerStart(e, option.id) : undefined}
-                    title=""
-                  >
-                    {/* Visual number circle - positioned within the grabbable area */}
-                    <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center">
-                      <div 
-                        className={`w-6 h-6 flex-shrink-0 rounded-full flex items-center justify-center text-sm font-medium ${
-                          disabled 
-                            ? 'bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400' 
-                            : listType === 'main'
-                              ? 'bg-blue-600 text-white'
-                              : 'bg-orange-500 text-white'
-                        }`}
-                      >
-                        {rankNumber}
-                      </div>
-                    </div>
-                  </div>
-                  
-                  {/* Center content - not grabbable */}
-                  <div className={`flex-1 flex items-center pl-9 pr-12 min-w-0 ${
-                    disabled
-                      ? 'text-gray-500 dark:text-gray-400'
-                      : 'text-gray-900 dark:text-white'
+          <div
+            ref={containerRef}
+            className={`flex-1 p-3 relative transition-all duration-200 ease-out ${
+              listItems.length === 0
+                ? 'border-2 border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/50 rounded-lg'
+                : ''
+            }`}
+            style={{
+              height: `${dynamicHeight}px`,
+              minHeight: `${totalItemHeight}px`
+            }}
+            role="listbox"
+            aria-label={listType === 'main' ? 'Ranked choice options' : 'No preference options'}
+            aria-describedby={`${listType}-description`}
+          >
+            {/* Show empty state message if list is empty */}
+            {listItems.length === 0 && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="text-center">
+                  <p className={`text-sm ${
+                    listType === 'noPreference'
+                      ? 'text-gray-500 dark:text-gray-400 font-medium'
+                      : 'text-gray-400 dark:text-gray-500'
                   }`}>
-                    <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />
-                  </div>
-                  
-                  {/* Right drag handle with grabbable region */}
-                  {!disabled && (
-                    <div 
-                      className="absolute -right-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
+                    {listType === 'main' ? 'Drag items here to rank them' : 'Drag items here to exclude from ranking'}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Render all items in this list */}
+            {listItems.map((option, index) => {
+              // Skip rendering the item in its original position if it's being dragged
+              if (dragState.isDragging && option.id === dragState.draggedId) {
+                return null;
+              }
+
+              return (
+                <div
+                  key={option.id}
+                  ref={el => {
+                    elementRefs.current[option.id] = el;
+                  }}
+                  className={`
+                    absolute left-0 right-0 rounded-md shadow-sm
+                    ${disabled ? 'cursor-not-allowed bg-gray-200 dark:bg-gray-600' : 'cursor-grab active:cursor-grabbing bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800'}
+                    ${keyboardMode && focusedItemId === option.id ? 'ring-2 ring-blue-500 ring-offset-2' : ''}
+                    border border-gray-300 dark:border-gray-500 p-3 select-none
+                    transition-colors duration-150
+                  `}
+                  style={{
+                    top: `${option.top}px`,
+                    height: `${itemHeight}px`,
+                    transition: dragState.isDragging ? 'top 0.2s ease' : 'top 0.3s ease',
+                    zIndex: 1
+                  }}
+                  onKeyDown={!disabled ? (e) => handleKeyDown(e, option.id) : undefined}
+                  onContextMenu={(e) => e.preventDefault()}
+                  tabIndex={disabled ? -1 : 0}
+                  role="option"
+                  aria-selected={keyboardMode && focusedItemId === option.id}
+                  aria-label={`${option.text}, ${listType === 'main' ? `ranked ${index + 1}` : 'no preference'}`}
+                  aria-describedby={`${option.id}-instructions`}
+                >
+                  <div className="flex items-center justify-between h-full relative">
+                    {/* Left drag handle with grabbable region */}
+                    <div
+                      className="absolute -left-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
                       style={{
                         width: 'calc(20% + 0.75rem)',
                         touchAction: 'none',
                         zIndex: 2
                       }}
-                      onPointerDown={(e) => handlePointerStart(e, option.id)}
+                      onPointerDown={!disabled ? (e) => handlePointerStart(e, option.id) : undefined}
                       title=""
-                    >
-                      {/* Visual hamburger menu - positioned within the grabbable area */}
-                      <div className="absolute right-5 top-1/2 -translate-y-1/2 w-6 h-6 flex flex-col items-center justify-center">
-                        <div className="w-4 h-0.5 bg-gray-400 mb-1"></div>
-                        <div className="w-4 h-0.5 bg-gray-400 mb-1"></div>
-                        <div className="w-4 h-0.5 bg-gray-400"></div>
-                      </div>
+                    />
+
+                    {/* Center content - not grabbable */}
+                    <div className={`flex-1 flex items-center pr-12 min-w-0 ${
+                      disabled
+                        ? 'text-gray-500 dark:text-gray-400'
+                        : 'text-gray-900 dark:text-white'
+                    }`}>
+                      <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />
                     </div>
-                  )}
+
+                    {/* Right drag handle with grabbable region */}
+                    {!disabled && (
+                      <div
+                        className="absolute -right-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
+                        style={{
+                          width: 'calc(20% + 0.75rem)',
+                          touchAction: 'none',
+                          zIndex: 2
+                        }}
+                        onPointerDown={(e) => handlePointerStart(e, option.id)}
+                        title=""
+                      >
+                        {/* Visual hamburger menu - positioned within the grabbable area */}
+                        <div className="absolute right-5 top-1/2 -translate-y-1/2 w-6 h-6 flex flex-col items-center justify-center">
+                          <div className="w-4 h-0.5 bg-gray-400 mb-1"></div>
+                          <div className="w-4 h-0.5 bg-gray-400 mb-1"></div>
+                          <div className="w-4 h-0.5 bg-gray-400"></div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <div id={`${option.id}-instructions`} className="absolute -left-[10000px] w-1 h-1 overflow-hidden">
+                    {keyboardMode && focusedItemId === option.id
+                      ? `Selected for moving. Use arrow keys to move within list, left arrow to move to main list, right arrow to move to no preference, escape to cancel.`
+                      : `Press Enter or Space to select for moving. Use arrow keys to navigate between options.`
+                    }
+                  </div>
                 </div>
-                <div id={`${option.id}-instructions`} className="absolute -left-[10000px] w-1 h-1 overflow-hidden">
-                  {keyboardMode && focusedItemId === option.id 
-                    ? `Selected for moving. Use arrow keys to move within list, left arrow to move to main list, right arrow to move to no preference, escape to cancel.`
-                    : `Press Enter or Space to select for moving. Use arrow keys to navigate between options.`
-                  }
-                </div>
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
         </div>
       </div>
     );

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -10,8 +10,8 @@ export interface BuiltInType {
 
 const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "yes_no", label: "Yes / No", icon: "👍" },
-  { value: "location", label: "Location", icon: "📍" },
   { value: "restaurant", label: "Restaurant", icon: "🍽️" },
+  { value: "location", label: "Location", icon: "📍" },
   { value: "movie", label: "Movie", icon: "🎬" },
   { value: "video_game", label: "Video Game", icon: "🎮" },
 ];

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -172,7 +172,7 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder="Built-in or custom category"
+          placeholder="Built-in or custom"
           className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed ${
             builtIn && !isOpen ? "pl-9" : ""
           } ${


### PR DESCRIPTION
## Summary
- Reorder category list: Restaurant before Location
- Remove "category" from placeholder text, add "(optional)" to header
- Move rank numbers to a static column outside items in voting UI, "Your Vote" summary, and results screen so numbers stay fixed while items reorder

## Test plan
- [ ] Create a poll and verify category dropdown shows Restaurant before Location
- [ ] Verify category field shows "(optional)" label and "Built-in or custom" placeholder
- [ ] Vote on a ranked choice poll and verify numbers stay fixed while dragging items
- [ ] After voting, verify "Your Vote" shows numbers aligned with items
- [ ] View results and verify position numbers are outside candidate rows and vertically centered