### PR TITLE
Fix participation poll status display and vote submission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,7 @@ The sections below contain mandatory rules. Follow them exactly.
   2. **Update CLAUDE.md** with any lessons learned, new patterns, pitfalls discovered, or infrastructure changes from the current work. Keep the knowledge base growing.
   3. **Rebase on main** (`git fetch origin main && git rebase origin/main`) to ensure the branch merges cleanly. Force-push if needed after rebase.
   4. Create the PR.
-  5. **Wait for PR checks to pass AND verify mergeability** before showing the PR link. Poll the GitHub check-runs API every 15s until all checks complete, and confirm `mergeable: true` on the PR. Report the link only after both succeed, or report failures.
+  5. **Wait for PR checks to pass AND verify mergeability** before showing the PR link. Poll **both** the check-runs API (`/commits/{sha}/check-runs`) AND the commit statuses API (`/commits/{sha}/statuses`) every 15s until all checks complete — GitHub Actions results appear in check-runs, but Vercel build status appears in commit statuses. Also confirm `mergeable: true` on the PR. Report the link only after both succeed, or report failures.
 
 ### Python Tooling: uv (Mandatory)
 

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -433,13 +433,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       if (voteId || poll.poll_type === 'nomination' || poll.poll_type === 'participation') {
         setIsLoadingVoteData(true);
 
-        // For participation polls without a stored vote ID, find the user's vote ID by name
+        // For participation polls without a stored vote ID, find the vote via participant name match
         const fetchParticipationVoteByName = async (pollId: string) => {
           const savedName = getUserName();
           if (!savedName) return null;
           const participants = await apiGetParticipants(pollId);
           const match = participants.find(p => p.voter_name === savedName);
-          return match ? { id: match.vote_id } : null;
+          if (!match) return null;
+          return fetchVoteData(match.vote_id);
         };
 
         let fetchPromise;


### PR DESCRIPTION
## Summary
- Fix participation poll page flickering between "not participating" and "participating" by adding a loading guard while fetching participant data
- Fix poll list always showing "Not happening" for participation polls (was checking `results.is_happening` which the API never returned)
- Add personalized poll list badges: "You're going alone", "You're going with N others", "It's happening without you"
- Fix vote submission 500 error on dev DBs from stale `vote_type_check` constraint (migration 081)
- Add `participating_vote_ids` and `participating_voter_names` to API results, with voter name fallback matching
- Map new fields in `toPollResults()` (was silently dropping them)

## Test plan
- [ ] Submit a participation vote on a new poll — should succeed without 500 error
- [ ] View a closed participation poll page — should show correct status without flickering
- [ ] Check the main poll list for a closed participation poll you voted on — should show personalized badge
- [ ] Check the main poll list for a participation poll you did not vote on — should show "It's happening without you" or "Not happening"

https://claude.ai/code/session_01Twmvbb7hEFh3zRz1VkVKRM