### PR TITLE
Fix participation poll status display and vote submission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -895,6 +895,8 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 
 - **Catch-all fallthrough in `get_results()`**: When adding new poll types, `server/routers/polls.py` has a catch-all return at the bottom returning `yes_count=None`. Any poll type without an explicit handler silently falls through and the frontend interprets `None` as `0`. Always add an explicit handler for each poll type.
 - **Frontend TODO stubs cause silent failures**: If the backend adds a new endpoint, check whether the frontend has TODO stubs (e.g., `setParticipants([])`) that need to be connected. Stubs cause incorrect UI without errors.
+- **`toPollResults()` in `lib/api.ts` is a manual field mapper** — when adding new fields to `PollResultsResponse` on the backend, you MUST also add them to `toPollResults()` or they'll be silently dropped. The function explicitly maps each field; unmapped fields from the API response are discarded.
+- **Dev server Pydantic schema caching**: Adding fields to a Pydantic `BaseModel` (like `PollResultsResponse`) requires a full API restart — `uvicorn` with hot-reload doesn't always pick up model schema changes. Use `dev-server-manager.sh upsert` to force a clean restart.
 
 ### Auto-Created Follow-Up Polls & Creator Secrets
 

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -447,6 +447,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             // This ensures that vote editing updates the existing record instead of creating new ones
             if (voteData && 'id' in voteData && voteData.id) {
               setUserVoteId(voteData.id);
+              // Backfill pollVoteIds localStorage so the poll list can show personalized badges
+              try {
+                const voteIds = JSON.parse(localStorage.getItem('pollVoteIds') || '{}');
+                if (!voteIds[poll.id]) {
+                  voteIds[poll.id] = voteData.id;
+                  localStorage.setItem('pollVoteIds', JSON.stringify(voteIds));
+                }
+              } catch (e) { /* ignore */ }
             }
 
             // For nomination polls, fetch results to show vote counts even when poll is open

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -432,22 +432,26 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       // OR if this is a nomination poll (to handle creator votes and aggregation)
       if (voteId || poll.poll_type === 'nomination' || poll.poll_type === 'participation') {
         setIsLoadingVoteData(true);
-        
-        // For nomination polls, always use aggregated data to handle multiple votes
-        // For other poll types, fetch by voteId or latest vote
-        // For participation polls without a stored vote ID, find the user's vote by name
+
+        // For participation polls without a stored vote ID, find the user's vote ID by name
         const fetchParticipationVoteByName = async (pollId: string) => {
           const savedName = getUserName();
           if (!savedName) return null;
-          const votes = await apiGetVotes(pollId);
-          return votes.find(v => v.voter_name === savedName) || null;
+          const participants = await apiGetParticipants(pollId);
+          const match = participants.find(p => p.voter_name === savedName);
+          return match ? { id: match.vote_id } : null;
         };
 
-        const fetchPromise = poll.poll_type === 'nomination'
-          ? fetchAggregatedVoteData(poll.id)
-          : (voteId ? fetchVoteData(voteId)
-            : (poll.poll_type === 'participation' ? fetchParticipationVoteByName(poll.id)
-              : fetchLatestUserVote(poll.id)));
+        let fetchPromise;
+        if (poll.poll_type === 'nomination') {
+          fetchPromise = fetchAggregatedVoteData(poll.id);
+        } else if (voteId) {
+          fetchPromise = fetchVoteData(voteId);
+        } else if (poll.poll_type === 'participation') {
+          fetchPromise = fetchParticipationVoteByName(poll.id);
+        } else {
+          fetchPromise = fetchLatestUserVote(poll.id);
+        }
           
         fetchPromise.then(voteData => {
           if (voteData) {

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -430,14 +430,24 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       
       // Fetch vote data from database if we have a vote ID
       // OR if this is a nomination poll (to handle creator votes and aggregation)
-      if (voteId || poll.poll_type === 'nomination') {
+      if (voteId || poll.poll_type === 'nomination' || poll.poll_type === 'participation') {
         setIsLoadingVoteData(true);
         
         // For nomination polls, always use aggregated data to handle multiple votes
         // For other poll types, fetch by voteId or latest vote
+        // For participation polls without a stored vote ID, find the user's vote by name
+        const fetchParticipationVoteByName = async (pollId: string) => {
+          const savedName = getUserName();
+          if (!savedName) return null;
+          const votes = await apiGetVotes(pollId);
+          return votes.find(v => v.voter_name === savedName) || null;
+        };
+
         const fetchPromise = poll.poll_type === 'nomination'
           ? fetchAggregatedVoteData(poll.id)
-          : (voteId ? fetchVoteData(voteId) : fetchLatestUserVote(poll.id));
+          : (voteId ? fetchVoteData(voteId)
+            : (poll.poll_type === 'participation' ? fetchParticipationVoteByName(poll.id)
+              : fetchLatestUserVote(poll.id)));
           
         fetchPromise.then(voteData => {
           if (voteData) {

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -122,7 +122,7 @@ const BADGE_COLORS = {
   gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
 };
 
-function getResultBadge(poll: Poll, results: PollResults | null | undefined, userVoteId?: string | null): ResultBadge {
+function getResultBadge(poll: Poll, results: PollResults | null | undefined, userVoteId?: string | null, userVoted?: boolean): ResultBadge {
   if (!results) {
     return { text: 'No results', emoji: '—', color: 'gray' };
   }
@@ -166,7 +166,8 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined, use
         const others = participatingCount - 1;
         return { text: `You're going with ${others} other${others > 1 ? 's' : ''}`, emoji: '🎉', color: 'green' };
       }
-      if (isHappening) return { text: "It's happening without you", emoji: '🎉', color: 'yellow' };
+      if (isHappening && !userVoted) return { text: "It's happening without you", emoji: '🎉', color: 'yellow' };
+      if (isHappening) return { text: 'Happening', emoji: '🎉', color: 'green' };
       return { text: 'Not happening', emoji: '✗', color: 'red' };
     }
     default:
@@ -201,10 +202,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const resultBadges = useMemo(() => {
     const badges: Record<string, ResultBadge> = {};
     for (const poll of closedPolls) {
-      badges[poll.id] = getResultBadge(poll, poll.results, pollVoteIds[poll.id]);
+      const userVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
+      badges[poll.id] = getResultBadge(poll, poll.results, pollVoteIds[poll.id], userVoted);
     }
     return badges;
-  }, [closedPolls, pollVoteIds]);
+  }, [closedPolls, pollVoteIds, votedPollIds, abstainedPollIds]);
   
   // Load voted and abstained polls from localStorage
   useEffect(() => {
@@ -225,7 +227,17 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       setVotedPollIds(voted);
       setAbstainedPollIds(abstained);
 
-      const voteIds = JSON.parse(localStorage.getItem('pollVoteIds') || '{}');
+      // Merge vote IDs from both localStorage formats
+      const voteIds: Record<string, string> = {};
+      // Format 1: pollVoteIds
+      const storedVoteIds = JSON.parse(localStorage.getItem('pollVoteIds') || '{}');
+      Object.assign(voteIds, storedVoteIds);
+      // Format 2: votedPolls entries with {voteId: ...} object format
+      Object.keys(votedPolls).forEach(id => {
+        if (!voteIds[id] && votedPolls[id]?.voteId) {
+          voteIds[id] = votedPolls[id].voteId;
+        }
+      });
       setPollVoteIds(voteIds);
     } catch (error) {
       console.error('Error loading voted polls:', error);

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -122,7 +122,7 @@ const BADGE_COLORS = {
   gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
 };
 
-function getResultBadge(poll: Poll, results: PollResults | null | undefined): ResultBadge {
+function getResultBadge(poll: Poll, results: PollResults | null | undefined, userVoteId?: string | null): ResultBadge {
   if (!results) {
     return { text: 'No results', emoji: '—', color: 'gray' };
   }
@@ -152,8 +152,6 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined): Re
       return { text: 'No suggestions', emoji: '—', color: 'gray' };
     }
     case 'participation': {
-      // Compute isHappening from yes_count (= participating count from priority algorithm)
-      // and the poll's min/max participant constraints
       const participatingCount = results.yes_count || 0;
       let isHappening = participatingCount > 0;
       if (results.min_participants != null && participatingCount < results.min_participants) {
@@ -162,7 +160,13 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined): Re
       if (results.max_participants != null && participatingCount > results.max_participants) {
         isHappening = false;
       }
-      if (isHappening) return { text: 'Happening', emoji: '🎉', color: 'green' };
+      const userIsParticipating = !!(userVoteId && results.participating_vote_ids?.includes(userVoteId));
+      if (isHappening && userIsParticipating) {
+        if (participatingCount === 1) return { text: "You're going alone", emoji: '😢', color: 'yellow' };
+        const others = participatingCount - 1;
+        return { text: `You're going with ${others} other${others > 1 ? 's' : ''}`, emoji: '🎉', color: 'green' };
+      }
+      if (isHappening) return { text: "It's happening without you", emoji: '🎉', color: 'yellow' };
       return { text: 'Not happening', emoji: '✗', color: 'red' };
     }
     default:
@@ -185,6 +189,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const [closedPolls, setClosedPolls] = useState<Poll[]>([]);
   const [votedPollIds, setVotedPollIds] = useState<Set<string>>(new Set());
   const [abstainedPollIds, setAbstainedPollIds] = useState<Set<string>>(new Set());
+  const [pollVoteIds, setPollVoteIds] = useState<Record<string, string>>({});
   const [modalPoll, setModalPoll] = useState<Poll | null>(null);
   const [showModal, setShowModal] = useState(false);
   const longPressTimer = useRef<NodeJS.Timeout | null>(null);
@@ -196,10 +201,10 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const resultBadges = useMemo(() => {
     const badges: Record<string, ResultBadge> = {};
     for (const poll of closedPolls) {
-      badges[poll.id] = getResultBadge(poll, poll.results);
+      badges[poll.id] = getResultBadge(poll, poll.results, pollVoteIds[poll.id]);
     }
     return badges;
-  }, [closedPolls]);
+  }, [closedPolls, pollVoteIds]);
   
   // Load voted and abstained polls from localStorage
   useEffect(() => {
@@ -219,6 +224,9 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       
       setVotedPollIds(voted);
       setAbstainedPollIds(abstained);
+
+      const voteIds = JSON.parse(localStorage.getItem('pollVoteIds') || '{}');
+      setPollVoteIds(voteIds);
     } catch (error) {
       console.error('Error loading voted polls:', error);
     }

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -152,7 +152,17 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined): Re
       return { text: 'No suggestions', emoji: '—', color: 'gray' };
     }
     case 'participation': {
-      if (results.is_happening) return { text: 'Happening', emoji: '🎉', color: 'green' };
+      // Compute isHappening from yes_count (= participating count from priority algorithm)
+      // and the poll's min/max participant constraints
+      const participatingCount = results.yes_count || 0;
+      let isHappening = participatingCount > 0;
+      if (results.min_participants != null && participatingCount < results.min_participants) {
+        isHappening = false;
+      }
+      if (results.max_participants != null && participatingCount > results.max_participants) {
+        isHappening = false;
+      }
+      if (isHappening) return { text: 'Happening', emoji: '🎉', color: 'green' };
       return { text: 'Not happening', emoji: '✗', color: 'red' };
     }
     default:

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Poll, PollResults } from "@/lib/types";
+import { getUserName } from "@/lib/userProfile";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
 import { getBuiltInType } from "@/components/TypeFieldInput";
@@ -122,7 +123,7 @@ const BADGE_COLORS = {
   gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
 };
 
-function getResultBadge(poll: Poll, results: PollResults | null | undefined, userVoteId?: string | null, userVoted?: boolean): ResultBadge {
+function getResultBadge(poll: Poll, results: PollResults | null | undefined, userVoteId?: string | null, userVoted?: boolean, userName?: string | null): ResultBadge {
   if (!results) {
     return { text: 'No results', emoji: '—', color: 'gray' };
   }
@@ -160,7 +161,11 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined, use
       if (results.max_participants != null && participatingCount > results.max_participants) {
         isHappening = false;
       }
-      const userIsParticipating = !!(userVoteId && results.participating_vote_ids?.includes(userVoteId));
+      // Check if user is participating by vote ID or by name match
+      const userIsParticipating = !!(
+        (userVoteId && results.participating_vote_ids?.includes(userVoteId)) ||
+        (userName && results.participating_voter_names?.includes(userName))
+      );
       if (isHappening && userIsParticipating) {
         if (participatingCount === 1) return { text: "You're going alone", emoji: '😢', color: 'yellow' };
         const others = participatingCount - 1;
@@ -199,14 +204,19 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
   const isScrolling = useRef(false);
   const [pressedPollId, setPressedPollId] = useState<string | null>(null);
   const [navigatingPollId, setNavigatingPollId] = useState<string | null>(null);
+  const savedUserName = useMemo(() => {
+    if (typeof window === 'undefined') return null;
+    return getUserName();
+  }, []);
+
   const resultBadges = useMemo(() => {
     const badges: Record<string, ResultBadge> = {};
     for (const poll of closedPolls) {
       const userVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
-      badges[poll.id] = getResultBadge(poll, poll.results, pollVoteIds[poll.id], userVoted);
+      badges[poll.id] = getResultBadge(poll, poll.results, pollVoteIds[poll.id], userVoted, savedUserName);
     }
     return badges;
-  }, [closedPolls, pollVoteIds, votedPollIds, abstainedPollIds]);
+  }, [closedPolls, pollVoteIds, votedPollIds, abstainedPollIds, savedUserName]);
   
   // Load voted and abstained polls from localStorage
   useEffect(() => {

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -161,7 +161,6 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined, use
       if (results.max_participants != null && participatingCount > results.max_participants) {
         isHappening = false;
       }
-      // Check if user is participating by vote ID or by name match
       const userIsParticipating = !!(
         (userVoteId && results.participating_vote_ids?.includes(userVoteId)) ||
         (userName && results.participating_voter_names?.includes(userName))
@@ -237,12 +236,9 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       setVotedPollIds(voted);
       setAbstainedPollIds(abstained);
 
-      // Merge vote IDs from both localStorage formats
       const voteIds: Record<string, string> = {};
-      // Format 1: pollVoteIds
       const storedVoteIds = JSON.parse(localStorage.getItem('pollVoteIds') || '{}');
       Object.assign(voteIds, storedVoteIds);
-      // Format 2: votedPolls entries with {voteId: ...} object format
       Object.keys(votedPolls).forEach(id => {
         if (!voteIds[id] && votedPolls[id]?.voteId) {
           voteIds[id] = votedPolls[id].voteId;

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -280,6 +280,19 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     return colors[voterIndex % colors.length];
   };
 
+  // Wait for participant data before rendering status
+  if (loading) {
+    return (
+      <div className="rounded-lg border-2 bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-600 p-6">
+        <div className="text-center">
+          <div className="text-gray-500 dark:text-gray-400 animate-pulse">
+            Loading results...
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // SCENARIO: No votes at all
   if (totalVotes === 0) {
     return (

--- a/database/migrations/081_fix_stale_vote_type_check_down.sql
+++ b/database/migrations/081_fix_stale_vote_type_check_down.sql
@@ -1,0 +1,3 @@
+-- Re-add the old constraint (without participation) for rollback
+ALTER TABLE votes ADD CONSTRAINT vote_type_check
+  CHECK (vote_type IN ('yes_no', 'ranked_choice', 'nomination'));

--- a/database/migrations/081_fix_stale_vote_type_check_up.sql
+++ b/database/migrations/081_fix_stale_vote_type_check_up.sql
@@ -1,0 +1,4 @@
+-- Drop stale vote_type_check constraint from migration 043 that doesn't include 'participation'.
+-- Migration 051 added votes_vote_type_check (with participation) but didn't drop the old
+-- vote_type_check, so both coexist and the old one rejects participation votes.
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_type_check;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -152,6 +152,8 @@ function toPollResults(data: any): PollResults & { ranked_choice_rounds?: ApiRan
     ranked_choice_rounds: data.ranked_choice_rounds ?? undefined,
     ranked_choice_winner: data.ranked_choice_winner ?? undefined,
     time_slot_rounds: data.time_slot_rounds ?? undefined,
+    participating_vote_ids: data.participating_vote_ids ?? undefined,
+    participating_voter_names: data.participating_voter_names ?? undefined,
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -117,6 +117,7 @@ export interface PollResults {
   is_happening?: boolean;
   nomination_counts?: NominationCount[];
   time_slot_rounds?: TimeSlotResult[];
+  participating_vote_ids?: string[];
 }
 
 export interface TimeSlotResult {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -118,6 +118,7 @@ export interface PollResults {
   nomination_counts?: NominationCount[];
   time_slot_rounds?: TimeSlotResult[];
   participating_vote_ids?: string[];
+  participating_voter_names?: (string | null)[];
 }
 
 export interface TimeSlotResult {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -118,7 +118,7 @@ export interface PollResults {
   nomination_counts?: NominationCount[];
   time_slot_rounds?: TimeSlotResult[];
   participating_vote_ids?: string[];
-  participating_voter_names?: (string | null)[];
+  participating_voter_names?: string[];
 }
 
 export interface TimeSlotResult {

--- a/server/models.py
+++ b/server/models.py
@@ -221,6 +221,7 @@ class PollResultsResponse(BaseModel):
     ranked_choice_winner: str | None = None
     time_slot_rounds: list[TimeSlotResponse] | None = None
     participating_vote_ids: list[str] | None = None
+    participating_voter_names: list[str | None] | None = None
 
 
 class ParticipantResponse(BaseModel):

--- a/server/models.py
+++ b/server/models.py
@@ -220,6 +220,7 @@ class PollResultsResponse(BaseModel):
     ranked_choice_rounds: list["RankedChoiceRoundResponse"] | None = None
     ranked_choice_winner: str | None = None
     time_slot_rounds: list[TimeSlotResponse] | None = None
+    participating_vote_ids: list[str] | None = None
 
 
 class ParticipantResponse(BaseModel):

--- a/server/models.py
+++ b/server/models.py
@@ -221,7 +221,7 @@ class PollResultsResponse(BaseModel):
     ranked_choice_winner: str | None = None
     time_slot_rounds: list[TimeSlotResponse] | None = None
     participating_vote_ids: list[str] | None = None
-    participating_voter_names: list[str | None] | None = None
+    participating_voter_names: list[str] | None = None
 
 
 class ParticipantResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1016,7 +1016,7 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             max_participants=poll.get("max_participants"),
             time_slot_rounds=time_slot_rounds_data,
             participating_vote_ids=[p.vote_id for p in participating],
-            participating_voter_names=[p.voter_name for p in participating],
+            participating_voter_names=[p.voter_name for p in participating if p.voter_name],
         )
 
     # For other poll types, return basic structure (to be extended in later phases)

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1015,6 +1015,7 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             min_participants=poll.get("min_participants"),
             max_participants=poll.get("max_participants"),
             time_slot_rounds=time_slot_rounds_data,
+            participating_vote_ids=[str(p["id"]) for p in participating],
         )
 
     # For other poll types, return basic structure (to be extended in later phases)

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1015,7 +1015,7 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             min_participants=poll.get("min_participants"),
             max_participants=poll.get("max_participants"),
             time_slot_rounds=time_slot_rounds_data,
-            participating_vote_ids=[str(p["id"]) for p in participating],
+            participating_vote_ids=[p.vote_id for p in participating],
         )
 
     # For other poll types, return basic structure (to be extended in later phases)

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1016,6 +1016,7 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             max_participants=poll.get("max_participants"),
             time_slot_rounds=time_slot_rounds_data,
             participating_vote_ids=[p.vote_id for p in participating],
+            participating_voter_names=[p.voter_name for p in participating],
         )
 
     # For other poll types, return basic structure (to be extended in later phases)


### PR DESCRIPTION
## Summary
- Fix participation poll page flickering between "not participating" and "participating" by adding a loading guard while fetching participant data
- Fix poll list always showing "Not happening" for participation polls (was checking `results.is_happening` which the API never returned)
- Add personalized poll list badges: "You're going alone", "You're going with N others", "It's happening without you"
- Fix vote submission 500 error on dev DBs from stale `vote_type_check` constraint (migration 081)
- Add `participating_vote_ids` and `participating_voter_names` to API results, with voter name fallback matching for users without stored vote IDs
- Map new fields in `toPollResults()` (was silently dropping them)

## Test plan
- [ ] Submit a participation vote on a new poll — should succeed without 500 error
- [ ] View a closed participation poll page — should show correct status without flickering
- [ ] Check the main poll list for a closed participation poll you voted on — should show personalized badge
- [ ] Check the main poll list for a participation poll you did not vote on — should show "It's happening without you" or "Not happening"

https://claude.ai/code/session_01Twmvbb7hEFh3zRz1VkVKRM