### PR TITLE
Fix suggestion pill height + always show result badge

### DIFF
--- a/components/NominationsList.tsx
+++ b/components/NominationsList.tsx
@@ -133,7 +133,7 @@ export default function NominationsList({
                   <OptionLabel text={nomination.option} metadata={meta} />
                 </div>
                 {showVoteCounts && (
-                  <span className={`px-2.5 py-1 text-sm font-bold ${
+                  <span className={`px-2.5 self-stretch flex items-center text-sm font-bold ${
                     isUserNomination
                       ? 'bg-blue-500 text-white'
                       : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -109,26 +109,59 @@ function getOptionDisplayName(optionKey: string, poll: Poll): string {
   return optionKey;
 }
 
-function getWinnerText(poll: Poll, results: PollResults): string | null {
+interface ResultBadge {
+  text: string;
+  emoji: string;
+  color: 'green' | 'red' | 'yellow' | 'gray';
+}
+
+const BADGE_COLORS = {
+  green: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200',
+  red: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200',
+  yellow: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200',
+  gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+};
+
+function getResultBadge(poll: Poll, results: PollResults | null | undefined): ResultBadge {
+  const timedOut = poll.close_reason === 'deadline';
+  const clockPrefix = timedOut ? '⏰' : '';
+
+  // No results data at all
+  if (!results) {
+    return { text: 'No results', emoji: clockPrefix || '—', color: 'gray' };
+  }
+
+  // No voters
+  if (results.total_votes === 0) {
+    return { text: 'No voters', emoji: clockPrefix || '🦗', color: 'gray' };
+  }
+
   switch (poll.poll_type) {
-    case 'yes_no':
-      if (results.winner === 'yes') return 'Yes';
-      if (results.winner === 'no') return 'No';
-      if (results.winner === 'tie') return 'Tie';
-      return null;
-    case 'ranked_choice':
-      if (!results.winner) return null;
-      return getOptionDisplayName(results.winner, poll);
-    case 'nomination':
-      if (results.nomination_counts && results.nomination_counts.length > 0) {
-        return getOptionDisplayName(results.nomination_counts[0].option, poll);
+    case 'yes_no': {
+      if (results.winner === 'yes') return { text: 'Yes', emoji: clockPrefix || '👑', color: 'green' };
+      if (results.winner === 'no') return { text: 'No', emoji: clockPrefix || '👑', color: 'red' };
+      if (results.winner === 'tie') return { text: 'Tie', emoji: clockPrefix || '🤝', color: 'yellow' };
+      return { text: 'No winner', emoji: clockPrefix || '—', color: 'gray' };
+    }
+    case 'ranked_choice': {
+      if (results.winner) {
+        return { text: getOptionDisplayName(results.winner, poll), emoji: clockPrefix || '👑', color: 'green' };
       }
-      return null;
-    case 'participation':
-      if (results.is_happening) return 'Happening';
-      return 'Not happening';
+      return { text: 'No winner', emoji: clockPrefix || '—', color: 'gray' };
+    }
+    case 'nomination': {
+      if (results.nomination_counts && results.nomination_counts.length > 0) {
+        const top = results.nomination_counts[0];
+        return { text: getOptionDisplayName(top.option, poll), emoji: clockPrefix || '👑', color: 'green' };
+      }
+      return { text: 'No suggestions', emoji: clockPrefix || '—', color: 'gray' };
+    }
+    case 'participation': {
+      if (results.is_happening) return { text: 'Happening', emoji: clockPrefix || '🎉', color: 'green' };
+      return { text: 'Not happening', emoji: clockPrefix || '✗', color: 'red' };
+    }
     default:
-      return null;
+      return { text: 'Closed', emoji: clockPrefix || '—', color: 'gray' };
   }
 }
 
@@ -155,15 +188,12 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const isScrolling = useRef(false);
   const [pressedPollId, setPressedPollId] = useState<string | null>(null);
   const [navigatingPollId, setNavigatingPollId] = useState<string | null>(null);
-  const winnerTexts = useMemo(() => {
-    const texts: Record<string, string> = {};
+  const resultBadges = useMemo(() => {
+    const badges: Record<string, ResultBadge> = {};
     for (const poll of closedPolls) {
-      if (poll.results) {
-        const winner = getWinnerText(poll, poll.results);
-        if (winner) texts[poll.id] = winner;
-      }
+      badges[poll.id] = getResultBadge(poll, poll.results);
     }
-    return texts;
+    return badges;
   }, [closedPolls]);
   
   // Load voted and abstained polls from localStorage
@@ -549,11 +579,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                             <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
                           </ClientOnly>
                         </div>
-                        {winnerTexts[poll.id] && (
+                        {resultBadges[poll.id] && (
                           <div className="flex items-center gap-1 max-w-[40%]">
-                            <span className="flex-shrink-0 text-xs leading-none -mt-px">👑</span>
-                            <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200 truncate">
-                              {winnerTexts[poll.id]}
+                            <span className="flex-shrink-0 text-xs leading-none -mt-px">{resultBadges[poll.id].emoji}</span>
+                            <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full truncate ${BADGE_COLORS[resultBadges[poll.id].color]}`}>
+                              {resultBadges[poll.id].text}
                             </span>
                           </div>
                         )}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -123,12 +123,10 @@ const BADGE_COLORS = {
 };
 
 function getResultBadge(poll: Poll, results: PollResults | null | undefined): ResultBadge {
-  // No results data at all
   if (!results) {
     return { text: 'No results', emoji: '—', color: 'gray' };
   }
 
-  // No voters
   if (results.total_votes === 0) {
     return { text: 'No voters', emoji: '🦗', color: 'gray' };
   }
@@ -576,14 +574,17 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                             <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
                           </ClientOnly>
                         </div>
-                        {resultBadges[poll.id] && (
-                          <div className="flex items-center gap-1 max-w-[40%]">
-                            <span className="flex-shrink-0 text-xs leading-none -mt-px">{resultBadges[poll.id].emoji}</span>
-                            <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full truncate ${BADGE_COLORS[resultBadges[poll.id].color]}`}>
-                              {resultBadges[poll.id].text}
-                            </span>
-                          </div>
-                        )}
+                        {(() => {
+                          const badge = resultBadges[poll.id];
+                          return badge && (
+                            <div className="flex items-center gap-1 max-w-[40%]">
+                              <span className="flex-shrink-0 text-xs leading-none -mt-px">{badge.emoji}</span>
+                              <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full truncate ${BADGE_COLORS[badge.color]}`}>
+                                {badge.text}
+                              </span>
+                            </div>
+                          );
+                        })()}
                       </div>
                     </div>
                   </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -123,45 +123,42 @@ const BADGE_COLORS = {
 };
 
 function getResultBadge(poll: Poll, results: PollResults | null | undefined): ResultBadge {
-  const timedOut = poll.close_reason === 'deadline';
-  const clockPrefix = timedOut ? '⏰' : '';
-
   // No results data at all
   if (!results) {
-    return { text: 'No results', emoji: clockPrefix || '—', color: 'gray' };
+    return { text: 'No results', emoji: '—', color: 'gray' };
   }
 
   // No voters
   if (results.total_votes === 0) {
-    return { text: 'No voters', emoji: clockPrefix || '🦗', color: 'gray' };
+    return { text: 'No voters', emoji: '🦗', color: 'gray' };
   }
 
   switch (poll.poll_type) {
     case 'yes_no': {
-      if (results.winner === 'yes') return { text: 'Yes', emoji: clockPrefix || '👑', color: 'green' };
-      if (results.winner === 'no') return { text: 'No', emoji: clockPrefix || '👑', color: 'red' };
-      if (results.winner === 'tie') return { text: 'Tie', emoji: clockPrefix || '🤝', color: 'yellow' };
-      return { text: 'No winner', emoji: clockPrefix || '—', color: 'gray' };
+      if (results.winner === 'yes') return { text: 'Yes', emoji: '👑', color: 'green' };
+      if (results.winner === 'no') return { text: 'No', emoji: '👑', color: 'red' };
+      if (results.winner === 'tie') return { text: 'Tie', emoji: '🤝', color: 'yellow' };
+      return { text: 'No winner', emoji: '—', color: 'gray' };
     }
     case 'ranked_choice': {
       if (results.winner) {
-        return { text: getOptionDisplayName(results.winner, poll), emoji: clockPrefix || '👑', color: 'green' };
+        return { text: getOptionDisplayName(results.winner, poll), emoji: '👑', color: 'green' };
       }
-      return { text: 'No winner', emoji: clockPrefix || '—', color: 'gray' };
+      return { text: 'No winner', emoji: '—', color: 'gray' };
     }
     case 'nomination': {
       if (results.nomination_counts && results.nomination_counts.length > 0) {
         const top = results.nomination_counts[0];
-        return { text: getOptionDisplayName(top.option, poll), emoji: clockPrefix || '👑', color: 'green' };
+        return { text: getOptionDisplayName(top.option, poll), emoji: '👑', color: 'green' };
       }
-      return { text: 'No suggestions', emoji: clockPrefix || '—', color: 'gray' };
+      return { text: 'No suggestions', emoji: '—', color: 'gray' };
     }
     case 'participation': {
-      if (results.is_happening) return { text: 'Happening', emoji: clockPrefix || '🎉', color: 'green' };
-      return { text: 'Not happening', emoji: clockPrefix || '✗', color: 'red' };
+      if (results.is_happening) return { text: 'Happening', emoji: '🎉', color: 'green' };
+      return { text: 'Not happening', emoji: '✗', color: 'red' };
     }
     default:
-      return { text: 'Closed', emoji: clockPrefix || '—', color: 'gray' };
+      return { text: 'Closed', emoji: '—', color: 'gray' };
   }
 }
 


### PR DESCRIPTION
## Summary
- **Suggestion pill vote count bg**: Added `self-stretch flex items-center` so the colored background always fills the full pill height (matching the location layout)
- **Poll list result badges**: Every closed poll now shows a contextual result badge — not just polls with a winner. Covers no voters (🦗), ties (🤝), not happening (✗), no suggestions (—), etc. with appropriate colors (green/red/yellow/gray)

## Test plan
- [ ] Check suggestion/nomination results with varying text lengths — colored count bg should always fill full pill height
- [ ] Check closed polls in the main list: polls with winners, ties, no voters, and participation polls all show appropriate badges
- [ ] Verify badge colors match outcome (green for winners, red for "No"/"Not happening", yellow for ties, gray for no voters/results)