### PR TITLE
Show poll response count in main poll list

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -427,13 +427,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                             <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
                           </ClientOnly>
                         </div>
-                        <div className="flex items-center gap-1">
-                          <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${BADGE_COLORS.gray}`}>
-                            {(poll.response_count ?? 0) > 0
-                              ? `${poll.response_count} ${poll.response_count === 1 ? 'response' : 'responses'}`
-                              : 'No responses yet'}
-                          </span>
-                        </div>
+                        <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${BADGE_COLORS.gray}`}>
+                          {(poll.response_count ?? 0) > 0
+                            ? `${poll.response_count} ${poll.response_count === 1 ? 'response' : 'responses'}`
+                            : 'No responses yet'}
+                        </span>
                       </div>
                     </div>
                   </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -421,10 +421,19 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                         {poll.title}
                       </h3>
-                      <div className="text-xs text-gray-400 dark:text-gray-500">
-                        <ClientOnly fallback={null}>
-                          <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
-                        </ClientOnly>
+                      <div className="flex items-center justify-between">
+                        <div className="text-xs text-gray-400 dark:text-gray-500">
+                          <ClientOnly fallback={null}>
+                            <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
+                          </ClientOnly>
+                        </div>
+                        {(poll.response_count ?? 0) > 0 && (
+                          <div className="flex items-center gap-1">
+                            <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${BADGE_COLORS.gray}`}>
+                              {poll.response_count} {poll.response_count === 1 ? 'response' : 'responses'}
+                            </span>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -427,13 +427,13 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                             <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
                           </ClientOnly>
                         </div>
-                        {(poll.response_count ?? 0) > 0 && (
-                          <div className="flex items-center gap-1">
-                            <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${BADGE_COLORS.gray}`}>
-                              {poll.response_count} {poll.response_count === 1 ? 'response' : 'responses'}
-                            </span>
-                          </div>
-                        )}
+                        <div className="flex items-center gap-1">
+                          <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${BADGE_COLORS.gray}`}>
+                            {(poll.response_count ?? 0) > 0
+                              ? `${poll.response_count} ${poll.response_count === 1 ? 'response' : 'responses'}`
+                              : 'No responses yet'}
+                          </span>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -128,6 +128,7 @@ function toPoll(data: any): Poll {
     reference_latitude: data.reference_latitude ?? undefined,
     reference_longitude: data.reference_longitude ?? undefined,
     reference_location_label: data.reference_location_label ?? undefined,
+    response_count: data.response_count ?? undefined,
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,6 +63,7 @@ export interface Poll {
   reference_latitude?: number | null;
   reference_longitude?: number | null;
   reference_location_label?: string | null;
+  response_count?: number | null;
   results?: PollResults | null;
 }
 

--- a/server/models.py
+++ b/server/models.py
@@ -159,6 +159,7 @@ class PollResponse(BaseModel):
     reference_latitude: float | None = None
     reference_longitude: float | None = None
     reference_location_label: str | None = None
+    response_count: int | None = None
     results: "PollResultsResponse | None" = None
 
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1149,12 +1149,15 @@ def get_accessible_polls(req: AccessiblePollsRequest):
             return [_row_to_poll(r) for r in rows]
 
         closed_poll_ids = []
+        open_poll_ids = []
         for r in rows:
             is_closed = r.get("is_closed", False)
             deadline = r.get("response_deadline")
             deadline_passed = deadline and deadline <= now
             if is_closed or deadline_passed:
                 closed_poll_ids.append(str(r["id"]))
+            else:
+                open_poll_ids.append(str(r["id"]))
 
         votes_by_poll: dict[str, list] = {pid: [] for pid in closed_poll_ids}
         if closed_poll_ids:
@@ -1167,6 +1170,16 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                 if pid in votes_by_poll:
                     votes_by_poll[pid].append(v)
 
+        # Count responses for open polls
+        response_counts: dict[str, int] = {}
+        if open_poll_ids:
+            count_rows = conn.execute(
+                "SELECT poll_id, COUNT(*) as cnt FROM votes WHERE poll_id = ANY(%(poll_ids)s) GROUP BY poll_id",
+                {"poll_ids": open_poll_ids},
+            ).fetchall()
+            for cr in count_rows:
+                response_counts[str(cr["poll_id"])] = cr["cnt"]
+
     results = []
     for r in rows:
         poll_resp = _row_to_poll(r)
@@ -1176,6 +1189,8 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                 poll_resp.results = _compute_results(dict(r), votes_by_poll[pid])
             except Exception:
                 logger.warning("Failed to compute results for poll %s", pid, exc_info=True)
+        if pid in response_counts:
+            poll_resp.response_count = response_counts[pid]
         results.append(poll_resp)
     return results
 


### PR DESCRIPTION
## Summary
- Open polls now show a response count badge (e.g. "3 responses" or "No responses yet") in the same position where closed polls show their result badge
- Response counts are fetched in the same `/api/polls/accessible` call via a lightweight `COUNT(*) GROUP BY` query for open polls
- Added `response_count` field to `PollResponse` model, `Poll` TypeScript type, and `toPoll()` mapping

## Test plan
- [ ] Create a new poll — should show "No responses yet" badge
- [ ] Vote on the poll, navigate back to home — should show "1 response"
- [ ] Verify closed polls still show their result badges as before

https://claude.ai/code/session_01LcUWJp62EwMserRAvrPooU