### PR TITLE
Fix missing empty expansion box after deleting an option

### DIFF
--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -108,8 +108,7 @@ export default function OptionsInput({
       newOptions.push('');
     }
 
-    // Ensure there's always a trailing empty field for expansion
-    if (newOptions.length > 0 && newOptions[newOptions.length - 1] !== '') {
+    if (newOptions[newOptions.length - 1] !== '') {
       newOptions.push('');
     }
 

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -108,6 +108,11 @@ export default function OptionsInput({
       newOptions.push('');
     }
 
+    // Ensure there's always a trailing empty field for expansion
+    if (newOptions.length > 0 && newOptions[newOptions.length - 1] !== '') {
+      newOptions.push('');
+    }
+
     setOptions(newOptions);
   };
 


### PR DESCRIPTION
## Summary
- When deleting an option in `OptionsInput`, the trailing empty expansion box could disappear, leaving only filled boxes with no way to add new options without editing an existing one
- `removeOption()` now ensures a trailing empty field always exists after removal

## Test plan
- [ ] Add 3+ options, delete the second-to-last one, verify an empty expansion box remains at the end
- [ ] Delete options down to one filled option, verify empty box is still present below it
- [ ] Verify typing in the last empty box still creates a new expansion box as before

https://claude.ai/code/session_01MCBKqKWg2BGS4v95Xn5YSj