### PR TITLE
Restrict time wheel limits for voter responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -837,6 +837,14 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Coalesce requestAnimationFrame calls.** On 120Hz displays, touchmove fires faster than rAF. Use a `rAFPending` flag to skip redundant frames and read the latest value at callback time (not call time).
 - **Touch listeners must go on the scroll container, not document.body.** `e.preventDefault()` on body touchmove doesn't suppress a child scroll container's native overscroll bounce. Attach listeners to the scrollable element directly.
 
+### Constrained Time Wheel Pickers (Voter Response)
+
+- **Voter time ranges must be strict subsets of the poll creator's window.** For non-cross-midnight poll windows (e.g., 9AM–5PM), enforce `voter_min < voter_max` — never allow cross-midnight voter ranges. For cross-midnight poll windows, only exclude exact equality (`min !== max`, which would be 24h). The `isValidVsSibling()` function in `TimeCounterInput.tsx` implements this.
+- **Filter wheel items, don't clamp after the fact.** Clamping after scroll causes visible snap-back. Instead, compute the valid hour/minute sets upfront so invalid values are never shown.
+- **Each picker must know the other picker's value** (`siblingValue` prop) to dynamically filter its options. The min picker shows only times strictly less than the current max, and vice versa. Hours with no valid minutes are hidden entirely.
+- **The AM/PM wheel in constrained mode is non-interactive** — wrapped in `pointerEvents: 'none'`, it auto-follows the selected hour via `selectedIndex`. This keeps hours in chronological order across AM/PM boundaries.
+- **When an hour change invalidates the current minute**, auto-select the minute giving the smallest positive duration to/from the sibling (≈1 increment gap). This avoids jarring jumps to arbitrary times.
+
 ### Cross-Midnight Time Windows
 
 - **Time windows where `max <= min` represent cross-midnight ranges** (e.g., 10 PM–2 AM). Equal start/end means a full 24-hour window. Use `<=` consistently in all cross-midnight detection — `<` misses the equal-times-as-24h case.

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -100,6 +100,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [loadingSuggestions, setLoadingSuggestions] = useState(false);
   const autoCloseTriggeredRef = useRef(false);
   const fetchResultsInFlight = useRef(false);
+  const fetchResultsLastCall = useRef(0);
 
   // Participation poll voter conditions - initialize with poll's constraints
   const [voterMinParticipants, setVoterMinParticipants] = useState<number | null>(poll.min_participants ?? 1);
@@ -280,8 +281,13 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   }, []);
 
   const fetchPollResults = useCallback(async () => {
-    if (fetchResultsInFlight.current) return; // Deduplicate concurrent calls
+    // Prevent rapid-fire calls: skip if already in-flight or called within last 2s.
+    // The 1-second timer and multiple effects can trigger this in quick succession
+    // (especially after Fast Refresh), leading to 429 rate-limit errors.
+    const now = Date.now();
+    if (fetchResultsInFlight.current || now - fetchResultsLastCall.current < 2000) return;
     fetchResultsInFlight.current = true;
+    fetchResultsLastCall.current = now;
     setLoadingResults(true);
     try {
       const results = await apiGetPollResults(poll.id);

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -99,6 +99,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [loadingSuggestions, setLoadingSuggestions] = useState(false);
   const autoCloseTriggeredRef = useRef(false);
+  const fetchResultsInFlight = useRef(false);
 
   // Participation poll voter conditions - initialize with poll's constraints
   const [voterMinParticipants, setVoterMinParticipants] = useState<number | null>(poll.min_participants ?? 1);
@@ -279,6 +280,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   }, []);
 
   const fetchPollResults = useCallback(async () => {
+    if (fetchResultsInFlight.current) return; // Deduplicate concurrent calls
+    fetchResultsInFlight.current = true;
     setLoadingResults(true);
     try {
       const results = await apiGetPollResults(poll.id);
@@ -293,6 +296,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       console.error('Error fetching poll results:', error);
     } finally {
       setLoadingResults(false);
+      fetchResultsInFlight.current = false;
     }
   }, [poll.id, poll.poll_type]);
 

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -188,6 +188,8 @@ export default function DayTimeWindowsInput({
         minValue={editingIndex !== null && windows[editingIndex] ? windows[editingIndex].min : "09:00"}
         maxValue={editingIndex !== null && windows[editingIndex] ? windows[editingIndex].max : "17:00"}
         onApply={handleModalApply}
+        constraintMin={pollWindows && editingIndex !== null && pollWindows[editingIndex] ? pollWindows[editingIndex].min : undefined}
+        constraintMax={pollWindows && editingIndex !== null && pollWindows[editingIndex] ? pollWindows[editingIndex].max : undefined}
       />
     </div>
   );

--- a/components/ScrollWheel.tsx
+++ b/components/ScrollWheel.tsx
@@ -188,6 +188,50 @@ export default function ScrollWheel({
     }
   }, [loop, itemHeight, rawToReal, selectedToScroll, items.length, updateItemStyles]);
 
+  // Correct scroll position to match selectedIndex (e.g. after parent clamped the value)
+  const correctPosition = useCallback(() => {
+    const el = containerRef.current;
+    if (!el || suppressScrollHandler.current) return;
+
+    const rawIdx = Math.round(el.scrollTop / itemHeight);
+    const realIdx = loop
+      ? rawToReal(rawIdx)
+      : Math.max(0, Math.min(items.length - 1, rawIdx));
+    const target = selectedIndexRef.current;
+    if (realIdx === target) return;
+
+    lastReportedIndex.current = target;
+    suppressScrollHandler.current = true;
+    let targetScroll: number;
+    if (loop) {
+      const currentRepStart = Math.floor(rawIdx / items.length) * items.length;
+      const candidates = [
+        currentRepStart - items.length + target,
+        currentRepStart + target,
+        currentRepStart + items.length + target,
+      ];
+      let best = candidates[1];
+      let bestDist = Math.abs(candidates[1] - rawIdx);
+      for (const c of candidates) {
+        const dist = Math.abs(c - rawIdx);
+        if (dist < bestDist) { bestDist = dist; best = c; }
+      }
+      targetScroll = best * itemHeight;
+    } else {
+      targetScroll = target * itemHeight;
+    }
+    el.scrollTo({ top: targetScroll, behavior: 'smooth' });
+    if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+    scrollTimeout.current = setTimeout(() => {
+      suppressScrollHandler.current = false;
+      updateItemStyles();
+    }, SMOOTH_SCROLL_SETTLE_MS);
+  }, [itemHeight, items.length, loop, rawToReal, updateItemStyles]);
+
+  // Keep a ref so touchend handler (created with [] deps) can access latest version
+  const correctPositionRef = useRef(correctPosition);
+  correctPositionRef.current = correctPosition;
+
   const handleScroll = useCallback(() => {
     if (suppressScrollHandler.current) return;
 
@@ -212,22 +256,31 @@ export default function ScrollWheel({
       }
     }
 
-    // Debounced loop re-centering (only needed for loop mode)
-    if (loop) {
-      if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
-      scrollTimeout.current = setTimeout(() => {
-        recenterLoop();
-      }, 150);
-    }
+    // Debounced scroll-settle actions (loop re-centering + constraint correction)
+    if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+    scrollTimeout.current = setTimeout(() => {
+      if (loop) recenterLoop();
+      // After scroll settles, snap to constrained position if parent clamped selectedIndex
+      if (!isTouching.current) {
+        correctPositionRef.current();
+      }
+    }, 150);
   }, [itemHeight, items.length, onChange, updateItemStyles, loop, rawToReal, recenterLoop]);
 
-  // Track touch state
+  // Track touch state — on touch end, schedule a correction check
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
     const onTouchStart = () => { isTouching.current = true; };
-    const onTouchEnd = () => { isTouching.current = false; };
+    const onTouchEnd = () => {
+      isTouching.current = false;
+      // After touch ends, wait for any momentum scroll to settle, then correct
+      if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+      scrollTimeout.current = setTimeout(() => {
+        correctPositionRef.current();
+      }, 150);
+    };
 
     el.addEventListener('touchstart', onTouchStart, { passive: true });
     el.addEventListener('touchend', onTouchEnd, { passive: true });

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -10,6 +10,8 @@ interface TimeCounterInputProps {
   disabled?: boolean;
   constraintMin?: string; // HH:MM 24h — lower bound of valid time window
   constraintMax?: string; // HH:MM 24h — upper bound of valid time window
+  siblingValue?: string | null; // HH:MM 24h — the other picker's current value
+  role?: 'min' | 'max'; // whether this is the min or max time picker
 }
 
 const HOURS = Array.from({ length: 12 }, (_, i) => i + 1); // 1-12
@@ -58,6 +60,8 @@ export default function TimeCounterInput({
   disabled = false,
   constraintMin,
   constraintMax,
+  siblingValue,
+  role,
 }: TimeCounterInputProps) {
   const minuteOptions = useMemo(() => getMinuteOptions(increment), [increment]);
   const minuteLabels = useMemo(() => minuteOptions.map(m => m.toString().padStart(2, '0')), [minuteOptions]);
@@ -68,6 +72,10 @@ export default function TimeCounterInput({
   const constrained = !!constraintMin && !!constraintMax;
   const cMinMins = constrained ? timeToMins(constraintMin!) : 0;
   const cMaxMins = constrained ? timeToMins(constraintMax!) : 0;
+
+  // Only filter out sibling value when constraint window is < 24h
+  const constraintIs24h = constrained && cMinMins === cMaxMins;
+  const sibMins = (siblingValue && constrained && !constraintIs24h) ? timeToMins(siblingValue) : -1;
 
   // Parse current value
   let currentHour24 = 9, currentMinute = 0;
@@ -88,8 +96,8 @@ export default function TimeCounterInput({
   const periodIndex = currentPeriod === 'AM' ? 0 : 1;
 
   // === CONSTRAINED MODE ===
-  // All valid hours in chronological order across AM/PM (e.g., 9,10,11,12,1,2,3,4,5).
-  // AM/PM wheel is visible but non-interactive — it follows the selected hour automatically.
+  // All valid hours in chronological order across AM/PM.
+  // Hours where every valid minute equals the sibling value are excluded.
 
   const constrainedHours = useMemo(() => {
     if (!constrained) return [];
@@ -101,7 +109,8 @@ export default function TimeCounterInput({
       if (seen.has(h24)) continue;
       let hasValid = false;
       for (let m = 0; m < 60; m += increment) {
-        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { hasValid = true; break; }
+        const t = h24 * 60 + m;
+        if (isInWindow(t, cMinMins, cMaxMins) && t !== sibMins) { hasValid = true; break; }
       }
       if (hasValid) {
         seen.add(h24);
@@ -110,7 +119,7 @@ export default function TimeCounterInput({
       }
     }
     return items;
-  }, [constrained, cMinMins, cMaxMins, increment]);
+  }, [constrained, cMinMins, cMaxMins, increment, sibMins]);
 
   const constrainedHourLabels = useMemo(
     () => constrainedHours.map(h => h.label),
@@ -122,13 +131,16 @@ export default function TimeCounterInput({
     return idx >= 0 ? idx : 0;
   }, [constrainedHours, currentHour24]);
 
-  // Minutes filtered for the selected constrained hour
+  // Minutes filtered for the selected constrained hour, excluding sibling-equal time
   const constrainedMinutes = useMemo(() => {
     if (!constrained || constrainedHours.length === 0) return minuteOptions;
     const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
-    const result = minuteOptions.filter(m => isInWindow(h24 * 60 + m, cMinMins, cMaxMins));
+    const result = minuteOptions.filter(m => {
+      const t = h24 * 60 + m;
+      return isInWindow(t, cMinMins, cMaxMins) && t !== sibMins;
+    });
     return result.length > 0 ? result : minuteOptions;
-  }, [constrained, constrainedHours, constrainedHourIndex, cMinMins, cMaxMins, minuteOptions]);
+  }, [constrained, constrainedHours, constrainedHourIndex, cMinMins, cMaxMins, minuteOptions, sibMins]);
 
   const constrainedMinuteLabels = useMemo(
     () => constrainedMinutes.map(m => m.toString().padStart(2, '0')),
@@ -162,13 +174,44 @@ export default function TimeCounterInput({
     if (!hourItem) return;
     const h24 = hourItem.hour24;
     let minute = currentMinute;
-    if (!isInWindow(h24 * 60 + minute, cMinMins, cMaxMins)) {
+
+    // Check if current minute is valid at this hour (in window and not equal to sibling)
+    const currentTotal = h24 * 60 + minute;
+    if (!isInWindow(currentTotal, cMinMins, cMaxMins) || currentTotal === sibMins) {
+      // Find the best replacement minute — prefer one that gives ~1 increment duration from sibling
+      const validMinutes: number[] = [];
       for (let m = 0; m < 60; m += increment) {
-        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { minute = m; break; }
+        const t = h24 * 60 + m;
+        if (isInWindow(t, cMinMins, cMaxMins) && t !== sibMins) {
+          validMinutes.push(m);
+        }
+      }
+      if (validMinutes.length > 0 && sibMins >= 0) {
+        // Pick the minute giving the smallest positive duration to/from sibling
+        let best = validMinutes[0];
+        let bestDur = Infinity;
+        for (const m of validMinutes) {
+          const t = h24 * 60 + m;
+          let dur: number;
+          if (role === 'min') {
+            // Duration from this (min) to sibling (max)
+            dur = sibMins >= t ? sibMins - t : 24 * 60 - t + sibMins;
+          } else {
+            // Duration from sibling (min) to this (max)
+            dur = t >= sibMins ? t - sibMins : 24 * 60 - sibMins + t;
+          }
+          if (dur > 0 && dur < bestDur) {
+            bestDur = dur;
+            best = m;
+          }
+        }
+        minute = best;
+      } else if (validMinutes.length > 0) {
+        minute = validMinutes[0];
       }
     }
     onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
-  }, [disabled, constrainedHours, currentMinute, cMinMins, cMaxMins, increment, onChange]);
+  }, [disabled, constrainedHours, currentMinute, cMinMins, cMaxMins, increment, onChange, sibMins, role]);
 
   const handleConstrainedMinuteChange = useCallback((newIdx: number) => {
     if (disabled) return;

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -74,7 +74,7 @@ export default function TimeCounterInput({
   }
   const { hour12: currentHour12, period: currentPeriod } = from24Hour(currentHour24);
 
-  // === UNCONSTRAINED MODE indices (existing logic) ===
+  // === UNCONSTRAINED MODE indices ===
   let hourIndex = currentHour12 - 1; // 1-12 -> 0-11
   let minuteIndex = minuteOptions.indexOf(currentMinute);
   if (minuteIndex === -1) {
@@ -85,64 +85,66 @@ export default function TimeCounterInput({
   }
   const periodIndex = currentPeriod === 'AM' ? 0 : 1;
 
-  // === CONSTRAINED MODE: compute effective (filtered) wheel items ===
-  const effectivePeriods = useMemo(() => {
-    if (!constrained) return PERIODS;
-    const result: string[] = [];
-    for (let m = 0; m < 720; m += increment) {
-      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('AM'); break; }
+  // === CONSTRAINED MODE: combined hour+period wheel ===
+  // Instead of separate hour and AM/PM wheels, show a single wheel with
+  // entries like "9 AM", "10 AM", ..., "12 PM", "1 PM", ..., "5 PM"
+  // in chronological order within the constraint window.
+
+  const constrainedHours = useMemo(() => {
+    if (!constrained) return [];
+    const items: { label: string; hour24: number }[] = [];
+    const seen = new Set<number>();
+    // Start from the constraint min hour to get correct chronological order
+    // (important for cross-midnight windows like 10 PM – 2 AM)
+    const startHour = Math.floor(cMinMins / 60);
+    for (let i = 0; i < 24; i++) {
+      const h24 = (startHour + i) % 24;
+      if (seen.has(h24)) continue;
+      // Check if any minute increment in this hour is valid
+      let hasValid = false;
+      for (let m = 0; m < 60; m += increment) {
+        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { hasValid = true; break; }
+      }
+      if (hasValid) {
+        seen.add(h24);
+        const { hour12, period } = from24Hour(h24);
+        items.push({ label: `${hour12} ${period}`, hour24: h24 });
+      }
     }
-    for (let m = 720; m < 1440; m += increment) {
-      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('PM'); break; }
-    }
-    return result.length > 0 ? result : PERIODS;
+    return items;
   }, [constrained, cMinMins, cMaxMins, increment]);
 
-  const effectivePeriodIndex = constrained
-    ? Math.max(0, effectivePeriods.indexOf(currentPeriod))
-    : periodIndex;
+  const constrainedHourLabels = useMemo(
+    () => constrainedHours.map(h => h.label),
+    [constrainedHours],
+  );
 
-  const effectiveHours = useMemo(() => {
-    if (!constrained) return HOURS;
-    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
-    const hours = new Set<number>();
-    for (let m = 0; m < 1440; m += increment) {
-      if (!isInWindow(m, cMinMins, cMaxMins)) continue;
-      const h24 = Math.floor(m / 60);
-      const { hour12, period: p } = from24Hour(h24);
-      if (p === period) hours.add(hour12);
-    }
-    const result = HOURS.filter(h => hours.has(h));
-    return result.length > 0 ? result : HOURS;
-  }, [constrained, cMinMins, cMaxMins, increment, effectivePeriodIndex, effectivePeriods]);
+  const constrainedHourIndex = useMemo(() => {
+    const idx = constrainedHours.findIndex(h => h.hour24 === currentHour24);
+    return idx >= 0 ? idx : 0;
+  }, [constrainedHours, currentHour24]);
 
-  const effectiveHourLabels = useMemo(() => effectiveHours.map(String), [effectiveHours]);
-
-  const effectiveHourIndex = constrained
-    ? Math.max(0, effectiveHours.indexOf(currentHour12))
-    : hourIndex;
-
-  const effectiveMinuteOptions = useMemo(() => {
-    if (!constrained) return minuteOptions;
-    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
-    const hour12 = effectiveHours[Math.min(effectiveHourIndex, effectiveHours.length - 1)];
-    if (!hour12) return minuteOptions;
-    const h24 = to24Hour(hour12, period);
+  // Minutes filtered for the selected constrained hour
+  const constrainedMinutes = useMemo(() => {
+    if (!constrained || constrainedHours.length === 0) return minuteOptions;
+    const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
     const result = minuteOptions.filter(m => isInWindow(h24 * 60 + m, cMinMins, cMaxMins));
     return result.length > 0 ? result : minuteOptions;
-  }, [constrained, cMinMins, cMaxMins, effectivePeriodIndex, effectivePeriods, effectiveHourIndex, effectiveHours, minuteOptions]);
+  }, [constrained, constrainedHours, constrainedHourIndex, cMinMins, cMaxMins, minuteOptions]);
 
-  const effectiveMinuteLabels = useMemo(() =>
-    effectiveMinuteOptions.map(m => m.toString().padStart(2, '0')),
-    [effectiveMinuteOptions]);
+  const constrainedMinuteLabels = useMemo(
+    () => constrainedMinutes.map(m => m.toString().padStart(2, '0')),
+    [constrainedMinutes],
+  );
 
-  const effectiveMinuteIndex = constrained
-    ? Math.max(0, effectiveMinuteOptions.indexOf(currentMinute))
-    : minuteIndex;
+  const constrainedMinuteIndex = useMemo(() => {
+    const idx = constrainedMinutes.indexOf(currentMinute);
+    return idx >= 0 ? idx : 0;
+  }, [constrainedMinutes, currentMinute]);
 
-  // Keep refs in sync with current parsed values
-  if (prevHourIndex.current === null) prevHourIndex.current = constrained ? effectiveHourIndex : hourIndex;
-  if (prevMinuteIndex.current === null) prevMinuteIndex.current = constrained ? effectiveMinuteIndex : minuteIndex;
+  // Keep refs in sync
+  if (prevHourIndex.current === null) prevHourIndex.current = hourIndex;
+  if (prevMinuteIndex.current === null) prevMinuteIndex.current = minuteIndex;
 
   // === EMIT FUNCTIONS ===
 
@@ -156,54 +158,39 @@ export default function TimeCounterInput({
     onChange(timeStr);
   };
 
-  const emitConstrained = useCallback((periodIdx: number, hourIdx: number, minuteIdx: number) => {
+  const handleConstrainedHourChange = useCallback((newIdx: number) => {
     if (disabled) return;
-    const period = effectivePeriods[periodIdx] as 'AM' | 'PM';
-    let hour12 = effectiveHours[hourIdx];
-    let minute = effectiveMinuteOptions[minuteIdx];
-
-    // Safety: if index out of range, use first valid value
-    if (hour12 === undefined) hour12 = effectiveHours[0] || 12;
-    if (minute === undefined) minute = effectiveMinuteOptions[0] || 0;
-
-    const h24 = to24Hour(hour12, period);
-    let timeMins = h24 * 60 + minute;
-
-    // If this combination isn't valid (can happen during period/hour transitions),
-    // find the nearest valid time in the constraint window
-    if (!isInWindow(timeMins, cMinMins, cMaxMins)) {
-      let bestTime = cMinMins;
-      let bestDist = Infinity;
-      for (let m = 0; m < 1440; m += increment) {
-        if (!isInWindow(m, cMinMins, cMaxMins)) continue;
-        const dist = Math.min(Math.abs(m - timeMins), 1440 - Math.abs(m - timeMins));
-        if (dist < bestDist) { bestDist = dist; bestTime = m; }
+    const hourItem = constrainedHours[newIdx];
+    if (!hourItem) return;
+    const h24 = hourItem.hour24;
+    // Keep current minute if still valid for the new hour, otherwise first valid
+    let minute = currentMinute;
+    if (!isInWindow(h24 * 60 + minute, cMinMins, cMaxMins)) {
+      for (let m = 0; m < 60; m += increment) {
+        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { minute = m; break; }
       }
-      timeMins = bestTime;
     }
+    onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
+  }, [disabled, constrainedHours, currentMinute, cMinMins, cMaxMins, increment, onChange]);
 
-    const h = Math.floor(timeMins / 60);
-    const min = timeMins % 60;
-    onChange(`${h.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}`);
-  }, [disabled, effectivePeriods, effectiveHours, effectiveMinuteOptions, cMinMins, cMaxMins, increment, onChange]);
+  const handleConstrainedMinuteChange = useCallback((newIdx: number) => {
+    if (disabled) return;
+    const minute = constrainedMinutes[newIdx];
+    if (minute === undefined) return;
+    const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
+    onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
+  }, [disabled, constrainedMinutes, constrainedHours, constrainedHourIndex, onChange]);
 
-  // === HANDLERS ===
+  // === UNCONSTRAINED HANDLERS ===
 
   const handleHourChange = (newHourIndex: number) => {
-    if (constrained) {
-      emitConstrained(effectivePeriodIndex, newHourIndex, effectiveMinuteIndex);
-      return;
-    }
     const prev = prevHourIndex.current ?? hourIndex;
     let newPeriod = periodIndex;
 
     // Detect crossing the 11↔12 boundary (noon/midnight crossing)
-    // 11 is index 10, 12 is index 11
     if (prev === 10 && newHourIndex === 11) {
-      // Scrolled from 11 → 12 (forward): toggle AM/PM
       newPeriod = periodIndex === 0 ? 1 : 0;
     } else if (prev === 11 && newHourIndex === 10) {
-      // Scrolled from 12 → 11 (backward): toggle AM/PM
       newPeriod = periodIndex === 0 ? 1 : 0;
     }
 
@@ -212,27 +199,18 @@ export default function TimeCounterInput({
   };
 
   const handleMinuteChange = (newMinuteIndex: number) => {
-    if (constrained) {
-      emitConstrained(effectivePeriodIndex, effectiveHourIndex, newMinuteIndex);
-      return;
-    }
     const prev = prevMinuteIndex.current ?? minuteIndex;
     const lastIdx = minuteOptions.length - 1;
     let newHourIdx = hourIndex;
     let newPeriod = periodIndex;
 
-    // Detect minute wraparound (e.g. 45→00 or 00→45)
     if (prev === lastIdx && newMinuteIndex === 0) {
-      // Scrolled past last minute → wrap forward, increment hour
       newHourIdx = (hourIndex + 1) % 12;
-      // If hour crosses 11→12 boundary, toggle AM/PM
       if (hourIndex === 10 && newHourIdx === 11) {
         newPeriod = periodIndex === 0 ? 1 : 0;
       }
     } else if (prev === 0 && newMinuteIndex === lastIdx) {
-      // Scrolled past first minute → wrap backward, decrement hour
       newHourIdx = (hourIndex - 1 + 12) % 12;
-      // If hour crosses 12→11 boundary, toggle AM/PM
       if (hourIndex === 11 && newHourIdx === 10) {
         newPeriod = periodIndex === 0 ? 1 : 0;
       }
@@ -244,10 +222,6 @@ export default function TimeCounterInput({
   };
 
   const handlePeriodChange = (newPeriodIndex: number) => {
-    if (constrained) {
-      emitConstrained(newPeriodIndex, effectiveHourIndex, effectiveMinuteIndex);
-      return;
-    }
     emit(hourIndex, minuteIndex, newPeriodIndex);
   };
 
@@ -257,13 +231,6 @@ export default function TimeCounterInput({
   const visibleItems = 5;
   const highlightTop = Math.floor(visibleItems / 2) * itemHeight;
 
-  const hourItems = constrained ? effectiveHourLabels : HOUR_LABELS;
-  const hourSelIdx = constrained ? effectiveHourIndex : hourIndex;
-  const minItems = constrained ? effectiveMinuteLabels : minuteLabels;
-  const minSelIdx = constrained ? effectiveMinuteIndex : minuteIndex;
-  const periodItems = constrained ? effectivePeriods : PERIODS;
-  const periodSelIdx = constrained ? effectivePeriodIndex : periodIndex;
-
   return (
     <div className={`relative flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
       {/* Unified highlight band spanning all wheels */}
@@ -271,34 +238,55 @@ export default function TimeCounterInput({
         className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-xl"
         style={{ top: highlightTop, height: itemHeight }}
       />
-      <ScrollWheel
-        key={constrained ? `h:${hourItems.join(',')}` : 'h'}
-        items={hourItems}
-        selectedIndex={hourSelIdx}
-        onChange={handleHourChange}
-        width={45}
-        loop={!constrained}
-        hideHighlight
-      />
-      <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
-      <ScrollWheel
-        key={constrained ? `m:${minItems.join(',')}` : 'm'}
-        items={minItems}
-        selectedIndex={minSelIdx}
-        onChange={handleMinuteChange}
-        width={45}
-        loop={!constrained}
-        hideHighlight
-      />
-      <div className="w-1" />
-      <ScrollWheel
-        key={constrained ? `p:${periodItems.join(',')}` : 'p'}
-        items={periodItems}
-        selectedIndex={periodSelIdx}
-        onChange={handlePeriodChange}
-        width={42}
-        hideHighlight
-      />
+      {constrained ? (
+        <>
+          <ScrollWheel
+            key={`ch:${constrainedHourLabels.join(',')}`}
+            items={constrainedHourLabels}
+            selectedIndex={constrainedHourIndex}
+            onChange={handleConstrainedHourChange}
+            width={62}
+            hideHighlight
+          />
+          <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
+          <ScrollWheel
+            key={`cm:${constrainedMinuteLabels.join(',')}`}
+            items={constrainedMinuteLabels}
+            selectedIndex={constrainedMinuteIndex}
+            onChange={handleConstrainedMinuteChange}
+            width={45}
+            hideHighlight
+          />
+        </>
+      ) : (
+        <>
+          <ScrollWheel
+            items={HOUR_LABELS}
+            selectedIndex={hourIndex}
+            onChange={handleHourChange}
+            width={45}
+            loop
+            hideHighlight
+          />
+          <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
+          <ScrollWheel
+            items={minuteLabels}
+            selectedIndex={minuteIndex}
+            onChange={handleMinuteChange}
+            width={45}
+            loop
+            hideHighlight
+          />
+          <div className="w-1" />
+          <ScrollWheel
+            items={PERIODS}
+            selectedIndex={periodIndex}
+            onChange={handlePeriodChange}
+            width={42}
+            hideHighlight
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -16,9 +16,6 @@ const HOURS = Array.from({ length: 12 }, (_, i) => i + 1); // 1-12
 const HOUR_LABELS = HOURS.map(String);
 const PERIODS = ['AM', 'PM'];
 
-/** Clock-order sort: 12 comes before 1 (12,1,2,...,11) */
-const CLOCK_ORDER = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-
 function getMinuteOptions(increment: number): number[] {
   const options: number[] = [];
   for (let m = 0; m < 60; m += increment) {
@@ -50,6 +47,9 @@ function isInWindow(mins: number, minMins: number, maxMins: number): boolean {
   }
   return mins >= minMins && mins <= maxMins;
 }
+
+// no-op handler for the locked AM/PM wheel
+function noop() {}
 
 export default function TimeCounterInput({
   value,
@@ -87,67 +87,62 @@ export default function TimeCounterInput({
   }
   const periodIndex = currentPeriod === 'AM' ? 0 : 1;
 
-  // === CONSTRAINED MODE: filtered 3-wheel items ===
+  // === CONSTRAINED MODE ===
+  // All valid hours in chronological order across AM/PM (e.g., 9,10,11,12,1,2,3,4,5).
+  // AM/PM wheel is visible but non-interactive — it follows the selected hour automatically.
 
-  const effectivePeriods = useMemo(() => {
-    if (!constrained) return PERIODS;
-    const result: string[] = [];
-    for (let m = 0; m < 720; m += increment) {
-      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('AM'); break; }
+  const constrainedHours = useMemo(() => {
+    if (!constrained) return [];
+    const items: { label: string; hour24: number }[] = [];
+    const seen = new Set<number>();
+    const startHour = Math.floor(cMinMins / 60);
+    for (let i = 0; i < 24; i++) {
+      const h24 = (startHour + i) % 24;
+      if (seen.has(h24)) continue;
+      let hasValid = false;
+      for (let m = 0; m < 60; m += increment) {
+        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { hasValid = true; break; }
+      }
+      if (hasValid) {
+        seen.add(h24);
+        const { hour12 } = from24Hour(h24);
+        items.push({ label: String(hour12), hour24: h24 });
+      }
     }
-    for (let m = 720; m < 1440; m += increment) {
-      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('PM'); break; }
-    }
-    return result.length > 0 ? result : PERIODS;
+    return items;
   }, [constrained, cMinMins, cMaxMins, increment]);
 
-  const effectivePeriodIndex = constrained
-    ? Math.max(0, effectivePeriods.indexOf(currentPeriod))
-    : periodIndex;
+  const constrainedHourLabels = useMemo(
+    () => constrainedHours.map(h => h.label),
+    [constrainedHours],
+  );
 
-  // Valid hours for the current period, in clock order (12, 1, 2, ..., 11)
-  const effectiveHours = useMemo(() => {
-    if (!constrained) return HOURS;
-    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
-    const hours = new Set<number>();
-    for (let m = 0; m < 1440; m += increment) {
-      if (!isInWindow(m, cMinMins, cMaxMins)) continue;
-      const h24 = Math.floor(m / 60);
-      const { hour12, period: p } = from24Hour(h24);
-      if (p === period) hours.add(hour12);
-    }
-    // Use clock order (12, 1, 2, ...) instead of numeric order (1, 2, ..., 12)
-    const result = CLOCK_ORDER.filter(h => hours.has(h));
-    return result.length > 0 ? result : HOURS;
-  }, [constrained, cMinMins, cMaxMins, increment, effectivePeriodIndex, effectivePeriods]);
+  const constrainedHourIndex = useMemo(() => {
+    const idx = constrainedHours.findIndex(h => h.hour24 === currentHour24);
+    return idx >= 0 ? idx : 0;
+  }, [constrainedHours, currentHour24]);
 
-  const effectiveHourLabels = useMemo(() => effectiveHours.map(String), [effectiveHours]);
-
-  const effectiveHourIndex = constrained
-    ? Math.max(0, effectiveHours.indexOf(currentHour12))
-    : hourIndex;
-
-  const effectiveMinuteOptions = useMemo(() => {
-    if (!constrained) return minuteOptions;
-    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
-    const hour12 = effectiveHours[Math.min(effectiveHourIndex, effectiveHours.length - 1)];
-    if (!hour12) return minuteOptions;
-    const h24 = to24Hour(hour12, period);
+  // Minutes filtered for the selected constrained hour
+  const constrainedMinutes = useMemo(() => {
+    if (!constrained || constrainedHours.length === 0) return minuteOptions;
+    const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
     const result = minuteOptions.filter(m => isInWindow(h24 * 60 + m, cMinMins, cMaxMins));
     return result.length > 0 ? result : minuteOptions;
-  }, [constrained, cMinMins, cMaxMins, effectivePeriodIndex, effectivePeriods, effectiveHourIndex, effectiveHours, minuteOptions]);
+  }, [constrained, constrainedHours, constrainedHourIndex, cMinMins, cMaxMins, minuteOptions]);
 
-  const effectiveMinuteLabels = useMemo(() =>
-    effectiveMinuteOptions.map(m => m.toString().padStart(2, '0')),
-    [effectiveMinuteOptions]);
+  const constrainedMinuteLabels = useMemo(
+    () => constrainedMinutes.map(m => m.toString().padStart(2, '0')),
+    [constrainedMinutes],
+  );
 
-  const effectiveMinuteIndex = constrained
-    ? Math.max(0, effectiveMinuteOptions.indexOf(currentMinute))
-    : minuteIndex;
+  const constrainedMinuteIndex = useMemo(() => {
+    const idx = constrainedMinutes.indexOf(currentMinute);
+    return idx >= 0 ? idx : 0;
+  }, [constrainedMinutes, currentMinute]);
 
   // Keep refs in sync
-  if (prevHourIndex.current === null) prevHourIndex.current = constrained ? effectiveHourIndex : hourIndex;
-  if (prevMinuteIndex.current === null) prevMinuteIndex.current = constrained ? effectiveMinuteIndex : minuteIndex;
+  if (prevHourIndex.current === null) prevHourIndex.current = hourIndex;
+  if (prevMinuteIndex.current === null) prevMinuteIndex.current = minuteIndex;
 
   // === EMIT FUNCTIONS ===
 
@@ -161,43 +156,31 @@ export default function TimeCounterInput({
     onChange(timeStr);
   };
 
-  const emitConstrained = useCallback((periodIdx: number, hourIdx: number, minuteIdx: number) => {
+  const handleConstrainedHourChange = useCallback((newIdx: number) => {
     if (disabled) return;
-    const period = effectivePeriods[periodIdx] as 'AM' | 'PM';
-    let hour12 = effectiveHours[hourIdx];
-    let minute = effectiveMinuteOptions[minuteIdx];
-
-    if (hour12 === undefined) hour12 = effectiveHours[0] || 12;
-    if (minute === undefined) minute = effectiveMinuteOptions[0] || 0;
-
-    const h24 = to24Hour(hour12, period);
-    let timeMins = h24 * 60 + minute;
-
-    // If this combination isn't valid (can happen during period/hour transitions),
-    // find the nearest valid time in the constraint window
-    if (!isInWindow(timeMins, cMinMins, cMaxMins)) {
-      let bestTime = cMinMins;
-      let bestDist = Infinity;
-      for (let m = 0; m < 1440; m += increment) {
-        if (!isInWindow(m, cMinMins, cMaxMins)) continue;
-        const dist = Math.min(Math.abs(m - timeMins), 1440 - Math.abs(m - timeMins));
-        if (dist < bestDist) { bestDist = dist; bestTime = m; }
+    const hourItem = constrainedHours[newIdx];
+    if (!hourItem) return;
+    const h24 = hourItem.hour24;
+    let minute = currentMinute;
+    if (!isInWindow(h24 * 60 + minute, cMinMins, cMaxMins)) {
+      for (let m = 0; m < 60; m += increment) {
+        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { minute = m; break; }
       }
-      timeMins = bestTime;
     }
+    onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
+  }, [disabled, constrainedHours, currentMinute, cMinMins, cMaxMins, increment, onChange]);
 
-    const h = Math.floor(timeMins / 60);
-    const min = timeMins % 60;
-    onChange(`${h.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}`);
-  }, [disabled, effectivePeriods, effectiveHours, effectiveMinuteOptions, cMinMins, cMaxMins, increment, onChange]);
+  const handleConstrainedMinuteChange = useCallback((newIdx: number) => {
+    if (disabled) return;
+    const minute = constrainedMinutes[newIdx];
+    if (minute === undefined) return;
+    const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
+    onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
+  }, [disabled, constrainedMinutes, constrainedHours, constrainedHourIndex, onChange]);
 
-  // === HANDLERS ===
+  // === UNCONSTRAINED HANDLERS ===
 
   const handleHourChange = (newHourIndex: number) => {
-    if (constrained) {
-      emitConstrained(effectivePeriodIndex, newHourIndex, effectiveMinuteIndex);
-      return;
-    }
     const prev = prevHourIndex.current ?? hourIndex;
     let newPeriod = periodIndex;
 
@@ -212,10 +195,6 @@ export default function TimeCounterInput({
   };
 
   const handleMinuteChange = (newMinuteIndex: number) => {
-    if (constrained) {
-      emitConstrained(effectivePeriodIndex, effectiveHourIndex, newMinuteIndex);
-      return;
-    }
     const prev = prevMinuteIndex.current ?? minuteIndex;
     const lastIdx = minuteOptions.length - 1;
     let newHourIdx = hourIndex;
@@ -239,10 +218,6 @@ export default function TimeCounterInput({
   };
 
   const handlePeriodChange = (newPeriodIndex: number) => {
-    if (constrained) {
-      emitConstrained(newPeriodIndex, effectiveHourIndex, effectiveMinuteIndex);
-      return;
-    }
     emit(hourIndex, minuteIndex, newPeriodIndex);
   };
 
@@ -252,13 +227,6 @@ export default function TimeCounterInput({
   const visibleItems = 5;
   const highlightTop = Math.floor(visibleItems / 2) * itemHeight;
 
-  const hourItems = constrained ? effectiveHourLabels : HOUR_LABELS;
-  const hourSelIdx = constrained ? effectiveHourIndex : hourIndex;
-  const minItems = constrained ? effectiveMinuteLabels : minuteLabels;
-  const minSelIdx = constrained ? effectiveMinuteIndex : minuteIndex;
-  const periodItems = constrained ? effectivePeriods : PERIODS;
-  const periodSelIdx = constrained ? effectivePeriodIndex : periodIndex;
-
   return (
     <div className={`relative flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
       {/* Unified highlight band spanning all wheels */}
@@ -266,34 +234,66 @@ export default function TimeCounterInput({
         className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-xl"
         style={{ top: highlightTop, height: itemHeight }}
       />
-      <ScrollWheel
-        key={constrained ? `h:${hourItems.join(',')}` : 'h'}
-        items={hourItems}
-        selectedIndex={hourSelIdx}
-        onChange={handleHourChange}
-        width={45}
-        loop={!constrained}
-        hideHighlight
-      />
-      <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
-      <ScrollWheel
-        key={constrained ? `m:${minItems.join(',')}` : 'm'}
-        items={minItems}
-        selectedIndex={minSelIdx}
-        onChange={handleMinuteChange}
-        width={45}
-        loop={!constrained}
-        hideHighlight
-      />
-      <div className="w-1" />
-      <ScrollWheel
-        key={constrained ? `p:${periodItems.join(',')}` : 'p'}
-        items={periodItems}
-        selectedIndex={periodSelIdx}
-        onChange={handlePeriodChange}
-        width={42}
-        hideHighlight
-      />
+      {constrained ? (
+        <>
+          <ScrollWheel
+            key={`h:${constrainedHourLabels.join(',')}`}
+            items={constrainedHourLabels}
+            selectedIndex={constrainedHourIndex}
+            onChange={handleConstrainedHourChange}
+            width={45}
+            hideHighlight
+          />
+          <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
+          <ScrollWheel
+            key={`m:${constrainedMinuteLabels.join(',')}`}
+            items={constrainedMinuteLabels}
+            selectedIndex={constrainedMinuteIndex}
+            onChange={handleConstrainedMinuteChange}
+            width={45}
+            hideHighlight
+          />
+          <div className="w-1" />
+          {/* AM/PM wheel: visible but non-interactive, follows the selected hour */}
+          <div style={{ pointerEvents: 'none' }}>
+            <ScrollWheel
+              items={PERIODS}
+              selectedIndex={periodIndex}
+              onChange={noop}
+              width={42}
+              hideHighlight
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <ScrollWheel
+            items={HOUR_LABELS}
+            selectedIndex={hourIndex}
+            onChange={handleHourChange}
+            width={45}
+            loop
+            hideHighlight
+          />
+          <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
+          <ScrollWheel
+            items={minuteLabels}
+            selectedIndex={minuteIndex}
+            onChange={handleMinuteChange}
+            width={45}
+            loop
+            hideHighlight
+          />
+          <div className="w-1" />
+          <ScrollWheel
+            items={PERIODS}
+            selectedIndex={periodIndex}
+            onChange={handlePeriodChange}
+            width={42}
+            hideHighlight
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -50,6 +50,28 @@ function isInWindow(mins: number, minMins: number, maxMins: number): boolean {
   return mins >= minMins && mins <= maxMins;
 }
 
+/**
+ * Check if a candidate time is valid relative to the sibling picker's value.
+ * For non-cross-midnight poll windows: min must be < max (no cross-midnight voter ranges).
+ * For cross-midnight poll windows: only exclude exact equality (min !== max).
+ */
+function isValidVsSibling(
+  t: number,
+  sibMins: number,
+  role: 'min' | 'max' | undefined,
+  pollCrossesMidnight: boolean,
+): boolean {
+  if (sibMins < 0) return true; // no sibling constraint
+  if (pollCrossesMidnight) {
+    // Cross-midnight poll: only prevent exact 24h (min === max)
+    return t !== sibMins;
+  }
+  // Non-cross-midnight poll: voter's min must be strictly < voter's max
+  if (role === 'min') return t < sibMins;
+  if (role === 'max') return t > sibMins;
+  return t !== sibMins; // fallback
+}
+
 // no-op handler for the locked AM/PM wheel
 function noop() {}
 
@@ -72,8 +94,9 @@ export default function TimeCounterInput({
   const constrained = !!constraintMin && !!constraintMax;
   const cMinMins = constrained ? timeToMins(constraintMin!) : 0;
   const cMaxMins = constrained ? timeToMins(constraintMax!) : 0;
+  const pollCrossesMidnight = constrained && cMaxMins <= cMinMins && cMinMins !== cMaxMins;
 
-  // Only filter out sibling value when constraint window is < 24h
+  // Only filter against sibling when constraint window is < 24h
   const constraintIs24h = constrained && cMinMins === cMaxMins;
   const sibMins = (siblingValue && constrained && !constraintIs24h) ? timeToMins(siblingValue) : -1;
 
@@ -97,7 +120,12 @@ export default function TimeCounterInput({
 
   // === CONSTRAINED MODE ===
   // All valid hours in chronological order across AM/PM.
-  // Hours where every valid minute equals the sibling value are excluded.
+  // Hours where no valid minute passes both window and sibling checks are excluded.
+
+  /** Check if time t is valid: in the poll window AND valid vs sibling */
+  const isTimeValid = useCallback((t: number) => {
+    return isInWindow(t, cMinMins, cMaxMins) && isValidVsSibling(t, sibMins, role, pollCrossesMidnight);
+  }, [cMinMins, cMaxMins, sibMins, role, pollCrossesMidnight]);
 
   const constrainedHours = useMemo(() => {
     if (!constrained) return [];
@@ -109,8 +137,7 @@ export default function TimeCounterInput({
       if (seen.has(h24)) continue;
       let hasValid = false;
       for (let m = 0; m < 60; m += increment) {
-        const t = h24 * 60 + m;
-        if (isInWindow(t, cMinMins, cMaxMins) && t !== sibMins) { hasValid = true; break; }
+        if (isTimeValid(h24 * 60 + m)) { hasValid = true; break; }
       }
       if (hasValid) {
         seen.add(h24);
@@ -119,7 +146,7 @@ export default function TimeCounterInput({
       }
     }
     return items;
-  }, [constrained, cMinMins, cMaxMins, increment, sibMins]);
+  }, [constrained, cMinMins, increment, isTimeValid]);
 
   const constrainedHourLabels = useMemo(
     () => constrainedHours.map(h => h.label),
@@ -131,16 +158,13 @@ export default function TimeCounterInput({
     return idx >= 0 ? idx : 0;
   }, [constrainedHours, currentHour24]);
 
-  // Minutes filtered for the selected constrained hour, excluding sibling-equal time
+  // Minutes filtered for the selected constrained hour
   const constrainedMinutes = useMemo(() => {
     if (!constrained || constrainedHours.length === 0) return minuteOptions;
     const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
-    const result = minuteOptions.filter(m => {
-      const t = h24 * 60 + m;
-      return isInWindow(t, cMinMins, cMaxMins) && t !== sibMins;
-    });
+    const result = minuteOptions.filter(m => isTimeValid(h24 * 60 + m));
     return result.length > 0 ? result : minuteOptions;
-  }, [constrained, constrainedHours, constrainedHourIndex, cMinMins, cMaxMins, minuteOptions, sibMins]);
+  }, [constrained, constrainedHours, constrainedHourIndex, minuteOptions, isTimeValid]);
 
   const constrainedMinuteLabels = useMemo(
     () => constrainedMinutes.map(m => m.toString().padStart(2, '0')),
@@ -175,16 +199,12 @@ export default function TimeCounterInput({
     const h24 = hourItem.hour24;
     let minute = currentMinute;
 
-    // Check if current minute is valid at this hour (in window and not equal to sibling)
-    const currentTotal = h24 * 60 + minute;
-    if (!isInWindow(currentTotal, cMinMins, cMaxMins) || currentTotal === sibMins) {
-      // Find the best replacement minute — prefer one that gives ~1 increment duration from sibling
+    // Check if current minute is valid at this hour
+    if (!isTimeValid(h24 * 60 + minute)) {
+      // Find valid minutes at this hour
       const validMinutes: number[] = [];
       for (let m = 0; m < 60; m += increment) {
-        const t = h24 * 60 + m;
-        if (isInWindow(t, cMinMins, cMaxMins) && t !== sibMins) {
-          validMinutes.push(m);
-        }
+        if (isTimeValid(h24 * 60 + m)) validMinutes.push(m);
       }
       if (validMinutes.length > 0 && sibMins >= 0) {
         // Pick the minute giving the smallest positive duration to/from sibling
@@ -194,10 +214,8 @@ export default function TimeCounterInput({
           const t = h24 * 60 + m;
           let dur: number;
           if (role === 'min') {
-            // Duration from this (min) to sibling (max)
             dur = sibMins >= t ? sibMins - t : 24 * 60 - t + sibMins;
           } else {
-            // Duration from sibling (min) to this (max)
             dur = t >= sibMins ? t - sibMins : 24 * 60 - sibMins + t;
           }
           if (dur > 0 && dur < bestDur) {
@@ -211,7 +229,7 @@ export default function TimeCounterInput({
       }
     }
     onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
-  }, [disabled, constrainedHours, currentMinute, cMinMins, cMaxMins, increment, onChange, sibMins, role]);
+  }, [disabled, constrainedHours, currentMinute, increment, onChange, sibMins, role, isTimeValid]);
 
   const handleConstrainedMinuteChange = useCallback((newIdx: number) => {
     if (disabled) return;

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -228,31 +228,33 @@ export default function TimeCounterInput({
   const highlightTop = Math.floor(visibleItems / 2) * itemHeight;
 
   return (
-    <div className={`relative flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
-      {/* Unified highlight band spanning all wheels */}
-      <div
-        className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-xl"
-        style={{ top: highlightTop, height: itemHeight }}
-      />
+    <div className={`flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
       {constrained ? (
         <>
-          <ScrollWheel
-            key={`h:${constrainedHourLabels.join(',')}`}
-            items={constrainedHourLabels}
-            selectedIndex={constrainedHourIndex}
-            onChange={handleConstrainedHourChange}
-            width={45}
-            hideHighlight
-          />
-          <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
-          <ScrollWheel
-            key={`m:${constrainedMinuteLabels.join(',')}`}
-            items={constrainedMinuteLabels}
-            selectedIndex={constrainedMinuteIndex}
-            onChange={handleConstrainedMinuteChange}
-            width={45}
-            hideHighlight
-          />
+          {/* Hour + minute wheels with highlight band (excludes AM/PM) */}
+          <div className="relative flex items-center gap-0">
+            <div
+              className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-xl"
+              style={{ top: highlightTop, height: itemHeight }}
+            />
+            <ScrollWheel
+              key={`h:${constrainedHourLabels.join(',')}`}
+              items={constrainedHourLabels}
+              selectedIndex={constrainedHourIndex}
+              onChange={handleConstrainedHourChange}
+              width={45}
+              hideHighlight
+            />
+            <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
+            <ScrollWheel
+              key={`m:${constrainedMinuteLabels.join(',')}`}
+              items={constrainedMinuteLabels}
+              selectedIndex={constrainedMinuteIndex}
+              onChange={handleConstrainedMinuteChange}
+              width={45}
+              hideHighlight
+            />
+          </div>
           <div className="w-1" />
           {/* AM/PM wheel: visible but non-interactive, follows the selected hour */}
           <div style={{ pointerEvents: 'none' }}>
@@ -266,7 +268,12 @@ export default function TimeCounterInput({
           </div>
         </>
       ) : (
-        <>
+        <div className="relative flex items-center gap-0">
+          {/* Unified highlight band spanning all wheels */}
+          <div
+            className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-xl"
+            style={{ top: highlightTop, height: itemHeight }}
+          />
           <ScrollWheel
             items={HOUR_LABELS}
             selectedIndex={hourIndex}
@@ -292,7 +299,7 @@ export default function TimeCounterInput({
             width={42}
             hideHighlight
           />
-        </>
+        </div>
       )}
     </div>
   );

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -16,6 +16,9 @@ const HOURS = Array.from({ length: 12 }, (_, i) => i + 1); // 1-12
 const HOUR_LABELS = HOURS.map(String);
 const PERIODS = ['AM', 'PM'];
 
+/** Clock-order sort: 12 comes before 1 (12,1,2,...,11) */
+const CLOCK_ORDER = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+
 function getMinuteOptions(increment: number): number[] {
   const options: number[] = [];
   for (let m = 0; m < 60; m += increment) {
@@ -43,7 +46,6 @@ function timeToMins(t: string): number {
 /** Check if a time (in minutes) falls within a window, handling cross-midnight */
 function isInWindow(mins: number, minMins: number, maxMins: number): boolean {
   if (maxMins <= minMins) {
-    // Cross-midnight (e.g., 22:00–02:00): valid if >= min OR <= max
     return mins >= minMins || mins <= maxMins;
   }
   return mins >= minMins && mins <= maxMins;
@@ -85,66 +87,67 @@ export default function TimeCounterInput({
   }
   const periodIndex = currentPeriod === 'AM' ? 0 : 1;
 
-  // === CONSTRAINED MODE: combined hour+period wheel ===
-  // Instead of separate hour and AM/PM wheels, show a single wheel with
-  // entries like "9 AM", "10 AM", ..., "12 PM", "1 PM", ..., "5 PM"
-  // in chronological order within the constraint window.
+  // === CONSTRAINED MODE: filtered 3-wheel items ===
 
-  const constrainedHours = useMemo(() => {
-    if (!constrained) return [];
-    const items: { label: string; hour24: number }[] = [];
-    const seen = new Set<number>();
-    // Start from the constraint min hour to get correct chronological order
-    // (important for cross-midnight windows like 10 PM – 2 AM)
-    const startHour = Math.floor(cMinMins / 60);
-    for (let i = 0; i < 24; i++) {
-      const h24 = (startHour + i) % 24;
-      if (seen.has(h24)) continue;
-      // Check if any minute increment in this hour is valid
-      let hasValid = false;
-      for (let m = 0; m < 60; m += increment) {
-        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { hasValid = true; break; }
-      }
-      if (hasValid) {
-        seen.add(h24);
-        const { hour12, period } = from24Hour(h24);
-        items.push({ label: `${hour12} ${period}`, hour24: h24 });
-      }
+  const effectivePeriods = useMemo(() => {
+    if (!constrained) return PERIODS;
+    const result: string[] = [];
+    for (let m = 0; m < 720; m += increment) {
+      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('AM'); break; }
     }
-    return items;
+    for (let m = 720; m < 1440; m += increment) {
+      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('PM'); break; }
+    }
+    return result.length > 0 ? result : PERIODS;
   }, [constrained, cMinMins, cMaxMins, increment]);
 
-  const constrainedHourLabels = useMemo(
-    () => constrainedHours.map(h => h.label),
-    [constrainedHours],
-  );
+  const effectivePeriodIndex = constrained
+    ? Math.max(0, effectivePeriods.indexOf(currentPeriod))
+    : periodIndex;
 
-  const constrainedHourIndex = useMemo(() => {
-    const idx = constrainedHours.findIndex(h => h.hour24 === currentHour24);
-    return idx >= 0 ? idx : 0;
-  }, [constrainedHours, currentHour24]);
+  // Valid hours for the current period, in clock order (12, 1, 2, ..., 11)
+  const effectiveHours = useMemo(() => {
+    if (!constrained) return HOURS;
+    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
+    const hours = new Set<number>();
+    for (let m = 0; m < 1440; m += increment) {
+      if (!isInWindow(m, cMinMins, cMaxMins)) continue;
+      const h24 = Math.floor(m / 60);
+      const { hour12, period: p } = from24Hour(h24);
+      if (p === period) hours.add(hour12);
+    }
+    // Use clock order (12, 1, 2, ...) instead of numeric order (1, 2, ..., 12)
+    const result = CLOCK_ORDER.filter(h => hours.has(h));
+    return result.length > 0 ? result : HOURS;
+  }, [constrained, cMinMins, cMaxMins, increment, effectivePeriodIndex, effectivePeriods]);
 
-  // Minutes filtered for the selected constrained hour
-  const constrainedMinutes = useMemo(() => {
-    if (!constrained || constrainedHours.length === 0) return minuteOptions;
-    const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
+  const effectiveHourLabels = useMemo(() => effectiveHours.map(String), [effectiveHours]);
+
+  const effectiveHourIndex = constrained
+    ? Math.max(0, effectiveHours.indexOf(currentHour12))
+    : hourIndex;
+
+  const effectiveMinuteOptions = useMemo(() => {
+    if (!constrained) return minuteOptions;
+    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
+    const hour12 = effectiveHours[Math.min(effectiveHourIndex, effectiveHours.length - 1)];
+    if (!hour12) return minuteOptions;
+    const h24 = to24Hour(hour12, period);
     const result = minuteOptions.filter(m => isInWindow(h24 * 60 + m, cMinMins, cMaxMins));
     return result.length > 0 ? result : minuteOptions;
-  }, [constrained, constrainedHours, constrainedHourIndex, cMinMins, cMaxMins, minuteOptions]);
+  }, [constrained, cMinMins, cMaxMins, effectivePeriodIndex, effectivePeriods, effectiveHourIndex, effectiveHours, minuteOptions]);
 
-  const constrainedMinuteLabels = useMemo(
-    () => constrainedMinutes.map(m => m.toString().padStart(2, '0')),
-    [constrainedMinutes],
-  );
+  const effectiveMinuteLabels = useMemo(() =>
+    effectiveMinuteOptions.map(m => m.toString().padStart(2, '0')),
+    [effectiveMinuteOptions]);
 
-  const constrainedMinuteIndex = useMemo(() => {
-    const idx = constrainedMinutes.indexOf(currentMinute);
-    return idx >= 0 ? idx : 0;
-  }, [constrainedMinutes, currentMinute]);
+  const effectiveMinuteIndex = constrained
+    ? Math.max(0, effectiveMinuteOptions.indexOf(currentMinute))
+    : minuteIndex;
 
   // Keep refs in sync
-  if (prevHourIndex.current === null) prevHourIndex.current = hourIndex;
-  if (prevMinuteIndex.current === null) prevMinuteIndex.current = minuteIndex;
+  if (prevHourIndex.current === null) prevHourIndex.current = constrained ? effectiveHourIndex : hourIndex;
+  if (prevMinuteIndex.current === null) prevMinuteIndex.current = constrained ? effectiveMinuteIndex : minuteIndex;
 
   // === EMIT FUNCTIONS ===
 
@@ -158,36 +161,46 @@ export default function TimeCounterInput({
     onChange(timeStr);
   };
 
-  const handleConstrainedHourChange = useCallback((newIdx: number) => {
+  const emitConstrained = useCallback((periodIdx: number, hourIdx: number, minuteIdx: number) => {
     if (disabled) return;
-    const hourItem = constrainedHours[newIdx];
-    if (!hourItem) return;
-    const h24 = hourItem.hour24;
-    // Keep current minute if still valid for the new hour, otherwise first valid
-    let minute = currentMinute;
-    if (!isInWindow(h24 * 60 + minute, cMinMins, cMaxMins)) {
-      for (let m = 0; m < 60; m += increment) {
-        if (isInWindow(h24 * 60 + m, cMinMins, cMaxMins)) { minute = m; break; }
+    const period = effectivePeriods[periodIdx] as 'AM' | 'PM';
+    let hour12 = effectiveHours[hourIdx];
+    let minute = effectiveMinuteOptions[minuteIdx];
+
+    if (hour12 === undefined) hour12 = effectiveHours[0] || 12;
+    if (minute === undefined) minute = effectiveMinuteOptions[0] || 0;
+
+    const h24 = to24Hour(hour12, period);
+    let timeMins = h24 * 60 + minute;
+
+    // If this combination isn't valid (can happen during period/hour transitions),
+    // find the nearest valid time in the constraint window
+    if (!isInWindow(timeMins, cMinMins, cMaxMins)) {
+      let bestTime = cMinMins;
+      let bestDist = Infinity;
+      for (let m = 0; m < 1440; m += increment) {
+        if (!isInWindow(m, cMinMins, cMaxMins)) continue;
+        const dist = Math.min(Math.abs(m - timeMins), 1440 - Math.abs(m - timeMins));
+        if (dist < bestDist) { bestDist = dist; bestTime = m; }
       }
+      timeMins = bestTime;
     }
-    onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
-  }, [disabled, constrainedHours, currentMinute, cMinMins, cMaxMins, increment, onChange]);
 
-  const handleConstrainedMinuteChange = useCallback((newIdx: number) => {
-    if (disabled) return;
-    const minute = constrainedMinutes[newIdx];
-    if (minute === undefined) return;
-    const h24 = constrainedHours[constrainedHourIndex]?.hour24 ?? 0;
-    onChange(`${h24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
-  }, [disabled, constrainedMinutes, constrainedHours, constrainedHourIndex, onChange]);
+    const h = Math.floor(timeMins / 60);
+    const min = timeMins % 60;
+    onChange(`${h.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}`);
+  }, [disabled, effectivePeriods, effectiveHours, effectiveMinuteOptions, cMinMins, cMaxMins, increment, onChange]);
 
-  // === UNCONSTRAINED HANDLERS ===
+  // === HANDLERS ===
 
   const handleHourChange = (newHourIndex: number) => {
+    if (constrained) {
+      emitConstrained(effectivePeriodIndex, newHourIndex, effectiveMinuteIndex);
+      return;
+    }
     const prev = prevHourIndex.current ?? hourIndex;
     let newPeriod = periodIndex;
 
-    // Detect crossing the 11↔12 boundary (noon/midnight crossing)
     if (prev === 10 && newHourIndex === 11) {
       newPeriod = periodIndex === 0 ? 1 : 0;
     } else if (prev === 11 && newHourIndex === 10) {
@@ -199,6 +212,10 @@ export default function TimeCounterInput({
   };
 
   const handleMinuteChange = (newMinuteIndex: number) => {
+    if (constrained) {
+      emitConstrained(effectivePeriodIndex, effectiveHourIndex, newMinuteIndex);
+      return;
+    }
     const prev = prevMinuteIndex.current ?? minuteIndex;
     const lastIdx = minuteOptions.length - 1;
     let newHourIdx = hourIndex;
@@ -222,6 +239,10 @@ export default function TimeCounterInput({
   };
 
   const handlePeriodChange = (newPeriodIndex: number) => {
+    if (constrained) {
+      emitConstrained(newPeriodIndex, effectiveHourIndex, effectiveMinuteIndex);
+      return;
+    }
     emit(hourIndex, minuteIndex, newPeriodIndex);
   };
 
@@ -231,6 +252,13 @@ export default function TimeCounterInput({
   const visibleItems = 5;
   const highlightTop = Math.floor(visibleItems / 2) * itemHeight;
 
+  const hourItems = constrained ? effectiveHourLabels : HOUR_LABELS;
+  const hourSelIdx = constrained ? effectiveHourIndex : hourIndex;
+  const minItems = constrained ? effectiveMinuteLabels : minuteLabels;
+  const minSelIdx = constrained ? effectiveMinuteIndex : minuteIndex;
+  const periodItems = constrained ? effectivePeriods : PERIODS;
+  const periodSelIdx = constrained ? effectivePeriodIndex : periodIndex;
+
   return (
     <div className={`relative flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
       {/* Unified highlight band spanning all wheels */}
@@ -238,55 +266,34 @@ export default function TimeCounterInput({
         className="absolute left-0 right-0 pointer-events-none bg-blue-200/50 dark:bg-blue-700/30 z-0 rounded-xl"
         style={{ top: highlightTop, height: itemHeight }}
       />
-      {constrained ? (
-        <>
-          <ScrollWheel
-            key={`ch:${constrainedHourLabels.join(',')}`}
-            items={constrainedHourLabels}
-            selectedIndex={constrainedHourIndex}
-            onChange={handleConstrainedHourChange}
-            width={62}
-            hideHighlight
-          />
-          <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
-          <ScrollWheel
-            key={`cm:${constrainedMinuteLabels.join(',')}`}
-            items={constrainedMinuteLabels}
-            selectedIndex={constrainedMinuteIndex}
-            onChange={handleConstrainedMinuteChange}
-            width={45}
-            hideHighlight
-          />
-        </>
-      ) : (
-        <>
-          <ScrollWheel
-            items={HOUR_LABELS}
-            selectedIndex={hourIndex}
-            onChange={handleHourChange}
-            width={45}
-            loop
-            hideHighlight
-          />
-          <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
-          <ScrollWheel
-            items={minuteLabels}
-            selectedIndex={minuteIndex}
-            onChange={handleMinuteChange}
-            width={45}
-            loop
-            hideHighlight
-          />
-          <div className="w-1" />
-          <ScrollWheel
-            items={PERIODS}
-            selectedIndex={periodIndex}
-            onChange={handlePeriodChange}
-            width={42}
-            hideHighlight
-          />
-        </>
-      )}
+      <ScrollWheel
+        key={constrained ? `h:${hourItems.join(',')}` : 'h'}
+        items={hourItems}
+        selectedIndex={hourSelIdx}
+        onChange={handleHourChange}
+        width={45}
+        loop={!constrained}
+        hideHighlight
+      />
+      <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
+      <ScrollWheel
+        key={constrained ? `m:${minItems.join(',')}` : 'm'}
+        items={minItems}
+        selectedIndex={minSelIdx}
+        onChange={handleMinuteChange}
+        width={45}
+        loop={!constrained}
+        hideHighlight
+      />
+      <div className="w-1" />
+      <ScrollWheel
+        key={constrained ? `p:${periodItems.join(',')}` : 'p'}
+        items={periodItems}
+        selectedIndex={periodSelIdx}
+        onChange={handlePeriodChange}
+        width={42}
+        hideHighlight
+      />
     </div>
   );
 }

--- a/components/TimeCounterInput.tsx
+++ b/components/TimeCounterInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useCallback } from 'react';
 import ScrollWheel from './ScrollWheel';
 
 interface TimeCounterInputProps {
@@ -8,6 +8,8 @@ interface TimeCounterInputProps {
   onChange: (value: string | null) => void;
   increment?: number; // minutes (used to generate minute options)
   disabled?: boolean;
+  constraintMin?: string; // HH:MM 24h — lower bound of valid time window
+  constraintMax?: string; // HH:MM 24h — upper bound of valid time window
 }
 
 const HOURS = Array.from({ length: 12 }, (_, i) => i + 1); // 1-12
@@ -33,11 +35,27 @@ function from24Hour(hour24: number): { hour12: number; period: 'AM' | 'PM' } {
   return { hour12, period };
 }
 
+function timeToMins(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** Check if a time (in minutes) falls within a window, handling cross-midnight */
+function isInWindow(mins: number, minMins: number, maxMins: number): boolean {
+  if (maxMins <= minMins) {
+    // Cross-midnight (e.g., 22:00–02:00): valid if >= min OR <= max
+    return mins >= minMins || mins <= maxMins;
+  }
+  return mins >= minMins && mins <= maxMins;
+}
+
 export default function TimeCounterInput({
   value,
   onChange,
   increment = 15,
   disabled = false,
+  constraintMin,
+  constraintMax,
 }: TimeCounterInputProps) {
   const minuteOptions = useMemo(() => getMinuteOptions(increment), [increment]);
   const minuteLabels = useMemo(() => minuteOptions.map(m => m.toString().padStart(2, '0')), [minuteOptions]);
@@ -45,28 +63,88 @@ export default function TimeCounterInput({
   const prevHourIndex = useRef<number | null>(null);
   const prevMinuteIndex = useRef<number | null>(null);
 
-  // Parse current value
-  let hourIndex = 8; // default 9 AM -> index 8 (9-1=8 in 0-based)
-  let minuteIndex = 0;
-  let periodIndex = 0; // AM
+  const constrained = !!constraintMin && !!constraintMax;
+  const cMinMins = constrained ? timeToMins(constraintMin!) : 0;
+  const cMaxMins = constrained ? timeToMins(constraintMax!) : 0;
 
+  // Parse current value
+  let currentHour24 = 9, currentMinute = 0;
   if (value) {
-    const [h24, m] = value.split(':').map(Number);
-    const { hour12, period } = from24Hour(h24);
-    hourIndex = hour12 - 1; // 1-12 -> 0-11
-    minuteIndex = minuteOptions.indexOf(m);
-    if (minuteIndex === -1) {
-      const nearest = minuteOptions.reduce((prev, curr) =>
-        Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
-      );
-      minuteIndex = minuteOptions.indexOf(nearest);
-    }
-    periodIndex = period === 'AM' ? 0 : 1;
+    [currentHour24, currentMinute] = value.split(':').map(Number);
   }
+  const { hour12: currentHour12, period: currentPeriod } = from24Hour(currentHour24);
+
+  // === UNCONSTRAINED MODE indices (existing logic) ===
+  let hourIndex = currentHour12 - 1; // 1-12 -> 0-11
+  let minuteIndex = minuteOptions.indexOf(currentMinute);
+  if (minuteIndex === -1) {
+    const nearest = minuteOptions.reduce((prev, curr) =>
+      Math.abs(curr - currentMinute) < Math.abs(prev - currentMinute) ? curr : prev
+    );
+    minuteIndex = minuteOptions.indexOf(nearest);
+  }
+  const periodIndex = currentPeriod === 'AM' ? 0 : 1;
+
+  // === CONSTRAINED MODE: compute effective (filtered) wheel items ===
+  const effectivePeriods = useMemo(() => {
+    if (!constrained) return PERIODS;
+    const result: string[] = [];
+    for (let m = 0; m < 720; m += increment) {
+      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('AM'); break; }
+    }
+    for (let m = 720; m < 1440; m += increment) {
+      if (isInWindow(m, cMinMins, cMaxMins)) { result.push('PM'); break; }
+    }
+    return result.length > 0 ? result : PERIODS;
+  }, [constrained, cMinMins, cMaxMins, increment]);
+
+  const effectivePeriodIndex = constrained
+    ? Math.max(0, effectivePeriods.indexOf(currentPeriod))
+    : periodIndex;
+
+  const effectiveHours = useMemo(() => {
+    if (!constrained) return HOURS;
+    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
+    const hours = new Set<number>();
+    for (let m = 0; m < 1440; m += increment) {
+      if (!isInWindow(m, cMinMins, cMaxMins)) continue;
+      const h24 = Math.floor(m / 60);
+      const { hour12, period: p } = from24Hour(h24);
+      if (p === period) hours.add(hour12);
+    }
+    const result = HOURS.filter(h => hours.has(h));
+    return result.length > 0 ? result : HOURS;
+  }, [constrained, cMinMins, cMaxMins, increment, effectivePeriodIndex, effectivePeriods]);
+
+  const effectiveHourLabels = useMemo(() => effectiveHours.map(String), [effectiveHours]);
+
+  const effectiveHourIndex = constrained
+    ? Math.max(0, effectiveHours.indexOf(currentHour12))
+    : hourIndex;
+
+  const effectiveMinuteOptions = useMemo(() => {
+    if (!constrained) return minuteOptions;
+    const period = effectivePeriods[effectivePeriodIndex] as 'AM' | 'PM';
+    const hour12 = effectiveHours[Math.min(effectiveHourIndex, effectiveHours.length - 1)];
+    if (!hour12) return minuteOptions;
+    const h24 = to24Hour(hour12, period);
+    const result = minuteOptions.filter(m => isInWindow(h24 * 60 + m, cMinMins, cMaxMins));
+    return result.length > 0 ? result : minuteOptions;
+  }, [constrained, cMinMins, cMaxMins, effectivePeriodIndex, effectivePeriods, effectiveHourIndex, effectiveHours, minuteOptions]);
+
+  const effectiveMinuteLabels = useMemo(() =>
+    effectiveMinuteOptions.map(m => m.toString().padStart(2, '0')),
+    [effectiveMinuteOptions]);
+
+  const effectiveMinuteIndex = constrained
+    ? Math.max(0, effectiveMinuteOptions.indexOf(currentMinute))
+    : minuteIndex;
 
   // Keep refs in sync with current parsed values
-  if (prevHourIndex.current === null) prevHourIndex.current = hourIndex;
-  if (prevMinuteIndex.current === null) prevMinuteIndex.current = minuteIndex;
+  if (prevHourIndex.current === null) prevHourIndex.current = constrained ? effectiveHourIndex : hourIndex;
+  if (prevMinuteIndex.current === null) prevMinuteIndex.current = constrained ? effectiveMinuteIndex : minuteIndex;
+
+  // === EMIT FUNCTIONS ===
 
   const emit = (h: number, m: number, p: number) => {
     if (disabled) return;
@@ -78,7 +156,44 @@ export default function TimeCounterInput({
     onChange(timeStr);
   };
 
+  const emitConstrained = useCallback((periodIdx: number, hourIdx: number, minuteIdx: number) => {
+    if (disabled) return;
+    const period = effectivePeriods[periodIdx] as 'AM' | 'PM';
+    let hour12 = effectiveHours[hourIdx];
+    let minute = effectiveMinuteOptions[minuteIdx];
+
+    // Safety: if index out of range, use first valid value
+    if (hour12 === undefined) hour12 = effectiveHours[0] || 12;
+    if (minute === undefined) minute = effectiveMinuteOptions[0] || 0;
+
+    const h24 = to24Hour(hour12, period);
+    let timeMins = h24 * 60 + minute;
+
+    // If this combination isn't valid (can happen during period/hour transitions),
+    // find the nearest valid time in the constraint window
+    if (!isInWindow(timeMins, cMinMins, cMaxMins)) {
+      let bestTime = cMinMins;
+      let bestDist = Infinity;
+      for (let m = 0; m < 1440; m += increment) {
+        if (!isInWindow(m, cMinMins, cMaxMins)) continue;
+        const dist = Math.min(Math.abs(m - timeMins), 1440 - Math.abs(m - timeMins));
+        if (dist < bestDist) { bestDist = dist; bestTime = m; }
+      }
+      timeMins = bestTime;
+    }
+
+    const h = Math.floor(timeMins / 60);
+    const min = timeMins % 60;
+    onChange(`${h.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}`);
+  }, [disabled, effectivePeriods, effectiveHours, effectiveMinuteOptions, cMinMins, cMaxMins, increment, onChange]);
+
+  // === HANDLERS ===
+
   const handleHourChange = (newHourIndex: number) => {
+    if (constrained) {
+      emitConstrained(effectivePeriodIndex, newHourIndex, effectiveMinuteIndex);
+      return;
+    }
     const prev = prevHourIndex.current ?? hourIndex;
     let newPeriod = periodIndex;
 
@@ -97,6 +212,10 @@ export default function TimeCounterInput({
   };
 
   const handleMinuteChange = (newMinuteIndex: number) => {
+    if (constrained) {
+      emitConstrained(effectivePeriodIndex, effectiveHourIndex, newMinuteIndex);
+      return;
+    }
     const prev = prevMinuteIndex.current ?? minuteIndex;
     const lastIdx = minuteOptions.length - 1;
     let newHourIdx = hourIndex;
@@ -125,12 +244,25 @@ export default function TimeCounterInput({
   };
 
   const handlePeriodChange = (newPeriodIndex: number) => {
+    if (constrained) {
+      emitConstrained(newPeriodIndex, effectiveHourIndex, effectiveMinuteIndex);
+      return;
+    }
     emit(hourIndex, minuteIndex, newPeriodIndex);
   };
+
+  // === RENDER ===
 
   const itemHeight = 40;
   const visibleItems = 5;
   const highlightTop = Math.floor(visibleItems / 2) * itemHeight;
+
+  const hourItems = constrained ? effectiveHourLabels : HOUR_LABELS;
+  const hourSelIdx = constrained ? effectiveHourIndex : hourIndex;
+  const minItems = constrained ? effectiveMinuteLabels : minuteLabels;
+  const minSelIdx = constrained ? effectiveMinuteIndex : minuteIndex;
+  const periodItems = constrained ? effectivePeriods : PERIODS;
+  const periodSelIdx = constrained ? effectivePeriodIndex : periodIndex;
 
   return (
     <div className={`relative flex items-center gap-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
@@ -140,26 +272,29 @@ export default function TimeCounterInput({
         style={{ top: highlightTop, height: itemHeight }}
       />
       <ScrollWheel
-        items={HOUR_LABELS}
-        selectedIndex={hourIndex}
+        key={constrained ? `h:${hourItems.join(',')}` : 'h'}
+        items={hourItems}
+        selectedIndex={hourSelIdx}
         onChange={handleHourChange}
         width={45}
-        loop
+        loop={!constrained}
         hideHighlight
       />
       <div className="text-xl font-semibold text-gray-900 dark:text-white px-0.5 self-center">:</div>
       <ScrollWheel
-        items={minuteLabels}
-        selectedIndex={minuteIndex}
+        key={constrained ? `m:${minItems.join(',')}` : 'm'}
+        items={minItems}
+        selectedIndex={minSelIdx}
         onChange={handleMinuteChange}
         width={45}
-        loop
+        loop={!constrained}
         hideHighlight
       />
       <div className="w-1" />
       <ScrollWheel
-        items={PERIODS}
-        selectedIndex={periodIndex}
+        key={constrained ? `p:${periodItems.join(',')}` : 'p'}
+        items={periodItems}
+        selectedIndex={periodSelIdx}
         onChange={handlePeriodChange}
         width={42}
         hideHighlight

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -131,35 +131,24 @@ export default function TimeGridModal({
     setLocalMaxTime(initMaxTime);
   }, [minValue, maxValue, isOpen]);
 
-  // In constrained mode, the poll window is less than 24h when constraintMin !== constraintMax.
-  // Prevent min == max (which means a 24h window) since that would exceed the poll window.
-  const constraintIs24h = !constraintMin || !constraintMax || constraintMin === constraintMax;
-
   // Allow free movement of min and max — cross-midnight ranges (max < min) are valid
   // When constraints exist (voter editing a poll window), clamp to poll bounds
+  // Note: min==max prevention is handled by the wheel item filtering in TimeCounterInput
   const handleMinChange = useCallback((newMin: string | null) => {
     if (newMin && constraintMin && constraintMax) {
       newMin = clampTimeMin(newMin, constraintMin, constraintMax);
     }
-    // Prevent min == max in constrained mode (would imply 24h, exceeding poll window)
-    if (newMin && newMin === localMaxTime && !constraintIs24h) {
-      return; // reject — wheel will snap back via correctPosition
-    }
     setLocalMinTime(newMin);
     setTransitionsEnabled(true);
-  }, [constraintMin, constraintMax, localMaxTime, constraintIs24h]);
+  }, [constraintMin, constraintMax]);
 
   const handleMaxChange = useCallback((newMax: string | null) => {
     if (newMax && constraintMin && constraintMax) {
       newMax = clampTimeMax(newMax, constraintMin, constraintMax);
     }
-    // Prevent min == max in constrained mode (would imply 24h, exceeding poll window)
-    if (newMax && newMax === localMinTime && !constraintIs24h) {
-      return; // reject — wheel will snap back via correctPosition
-    }
     setLocalMaxTime(newMax);
     setTransitionsEnabled(true);
-  }, [constraintMin, constraintMax, localMinTime, constraintIs24h]);
+  }, [constraintMin, constraintMax]);
 
   // Reset transitions when modal reopens so the duration bar doesn't animate on open
   useEffect(() => {

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -23,12 +23,46 @@ function minutesToTime(totalMinutes: number): string {
   return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
 }
 
+/** Clamp the "start" time so it can't go below the poll window's min */
+function clampTimeMin(value: string, constraintMin: string, constraintMax: string): string {
+  const crossesMidnight = constraintMax <= constraintMin;
+  if (!crossesMidnight) {
+    // Normal window: min can't go below constraintMin
+    return value < constraintMin ? constraintMin : value;
+  } else {
+    // Cross-midnight: excluded zone is (constraintMax, constraintMin)
+    // If value is in the excluded zone, snap to constraintMin
+    if (value > constraintMax && value < constraintMin) {
+      return constraintMin;
+    }
+    return value;
+  }
+}
+
+/** Clamp the "end" time so it can't go above the poll window's max */
+function clampTimeMax(value: string, constraintMin: string, constraintMax: string): string {
+  const crossesMidnight = constraintMax <= constraintMin;
+  if (!crossesMidnight) {
+    // Normal window: max can't go above constraintMax
+    return value > constraintMax ? constraintMax : value;
+  } else {
+    // Cross-midnight: excluded zone is (constraintMax, constraintMin)
+    // If value is in the excluded zone, snap to constraintMax
+    if (value > constraintMax && value < constraintMin) {
+      return constraintMax;
+    }
+    return value;
+  }
+}
+
 interface TimeGridModalProps {
   isOpen: boolean;
   onClose: () => void;
   minValue: string | null;
   maxValue: string | null;
   onApply: (min: string | null, max: string | null) => void;
+  constraintMin?: string;  // Poll window's min — voter's min can't go below this
+  constraintMax?: string;  // Poll window's max — voter's max can't go above this
 }
 
 export default function TimeGridModal({
@@ -37,6 +71,8 @@ export default function TimeGridModal({
   minValue,
   maxValue,
   onApply,
+  constraintMin,
+  constraintMax,
 }: TimeGridModalProps) {
   const [localMinTime, setLocalMinTime] = useState<string | null>(minValue);
   const [localMaxTime, setLocalMaxTime] = useState<string | null>(maxValue);
@@ -96,15 +132,24 @@ export default function TimeGridModal({
   }, [minValue, maxValue, isOpen]);
 
   // Allow free movement of min and max — cross-midnight ranges (max < min) are valid
+  // When constraints exist (voter editing a poll window), clamp to poll bounds
   const handleMinChange = useCallback((newMin: string | null) => {
-    setLocalMinTime(newMin);
+    if (newMin && constraintMin && constraintMax) {
+      setLocalMinTime(clampTimeMin(newMin, constraintMin, constraintMax));
+    } else {
+      setLocalMinTime(newMin);
+    }
     setTransitionsEnabled(true);
-  }, []);
+  }, [constraintMin, constraintMax]);
 
   const handleMaxChange = useCallback((newMax: string | null) => {
-    setLocalMaxTime(newMax);
+    if (newMax && constraintMin && constraintMax) {
+      setLocalMaxTime(clampTimeMax(newMax, constraintMin, constraintMax));
+    } else {
+      setLocalMaxTime(newMax);
+    }
     setTransitionsEnabled(true);
-  }, []);
+  }, [constraintMin, constraintMax]);
 
   // Reset transitions when modal reopens so the duration bar doesn't animate on open
   useEffect(() => {

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -131,25 +131,35 @@ export default function TimeGridModal({
     setLocalMaxTime(initMaxTime);
   }, [minValue, maxValue, isOpen]);
 
+  // In constrained mode, the poll window is less than 24h when constraintMin !== constraintMax.
+  // Prevent min == max (which means a 24h window) since that would exceed the poll window.
+  const constraintIs24h = !constraintMin || !constraintMax || constraintMin === constraintMax;
+
   // Allow free movement of min and max — cross-midnight ranges (max < min) are valid
   // When constraints exist (voter editing a poll window), clamp to poll bounds
   const handleMinChange = useCallback((newMin: string | null) => {
     if (newMin && constraintMin && constraintMax) {
-      setLocalMinTime(clampTimeMin(newMin, constraintMin, constraintMax));
-    } else {
-      setLocalMinTime(newMin);
+      newMin = clampTimeMin(newMin, constraintMin, constraintMax);
     }
+    // Prevent min == max in constrained mode (would imply 24h, exceeding poll window)
+    if (newMin && newMin === localMaxTime && !constraintIs24h) {
+      return; // reject — wheel will snap back via correctPosition
+    }
+    setLocalMinTime(newMin);
     setTransitionsEnabled(true);
-  }, [constraintMin, constraintMax]);
+  }, [constraintMin, constraintMax, localMaxTime, constraintIs24h]);
 
   const handleMaxChange = useCallback((newMax: string | null) => {
     if (newMax && constraintMin && constraintMax) {
-      setLocalMaxTime(clampTimeMax(newMax, constraintMin, constraintMax));
-    } else {
-      setLocalMaxTime(newMax);
+      newMax = clampTimeMax(newMax, constraintMin, constraintMax);
     }
+    // Prevent min == max in constrained mode (would imply 24h, exceeding poll window)
+    if (newMax && newMax === localMinTime && !constraintIs24h) {
+      return; // reject — wheel will snap back via correctPosition
+    }
+    setLocalMaxTime(newMax);
     setTransitionsEnabled(true);
-  }, [constraintMin, constraintMax]);
+  }, [constraintMin, constraintMax, localMinTime, constraintIs24h]);
 
   // Reset transitions when modal reopens so the duration bar doesn't animate on open
   useEffect(() => {

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -252,6 +252,8 @@ export default function TimeGridModal({
             onMinChange={handleMinChange}
             onMaxChange={handleMaxChange}
             increment={15}
+            constraintMin={constraintMin}
+            constraintMax={constraintMax}
           />
         </div>
       </div>

--- a/components/TimeMinMaxCounter.tsx
+++ b/components/TimeMinMaxCounter.tsx
@@ -9,6 +9,8 @@ interface TimeMinMaxCounterProps {
   onMaxChange: (value: string | null) => void;
   increment?: number; // minutes
   disabled?: boolean;
+  constraintMin?: string; // HH:MM 24h — poll window lower bound
+  constraintMax?: string; // HH:MM 24h — poll window upper bound
 }
 
 export default function TimeMinMaxCounter({
@@ -18,6 +20,8 @@ export default function TimeMinMaxCounter({
   onMaxChange,
   increment = 15,
   disabled = false,
+  constraintMin,
+  constraintMax,
 }: TimeMinMaxCounterProps) {
   return (
     <div className="flex justify-center items-center gap-1.5">
@@ -26,6 +30,8 @@ export default function TimeMinMaxCounter({
         onChange={onMinChange}
         increment={increment}
         disabled={disabled}
+        constraintMin={constraintMin}
+        constraintMax={constraintMax}
       />
       <span className="text-base text-gray-400 dark:text-gray-500">–</span>
       <TimeCounterInput
@@ -33,6 +39,8 @@ export default function TimeMinMaxCounter({
         onChange={onMaxChange}
         increment={increment}
         disabled={disabled}
+        constraintMin={constraintMin}
+        constraintMax={constraintMax}
       />
     </div>
   );

--- a/components/TimeMinMaxCounter.tsx
+++ b/components/TimeMinMaxCounter.tsx
@@ -32,6 +32,8 @@ export default function TimeMinMaxCounter({
         disabled={disabled}
         constraintMin={constraintMin}
         constraintMax={constraintMax}
+        siblingValue={maxValue}
+        role="min"
       />
       <span className="text-base text-gray-400 dark:text-gray-500">–</span>
       <TimeCounterInput
@@ -41,6 +43,8 @@ export default function TimeMinMaxCounter({
         disabled={disabled}
         constraintMin={constraintMin}
         constraintMax={constraintMax}
+        siblingValue={minValue}
+        role="max"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Constrain time wheel pickers so voters can only select times within the poll creator's original time window — invalid hours/minutes are hidden, not clamped after the fact
- For non-cross-midnight poll windows (e.g., 9AM–5PM), enforce voter min < max to prevent cross-midnight ranges that exceed the poll window
- AM/PM wheel is visible but non-interactive in constrained mode — auto-follows the selected hour for chronological ordering
- Fix 429 rate-limit errors from rapid `fetchPollResults` calls with in-flight guard + 2-second cooldown
- Blue highlight band scoped to hour+minute wheels only (excludes non-interactive AM/PM)

## Test plan
- [ ] Create a participation poll with a 9AM–5PM time window
- [ ] Vote and verify the time wheels only show hours 9–5 and valid minutes within that range
- [ ] Verify min picker cannot exceed max picker (and vice versa)
- [ ] Verify AM/PM wheel auto-switches when scrolling across noon boundary
- [ ] Test cross-midnight poll windows (e.g., 10PM–2AM) still work correctly
- [ ] Verify no 429 errors in console during rapid poll result loading

https://claude.ai/code/session_017UkWLj51oVBfYxoyVqAd41