### PR TITLE
Add link validation in title, clickable links in details

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -383,6 +383,10 @@ function CreatePollContent() {
       return "Title must be 100 characters or less.";
     }
 
+    if (/https?:\/\/\S+|www\.\S+/i.test(title)) {
+      return "Links aren't allowed in the title. Use the Details field for links.";
+    }
+
     // Check custom deadline if selected
     if (deadlineOption === "custom") {
       if (!customDate || !customTime) {

--- a/components/PollDetails.tsx
+++ b/components/PollDetails.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 
 interface PollDetailsProps {
   details: string;
@@ -13,10 +13,36 @@ const EXPANDED_LINES = 20;
 const COLLAPSED_HEIGHT = COLLAPSED_LINES * LINE_HEIGHT;
 const EXPANDED_HEIGHT = EXPANDED_LINES * LINE_HEIGHT;
 
+const URL_REGEX = /(https?:\/\/\S+|www\.\S+)/gi;
+
+function renderWithLinks(text: string) {
+  const parts = text.split(URL_REGEX);
+  return parts.map((part, i) => {
+    if (i % 2 === 1) {
+      // Odd indices are captured URL matches from split
+      const href = part.startsWith('http') ? part : `https://${part}`;
+      return (
+        <a
+          key={i}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 dark:text-blue-400 underline break-all"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+}
+
 export default function PollDetails({ details }: PollDetailsProps) {
   const [expanded, setExpanded] = useState(false);
   const [needsTruncation, setNeedsTruncation] = useState(false);
   const collapsedRef = useRef<HTMLDivElement>(null);
+  const renderedDetails = useMemo(() => renderWithLinks(details), [details]);
 
   useEffect(() => {
     if (collapsedRef.current) {
@@ -42,7 +68,7 @@ export default function PollDetails({ details }: PollDetailsProps) {
             } : {}),
           }}
         >
-          {details}
+          {renderedDetails}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Detect URLs in poll title and show validation error directing users to put links in the Details field instead
- Render URLs in the Details section as clickable links (blue, underlined, open in new tab)
- Memoize link rendering to avoid unnecessary work on parent re-renders

## Test plan
- [ ] Create a poll with a URL in the title (e.g. "Check out https://example.com") — should see validation error
- [ ] Create a poll with a www link in the title (e.g. "Visit www.example.com") — should see validation error
- [ ] Create a poll with details containing URLs — links should render as clickable blue text
- [ ] Verify www.example.com links get https:// prepended when clicked

https://claude.ai/code/session_01DUV89mCS1YgLuqe9rfPsBe