### PR TITLE
Fix home button unresponsive after small scroll

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -23,6 +23,9 @@ const isIOSSPWAStandalone = () =>
 // Session-scoped in-app navigation counter (per-tab, cleared on tab close).
 const NAV_COUNT_KEY = 'app_nav_count';
 
+// Bottom bar scroll behavior
+const SCROLL_TOP_SAFE_ZONE = 50; // Don't hide bottom bar when within this many px of top
+
 // Pull-to-refresh constants (iOS PWA only)
 const PTR_THRESHOLD = 240;  // px of raw touch movement to trigger refresh
 const PTR_CIRCUMFERENCE = 2 * Math.PI * 10; // SVG arc circumference (radius=10)
@@ -161,10 +164,10 @@ export default function Template({ children }: AppTemplateProps) {
         return;
       }
 
-      // Don't hide the bottom bar when barely scrolled from top.
-      // A tiny accidental scroll (e.g. 12px) would otherwise hide the bar,
-      // and on pages with little content the user can't scroll up to get it back.
-      if (currentScrollY < 50) {
+      // Keep bottom bar visible near the top so a tiny scroll can't hide it
+      // on pages with little content where the user can't scroll up to recover.
+      if (currentScrollY < SCROLL_TOP_SAFE_ZONE) {
+        setVisible(true);
         lastScrollY.current = currentScrollY;
         return;
       }

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -161,6 +161,14 @@ export default function Template({ children }: AppTemplateProps) {
         return;
       }
 
+      // Don't hide the bottom bar when barely scrolled from top.
+      // A tiny accidental scroll (e.g. 12px) would otherwise hide the bar,
+      // and on pages with little content the user can't scroll up to get it back.
+      if (currentScrollY < 50) {
+        lastScrollY.current = currentScrollY;
+        return;
+      }
+
       // iOS rubber band past the bottom — ignore and clamp lastScrollY
       if (currentScrollY > maxScrollY) {
         isInBounceRef.current = true;


### PR DESCRIPTION
## Summary
- The bottom bar's scroll-to-hide threshold was only 5px, so a tiny accidental scroll (e.g. 12px) on poll pages would hide the bar with `pointer-events-none`, making Home/Profile buttons untappable
- Added a `SCROLL_TOP_SAFE_ZONE` (50px) — the bottom bar stays visible and interactive when near the top of the page
- Also fixes bar recovery: `setVisible(true)` ensures the bar reappears when scrolling back into the safe zone after being hidden

## Test plan
- [ ] On iOS PWA, create a poll and get redirected to the voting page
- [ ] Tap the Home button in the bottom bar — should navigate home
- [ ] Scroll down slightly (< 50px) — bottom bar should remain visible
- [ ] Scroll down past 50px — bottom bar should hide
- [ ] Scroll back up into the top 50px — bottom bar should reappear

https://claude.ai/code/session_01G3Nr2dPR6oLdDfHazy7VjY