### PR TITLE
Move poll Yes/No buttons above conditions

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1739,33 +1739,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                 </div>
               ) : (
                 <>
-                  <div className="mb-4">
-                    <h3 className="text-lg font-semibold mb-4 text-center">Your Conditions</h3>
-                    <ParticipationConditions
-                      minValue={voterMinParticipants}
-                      maxValue={voterMaxParticipants}
-                      maxEnabled={voterMaxEnabled}
-                      onMinChange={setVoterMinParticipants}
-                      onMaxChange={setVoterMaxParticipants}
-                      onMaxEnabledChange={setVoterMaxEnabled}
-                      disabled={isSubmitting}
-                      pollMinParticipants={poll.min_participants}
-                      pollMaxParticipants={poll.max_participants}
-                      durationMinValue={durationMinValue}
-                      durationMaxValue={durationMaxValue}
-                      durationMinEnabled={durationMinEnabled}
-                      durationMaxEnabled={durationMaxEnabled}
-                      onDurationMinChange={setDurationMinValue}
-                      onDurationMaxChange={setDurationMaxValue}
-                      onDurationMinEnabledChange={setDurationMinEnabled}
-                      onDurationMaxEnabledChange={setDurationMaxEnabled}
-                      dayTimeWindows={voterDayTimeWindows}
-                      onDayTimeWindowsChange={setVoterDayTimeWindows}
-                      pollDayTimeWindows={poll.day_time_windows || undefined}
-                      pollDurationWindow={poll.duration_window || undefined}
-                    />
-                  </div>
-
                   <div className="mb-4 text-center">
                     <YesNoAbstainButtons
                       yesNoChoice={yesNoChoice}
@@ -1773,6 +1746,41 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       onNoClick={() => handleYesNoVote('no')}
                       disabled={isSubmitting}
                     />
+                  </div>
+
+                  <div
+                    className="overflow-hidden transition-all duration-300 ease-in-out"
+                    style={{
+                      maxHeight: yesNoChoice === 'no' ? '0px' : '2000px',
+                      opacity: yesNoChoice === 'no' ? 0 : 1,
+                    }}
+                  >
+                    <div className="mb-4">
+                      <h3 className="text-lg font-semibold mb-4 text-center">Your Conditions</h3>
+                      <ParticipationConditions
+                        minValue={voterMinParticipants}
+                        maxValue={voterMaxParticipants}
+                        maxEnabled={voterMaxEnabled}
+                        onMinChange={setVoterMinParticipants}
+                        onMaxChange={setVoterMaxParticipants}
+                        onMaxEnabledChange={setVoterMaxEnabled}
+                        disabled={isSubmitting}
+                        pollMinParticipants={poll.min_participants}
+                        pollMaxParticipants={poll.max_participants}
+                        durationMinValue={durationMinValue}
+                        durationMaxValue={durationMaxValue}
+                        durationMinEnabled={durationMinEnabled}
+                        durationMaxEnabled={durationMaxEnabled}
+                        onDurationMinChange={setDurationMinValue}
+                        onDurationMaxChange={setDurationMaxValue}
+                        onDurationMinEnabledChange={setDurationMinEnabled}
+                        onDurationMaxEnabledChange={setDurationMaxEnabled}
+                        dayTimeWindows={voterDayTimeWindows}
+                        onDayTimeWindowsChange={setVoterDayTimeWindows}
+                        pollDayTimeWindows={poll.day_time_windows || undefined}
+                        pollDurationWindow={poll.duration_window || undefined}
+                      />
+                    </div>
                   </div>
 
                   {voteError && (

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1749,13 +1749,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   </div>
 
                   <div
-                    className="overflow-hidden transition-all duration-300 ease-in-out"
+                    className="grid transition-[grid-template-rows,opacity] duration-300 ease-in-out"
                     style={{
-                      maxHeight: yesNoChoice === 'no' ? '0px' : '2000px',
+                      gridTemplateRows: yesNoChoice === 'no' ? '0fr' : '1fr',
                       opacity: yesNoChoice === 'no' ? 0 : 1,
                     }}
                   >
-                    <div className="mb-4">
+                    <div className="overflow-hidden min-h-0">
+                      <div className="mb-4">
                       <h3 className="text-lg font-semibold mb-4 text-center">Your Conditions</h3>
                       <ParticipationConditions
                         minValue={voterMinParticipants}
@@ -1780,6 +1781,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                         pollDayTimeWindows={poll.day_time_windows || undefined}
                         pollDurationWindow={poll.duration_window || undefined}
                       />
+                      </div>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary
- Moves Yes/No buttons to the top of the participation poll ballot, above "Your Conditions"
- When user selects No, conditions section smoothly collapses using CSS grid animation (`grid-template-rows: 0fr/1fr`)
- Conditions stay mounted when collapsed to preserve user-entered values if they toggle back to Yes

## Test plan
- [ ] Open a participation poll and verify Yes/No buttons appear above conditions
- [ ] Click No and verify conditions collapse with smooth animation
- [ ] Click Yes after No and verify conditions expand back with values preserved
- [ ] Verify initial state (no choice) shows conditions visible
- [ ] Test on mobile viewport

https://claude.ai/code/session_016VGCAadsbga2EX9DwXgCh1