### PR TITLE
Compact time slot rounds display

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -21,7 +21,7 @@ import GradientBorderButton from "@/components/GradientBorderButton";
 import OptionLabel from "@/components/OptionLabel";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
-import { Poll, PollResults, OptionsMetadata } from "@/lib/types";
+import { Poll, PollResults, OptionsMetadata, DayTimeWindow } from "@/lib/types";
 import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, apiFindDuplicatePoll, ApiVote } from "@/lib/api";
 import VoteOnItModal from "@/components/VoteOnItModal";
 import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
@@ -138,8 +138,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     const minDurMinutes = durationMinEnabled && durationMinValue != null
       ? Math.round(durationMinValue * 60) : null;
     if (minDurMinutes == null || minDurMinutes <= 0) return false;
-    return voterDayTimeWindows.some((dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) =>
-      dtw.windows.some((w: { min: string; max: string; enabled?: boolean }) =>
+    return voterDayTimeWindows.some((dtw: DayTimeWindow) =>
+      dtw.windows.some(w =>
         w.enabled !== false && windowDurationMinutes(w) < minDurMinutes
       )
     );
@@ -892,22 +892,20 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     // Participation poll time window validation
     if (poll.poll_type === 'participation' && yesNoChoice === 'yes' && !isAbstaining) {
       const pollHasTimeWindows = poll.day_time_windows && poll.day_time_windows.some(
-        (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) => dtw.windows.length > 0
+        (dtw: DayTimeWindow) => dtw.windows.length > 0
       );
       if (pollHasTimeWindows) {
         const enabledWindows = voterDayTimeWindows.flatMap(
-          (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) =>
-            dtw.windows.filter((w: { enabled?: boolean }) => w.enabled !== false)
+          (dtw: DayTimeWindow) => dtw.windows.filter(w => w.enabled !== false)
         );
         if (enabledWindows.length === 0) {
           setVoteError("Please enable at least one time window, or vote No.");
           return;
         }
-        // Check minimum duration on enabled windows
         const minDurMinutes = durationMinEnabled && durationMinValue != null
           ? Math.round(durationMinValue * 60) : null;
         if (minDurMinutes != null && minDurMinutes > 0) {
-          const tooShort = enabledWindows.some((w: { min: string; max: string }) =>
+          const tooShort = enabledWindows.some(w =>
             windowDurationMinutes(w) < minDurMinutes
           );
           if (tooShort) {

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -22,14 +22,13 @@ interface TimeSlotRoundsDisplayProps {
 
 /**
  * Displays elimination rounds for participation poll time slots.
- * Users can navigate between rounds to see alternative time slots.
+ * Compact table-like layout with one row per time slot.
  */
 export default function TimeSlotRoundsDisplay({
   allRounds,
   allVoters,
   currentUserVoteId,
 }: TimeSlotRoundsDisplayProps) {
-  // Generate consistent colors for participant bubbles (matching VoterList)
   const getParticipantColor = (voteId: string) => {
     const colors = [
       'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
@@ -75,13 +74,18 @@ export default function TimeSlotRoundsDisplay({
     const [hours, minutes] = timeStr.split(':').map(Number);
     const period = hours >= 12 ? 'PM' : 'AM';
     const displayHours = hours % 12 || 12;
-    const suffix = showNextDay ? ' +1' : '';
-    return `${displayHours}:${minutes.toString().padStart(2, '0')} ${period}${suffix}`;
+    const suffix = showNextDay ? '+1' : '';
+    return `${displayHours}:${minutes.toString().padStart(2, '0')}${suffix}`;
+  };
+
+  const formatPeriod = (timeStr: string): string => {
+    const [hours] = timeStr.split(':').map(Number);
+    return hours >= 12 ? 'PM' : 'AM';
   };
 
   const formatDuration = (hours: number): string => {
-    if (hours === 1) return '1 hr';
-    return `${hours} hrs`;
+    if (hours === 1) return '1h';
+    return `${hours}h`;
   };
 
   if (allRounds.length === 0) {
@@ -92,30 +96,52 @@ export default function TimeSlotRoundsDisplay({
     );
   }
 
+  // Group current slots by date
+  const slotsByDate = currentSlots.reduce((acc, slot) => {
+    if (!acc[slot.slot_date]) acc[slot.slot_date] = [];
+    acc[slot.slot_date].push(slot);
+    return acc;
+  }, {} as Record<string, TimeSlot[]>);
+
+  // Check if start/end AM/PM are same for a compact format
+  const formatTimeRange = (slot: TimeSlot) => {
+    const startPeriod = formatPeriod(slot.slot_start_time);
+    const isNextDay = slot.slot_end_time <= slot.slot_start_time;
+    const endPeriod = formatPeriod(slot.slot_end_time);
+    const start = formatTime(slot.slot_start_time);
+    const end = formatTime(slot.slot_end_time, isNextDay);
+
+    // If same period, only show it on the end time
+    if (startPeriod === endPeriod && !isNextDay) {
+      return `${start}\u2013${end} ${endPeriod}`;
+    }
+    return `${start} ${startPeriod}\u2013${end} ${endPeriod}`;
+  };
+
   return (
     <div className="w-full max-w-2xl mx-auto">
       {/* Round header with navigation */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-3">
         <button
           onClick={() => setCurrentRound(r => Math.max(1, r - 1))}
           disabled={currentRound === 1}
-          className={`p-2 rounded ${
+          className={`p-1.5 rounded ${
             currentRound === 1
               ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
               : 'text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900'
           }`}
           aria-label="Previous round"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
         </button>
 
         <div className="text-center flex-1">
-          <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
             Round {currentRound} of {totalRounds}
           </div>
-          <div className="text-sm text-gray-600 dark:text-gray-400">
+          <div className="text-xs text-gray-500 dark:text-gray-400">
             {participantCount} {participantCount === 1 ? 'participant' : 'participants'}
           </div>
         </div>
@@ -123,73 +149,95 @@ export default function TimeSlotRoundsDisplay({
         <button
           onClick={() => setCurrentRound(r => Math.min(totalRounds, r + 1))}
           disabled={currentRound === totalRounds}
-          className={`p-2 rounded ${
+          className={`p-1.5 rounded ${
             currentRound === totalRounds
               ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
               : 'text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900'
           }`}
           aria-label="Next round"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
         </button>
       </div>
 
-      {/* Time slots list */}
-      <div className="space-y-3 max-h-96 overflow-y-auto">
-        {currentSlots.map((slot, index) => (
-          <div
-            key={index}
-            className={`border rounded-lg p-4 ${
-              slot.is_winner
-                ? 'bg-green-50 dark:bg-green-900 border-green-300 dark:border-green-700'
-                : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700'
-            }`}
-          >
-            <div className="flex items-center justify-between mb-2">
-              <div className="font-semibold text-gray-900 dark:text-gray-100">
-                {formatDate(slot.slot_date)} @ {formatTime(slot.slot_start_time)}-{formatTime(slot.slot_end_time, slot.slot_end_time <= slot.slot_start_time)}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">
-                ({formatDuration(slot.duration_hours)})
-              </div>
+      {/* Compact time slots grouped by date */}
+      <div className="border rounded-lg overflow-hidden dark:border-gray-700">
+        {Object.entries(slotsByDate).map(([date, slots], groupIdx) => (
+          <div key={date}>
+            {/* Date header */}
+            <div className={`px-3 py-1.5 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide ${
+              groupIdx > 0 ? 'border-t dark:border-gray-700' : ''
+            }`}>
+              {formatDate(date)}
             </div>
 
-            <div className="flex flex-wrap gap-2 mt-2">
-              {slot.participant_names.map((name, idx) => {
-                const voteId = slot.participant_vote_ids[idx];
-                const isCurrentUser = voteId === currentUserVoteId;
-                const colorClass = voteId ? getParticipantColor(voteId) : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
-                const displayName = isCurrentUser
-                  ? (name ? `You (${name})` : 'You')
-                  : name;
+            {/* Slot rows */}
+            {slots.map((slot, index) => {
+              const isWinner = slot.is_winner;
+              return (
+                <div
+                  key={index}
+                  className={`flex items-center px-3 py-2 ${
+                    index > 0 ? 'border-t border-gray-100 dark:border-gray-750' : ''
+                  } ${
+                    isWinner
+                      ? 'bg-green-50 dark:bg-green-900/30'
+                      : 'bg-white dark:bg-gray-800'
+                  }`}
+                >
+                  {/* Winner indicator */}
+                  <div className="w-5 flex-shrink-0">
+                    {isWinner && (
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                      </svg>
+                    )}
+                  </div>
 
-                return (
-                  <span
-                    key={voteId || idx}
-                    className={`inline-block px-3 py-1 rounded-full text-sm ${
-                      isCurrentUser ? 'font-bold border-2 border-blue-500 dark:border-blue-400' : 'font-medium'
-                    } ${colorClass}`}
-                  >
-                    {displayName}
-                  </span>
-                );
-              })}
-            </div>
+                  {/* Time range */}
+                  <div className={`flex-1 min-w-0 ${isWinner ? 'font-semibold' : ''}`}>
+                    <span className="text-sm text-gray-900 dark:text-gray-100">
+                      {formatTimeRange(slot)}
+                    </span>
+                    <span className="text-xs text-gray-400 dark:text-gray-500 ml-1.5">
+                      {formatDuration(slot.duration_hours)}
+                    </span>
+                  </div>
 
-            {slot.is_winner && (
-              <div className="mt-2 text-sm font-semibold text-green-700 dark:text-green-300">
-                Selected Time
-              </div>
-            )}
+                  {/* Participant badges - compact */}
+                  <div className="flex flex-wrap gap-1 justify-end ml-2">
+                    {slot.participant_names.map((name, idx) => {
+                      const voteId = slot.participant_vote_ids[idx];
+                      const isCurrentUser = voteId === currentUserVoteId;
+                      const colorClass = voteId ? getParticipantColor(voteId) : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
+                      const displayName = isCurrentUser
+                        ? (name ? `You (${name})` : 'You')
+                        : (name || 'Anonymous');
+
+                      return (
+                        <span
+                          key={voteId || idx}
+                          className={`inline-block px-2 py-0.5 rounded-full text-xs ${
+                            isCurrentUser ? 'font-bold ring-1 ring-blue-500 dark:ring-blue-400' : 'font-medium'
+                          } ${colorClass}`}
+                        >
+                          {displayName}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         ))}
       </div>
 
       {/* Round indicator dots */}
       {totalRounds > 1 && (
-        <div className="flex justify-center gap-2 mt-4">
+        <div className="flex justify-center gap-2 mt-3">
           {Array.from({ length: totalRounds }, (_, i) => i + 1).map((roundNum) => (
             <button
               key={roundNum}

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -20,9 +20,11 @@ interface TimeSlotRoundsDisplayProps {
   currentUserVoteId: string | null;
 }
 
+const COLLAPSED_VISIBLE = 3;
+
 /**
  * Displays elimination rounds for participation poll time slots.
- * Compact table-like layout with one row per time slot.
+ * Shows winner + a few rows by default, expandable to see all.
  */
 export default function TimeSlotRoundsDisplay({
   allRounds,
@@ -57,6 +59,7 @@ export default function TimeSlotRoundsDisplay({
 
   const totalRounds = Math.max(...Object.keys(roundsByNumber).map(Number));
   const [currentRound, setCurrentRound] = useState(1);
+  const [expanded, setExpanded] = useState(false);
 
   const currentSlots = roundsByNumber[currentRound] || [];
   const participantCount = currentSlots.length > 0 ? currentSlots[0].participant_count : 0;
@@ -88,6 +91,19 @@ export default function TimeSlotRoundsDisplay({
     return `${hours}h`;
   };
 
+  const formatTimeRange = (slot: TimeSlot) => {
+    const startPeriod = formatPeriod(slot.slot_start_time);
+    const isNextDay = slot.slot_end_time <= slot.slot_start_time;
+    const endPeriod = formatPeriod(slot.slot_end_time);
+    const start = formatTime(slot.slot_start_time);
+    const end = formatTime(slot.slot_end_time, isNextDay);
+
+    if (startPeriod === endPeriod && !isNextDay) {
+      return `${start}\u2013${end} ${endPeriod}`;
+    }
+    return `${start} ${startPeriod}\u2013${end} ${endPeriod}`;
+  };
+
   if (allRounds.length === 0) {
     return (
       <div className="text-center text-gray-600 dark:text-gray-400">
@@ -96,26 +112,104 @@ export default function TimeSlotRoundsDisplay({
     );
   }
 
-  // Group current slots by date
+  // Group current slots by date, with winner slots first within each date
   const slotsByDate = currentSlots.reduce((acc, slot) => {
     if (!acc[slot.slot_date]) acc[slot.slot_date] = [];
     acc[slot.slot_date].push(slot);
     return acc;
   }, {} as Record<string, TimeSlot[]>);
 
-  // Check if start/end AM/PM are same for a compact format
-  const formatTimeRange = (slot: TimeSlot) => {
-    const startPeriod = formatPeriod(slot.slot_start_time);
-    const isNextDay = slot.slot_end_time <= slot.slot_start_time;
-    const endPeriod = formatPeriod(slot.slot_end_time);
-    const start = formatTime(slot.slot_start_time);
-    const end = formatTime(slot.slot_end_time, isNextDay);
+  // Flatten into display order: all date groups with slots
+  const allDisplaySlots: { slot: TimeSlot; date: string; isFirstInDate: boolean }[] = [];
+  for (const [date, slots] of Object.entries(slotsByDate)) {
+    slots.forEach((slot, i) => {
+      allDisplaySlots.push({ slot, date, isFirstInDate: i === 0 });
+    });
+  }
 
-    // If same period, only show it on the end time
-    if (startPeriod === endPeriod && !isNextDay) {
-      return `${start}\u2013${end} ${endPeriod}`;
+  // Determine which slots to show: winner always visible, then first few
+  const winnerIdx = allDisplaySlots.findIndex(s => s.slot.is_winner);
+  const needsCollapse = allDisplaySlots.length > COLLAPSED_VISIBLE + 1;
+  const showAll = expanded || !needsCollapse;
+
+  let visibleSlots: typeof allDisplaySlots;
+  if (showAll) {
+    visibleSlots = allDisplaySlots;
+  } else {
+    // Show winner + first COLLAPSED_VISIBLE non-winner slots
+    const nonWinnerSlots = allDisplaySlots.filter((_, i) => i !== winnerIdx);
+    const visible = new Set<number>();
+    if (winnerIdx >= 0) visible.add(winnerIdx);
+    for (let i = 0; i < Math.min(COLLAPSED_VISIBLE, nonWinnerSlots.length); i++) {
+      const origIdx = allDisplaySlots.indexOf(nonWinnerSlots[i]);
+      visible.add(origIdx);
     }
-    return `${start} ${startPeriod}\u2013${end} ${endPeriod}`;
+    visibleSlots = allDisplaySlots.filter((_, i) => visible.has(i));
+  }
+
+  const hiddenCount = allDisplaySlots.length - visibleSlots.length;
+
+  const renderSlotRow = (item: typeof allDisplaySlots[0], index: number) => {
+    const { slot, date, isFirstInDate } = item;
+    const isWinner = slot.is_winner;
+    return (
+      <React.Fragment key={`${date}-${index}`}>
+        {isFirstInDate && (
+          <div className="px-3 py-1 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide border-t border-gray-100 dark:border-gray-700 first:border-t-0">
+            {formatDate(date)}
+          </div>
+        )}
+        <div
+          className={`flex items-center px-3 py-1.5 border-t border-gray-100 dark:border-gray-700 ${
+            isWinner
+              ? 'bg-green-50 dark:bg-green-900/30'
+              : 'bg-white dark:bg-gray-800'
+          }`}
+        >
+          {/* Winner checkmark */}
+          <div className="w-5 flex-shrink-0">
+            {isWinner && (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+            )}
+          </div>
+
+          {/* Time range */}
+          <div className={`flex-1 min-w-0 ${isWinner ? 'font-semibold' : ''}`}>
+            <span className="text-sm text-gray-900 dark:text-gray-100">
+              {formatTimeRange(slot)}
+            </span>
+            <span className="text-xs text-gray-400 dark:text-gray-500 ml-1.5">
+              {formatDuration(slot.duration_hours)}
+            </span>
+          </div>
+
+          {/* Participant badges */}
+          <div className="flex flex-wrap gap-1 justify-end ml-2">
+            {slot.participant_names.map((name, idx) => {
+              const voteId = slot.participant_vote_ids[idx];
+              const isCurrentUser = voteId === currentUserVoteId;
+              const colorClass = voteId ? getParticipantColor(voteId) : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
+              const displayName = isCurrentUser
+                ? (name ? `You (${name})` : 'You')
+                : (name || 'Anonymous');
+
+              return (
+                <span
+                  key={voteId || idx}
+                  className={`inline-block px-2 py-0.5 rounded-full text-xs ${
+                    isCurrentUser ? 'font-bold ring-1 ring-blue-500 dark:ring-blue-400' : 'font-medium'
+                  } ${colorClass}`}
+                >
+                  {displayName}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      </React.Fragment>
+    );
   };
 
   return (
@@ -142,7 +236,7 @@ export default function TimeSlotRoundsDisplay({
             Round {currentRound} of {totalRounds}
           </div>
           <div className="text-xs text-gray-500 dark:text-gray-400">
-            {participantCount} {participantCount === 1 ? 'participant' : 'participants'}
+            {participantCount} {participantCount === 1 ? 'participant' : 'participants'} &middot; {allDisplaySlots.length} time slots
           </div>
         </div>
 
@@ -162,77 +256,22 @@ export default function TimeSlotRoundsDisplay({
         </button>
       </div>
 
-      {/* Compact time slots grouped by date */}
+      {/* Compact time slots */}
       <div className="border rounded-lg overflow-hidden dark:border-gray-700">
-        {Object.entries(slotsByDate).map(([date, slots], groupIdx) => (
-          <div key={date}>
-            {/* Date header */}
-            <div className={`px-3 py-1.5 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide ${
-              groupIdx > 0 ? 'border-t dark:border-gray-700' : ''
-            }`}>
-              {formatDate(date)}
-            </div>
+        {visibleSlots.map((item, index) => renderSlotRow(item, index))}
 
-            {/* Slot rows */}
-            {slots.map((slot, index) => {
-              const isWinner = slot.is_winner;
-              return (
-                <div
-                  key={index}
-                  className={`flex items-center px-3 py-2 ${
-                    index > 0 ? 'border-t border-gray-100 dark:border-gray-750' : ''
-                  } ${
-                    isWinner
-                      ? 'bg-green-50 dark:bg-green-900/30'
-                      : 'bg-white dark:bg-gray-800'
-                  }`}
-                >
-                  {/* Winner indicator */}
-                  <div className="w-5 flex-shrink-0">
-                    {isWinner && (
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400" viewBox="0 0 20 20" fill="currentColor">
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                      </svg>
-                    )}
-                  </div>
-
-                  {/* Time range */}
-                  <div className={`flex-1 min-w-0 ${isWinner ? 'font-semibold' : ''}`}>
-                    <span className="text-sm text-gray-900 dark:text-gray-100">
-                      {formatTimeRange(slot)}
-                    </span>
-                    <span className="text-xs text-gray-400 dark:text-gray-500 ml-1.5">
-                      {formatDuration(slot.duration_hours)}
-                    </span>
-                  </div>
-
-                  {/* Participant badges - compact */}
-                  <div className="flex flex-wrap gap-1 justify-end ml-2">
-                    {slot.participant_names.map((name, idx) => {
-                      const voteId = slot.participant_vote_ids[idx];
-                      const isCurrentUser = voteId === currentUserVoteId;
-                      const colorClass = voteId ? getParticipantColor(voteId) : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
-                      const displayName = isCurrentUser
-                        ? (name ? `You (${name})` : 'You')
-                        : (name || 'Anonymous');
-
-                      return (
-                        <span
-                          key={voteId || idx}
-                          className={`inline-block px-2 py-0.5 rounded-full text-xs ${
-                            isCurrentUser ? 'font-bold ring-1 ring-blue-500 dark:ring-blue-400' : 'font-medium'
-                          } ${colorClass}`}
-                        >
-                          {displayName}
-                        </span>
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        ))}
+        {/* Expand/collapse toggle */}
+        {needsCollapse && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="w-full px-3 py-2 text-center text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-50 dark:hover:bg-gray-700 border-t border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800"
+          >
+            {expanded
+              ? 'Show less'
+              : `Show ${hiddenCount} more time slot${hiddenCount === 1 ? '' : 's'}`
+            }
+          </button>
+        )}
       </div>
 
       {/* Round indicator dots */}

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 
 export interface TimeSlot {
   round_number: number;
@@ -22,87 +22,142 @@ interface TimeSlotRoundsDisplayProps {
 
 const COLLAPSED_VISIBLE = 3;
 
-/**
- * Displays elimination rounds for participation poll time slots.
- * Shows winner + a few rows by default, expandable to see all.
- */
+const PARTICIPANT_COLORS = [
+  'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+  'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200',
+  'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
+  'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200',
+];
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+function formatTime(timeStr: string, showNextDay?: boolean): string {
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  const displayHours = hours % 12 || 12;
+  const suffix = showNextDay ? '+1' : '';
+  return `${displayHours}:${minutes.toString().padStart(2, '0')}${suffix}`;
+}
+
+function formatPeriod(timeStr: string): string {
+  const [hours] = timeStr.split(':').map(Number);
+  return hours >= 12 ? 'PM' : 'AM';
+}
+
+function formatDuration(hours: number): string {
+  return hours === 1 ? '1h' : `${hours}h`;
+}
+
+function formatTimeRange(slot: TimeSlot): string {
+  const startPeriod = formatPeriod(slot.slot_start_time);
+  const isNextDay = slot.slot_end_time <= slot.slot_start_time;
+  const endPeriod = formatPeriod(slot.slot_end_time);
+  const start = formatTime(slot.slot_start_time);
+  const end = formatTime(slot.slot_end_time, isNextDay);
+
+  if (startPeriod === endPeriod && !isNextDay) {
+    return `${start}\u2013${end} ${endPeriod}`;
+  }
+  return `${start} ${startPeriod}\u2013${end} ${endPeriod}`;
+}
+
+interface DisplaySlot {
+  slot: TimeSlot;
+  date: string;
+  isFirstInDate: boolean;
+}
+
 export default function TimeSlotRoundsDisplay({
   allRounds,
   allVoters,
   currentUserVoteId,
 }: TimeSlotRoundsDisplayProps) {
-  const getParticipantColor = (voteId: string) => {
-    const colors = [
-      'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-      'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-      'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
-      'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200',
-      'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-      'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
-      'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-      'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200',
-    ];
-
-    const voterIndex = allVoters.findIndex(v => v.id === voteId);
-    if (voterIndex === -1) return colors[0];
-    return colors[voterIndex % colors.length];
-  };
-
-  // Group slots by round number
-  const roundsByNumber = allRounds.reduce((acc, slot) => {
-    if (!acc[slot.round_number]) {
-      acc[slot.round_number] = [];
-    }
-    acc[slot.round_number].push(slot);
-    return acc;
-  }, {} as Record<number, TimeSlot[]>);
-
-  const totalRounds = Math.max(...Object.keys(roundsByNumber).map(Number));
   const [currentRound, setCurrentRound] = useState(1);
   const [expanded, setExpanded] = useState(false);
+
+  // Build a vote ID -> color index map from allVoters (or fallback to stable ordering from data)
+  const colorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    if (allVoters.length > 0) {
+      allVoters.forEach((v, i) => map.set(v.id, PARTICIPANT_COLORS[i % PARTICIPANT_COLORS.length]));
+    } else {
+      // Derive unique vote IDs from all rounds in stable order
+      const seen = new Set<string>();
+      for (const slot of allRounds) {
+        for (const id of slot.participant_vote_ids) {
+          if (id && !seen.has(id)) {
+            map.set(id, PARTICIPANT_COLORS[seen.size % PARTICIPANT_COLORS.length]);
+            seen.add(id);
+          }
+        }
+      }
+    }
+    return map;
+  }, [allVoters, allRounds]);
+
+  const { roundsByNumber, totalRounds } = useMemo(() => {
+    const byNumber = allRounds.reduce((acc, slot) => {
+      if (!acc[slot.round_number]) acc[slot.round_number] = [];
+      acc[slot.round_number].push(slot);
+      return acc;
+    }, {} as Record<number, TimeSlot[]>);
+    return {
+      roundsByNumber: byNumber,
+      totalRounds: Math.max(...Object.keys(byNumber).map(Number)),
+    };
+  }, [allRounds]);
 
   const currentSlots = roundsByNumber[currentRound] || [];
   const participantCount = currentSlots.length > 0 ? currentSlots[0].participant_count : 0;
 
-  const formatDate = (dateStr: string): string => {
-    const date = new Date(dateStr + 'T00:00:00');
-    return date.toLocaleDateString('en-US', {
-      weekday: 'short',
-      month: 'short',
-      day: 'numeric'
-    });
-  };
-
-  const formatTime = (timeStr: string, showNextDay?: boolean): string => {
-    const [hours, minutes] = timeStr.split(':').map(Number);
-    const period = hours >= 12 ? 'PM' : 'AM';
-    const displayHours = hours % 12 || 12;
-    const suffix = showNextDay ? '+1' : '';
-    return `${displayHours}:${minutes.toString().padStart(2, '0')}${suffix}`;
-  };
-
-  const formatPeriod = (timeStr: string): string => {
-    const [hours] = timeStr.split(':').map(Number);
-    return hours >= 12 ? 'PM' : 'AM';
-  };
-
-  const formatDuration = (hours: number): string => {
-    if (hours === 1) return '1h';
-    return `${hours}h`;
-  };
-
-  const formatTimeRange = (slot: TimeSlot) => {
-    const startPeriod = formatPeriod(slot.slot_start_time);
-    const isNextDay = slot.slot_end_time <= slot.slot_start_time;
-    const endPeriod = formatPeriod(slot.slot_end_time);
-    const start = formatTime(slot.slot_start_time);
-    const end = formatTime(slot.slot_end_time, isNextDay);
-
-    if (startPeriod === endPeriod && !isNextDay) {
-      return `${start}\u2013${end} ${endPeriod}`;
+  const { allDisplaySlots, winnerIdx } = useMemo(() => {
+    const slots: DisplaySlot[] = [];
+    let winner = -1;
+    // Group by date and flatten in one pass
+    let prevDate = '';
+    for (const slot of currentSlots) {
+      const isFirst = slot.slot_date !== prevDate;
+      if (slot.is_winner) winner = slots.length;
+      slots.push({ slot, date: slot.slot_date, isFirstInDate: isFirst });
+      prevDate = slot.slot_date;
     }
-    return `${start} ${startPeriod}\u2013${end} ${endPeriod}`;
-  };
+    return { allDisplaySlots: slots, winnerIdx: winner };
+  }, [currentSlots]);
+
+  const needsCollapse = allDisplaySlots.length > COLLAPSED_VISIBLE + 1;
+  const showAll = expanded || !needsCollapse;
+
+  const visibleSlots = useMemo(() => {
+    if (showAll) return allDisplaySlots;
+    // Show winner (if exists) + first COLLAPSED_VISIBLE other slots
+    const visible: DisplaySlot[] = [];
+    let added = 0;
+    for (let i = 0; i < allDisplaySlots.length && (added < COLLAPSED_VISIBLE || i === winnerIdx); i++) {
+      if (i === winnerIdx) {
+        visible.push(allDisplaySlots[i]);
+      } else if (added < COLLAPSED_VISIBLE) {
+        visible.push(allDisplaySlots[i]);
+        added++;
+      }
+    }
+    // Ensure winner is included even if beyond COLLAPSED_VISIBLE range
+    if (winnerIdx >= 0 && !visible.includes(allDisplaySlots[winnerIdx])) {
+      visible.push(allDisplaySlots[winnerIdx]);
+    }
+    return visible;
+  }, [allDisplaySlots, winnerIdx, showAll]);
+
+  const hiddenCount = allDisplaySlots.length - visibleSlots.length;
 
   if (allRounds.length === 0) {
     return (
@@ -112,44 +167,7 @@ export default function TimeSlotRoundsDisplay({
     );
   }
 
-  // Group current slots by date, with winner slots first within each date
-  const slotsByDate = currentSlots.reduce((acc, slot) => {
-    if (!acc[slot.slot_date]) acc[slot.slot_date] = [];
-    acc[slot.slot_date].push(slot);
-    return acc;
-  }, {} as Record<string, TimeSlot[]>);
-
-  // Flatten into display order: all date groups with slots
-  const allDisplaySlots: { slot: TimeSlot; date: string; isFirstInDate: boolean }[] = [];
-  for (const [date, slots] of Object.entries(slotsByDate)) {
-    slots.forEach((slot, i) => {
-      allDisplaySlots.push({ slot, date, isFirstInDate: i === 0 });
-    });
-  }
-
-  // Determine which slots to show: winner always visible, then first few
-  const winnerIdx = allDisplaySlots.findIndex(s => s.slot.is_winner);
-  const needsCollapse = allDisplaySlots.length > COLLAPSED_VISIBLE + 1;
-  const showAll = expanded || !needsCollapse;
-
-  let visibleSlots: typeof allDisplaySlots;
-  if (showAll) {
-    visibleSlots = allDisplaySlots;
-  } else {
-    // Show winner + first COLLAPSED_VISIBLE non-winner slots
-    const nonWinnerSlots = allDisplaySlots.filter((_, i) => i !== winnerIdx);
-    const visible = new Set<number>();
-    if (winnerIdx >= 0) visible.add(winnerIdx);
-    for (let i = 0; i < Math.min(COLLAPSED_VISIBLE, nonWinnerSlots.length); i++) {
-      const origIdx = allDisplaySlots.indexOf(nonWinnerSlots[i]);
-      visible.add(origIdx);
-    }
-    visibleSlots = allDisplaySlots.filter((_, i) => visible.has(i));
-  }
-
-  const hiddenCount = allDisplaySlots.length - visibleSlots.length;
-
-  const renderSlotRow = (item: typeof allDisplaySlots[0], index: number) => {
+  const renderSlotRow = (item: DisplaySlot, index: number) => {
     const { slot, date, isFirstInDate } = item;
     const isWinner = slot.is_winner;
     return (
@@ -166,7 +184,6 @@ export default function TimeSlotRoundsDisplay({
               : 'bg-white dark:bg-gray-800'
           }`}
         >
-          {/* Winner checkmark */}
           <div className="w-5 flex-shrink-0">
             {isWinner && (
               <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400" viewBox="0 0 20 20" fill="currentColor">
@@ -175,7 +192,6 @@ export default function TimeSlotRoundsDisplay({
             )}
           </div>
 
-          {/* Time range */}
           <div className={`flex-1 min-w-0 ${isWinner ? 'font-semibold' : ''}`}>
             <span className="text-sm text-gray-900 dark:text-gray-100">
               {formatTimeRange(slot)}
@@ -185,12 +201,11 @@ export default function TimeSlotRoundsDisplay({
             </span>
           </div>
 
-          {/* Participant badges */}
           <div className="flex flex-wrap gap-1 justify-end ml-2">
             {slot.participant_names.map((name, idx) => {
               const voteId = slot.participant_vote_ids[idx];
               const isCurrentUser = voteId === currentUserVoteId;
-              const colorClass = voteId ? getParticipantColor(voteId) : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200';
+              const colorClass = (voteId && colorMap.get(voteId)) || PARTICIPANT_COLORS[0];
               const displayName = isCurrentUser
                 ? (name ? `You (${name})` : 'You')
                 : (name || 'Anonymous');
@@ -214,7 +229,6 @@ export default function TimeSlotRoundsDisplay({
 
   return (
     <div className="w-full max-w-2xl mx-auto">
-      {/* Round header with navigation */}
       <div className="flex items-center justify-between mb-3">
         <button
           onClick={() => setCurrentRound(r => Math.max(1, r - 1))}
@@ -256,11 +270,9 @@ export default function TimeSlotRoundsDisplay({
         </button>
       </div>
 
-      {/* Compact time slots */}
       <div className="border rounded-lg overflow-hidden dark:border-gray-700">
         {visibleSlots.map((item, index) => renderSlotRow(item, index))}
 
-        {/* Expand/collapse toggle */}
         {needsCollapse && (
           <button
             onClick={() => setExpanded(!expanded)}
@@ -274,7 +286,6 @@ export default function TimeSlotRoundsDisplay({
         )}
       </div>
 
-      {/* Round indicator dots */}
       {totalRounds > 1 && (
         <div className="flex justify-center gap-2 mt-3">
           {Array.from({ length: totalRounds }, (_, i) => i + 1).map((roundNum) => (


### PR DESCRIPTION
## Summary
- Replace full cards per time slot with compact table-like rows (date header + one-line per slot)
- Add collapse/expand: shows winner + 3 slots by default, "Show N more" toggle for the rest
- Fix participant color mapping (was broken when allVoters was empty — now derives colors from slot data)
- Memoize grouping, flattening, and visibility filtering to avoid recomputing on every render
- Replace inline type annotations with imported DayTimeWindow type

## Test plan
- [ ] Verify closed participation polls show compact time slot rows
- [ ] Verify winner row has green checkmark and highlight
- [ ] Verify "Show N more time slots" expands/collapses correctly
- [ ] Verify participant colors are consistent across slots
- [ ] Verify round navigation still works

https://claude.ai/code/session_012E4PFGrysAWXTB1m7eLkFp