### PR TITLE
Auto-regenerate poll titles when copying polls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -901,6 +901,7 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Auto-created polls share the parent's `creator_secret`**, but the browser only stores secrets for polls it created directly. When navigating to an auto-created follow-up poll (e.g., preferences poll from a nomination poll), the browser must propagate the parent's secret to the child. Do this both on navigation (in the close handler) and on page load (check `poll.follow_up_to` and propagate if the parent's secret is known).
 - **Use `recordPollCreation()` from `lib/browserPollAccess.ts`** instead of calling `storeCreatorSecret()` + `addAccessiblePollId()` separately. The higher-level function already does both.
 - **Poll data snapshots (fork/duplicate/follow-up)** are passed between pages via localStorage. When adding new poll fields, update `buildPollSnapshot()` in `lib/pollCreator.ts` — it's used by `FollowUpModal.tsx`, `DuplicateButton.tsx`, and `ForkButton.tsx`.
+- **PWA clients cache old JS bundles** — snapshot structure changes (new fields in `buildPollSnapshot`) won't take effect until users get new JS. Always add backward-compatible detection in the consumer (create-poll page) rather than relying solely on snapshot fields. The `is_auto_title` detection uses a ref-based comparison against `generateTitle()` output to handle old snapshots that lack the field.
 
 ### Textarea Sizing & Inline-Block Gaps
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -98,6 +98,7 @@ function CreatePollContent() {
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const [isAutoTitle, setIsAutoTitle] = useState(true);
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const loadedTitleRef = useRef<string | null>(null);
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
   const [autoCreatePreferences, setAutoCreatePreferences] = useState(true);
   const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
@@ -212,17 +213,17 @@ function CreatePollContent() {
     }
   }, [isAutoTitle, generateTitle]);
 
-  // After loading duplicate/fork data, detect if the title was auto-generated
-  // by comparing it to what generateTitle() produces with the loaded options.
-  // This handles both old snapshots (without is_auto_title) and new ones.
+  // Detect auto-generated titles from copied polls (handles old snapshots without is_auto_title)
   useEffect(() => {
-    if (!isAutoTitle && (duplicateOfParam || forkOfParam) && title) {
+    const loaded = loadedTitleRef.current;
+    if (!isAutoTitle && loaded) {
       const generated = generateTitle();
-      if (generated && title === generated.slice(0, 100)) {
+      if (generated && loaded === generated.slice(0, 100)) {
+        loadedTitleRef.current = null;
         setIsAutoTitle(true);
       }
     }
-  }, [duplicateOfParam, forkOfParam, isAutoTitle, title, generateTitle]);
+  }, [isAutoTitle, generateTitle]);
 
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
@@ -544,10 +545,9 @@ function CreatePollContent() {
 
           // Auto-fill form with fork data
           setTitle(forkData.title || "");
-          if (forkData.is_auto_title) {
-            setIsAutoTitle(true);
-          } else if (forkData.title) {
+          if (!forkData.is_auto_title && forkData.title) {
             setIsAutoTitle(false);
+            loadedTitleRef.current = forkData.title;
           }
           setDetails(forkData.details || "");
           if (forkData.details) setDetailsOpen(true);
@@ -635,10 +635,9 @@ function CreatePollContent() {
 
           // Auto-fill form with duplicate data
           setTitle(duplicateData.title || "");
-          if (duplicateData.is_auto_title) {
-            setIsAutoTitle(true);
-          } else if (duplicateData.title) {
+          if (!duplicateData.is_auto_title && duplicateData.title) {
             setIsAutoTitle(false);
+            loadedTitleRef.current = duplicateData.title;
           }
           setDetails(duplicateData.details || "");
           if (duplicateData.details) setDetailsOpen(true);
@@ -731,10 +730,9 @@ function CreatePollContent() {
 
           // Auto-fill form with preference poll type and nominated options
           setTitle(voteData.title || "");
-          if (voteData.is_auto_title) {
-            setIsAutoTitle(true);
-          } else if (voteData.title) {
+          if (!voteData.is_auto_title && voteData.title) {
             setIsAutoTitle(false);
+            loadedTitleRef.current = voteData.title;
           }
           setPollType('poll'); // Set to preference poll
           setOptions(voteData.options && voteData.options.length > 0 ? voteData.options : ['']);

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -532,7 +532,11 @@ function CreatePollContent() {
 
           // Auto-fill form with fork data
           setTitle(forkData.title || "");
-          if (forkData.title) setIsAutoTitle(false);
+          if (forkData.is_auto_title) {
+            setIsAutoTitle(true);
+          } else if (forkData.title) {
+            setIsAutoTitle(false);
+          }
           setDetails(forkData.details || "");
           if (forkData.details) setDetailsOpen(true);
 
@@ -619,7 +623,11 @@ function CreatePollContent() {
 
           // Auto-fill form with duplicate data
           setTitle(duplicateData.title || "");
-          if (duplicateData.title) setIsAutoTitle(false);
+          if (duplicateData.is_auto_title) {
+            setIsAutoTitle(true);
+          } else if (duplicateData.title) {
+            setIsAutoTitle(false);
+          }
           setDetails(duplicateData.details || "");
           if (duplicateData.details) setDetailsOpen(true);
 
@@ -711,7 +719,11 @@ function CreatePollContent() {
 
           // Auto-fill form with preference poll type and nominated options
           setTitle(voteData.title || "");
-          if (voteData.title) setIsAutoTitle(false);
+          if (voteData.is_auto_title) {
+            setIsAutoTitle(true);
+          } else if (voteData.title) {
+            setIsAutoTitle(false);
+          }
           setPollType('poll'); // Set to preference poll
           setOptions(voteData.options && voteData.options.length > 0 ? voteData.options : ['']);
 
@@ -988,7 +1000,8 @@ function CreatePollContent() {
         title,
         poll_type: dbPollType,
         response_deadline: responseDeadline,
-        creator_secret: creatorSecret
+        creator_secret: creatorSecret,
+        is_auto_title: isAutoTitle,
       };
 
       // Add creator_name if provided (may fail if column doesn't exist yet)

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -212,6 +212,18 @@ function CreatePollContent() {
     }
   }, [isAutoTitle, generateTitle]);
 
+  // After loading duplicate/fork data, detect if the title was auto-generated
+  // by comparing it to what generateTitle() produces with the loaded options.
+  // This handles both old snapshots (without is_auto_title) and new ones.
+  useEffect(() => {
+    if (!isAutoTitle && (duplicateOfParam || forkOfParam) && title) {
+      const generated = generateTitle();
+      if (generated && title === generated.slice(0, 100)) {
+        setIsAutoTitle(true);
+      }
+    }
+  }, [duplicateOfParam, forkOfParam, isAutoTitle, title, generateTitle]);
+
   // Helper to re-enable form elements
   const reEnableForm = useCallback((form: HTMLFormElement | null) => {
     if (form) {

--- a/database/migrations/080_add_is_auto_title_down.sql
+++ b/database/migrations/080_add_is_auto_title_down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE polls DROP COLUMN IF EXISTS is_auto_title;

--- a/database/migrations/080_add_is_auto_title_up.sql
+++ b/database/migrations/080_add_is_auto_title_up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE polls ADD COLUMN is_auto_title BOOLEAN NOT NULL DEFAULT false;

--- a/lib/pollCreator.ts
+++ b/lib/pollCreator.ts
@@ -92,6 +92,7 @@ export function buildPollSnapshot(poll: Poll) {
     details: poll.details,
     category: poll.category,
     options_metadata: poll.options_metadata,
+    is_auto_title: poll.is_auto_title,
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,6 +63,7 @@ export interface Poll {
   reference_latitude?: number | null;
   reference_longitude?: number | null;
   reference_location_label?: string | null;
+  is_auto_title?: boolean;
   response_count?: number | null;
   results?: PollResults | null;
 }

--- a/server/models.py
+++ b/server/models.py
@@ -55,6 +55,8 @@ class CreatePollRequest(BaseModel):
     category: str | None = None
     # Metadata for options (thumbnail URLs, info links) keyed by option label
     options_metadata: dict | None = None
+    # Whether the title was auto-generated from poll options
+    is_auto_title: bool = False
     # Reference location for proximity-based search
     reference_latitude: float | None = None
     reference_longitude: float | None = None
@@ -159,6 +161,7 @@ class PollResponse(BaseModel):
     reference_latitude: float | None = None
     reference_longitude: float | None = None
     reference_location_label: str | None = None
+    is_auto_title: bool = False
     response_count: int | None = None
     results: "PollResultsResponse | None" = None
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -252,6 +252,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         reference_latitude=row.get("reference_latitude"),
         reference_longitude=row.get("reference_longitude"),
         reference_location_label=row.get("reference_location_label"),
+        is_auto_title=row.get("is_auto_title", False),
     )
 
 
@@ -477,6 +478,7 @@ def create_poll(req: CreatePollRequest):
                                category, options_metadata,
                                reference_latitude, reference_longitude,
                                reference_location_label,
+                               is_auto_title,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
@@ -494,6 +496,7 @@ def create_poll(req: CreatePollRequest):
                     %(category)s, %(options_metadata)s::jsonb,
                     %(reference_latitude)s, %(reference_longitude)s,
                     %(reference_location_label)s,
+                    %(is_auto_title)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -531,6 +534,7 @@ def create_poll(req: CreatePollRequest):
                 "reference_latitude": req.reference_latitude,
                 "reference_longitude": req.reference_longitude,
                 "reference_location_label": req.reference_location_label,
+                "is_auto_title": req.is_auto_title,
                 "now": now,
             },
         ).fetchone()


### PR DESCRIPTION
## Summary
- Store `is_auto_title` flag on polls so copied polls can re-enable auto-title generation
- Add backward-compatible detection that compares loaded title to `generateTitle()` output, handling old PWA-cached JS that lacks the new snapshot field
- Uses a ref-based approach so detection only fires once on data load, not on every user keystroke

## Test plan
- [ ] Create a poll with auto-generated title (e.g. ranked choice with restaurant options)
- [ ] Copy it — title should show as auto-generated (clickable "Title: ..." display, not input field)
- [ ] Edit an option — title should update automatically
- [ ] Create a poll with manually edited title, copy it — title should remain static
- [ ] Manually type a title matching the auto-generated one — should NOT re-enable auto-title

https://claude.ai/code/session_019n5bwvWxMVfcDsCyTJLd67