### PR TITLE
Time range validation and voter toggle checkboxes

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -449,6 +449,28 @@ function CreatePollContent() {
       if (emptyDays.length > 0) {
         return "Every selected day must have at least one time slot. Add time slots or remove empty days.";
       }
+      // Check minimum duration on all time windows
+      if (durationMinEnabled && durationMinValue != null) {
+        const minDurMinutes = Math.round(durationMinValue * 60);
+        if (minDurMinutes > 0) {
+          const tooShort = dayTimeWindows.some(dtw =>
+            dtw.windows.some(w => {
+              const [sh, sm] = w.min.split(':').map(Number);
+              const [eh, em] = w.max.split(':').map(Number);
+              const startMins = sh * 60 + sm;
+              const endMins = eh * 60 + em;
+              const dur = endMins <= startMins ? (1440 - startMins) + endMins : endMins - startMins;
+              return dur < minDurMinutes;
+            })
+          );
+          if (tooShort) {
+            const hours = Math.floor(minDurMinutes / 60);
+            const mins = minDurMinutes % 60;
+            const label = hours > 0 && mins > 0 ? `${hours}h ${mins}m` : hours > 0 ? `${hours}h` : `${mins}m`;
+            return `Each time window must be at least ${label} long (the minimum duration).`;
+          }
+        }
+      }
     }
 
     return null;

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -19,6 +19,7 @@ import MinMaxCounter from "@/components/MinMaxCounter";
 import ParticipationConditions, { DayTimeWindow } from "@/components/ParticipationConditions";
 import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
 import ReferenceLocationInput from "@/components/ReferenceLocationInput";
+import { windowDurationMinutes, formatDurationLabel } from "@/lib/timeUtils";
 export const dynamic = 'force-dynamic';
 
 // Matches the rendered height of a single-line <input> with py-2 padding.
@@ -454,20 +455,10 @@ function CreatePollContent() {
         const minDurMinutes = Math.round(durationMinValue * 60);
         if (minDurMinutes > 0) {
           const tooShort = dayTimeWindows.some(dtw =>
-            dtw.windows.some(w => {
-              const [sh, sm] = w.min.split(':').map(Number);
-              const [eh, em] = w.max.split(':').map(Number);
-              const startMins = sh * 60 + sm;
-              const endMins = eh * 60 + em;
-              const dur = endMins <= startMins ? (1440 - startMins) + endMins : endMins - startMins;
-              return dur < minDurMinutes;
-            })
+            dtw.windows.some(w => windowDurationMinutes(w) < minDurMinutes)
           );
           if (tooShort) {
-            const hours = Math.floor(minDurMinutes / 60);
-            const mins = minDurMinutes % 60;
-            const label = hours > 0 && mins > 0 ? `${hours}h ${mins}m` : hours > 0 ? `${hours}h` : `${mins}m`;
-            return `Each time window must be at least ${label} long (the minimum duration).`;
+            return `Each time window must be at least ${formatDurationLabel(minDurMinutes)} long (the minimum duration).`;
           }
         }
       }

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -875,6 +875,43 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       return;
     }
 
+    // Participation poll time window validation
+    if (poll.poll_type === 'participation' && yesNoChoice === 'yes' && !isAbstaining) {
+      const pollHasTimeWindows = poll.day_time_windows && poll.day_time_windows.some(
+        (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) => dtw.windows.length > 0
+      );
+      if (pollHasTimeWindows) {
+        const enabledWindows = voterDayTimeWindows.flatMap(
+          (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) =>
+            dtw.windows.filter((w: { enabled?: boolean }) => w.enabled !== false)
+        );
+        if (enabledWindows.length === 0) {
+          setVoteError("Please enable at least one time window, or vote No.");
+          return;
+        }
+        // Check minimum duration on enabled windows
+        const minDurMinutes = durationMinEnabled && durationMinValue != null
+          ? Math.round(durationMinValue * 60) : null;
+        if (minDurMinutes != null && minDurMinutes > 0) {
+          const tooShort = enabledWindows.some((w: { min: string; max: string }) => {
+            const [sh, sm] = w.min.split(':').map(Number);
+            const [eh, em] = w.max.split(':').map(Number);
+            const startMins = sh * 60 + sm;
+            const endMins = eh * 60 + em;
+            const dur = endMins <= startMins ? (1440 - startMins) + endMins : endMins - startMins;
+            return dur < minDurMinutes;
+          });
+          if (tooShort) {
+            const hours = Math.floor(minDurMinutes / 60);
+            const mins = minDurMinutes % 60;
+            const label = hours > 0 && mins > 0 ? `${hours}h ${mins}m` : hours > 0 ? `${hours}h` : `${mins}m`;
+            setVoteError(`Each enabled time window must be at least ${label} long.`);
+            return;
+          }
+        }
+      }
+    }
+
     if (poll.poll_type === 'ranked_choice' && !isAbstaining) {
       const filteredRankedChoices = rankedChoices.filter(choice => choice && choice.trim().length > 0);
       if (filteredRankedChoices.length === 0) {

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1815,7 +1815,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
                   {hasTimeWindowTooShort && (
                     <div className="mb-3 p-3 bg-red-50 dark:bg-red-900/30 border border-red-300 dark:border-red-600 rounded-md">
-                      <p className="text-sm text-red-700 dark:text-red-300">Some time windows are shorter than your minimum duration.</p>
+                      <p className="text-sm text-red-700 dark:text-red-300">Time window cannot be shorter than minimum duration.</p>
                     </div>
                   )}
 

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -32,6 +32,7 @@ import ParticipationConditions from "@/components/ParticipationConditions";
 import TimeSlotRoundsDisplay from "@/components/TimeSlotRoundsDisplay";
 import PollDetails from "@/components/PollDetails";
 import SubPollField from "@/components/SubPollField";
+import { windowDurationMinutes, formatDurationLabel } from "@/lib/timeUtils";
 
 interface PollPageClientProps {
   poll: Poll;
@@ -138,15 +139,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       ? Math.round(durationMinValue * 60) : null;
     if (minDurMinutes == null || minDurMinutes <= 0) return false;
     return voterDayTimeWindows.some((dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) =>
-      dtw.windows.some((w: { min: string; max: string; enabled?: boolean }) => {
-        if (w.enabled === false) return false;
-        const [sh, sm] = w.min.split(':').map(Number);
-        const [eh, em] = w.max.split(':').map(Number);
-        const startMins = sh * 60 + sm;
-        const endMins = eh * 60 + em;
-        const dur = endMins <= startMins ? (1440 - startMins) + endMins : endMins - startMins;
-        return dur < minDurMinutes;
-      })
+      dtw.windows.some((w: { min: string; max: string; enabled?: boolean }) =>
+        w.enabled !== false && windowDurationMinutes(w) < minDurMinutes
+      )
     );
   }, [poll.poll_type, voterDayTimeWindows, durationMinEnabled, durationMinValue]);
 
@@ -912,19 +907,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         const minDurMinutes = durationMinEnabled && durationMinValue != null
           ? Math.round(durationMinValue * 60) : null;
         if (minDurMinutes != null && minDurMinutes > 0) {
-          const tooShort = enabledWindows.some((w: { min: string; max: string }) => {
-            const [sh, sm] = w.min.split(':').map(Number);
-            const [eh, em] = w.max.split(':').map(Number);
-            const startMins = sh * 60 + sm;
-            const endMins = eh * 60 + em;
-            const dur = endMins <= startMins ? (1440 - startMins) + endMins : endMins - startMins;
-            return dur < minDurMinutes;
-          });
+          const tooShort = enabledWindows.some((w: { min: string; max: string }) =>
+            windowDurationMinutes(w) < minDurMinutes
+          );
           if (tooShort) {
-            const hours = Math.floor(minDurMinutes / 60);
-            const mins = minDurMinutes % 60;
-            const label = hours > 0 && mins > 0 ? `${hours}h ${mins}m` : hours > 0 ? `${hours}h` : `${mins}m`;
-            setVoteError(`Each enabled time window must be at least ${label} long.`);
+            setVoteError(`Each enabled time window must be at least ${formatDurationLabel(minDurMinutes)} long.`);
             return;
           }
         }

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -131,6 +131,25 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     return participatingVoterIds.includes(userVoteData.id);
   }, [poll.poll_type, userVoteData, participatingVoterIds]);
   
+  // Check if any enabled voter time window is shorter than the minimum duration
+  const hasTimeWindowTooShort = useMemo(() => {
+    if (poll.poll_type !== 'participation') return false;
+    const minDurMinutes = durationMinEnabled && durationMinValue != null
+      ? Math.round(durationMinValue * 60) : null;
+    if (minDurMinutes == null || minDurMinutes <= 0) return false;
+    return voterDayTimeWindows.some((dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) =>
+      dtw.windows.some((w: { min: string; max: string; enabled?: boolean }) => {
+        if (w.enabled === false) return false;
+        const [sh, sm] = w.min.split(':').map(Number);
+        const [eh, em] = w.max.split(':').map(Number);
+        const startMins = sh * 60 + sm;
+        const endMins = eh * 60 + em;
+        const dur = endMins <= startMins ? (1440 - startMins) + endMins : endMins - startMins;
+        return dur < minDurMinutes;
+      })
+    );
+  }, [poll.poll_type, voterDayTimeWindows, durationMinEnabled, durationMinValue]);
+
   const isPollClosed = useMemo(() => {
     // If manually reopened, stay open regardless of deadline
     if (manuallyReopened && !pollClosed) return false;
@@ -1793,6 +1812,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       placeholder="Enter your name..."
                     />
                   </div>
+
+                  {hasTimeWindowTooShort && (
+                    <div className="mb-3 p-3 bg-red-50 dark:bg-red-900/30 border border-red-300 dark:border-red-600 rounded-md">
+                      <p className="text-sm text-red-700 dark:text-red-300">Some time windows are shorter than your minimum duration.</p>
+                    </div>
+                  )}
 
                   <button
                     type="button"

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import TimeGridModal from './TimeGridModal';
+import { windowDurationMinutes } from '@/lib/timeUtils';
 
 interface TimeWindow {
   min: string; // HH:MM format
@@ -17,23 +18,6 @@ interface DayTimeWindowsInputProps {
   disabled?: boolean;
   pollWindows?: TimeWindow[]; // Creator's windows for this day (constrains voter edits)
   minDurationMinutes?: number | null; // Minimum duration in minutes for validation
-}
-
-/** Convert "HH:MM" to total minutes since midnight */
-function timeToMinutes(t: string): number {
-  const [h, m] = t.split(':').map(Number);
-  return h * 60 + m;
-}
-
-/** Calculate window duration in minutes, handling cross-midnight */
-function windowDurationMinutes(w: TimeWindow): number {
-  const minMins = timeToMinutes(w.min);
-  const maxMins = timeToMinutes(w.max);
-  if (maxMins <= minMins) {
-    // Cross-midnight or equal (24h)
-    return (1440 - minMins) + maxMins;
-  }
-  return maxMins - minMins;
 }
 
 // Format time in 12-hour format (compact) - returns {time, period}
@@ -124,7 +108,7 @@ export default function DayTimeWindowsInput({
 
   const handleToggleWindow = (index: number) => {
     const updated = windows.map((w, i) =>
-      i === index ? { ...w, enabled: !(w.enabled !== false) } : w
+      i === index ? { ...w, enabled: w.enabled === false } : w
     );
     onChange(updated);
   };

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -213,11 +213,6 @@ export default function DayTimeWindowsInput({
                   );
                 })()}
               </button>
-              {isTooShort && (
-                <span className="text-xs text-red-600 dark:text-red-400 whitespace-nowrap">
-                  Too short
-                </span>
-              )}
             </div>
           );
         })}

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -6,6 +6,7 @@ import TimeGridModal from './TimeGridModal';
 interface TimeWindow {
   min: string; // HH:MM format
   max: string; // HH:MM format
+  enabled?: boolean; // For voter form: whether this window is active (default true)
 }
 
 interface DayTimeWindowsInputProps {
@@ -15,6 +16,24 @@ interface DayTimeWindowsInputProps {
   onDelete: () => void; // Delete entire day
   disabled?: boolean;
   pollWindows?: TimeWindow[]; // Creator's windows for this day (constrains voter edits)
+  minDurationMinutes?: number | null; // Minimum duration in minutes for validation
+}
+
+/** Convert "HH:MM" to total minutes since midnight */
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** Calculate window duration in minutes, handling cross-midnight */
+function windowDurationMinutes(w: TimeWindow): number {
+  const minMins = timeToMinutes(w.min);
+  const maxMins = timeToMinutes(w.max);
+  if (maxMins <= minMins) {
+    // Cross-midnight or equal (24h)
+    return (1440 - minMins) + maxMins;
+  }
+  return maxMins - minMins;
 }
 
 // Format time in 12-hour format (compact) - returns {time, period}
@@ -62,6 +81,7 @@ export default function DayTimeWindowsInput({
   onDelete,
   disabled = false,
   pollWindows,
+  minDurationMinutes,
 }: DayTimeWindowsInputProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -102,6 +122,15 @@ export default function DayTimeWindowsInput({
     }
   };
 
+  const handleToggleWindow = (index: number) => {
+    const updated = windows.map((w, i) =>
+      i === index ? { ...w, enabled: !(w.enabled !== false) } : w
+    );
+    onChange(updated);
+  };
+
+  const isVoterForm = !!pollWindows;
+
   return (
     <div className="flex items-center gap-3 p-1.5 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
       {/* Left: Day display */}
@@ -116,54 +145,82 @@ export default function DayTimeWindowsInput({
 
       {/* Right: Time windows */}
       <div className="flex-1 flex flex-wrap gap-2 items-center justify-end">
-        {windows.map((window, index) => (
-          <div
-            key={index}
-            className="flex items-center gap-2"
-          >
-            <button
-              type="button"
-              onClick={() => handleDeleteWindow(index)}
-              disabled={disabled}
-              className="p-1 text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Delete time window"
+        {windows.map((window, index) => {
+          const isEnabled = window.enabled !== false;
+          const duration = windowDurationMinutes(window);
+          const isTooShort = isEnabled && minDurationMinutes != null && minDurationMinutes > 0 && duration < minDurationMinutes;
+          return (
+            <div
+              key={index}
+              className="flex items-center gap-2"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              onClick={() => handleEditWindow(index)}
-              disabled={disabled}
-              className="w-[168px] py-1.5 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-full text-sm font-medium border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-650 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-center"
-            >
-              {(() => {
-                const minFormatted = formatTime12Hour(window.min);
-                const maxFormatted = formatTime12Hour(window.max);
-                const isCrossMidnight = window.max <= window.min;
-                return (
-                  <>
-                    {minFormatted.time}
-                    <span className={`ml-0.5 ${minFormatted.period === 'AM' ? 'text-orange-500 dark:text-orange-400' : 'text-purple-600 dark:text-purple-400'}`}>
-                      {minFormatted.period}
-                    </span>
-                    {' - '}
-                    {maxFormatted.time}
-                    <span className={`ml-0.5 ${maxFormatted.period === 'AM' ? 'text-orange-500 dark:text-orange-400' : 'text-purple-600 dark:text-purple-400'}`}>
-                      {maxFormatted.period}
-                    </span>
-                    {isCrossMidnight && (
-                      <span className="ml-0.5 text-amber-600 dark:text-amber-400 text-xs font-semibold">
-                        +1
+              {isVoterForm ? (
+                <label className="flex items-center p-1 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={isEnabled}
+                    onChange={() => handleToggleWindow(index)}
+                    disabled={disabled}
+                    className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 cursor-pointer"
+                  />
+                </label>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => handleDeleteWindow(index)}
+                  disabled={disabled}
+                  className="p-1 text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                  aria-label="Delete time window"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => isEnabled && handleEditWindow(index)}
+                disabled={disabled || !isEnabled}
+                className={`w-[168px] py-1.5 rounded-full text-sm font-medium border transition-colors text-center ${
+                  !isEnabled
+                    ? 'bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-default opacity-50'
+                    : isTooShort
+                      ? 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-400 dark:border-red-500 hover:bg-red-100 dark:hover:bg-red-900/50'
+                      : 'bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-650'
+                } disabled:cursor-not-allowed`}
+              >
+                {(() => {
+                  const minFormatted = formatTime12Hour(window.min);
+                  const maxFormatted = formatTime12Hour(window.max);
+                  const isCrossMidnight = window.max <= window.min;
+                  return (
+                    <>
+                      {minFormatted.time}
+                      <span className={`ml-0.5 ${!isEnabled ? '' : minFormatted.period === 'AM' ? 'text-orange-500 dark:text-orange-400' : 'text-purple-600 dark:text-purple-400'}`}>
+                        {minFormatted.period}
                       </span>
-                    )}
-                  </>
-                );
-              })()}
-            </button>
-          </div>
-        ))}
+                      {' - '}
+                      {maxFormatted.time}
+                      <span className={`ml-0.5 ${!isEnabled ? '' : maxFormatted.period === 'AM' ? 'text-orange-500 dark:text-orange-400' : 'text-purple-600 dark:text-purple-400'}`}>
+                        {maxFormatted.period}
+                      </span>
+                      {isCrossMidnight && isEnabled && (
+                        <span className="ml-0.5 text-amber-600 dark:text-amber-400 text-xs font-semibold">
+                          +1
+                        </span>
+                      )}
+                    </>
+                  );
+                })()}
+              </button>
+              {isTooShort && (
+                <span className="text-xs text-red-600 dark:text-red-400 whitespace-nowrap">
+                  Too short
+                </span>
+              )}
+            </div>
+          );
+        })}
 
         {/* Add button - hidden on voter ballots */}
         {!pollWindows && (
@@ -190,6 +247,7 @@ export default function DayTimeWindowsInput({
         onApply={handleModalApply}
         constraintMin={pollWindows && editingIndex !== null && pollWindows[editingIndex] ? pollWindows[editingIndex].min : undefined}
         constraintMax={pollWindows && editingIndex !== null && pollWindows[editingIndex] ? pollWindows[editingIndex].max : undefined}
+        minDurationMinutes={minDurationMinutes}
       />
     </div>
   );

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -213,6 +213,11 @@ export default function DayTimeWindowsInput({
                   );
                 })()}
               </button>
+              {isTooShort && (
+                <span className="text-xs text-red-600 dark:text-red-400 whitespace-nowrap">
+                  Too short
+                </span>
+              )}
             </div>
           );
         })}

--- a/components/MinMaxCounter.tsx
+++ b/components/MinMaxCounter.tsx
@@ -18,7 +18,7 @@ interface MinMaxCounterProps {
   formatValue?: (value: number) => string;
   minCheckboxEnabled?: boolean;
   onMinCheckboxChange?: (enabled: boolean) => void;
-  deferValidation?: boolean;
+
 }
 
 export default function MinMaxCounter({
@@ -37,7 +37,7 @@ export default function MinMaxCounter({
   formatValue,
   minCheckboxEnabled = false,
   onMinCheckboxChange,
-  deferValidation = false,
+
 }: MinMaxCounterProps) {
   const handleMinChange = (newMin: number | null) => {
     onMinChange(newMin);

--- a/components/MinMaxCounter.tsx
+++ b/components/MinMaxCounter.tsx
@@ -41,29 +41,28 @@ export default function MinMaxCounter({
 }: MinMaxCounterProps) {
   const handleMinChange = (newMin: number | null) => {
     onMinChange(newMin);
-    if (!deferValidation && maxEnabled && maxValue !== null && newMin !== null && newMin > maxValue) {
-      onMaxChange(newMin);
+    // Push max up to stay >= min, within limits
+    if (maxEnabled && maxValue !== null && newMin !== null && newMin > maxValue) {
+      const pushed = maxLimit !== undefined ? Math.min(newMin, maxLimit) : newMin;
+      onMaxChange(pushed);
     }
   };
 
   const handleMaxChange = (newMax: number | null) => {
-    const minVal = minValue ?? minLimit;
-    if (deferValidation) {
-      if (!maxEnabled && newMax !== null) {
-        onMaxEnabledChange(true);
-      }
-      onMaxChange(newMax);
-      return;
+    if (!maxEnabled && newMax !== null) {
+      onMaxEnabledChange(true);
     }
-    if (newMax !== null && newMax >= minVal) {
+    if (newMax !== null) {
       if (maxLimit !== undefined && newMax > maxLimit) {
         newMax = maxLimit;
       }
-      if (!maxEnabled) {
-        onMaxEnabledChange(true);
-      }
       onMaxChange(newMax);
-    } else if (newMax === null) {
+      // Push min down to stay <= max, within limits
+      const minVal = minValue ?? minLimit;
+      if (newMax < minVal) {
+        onMinChange(Math.max(newMax, minLimit));
+      }
+    } else {
       onMaxChange(null);
     }
   };
@@ -102,7 +101,7 @@ export default function MinMaxCounter({
               onChange={handleMinChange}
               increment={increment}
               min={minLimit}
-              max={maxEnabled && maxValue !== null ? maxValue : maxLimit}
+              max={maxLimit}
               disabled={disabled || (onMinCheckboxChange !== undefined && !minCheckboxEnabled)}
               arrowPosition="left"
               formatValue={formatValue}
@@ -117,7 +116,7 @@ export default function MinMaxCounter({
               value={maxEnabled ? maxValue : null}
               onChange={handleMaxChange}
               increment={increment}
-              min={minValue ?? minLimit}
+              min={minLimit}
               max={maxLimit}
               disabled={disabled || !maxEnabled}
               arrowPosition="right"

--- a/components/MinMaxCounter.tsx
+++ b/components/MinMaxCounter.tsx
@@ -102,7 +102,7 @@ export default function MinMaxCounter({
               onChange={handleMinChange}
               increment={increment}
               min={minLimit}
-              max={maxLimit}
+              max={maxEnabled && maxValue !== null ? maxValue : maxLimit}
               disabled={disabled || (onMinCheckboxChange !== undefined && !minCheckboxEnabled)}
               arrowPosition="left"
               formatValue={formatValue}

--- a/components/ParticipationConditions.tsx
+++ b/components/ParticipationConditions.tsx
@@ -6,6 +6,7 @@ import DayTimeWindowsInput from './DayTimeWindowsInput';
 export interface TimeWindow {
   min: string;
   max: string;
+  enabled?: boolean; // For voter form: whether this window is active (default true)
 }
 
 export interface DayTimeWindow {
@@ -115,6 +116,11 @@ export default function ParticipationConditions({
   const selectedDays = dayTimeWindows.map(dtw => dtw.day);
   const allowedDays = pollDayTimeWindows?.map(dtw => dtw.day);
 
+  // Convert minimum duration from hours to minutes for time window validation
+  const minDurationMinutes = durationMinEnabled && durationMinValue != null
+    ? Math.round(durationMinValue * 60)
+    : null;
+
   return (
     <div className="space-y-3" data-testid="participation-conditions">
       {/* Participants */}
@@ -193,6 +199,7 @@ export default function ParticipationConditions({
               onDelete={() => handleDeleteDay(dayTimeWindow.day)}
               disabled={disabled}
               pollWindows={pollDayTimeWindows?.find(p => p.day === dayTimeWindow.day)?.windows}
+              minDurationMinutes={minDurationMinutes}
             />
           ))}
 

--- a/components/ParticipationConditions.tsx
+++ b/components/ParticipationConditions.tsx
@@ -141,7 +141,7 @@ export default function ParticipationConditions({
             maxLimit={enforcedMaxLimit}
             maxRequired={maxRequired}
             disabled={disabled}
-            deferValidation={true}
+
           />
         </div>
       </div>
@@ -168,7 +168,7 @@ export default function ParticipationConditions({
             formatValue={formatDurationValue}
             minCheckboxEnabled={durationMinEnabled}
             onMinCheckboxChange={onDurationMinEnabledChange}
-            deferValidation={true}
+
           />
         </div>
       )}

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -63,6 +63,7 @@ interface TimeGridModalProps {
   onApply: (min: string | null, max: string | null) => void;
   constraintMin?: string;  // Poll window's min — voter's min can't go below this
   constraintMax?: string;  // Poll window's max — voter's max can't go above this
+  minDurationMinutes?: number | null; // Minimum required duration in minutes
 }
 
 export default function TimeGridModal({
@@ -73,6 +74,7 @@ export default function TimeGridModal({
   onApply,
   constraintMin,
   constraintMax,
+  minDurationMinutes: minDurationMinutesProp,
 }: TimeGridModalProps) {
   const [localMinTime, setLocalMinTime] = useState<string | null>(minValue);
   const [localMaxTime, setLocalMaxTime] = useState<string | null>(maxValue);
@@ -200,6 +202,8 @@ export default function TimeGridModal({
     ? MIN_WIDTH_PCT + (MAX_WIDTH_PCT - MIN_WIDTH_PCT) * ((durationMinutes - MIN_DURATION) / (MAX_DURATION - MIN_DURATION))
     : 0;
 
+  const isBelowMinDuration = minDurationMinutesProp != null && minDurationMinutesProp > 0 && durationMinutes > 0 && durationMinutes < minDurationMinutesProp;
+
   return (
     <div
       ref={backdropRef}
@@ -230,15 +234,31 @@ export default function TimeGridModal({
         {durationMinutes > 0 && (
           <div className="px-3 pt-1 flex flex-col items-center gap-0.5">
             <div
-              className={`h-7 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center ${transitionsEnabled ? 'transition-all duration-200' : ''}`}
+              className={`h-7 rounded-full flex items-center justify-center ${
+                isBelowMinDuration
+                  ? 'bg-red-100 dark:bg-red-900/40'
+                  : 'bg-blue-100 dark:bg-blue-900/40'
+              } ${transitionsEnabled ? 'transition-all duration-200' : ''}`}
               style={{ width: `${widthPct}%` }}
             >
-              <span className="text-xs font-medium text-blue-600 dark:text-blue-400 whitespace-nowrap">
+              <span className={`text-xs font-medium whitespace-nowrap ${
+                isBelowMinDuration
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-blue-600 dark:text-blue-400'
+              }`}>
                 {durationLabel}
               </span>
             </div>
-            <span className={`text-xs font-medium ${crossesMidnight ? 'text-amber-600 dark:text-amber-400' : 'text-transparent'}`}>
-              Crosses midnight (+1 day)
+            <span className={`text-xs font-medium ${
+              isBelowMinDuration
+                ? 'text-red-600 dark:text-red-400'
+                : crossesMidnight
+                  ? 'text-amber-600 dark:text-amber-400'
+                  : 'text-transparent'
+            }`}>
+              {isBelowMinDuration
+                ? `Minimum ${Math.floor(minDurationMinutesProp! / 60) > 0 ? `${Math.floor(minDurationMinutesProp! / 60)}h` : ''}${minDurationMinutesProp! % 60 > 0 ? `${minDurationMinutesProp! % 60}m` : ''}`
+                : 'Crosses midnight (+1 day)'}
             </span>
           </div>
         )}

--- a/components/TimeGridModal.tsx
+++ b/components/TimeGridModal.tsx
@@ -2,18 +2,13 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import TimeMinMaxCounter from './TimeMinMaxCounter';
+import { timeToMinutes, formatDurationLabel } from '@/lib/timeUtils';
 
 // Duration bar width scaling constants
 const MIN_DURATION = 15; // minutes
 const MAX_DURATION = 24 * 60;
 const MIN_WIDTH_PCT = 10;
 const MAX_WIDTH_PCT = 100;
-
-/** Convert "HH:MM" to total minutes since midnight */
-function timeToMinutes(t: string): number {
-  const [h, m] = t.split(':').map(Number);
-  return h * 60 + m;
-}
 
 /** Convert total minutes since midnight to "HH:MM" */
 function minutesToTime(totalMinutes: number): string {
@@ -74,7 +69,7 @@ export default function TimeGridModal({
   onApply,
   constraintMin,
   constraintMax,
-  minDurationMinutes: minDurationMinutesProp,
+  minDurationMinutes,
 }: TimeGridModalProps) {
   const [localMinTime, setLocalMinTime] = useState<string | null>(minValue);
   const [localMaxTime, setLocalMaxTime] = useState<string | null>(maxValue);
@@ -188,21 +183,13 @@ export default function TimeGridModal({
     durationMinutes = crossesMidnight
       ? (MAX_DURATION - minMins) + maxMins
       : maxMins - minMins;
-    const hours = Math.floor(durationMinutes / 60);
-    const mins = durationMinutes % 60;
-    if (hours > 0 && mins > 0) {
-      durationLabel = `${hours}h ${mins}m`;
-    } else if (hours > 0) {
-      durationLabel = `${hours}h`;
-    } else {
-      durationLabel = `${mins}m`;
-    }
+    durationLabel = formatDurationLabel(durationMinutes);
   }
   const widthPct = durationMinutes > 0
     ? MIN_WIDTH_PCT + (MAX_WIDTH_PCT - MIN_WIDTH_PCT) * ((durationMinutes - MIN_DURATION) / (MAX_DURATION - MIN_DURATION))
     : 0;
 
-  const isBelowMinDuration = minDurationMinutesProp != null && minDurationMinutesProp > 0 && durationMinutes > 0 && durationMinutes < minDurationMinutesProp;
+  const isBelowMinDuration = minDurationMinutes != null && minDurationMinutes > 0 && durationMinutes > 0 && durationMinutes < minDurationMinutes;
 
   return (
     <div
@@ -257,7 +244,7 @@ export default function TimeGridModal({
                   : 'text-transparent'
             }`}>
               {isBelowMinDuration
-                ? `Minimum ${Math.floor(minDurationMinutesProp! / 60) > 0 ? `${Math.floor(minDurationMinutesProp! / 60)}h` : ''}${minDurationMinutesProp! % 60 > 0 ? `${minDurationMinutesProp! % 60}m` : ''}`
+                ? `Minimum ${formatDurationLabel(minDurationMinutes!)}`
                 : 'Crosses midnight (+1 day)'}
             </span>
           </div>

--- a/lib/timeUtils.ts
+++ b/lib/timeUtils.ts
@@ -1,0 +1,24 @@
+/** Convert "HH:MM" to total minutes since midnight */
+export function timeToMinutes(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** Calculate window duration in minutes, handling cross-midnight */
+export function windowDurationMinutes(w: { min: string; max: string }): number {
+  const minMins = timeToMinutes(w.min);
+  const maxMins = timeToMinutes(w.max);
+  if (maxMins <= minMins) {
+    return (1440 - minMins) + maxMins;
+  }
+  return maxMins - minMins;
+}
+
+/** Format a duration in minutes as a compact label (e.g. "2h 30m", "45m", "1h") */
+export function formatDurationLabel(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours > 0 && mins > 0) return `${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${mins}m`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,6 +71,7 @@ export interface Poll {
 export interface TimeWindow {
   min: string; // HH:MM format
   max: string; // HH:MM format
+  enabled?: boolean; // For voter form: whether this window is active (default true)
 }
 
 export interface DayTimeWindow {


### PR DESCRIPTION
## Summary
- Time windows shorter than minimum duration are highlighted red and blocked at submit time
- TimeGridModal duration bar turns red with "Minimum Xh Ym" label when below threshold
- Voter form shows checkboxes to enable/disable time windows (replaces trash cans); unchecked windows are faded and non-interactive
- Min/max counters push each other to stay equal instead of blocking arrows
- Voting blocked if poll has time windows but voter enabled none
- Extracted shared `lib/timeUtils.ts` with `timeToMinutes`, `windowDurationMinutes`, `formatDurationLabel`
- Removed unused `deferValidation` prop from MinMaxCounter

## Test plan
- [ ] Create participation poll with min duration and time windows; verify windows shorter than min duration show red highlight
- [ ] Verify creation form blocks submit with "too short" validation error
- [ ] Vote on participation poll: verify checkboxes appear instead of trash cans
- [ ] Uncheck all windows and vote Yes — verify error "Please enable at least one time window"
- [ ] Enable a too-short window and vote Yes — verify duration validation error
- [ ] Test min/max participant and duration counters push each other when crossing

https://claude.ai/code/session_01LFDd8wRBtGJTWRw6JujRra