### PR TITLE
Compact Respondents layout with inline header

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1348,7 +1348,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
         {/* Voter list for closed polls - always shown after Follow-up button */}
         {isPollClosed && (
-          <div className="mt-8">
+          <div className="mt-4">
             <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
           </div>
         )}
@@ -1488,7 +1488,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
                   {/* Voter list for open yes/no polls - shown after Follow-up button when voted */}
                   {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-8">
+                    <div className="mt-4">
                       <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
                     </div>
                   )}
@@ -1659,7 +1659,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   )}
 
                   {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-8">
+                    <div className="mt-4">
                       <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
                     </div>
                   )}
@@ -1921,7 +1921,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
                   {/* Voter list for open ranked choice polls - shown after Follow-up button when voted */}
                   {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-8">
+                    <div className="mt-4">
                       <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
                     </div>
                   )}

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -62,7 +62,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
     return (
       <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-sm font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
+          <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
           {/* Shimmer effect for loading voter bubbles */}
           {[1, 2, 3, 4, 5].map((i) => (
             <div
@@ -83,7 +83,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
     return (
       <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-sm font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
+          <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
           <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
         </div>
       </div>
@@ -159,7 +159,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
   return (
     <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
       <div className="flex flex-wrap items-center gap-1.5">
-        <span className="text-sm font-bold text-gray-900 dark:text-white mr-1">
+        <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">
           Respondents ({voters.length})
         </span>
 

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -14,6 +14,8 @@ interface VoterListProps {
   refreshTrigger?: number; // Optional prop to trigger refresh
 }
 
+const CARD_CLASS = "bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm";
+
 export default function VoterList({ pollId, className = "", refreshTrigger }: VoterListProps) {
   const [voters, setVoters] = useState<Voter[]>([]);
   const [initialLoading, setInitialLoading] = useState(true);
@@ -60,7 +62,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
   if (initialLoading) {
     return (
-      <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
+      <div className={`${CARD_CLASS} ${className}`}>
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
           {/* Shimmer effect for loading voter bubbles */}
@@ -81,7 +83,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
   if (error) {
     return (
-      <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
+      <div className={`${CARD_CLASS} ${className}`}>
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
           <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
@@ -157,7 +159,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
   };
 
   return (
-    <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
+    <div className={`${CARD_CLASS} ${className}`}>
       <div className="flex flex-wrap items-center gap-1.5">
         <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">
           Respondents ({voters.length})

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -67,10 +67,10 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              className="animate-pulse inline-block px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700"
+              className="animate-pulse inline-block px-3 py-1 rounded-full bg-gray-200 dark:bg-gray-700"
               style={{
-                width: `${50 + (i * 12) % 30}px`,
-                height: '24px'
+                width: `${60 + (i * 15) % 40}px`,
+                height: '28px'
               }}
             />
           ))}
@@ -173,7 +173,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
           return (
             <span
               key={voter.id}
-              className={`inline-block px-2 py-0.5 rounded-full text-xs ${
+              className={`inline-block px-3 py-1 rounded-full text-sm ${
                 isCurrentUser ? 'font-bold ring-2 ring-blue-500 dark:ring-blue-400' : 'font-medium'
               } ${getVoterColor(index)}`}
             >
@@ -184,7 +184,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
         {/* Anonymous voters count */}
         {adjustedAnonymousCount > 0 && (
-          <span className="inline-block px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600 text-xs text-gray-600 dark:text-gray-300 italic">
+          <span className="inline-block px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600 text-sm text-gray-600 dark:text-gray-300 italic">
             {adjustedAnonymousCount} × Anonymous
           </span>
         )}

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -60,17 +60,17 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
   if (initialLoading) {
     return (
-      <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm ${className}`}>
-        <div className="flex flex-wrap items-center gap-2">
-          <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-3 w-full text-center">Respondents</h3>
+      <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-sm font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
           {/* Shimmer effect for loading voter bubbles */}
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              className="animate-pulse inline-block px-3 py-1 rounded-full bg-gray-200 dark:bg-gray-700"
+              className="animate-pulse inline-block px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700"
               style={{
-                width: `${60 + (i * 15) % 40}px`,
-                height: '28px'
+                width: `${50 + (i * 12) % 30}px`,
+                height: '24px'
               }}
             />
           ))}
@@ -81,9 +81,9 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
   if (error) {
     return (
-      <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm ${className}`}>
-        <div className="flex flex-wrap items-center gap-2">
-          <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-3 w-full text-center">Respondents</h3>
+      <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-sm font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
           <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
         </div>
       </div>
@@ -157,11 +157,11 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
   };
 
   return (
-    <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm ${className}`}>
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <h3 className="text-lg font-bold text-gray-900 dark:text-white w-full text-center mb-3">
+    <div className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm ${className}`}>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-sm font-bold text-gray-900 dark:text-white mr-1">
           Respondents ({voters.length})
-        </h3>
+        </span>
 
         {/* Named voters - displayed as colored bubbles in a flowing layout */}
         {namedVoters.map((voter, index) => {
@@ -173,7 +173,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
           return (
             <span
               key={voter.id}
-              className={`inline-block px-3 py-1 rounded-full text-sm ${
+              className={`inline-block px-2 py-0.5 rounded-full text-xs ${
                 isCurrentUser ? 'font-bold ring-2 ring-blue-500 dark:ring-blue-400' : 'font-medium'
               } ${getVoterColor(index)}`}
             >
@@ -184,11 +184,9 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
         {/* Anonymous voters count */}
         {adjustedAnonymousCount > 0 && (
-          <div className="inline-block px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600">
-            <span className="text-sm text-gray-600 dark:text-gray-300 italic">
-              {adjustedAnonymousCount} × Anonymous {adjustedAnonymousCount === 1 ? 'voter' : 'voters'}
-            </span>
-          </div>
+          <span className="inline-block px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600 text-xs text-gray-600 dark:text-gray-300 italic">
+            {adjustedAnonymousCount} × Anonymous
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Respondents header now flows inline with name bubbles instead of taking a full centered line
- Reduced card padding from `p-6` to `px-3 py-2` for a tighter layout
- Tightened gap between items from `gap-2` to `gap-1.5`
- Simplified anonymous voter label from nested div>span to single span
- Reduced external margin from `mt-8` to `mt-4`
- Extracted repeated card class string to `CARD_CLASS` constant

## Test plan
- [ ] Verify Respondents section renders compactly with header inline next to name bubbles
- [ ] Check loading shimmer state looks correct
- [ ] Check with anonymous voters present
- [ ] Verify dark mode styling

https://claude.ai/code/session_01JeQyr15PBQPbiFaqdhnKfy