### PR TITLE
Use compact name field in all voting forms

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -191,7 +191,6 @@ function CreatePollContent() {
     return "Who's in?";
   }, [pollType, category, options, locationMode, locationValue, locationOptions]);
 
-
   // Focus details textarea when opening
   useEffect(() => {
     if (detailsOpen) {
@@ -929,7 +928,6 @@ function CreatePollContent() {
     
     return ` (${displayParts.join(', ')})`;
   };
-
 
   const handleSubmitClick = (e: React.FormEvent | React.MouseEvent) => {
     e.preventDefault();

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
 import type { OptionsMetadata } from "@/lib/types";
+import CompactNameField from "@/components/CompactNameField";
 import TypeFieldInput, { getBuiltInType, isLocationLikeCategory } from "@/components/TypeFieldInput";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
@@ -93,8 +94,6 @@ function CreatePollContent() {
   const isSubmittingRef = useRef(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [creatorName, setCreatorName] = useState<string>("");
-  const [isEditingName, setIsEditingName] = useState(false);
-  const nameInputRef = useRef<HTMLInputElement>(null);
   const [originalPollData, setOriginalPollData] = useState<any>(null);
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const [isAutoTitle, setIsAutoTitle] = useState(true);
@@ -192,12 +191,6 @@ function CreatePollContent() {
     return "Who's in?";
   }, [pollType, category, options, locationMode, locationValue, locationOptions]);
 
-  // Focus name input when switching to edit mode
-  useEffect(() => {
-    if (isEditingName) {
-      nameInputRef.current?.focus();
-    }
-  }, [isEditingName]);
 
   // Focus details textarea when opening
   useEffect(() => {
@@ -937,10 +930,6 @@ function CreatePollContent() {
     return ` (${displayParts.join(', ')})`;
   };
 
-  const handleEditName = () => {
-    setIsEditingName(true);
-    setTimeout(() => nameInputRef.current?.focus(), 0);
-  };
 
   const handleSubmitClick = (e: React.FormEvent | React.MouseEvent) => {
     e.preventDefault();
@@ -1586,46 +1575,7 @@ function CreatePollContent() {
             )}
           </div>
 
-          <div>
-            {isEditingName ? (
-              <>
-                <label htmlFor="creatorName" className="block text-sm font-medium mb-1">
-                  Your Name{!creatorName.trim() && <>{' '}<span className="font-normal">(optional)</span></>}
-                </label>
-                <input
-                  ref={nameInputRef}
-                  type="text"
-                  id="creatorName"
-                  value={creatorName}
-                  onChange={(e) => setCreatorName(e.target.value)}
-                  onBlur={() => setIsEditingName(false)}
-                  disabled={isLoading}
-                  maxLength={50}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                  placeholder="Enter your name..."
-                />
-              </>
-            ) : creatorName.trim() ? (
-              <button
-                type="button"
-                onClick={handleEditName}
-                className="block text-sm font-medium text-left"
-              >
-                Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{creatorName.trim()}</span>
-              </button>
-            ) : (
-              <div className="text-sm font-medium">
-                Your Name <span className="font-normal">(optional)</span>:{' '}
-                <button
-                  type="button"
-                  onClick={handleEditName}
-                  className="font-normal text-blue-600 dark:text-blue-400"
-                >
-                  Add
-                </button>
-              </div>
-            )}
-          </div>
+          <CompactNameField name={creatorName} setName={setCreatorName} disabled={isLoading} />
           
           {!isFormValid() && !isLoading && (
             <div className="text-center text-red-600 dark:text-red-400 text-sm mb-3">

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -133,6 +133,20 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     return participatingVoterIds.includes(userVoteData.id);
   }, [poll.poll_type, userVoteData, participatingVoterIds]);
   
+  // Check if poll has time windows but none are enabled (voter voted Yes with all days unchecked)
+  const hasNoEnabledTimeWindows = useMemo(() => {
+    if (poll.poll_type !== 'participation') return false;
+    const pollHasTimeWindows = poll.day_time_windows && poll.day_time_windows.some(
+      (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) => dtw.windows.length > 0
+    );
+    if (!pollHasTimeWindows) return false;
+    const enabledWindows = voterDayTimeWindows.flatMap(
+      (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) =>
+        dtw.windows.filter((w: { enabled?: boolean }) => w.enabled !== false)
+    );
+    return enabledWindows.length === 0;
+  }, [poll.poll_type, poll.day_time_windows, voterDayTimeWindows]);
+
   // Check if any enabled voter time window is shorter than the minimum duration
   const hasTimeWindowTooShort = useMemo(() => {
     if (poll.poll_type !== 'participation') return false;
@@ -1782,10 +1796,16 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     </div>
                   )}
 
+                  {yesNoChoice === 'yes' && hasNoEnabledTimeWindows && (
+                    <div className="mb-3 p-3 bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-300 dark:border-yellow-600 rounded-md">
+                      <p className="text-sm text-yellow-700 dark:text-yellow-300">Enable at least one time window, or vote No.</p>
+                    </div>
+                  )}
+
                   <button
                     type="button"
                     onClick={handleVoteClick}
-                    disabled={isSubmitting || (!yesNoChoice && !isAbstaining)}
+                    disabled={isSubmitting || (!yesNoChoice && !isAbstaining) || (yesNoChoice === 'yes' && hasNoEnabledTimeWindows)}
                     className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
                   >
                     {isSubmitting ? 'Submitting...' : 'Submit Vote'}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAppPrefetch } from "@/lib/prefetch";
 import Countdown from "@/components/Countdown";
+import CompactNameField from "@/components/CompactNameField";
 import RankableOptions from "@/components/RankableOptions";
 import PollResultsDisplay from "@/components/PollResults";
 import SuggestionVotingInterface from "@/components/SuggestionVotingInterface";
@@ -1594,20 +1595,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   </div>
 
                   <div className="mb-4">
-                    <label htmlFor="voterName" className="block text-sm font-medium mb-1">
-                      Your Name (optional)
-                    </label>
-                    <input
-                      type="text"
-                      id="voterName"
-                      value={voterName}
-                      onChange={(e) => setVoterName(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
-                      placeholder="Enter your name..."
-                      maxLength={50}
-                    />
+                    <CompactNameField name={voterName} setName={setVoterName} />
                   </div>
-                  
+
                   <button
                     onClick={handleVoteClick}
                     disabled={isSubmitting || (!yesNoChoice && !isAbstaining)}
@@ -1783,19 +1773,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   )}
 
                   <div className="mb-4">
-                    <label htmlFor="voterName" className="block text-sm font-medium mb-1">
-                      Your Name <span className="text-gray-500 font-normal">(optional)</span>
-                    </label>
-                    <input
-                      type="text"
-                      id="voterName"
-                      value={voterName}
-                      onChange={(e) => setVoterName(e.target.value)}
-                      disabled={isSubmitting}
-                      maxLength={30}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                      placeholder="Enter your name..."
-                    />
+                    <CompactNameField name={voterName} setName={setVoterName} disabled={isSubmitting} maxLength={30} />
                   </div>
 
                   {hasTimeWindowTooShort && (
@@ -2070,18 +2048,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   </div>
 
                   <div className="mt-4">
-                    <label htmlFor="voterNameRanked" className="block text-sm font-medium mb-1">
-                      Your Name (optional)
-                    </label>
-                    <input
-                      type="text"
-                      id="voterNameRanked"
-                      value={voterName}
-                      onChange={(e) => setVoterName(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
-                      placeholder="Enter your name..."
-                      maxLength={50}
-                    />
+                    <CompactNameField name={voterName} setName={setVoterName} />
                   </div>
                   
                   <button

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -136,15 +136,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   // Check if poll has time windows but none are enabled (voter voted Yes with all days unchecked)
   const hasNoEnabledTimeWindows = useMemo(() => {
     if (poll.poll_type !== 'participation') return false;
-    const pollHasTimeWindows = poll.day_time_windows && poll.day_time_windows.some(
-      (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) => dtw.windows.length > 0
+    if (!poll.day_time_windows?.some((dtw: DayTimeWindow) => dtw.windows.length > 0)) return false;
+    return !voterDayTimeWindows.some(
+      (dtw: DayTimeWindow) => dtw.windows.some(w => w.enabled !== false)
     );
-    if (!pollHasTimeWindows) return false;
-    const enabledWindows = voterDayTimeWindows.flatMap(
-      (dtw: { windows: { min: string; max: string; enabled?: boolean }[] }) =>
-        dtw.windows.filter((w: { enabled?: boolean }) => w.enabled !== false)
-    );
-    return enabledWindows.length === 0;
   }, [poll.poll_type, poll.day_time_windows, voterDayTimeWindows]);
 
   // Check if any enabled voter time window is shorter than the minimum duration

--- a/components/CompactNameField.tsx
+++ b/components/CompactNameField.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+interface CompactNameFieldProps {
+  name: string;
+  setName: (name: string) => void;
+  disabled?: boolean;
+  maxLength?: number;
+}
+
+export default function CompactNameField({ name, setName, disabled = false, maxLength = 50 }: CompactNameFieldProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+    }
+  }, [isEditing]);
+
+  const handleEdit = () => {
+    setIsEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  if (isEditing) {
+    return (
+      <div>
+        <label htmlFor="compactName" className="block text-sm font-medium mb-1">
+          Your Name{!name.trim() && <>{' '}<span className="font-normal">(optional)</span></>}
+        </label>
+        <input
+          ref={inputRef}
+          type="text"
+          id="compactName"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => setIsEditing(false)}
+          disabled={disabled}
+          maxLength={maxLength}
+          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          placeholder="Enter your name..."
+        />
+      </div>
+    );
+  }
+
+  if (name.trim()) {
+    return (
+      <button
+        type="button"
+        onClick={handleEdit}
+        className="block text-sm font-medium text-left"
+      >
+        Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{name.trim()}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="text-sm font-medium">
+      Your Name <span className="font-normal">(optional)</span>:{' '}
+      <button
+        type="button"
+        onClick={handleEdit}
+        className="font-normal text-blue-600 dark:text-blue-400"
+      >
+        Add
+      </button>
+    </div>
+  );
+}

--- a/components/CompactNameField.tsx
+++ b/components/CompactNameField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId } from 'react';
 
 interface CompactNameFieldProps {
   name: string;
@@ -12,6 +12,7 @@ interface CompactNameFieldProps {
 export default function CompactNameField({ name, setName, disabled = false, maxLength = 50 }: CompactNameFieldProps) {
   const [isEditing, setIsEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const id = useId();
 
   useEffect(() => {
     if (isEditing) {
@@ -19,21 +20,16 @@ export default function CompactNameField({ name, setName, disabled = false, maxL
     }
   }, [isEditing]);
 
-  const handleEdit = () => {
-    setIsEditing(true);
-    setTimeout(() => inputRef.current?.focus(), 0);
-  };
-
   if (isEditing) {
     return (
       <div>
-        <label htmlFor="compactName" className="block text-sm font-medium mb-1">
-          Your Name{!name.trim() && <>{' '}<span className="font-normal">(optional)</span></>}
+        <label htmlFor={id} className="block text-sm font-medium mb-1">
+          Your Name{!name.trim() && <> <span className="font-normal">(optional)</span></>}
         </label>
         <input
           ref={inputRef}
           type="text"
-          id="compactName"
+          id={id}
           value={name}
           onChange={(e) => setName(e.target.value)}
           onBlur={() => setIsEditing(false)}
@@ -50,7 +46,7 @@ export default function CompactNameField({ name, setName, disabled = false, maxL
     return (
       <button
         type="button"
-        onClick={handleEdit}
+        onClick={() => setIsEditing(true)}
         className="block text-sm font-medium text-left"
       >
         Your Name: <span className="font-normal text-blue-600 dark:text-blue-400">{name.trim()}</span>
@@ -63,7 +59,7 @@ export default function CompactNameField({ name, setName, disabled = false, maxL
       Your Name <span className="font-normal">(optional)</span>:{' '}
       <button
         type="button"
-        onClick={handleEdit}
+        onClick={() => setIsEditing(true)}
         className="font-normal text-blue-600 dark:text-blue-400"
       >
         Add

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -5,6 +5,7 @@ import PollResultsDisplay from "@/components/PollResults";
 import OptionsInput, { type OptionsMetadata } from "@/components/OptionsInput";
 import { isLocationLikeCategory } from "@/components/TypeFieldInput";
 import SuggestionsList from "@/components/SuggestionsList";
+import CompactNameField from "@/components/CompactNameField";
 import OptionLabel from "@/components/OptionLabel";
 import PollManagementButtons from "@/components/PollManagementButtons";
 import VoterList from "@/components/VoterList";
@@ -383,18 +384,7 @@ export default function SuggestionVotingInterface({
 
       {/* Voter Name Input */}
       <div className="mb-3">
-        <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-          Your name (optional)
-        </label>
-        <input
-          type="text"
-          value={voterName}
-          onChange={(e) => setVoterName(e.target.value)}
-          disabled={isSubmitting}
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-          placeholder="Enter your name (optional)"
-          maxLength={50}
-        />
+        <CompactNameField name={voterName} setName={setVoterName} disabled={isSubmitting} />
       </div>
 
       {/* Submit Button */}


### PR DESCRIPTION
## Summary
- Extract reusable `CompactNameField` component (collapsed "Add" button → clickable name display → expandable input)
- Replace always-visible name inputs in all 4 voting forms (yes/no, participation, ranked choice, suggestion) and the create-poll page
- Disable submit on participation polls when Yes is selected but no time windows are enabled, with a warning message

## Test plan
- [ ] Verify compact name field works in all poll types (shows Add, expands on click, collapses on blur)
- [ ] Verify participation poll disables Submit when Yes + no time windows enabled
- [ ] Verify warning message appears for no-time-windows case
- [ ] Verify create-poll page name field still works correctly

https://claude.ai/code/session_01EdtJiB7D7DaCHUiGonR8Th