### PR TITLE
Group time slots compactly, add Result page

### DIFF
--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -283,7 +283,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
   // Wait for participant data before rendering status
   if (loading) {
     return (
-      <div className="rounded-lg border-2 bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-600 p-6">
+      <div className="rounded-lg border-2 bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-600 px-4 py-3">
         <div className="text-center">
           <div className="text-gray-500 dark:text-gray-400 animate-pulse">
             Loading results...
@@ -296,9 +296,9 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
   // SCENARIO: No votes at all
   if (totalVotes === 0) {
     return (
-      <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 p-6">
+      <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
         <div className="text-center">
-          <div className="text-2xl font-bold mb-2 text-red-800 dark:text-red-200">
+          <div className="text-xl font-bold mb-1 text-red-800 dark:text-red-200">
             Not happening
           </div>
           <div className="text-sm text-red-700 dark:text-red-300">
@@ -321,26 +321,26 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
       const isAlone = participants.length === 1;
 
       return (
-        <div className="rounded-lg border-2 bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 p-6">
+        <div className="rounded-lg border-2 bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 px-4 py-3">
           <div className="text-center">
-            <div className="text-2xl font-bold mb-4 text-green-800 dark:text-green-200">
+            <div className="text-xl font-bold mb-1 text-green-800 dark:text-green-200">
               🎉 You&apos;re participating!
             </div>
             {isAlone ? (
-              <div className="text-lg text-green-700 dark:text-green-300">
+              <div className="text-sm text-green-700 dark:text-green-300">
                 😢 All alone
               </div>
             ) : (
               <div>
-                <div className="text-sm text-green-700 dark:text-green-300 mb-2">
+                <div className="text-xs text-green-700 dark:text-green-300 mb-1">
                   along with
                 </div>
-                <div className="flex flex-wrap items-center justify-center gap-2">
+                <div className="flex flex-wrap items-center justify-center gap-1.5">
                   {/* Other named participants */}
                   {otherParticipants.map((participant) => (
                     <span
                       key={participant.id}
-                      className={`inline-block px-3 py-1 rounded-full text-sm ${getParticipantColor(participant.vote_id!, false)}`}
+                      className={`inline-block px-2 py-0.5 rounded-full text-sm ${getParticipantColor(participant.vote_id!, false)}`}
                     >
                       {participant.voter_name}
                     </span>
@@ -348,7 +348,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
                   {/* Anonymous participants (excluding current user) */}
                   {otherAnonymousCount > 0 && (
-                    <div className="inline-block px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600">
+                    <div className="inline-block px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600">
                       <span className="text-sm text-gray-600 dark:text-gray-300 italic">
                         {otherAnonymousCount} × Anonymous
                       </span>
@@ -365,12 +365,12 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     // Scenario: Event IS happening, user voted YES but is NOT in participant list (needs weren't met)
     if (isHappening && userVotedYes && !userIsInParticipantList) {
       return (
-        <div className="rounded-lg border-2 bg-yellow-100 dark:bg-yellow-900 border-yellow-400 dark:border-yellow-600 p-6">
+        <div className="rounded-lg border-2 bg-yellow-100 dark:bg-yellow-900 border-yellow-400 dark:border-yellow-600 px-4 py-3">
           <div className="text-center">
-            <div className="text-2xl font-bold mb-4 text-yellow-800 dark:text-yellow-200">
+            <div className="text-xl font-bold mb-1 text-yellow-800 dark:text-yellow-200">
               You&apos;re not participating
             </div>
-            <div className="flex flex-wrap items-center justify-center gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-1.5">
               <span className="text-sm text-yellow-700 dark:text-yellow-300">
                 but these are
               </span>
@@ -378,7 +378,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
               {namedParticipants.map((participant) => (
                 <span
                   key={participant.id}
-                  className={`inline-block px-3 py-1 rounded-full text-sm ${getParticipantColor(participant.vote_id!, false)}`}
+                  className={`inline-block px-2 py-0.5 rounded-full text-sm ${getParticipantColor(participant.vote_id!, false)}`}
                 >
                   {participant.voter_name}
                 </span>
@@ -386,7 +386,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
               {/* Anonymous participants */}
               {anonymousParticipantCount > 0 && (
-                <div className="inline-block px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600">
+                <div className="inline-block px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600">
                   <span className="text-sm text-gray-600 dark:text-gray-300 italic">
                     {anonymousParticipantCount} × Anonymous
                   </span>
@@ -401,12 +401,12 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     // Scenario: Event IS happening, user voted NO or didn't vote
     if (isHappening && (userVotedNo || !userVoteData)) {
       return (
-        <div className="rounded-lg border-2 bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 p-6">
+        <div className="rounded-lg border-2 bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 px-4 py-3">
           <div className="text-center">
-            <div className="text-2xl font-bold mb-4 text-green-800 dark:text-green-200">
+            <div className="text-xl font-bold mb-1 text-green-800 dark:text-green-200">
               You&apos;re not participating
             </div>
-            <div className="flex flex-wrap items-center justify-center gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-1.5">
               <span className="text-sm text-green-700 dark:text-green-300">
                 but these are
               </span>
@@ -414,7 +414,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
               {namedParticipants.map((participant) => (
                 <span
                   key={participant.id}
-                  className={`inline-block px-3 py-1 rounded-full text-sm ${getParticipantColor(participant.vote_id!, false)}`}
+                  className={`inline-block px-2 py-0.5 rounded-full text-sm ${getParticipantColor(participant.vote_id!, false)}`}
                 >
                   {participant.voter_name}
                 </span>
@@ -422,7 +422,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
               {/* Anonymous participants */}
               {anonymousParticipantCount > 0 && (
-                <div className="inline-block px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600">
+                <div className="inline-block px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600">
                   <span className="text-sm text-gray-600 dark:text-gray-300 italic">
                     {anonymousParticipantCount} × Anonymous
                   </span>
@@ -484,7 +484,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
       // Check if there are no participants at all
       if (yesCount === 0) {
         return (
-          <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 p-6">
+          <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
             <div className="text-center">
               <div className="text-xl font-bold text-red-800 dark:text-red-200">
                 No one is participating
@@ -495,9 +495,9 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
       }
 
       return (
-        <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 p-6">
+        <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
           <div className="text-center">
-            <div className="text-xl font-bold mb-2 text-red-800 dark:text-red-200">
+            <div className="text-xl font-bold mb-1 text-red-800 dark:text-red-200">
               ✗ Not happening
             </div>
             <div className="text-sm text-red-700 dark:text-red-300">

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -259,11 +259,65 @@ export default function TimeSlotRoundsDisplay({
 
   const groups = useMemo(() => buildGroups(currentSlots), [currentSlots]);
 
+  // Check if all groups share a single date so we can show it once as a header
+  const allDates = useMemo(() => {
+    const dates = new Set<string>();
+    for (const g of groups) {
+      for (const dr of g.dateRanges) dates.add(dr.date);
+    }
+    return [...dates].sort();
+  }, [groups]);
+  const singleDate = allDates.length === 1 ? allDates[0] : null;
+
   const COLLAPSED_GROUPS = 4;
   const needsCollapse = groups.length > COLLAPSED_GROUPS + 1;
   const showAll = expanded || !needsCollapse;
   const visibleGroups = showAll ? groups : groups.slice(0, COLLAPSED_GROUPS);
   const hiddenGroupCount = groups.length - visibleGroups.length;
+
+  if (allRounds.length === 0) {
+    return (
+      <div className="text-center text-gray-600 dark:text-gray-400">
+        No time slots available
+      </div>
+    );
+  }
+
+  // Result page: simple labeled layout with a back arrow to see rounds
+  if (isResultPage && winnerSlot) {
+    return (
+      <div className="w-full max-w-2xl mx-auto">
+        <div className="border rounded-lg overflow-hidden dark:border-gray-700 bg-white dark:bg-gray-800">
+          <div className="px-4 py-2.5 flex items-center">
+            <button
+              onClick={() => setCurrentPage(totalRounds)}
+              className="p-1.5 -ml-1 mr-2 rounded text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+              aria-label="View considered time slots"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <div className="flex-1 space-y-0.5">
+              <div className="flex items-baseline gap-2">
+                <span className="text-xs text-gray-500 dark:text-gray-400 w-8">Time</span>
+                <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {formatTimeRange(winnerSlot)}
+                </span>
+                <span className="text-xs text-gray-400 dark:text-gray-500">{formatDuration(winnerSlot.duration_hours)}</span>
+              </div>
+              <div className="flex items-baseline gap-2">
+                <span className="text-xs text-gray-500 dark:text-gray-400 w-8">Date</span>
+                <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {formatDate(winnerSlot.slot_date)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const renderParticipantPills = (group: SlotGroup) => (
     <div className="flex flex-wrap gap-1">
@@ -288,62 +342,6 @@ export default function TimeSlotRoundsDisplay({
       })}
     </div>
   );
-
-  // (result page rendering handled separately below)
-
-  if (allRounds.length === 0) {
-    return (
-      <div className="text-center text-gray-600 dark:text-gray-400">
-        No time slots available
-      </div>
-    );
-  }
-
-  // Result page: simple labeled layout with a back arrow to see rounds
-  if (isResultPage && winnerSlot) {
-    return (
-      <div className="w-full max-w-2xl mx-auto">
-        <div className="border rounded-lg overflow-hidden dark:border-gray-700 bg-white dark:bg-gray-800">
-          <div className="px-4 py-2.5 flex items-start justify-between">
-            <div className="space-y-1">
-              <div>
-                <span className="text-xs text-gray-500 dark:text-gray-400">Time</span>
-                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                  {formatTimeRange(winnerSlot)} <span className="font-normal text-gray-400 dark:text-gray-500">{formatDuration(winnerSlot.duration_hours)}</span>
-                </div>
-              </div>
-              <div>
-                <span className="text-xs text-gray-500 dark:text-gray-400">Date</span>
-                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                  {formatDate(winnerSlot.slot_date)}
-                </div>
-              </div>
-            </div>
-            <button
-              onClick={() => setCurrentPage(totalRounds)}
-              className="p-1 rounded text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-              aria-label="View rounds"
-              title="View considered time slots"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Check if all groups share a single date so we can show it once as a header
-  const allDates = useMemo(() => {
-    const dates = new Set<string>();
-    for (const g of groups) {
-      for (const dr of g.dateRanges) dates.add(dr.date);
-    }
-    return [...dates].sort();
-  }, [groups]);
-  const singleDate = allDates.length === 1 ? allDates[0] : null;
 
   const formatGroupRanges = (group: SlotGroup): string => {
     return group.dateRanges.map(dr => {

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useMemo } from 'react';
+import { timeToMinutes } from '@/lib/timeUtils';
 
 export interface TimeSlot {
   round_number: number;
@@ -75,7 +76,6 @@ interface StartTimeRange {
   first: string; // HH:MM
   last: string;  // HH:MM
   count: number;
-  step: number;  // minutes between consecutive slots
 }
 
 interface DateRanges {
@@ -93,11 +93,6 @@ interface SlotGroup {
   slotCount: number;
 }
 
-function timeToMinutes(timeStr: string): number {
-  const [h, m] = timeStr.split(':').map(Number);
-  return h * 60 + m;
-}
-
 function minutesToTimeStr(mins: number): string {
   const h = Math.floor(mins / 60) % 24;
   const m = mins % 60;
@@ -107,7 +102,7 @@ function minutesToTimeStr(mins: number): string {
 function findContiguousRanges(sortedMinutes: number[]): StartTimeRange[] {
   if (sortedMinutes.length === 0) return [];
   if (sortedMinutes.length === 1) {
-    return [{ first: minutesToTimeStr(sortedMinutes[0]), last: minutesToTimeStr(sortedMinutes[0]), count: 1, step: 0 }];
+    return [{ first: minutesToTimeStr(sortedMinutes[0]), last: minutesToTimeStr(sortedMinutes[0]), count: 1 }];
   }
 
   // Detect step as minimum positive gap
@@ -127,13 +122,13 @@ function findContiguousRanges(sortedMinutes: number[]): StartTimeRange[] {
       prev = sortedMinutes[i];
       count++;
     } else {
-      ranges.push({ first: minutesToTimeStr(start), last: minutesToTimeStr(prev), count, step: minStep });
+      ranges.push({ first: minutesToTimeStr(start), last: minutesToTimeStr(prev), count });
       start = sortedMinutes[i];
       prev = sortedMinutes[i];
       count = 1;
     }
   }
-  ranges.push({ first: minutesToTimeStr(start), last: minutesToTimeStr(prev), count, step: minStep });
+  ranges.push({ first: minutesToTimeStr(start), last: minutesToTimeStr(prev), count });
 
   return ranges;
 }
@@ -203,7 +198,6 @@ function formatStartTimeRange(range: StartTimeRange): string {
   return `${formatTime(range.first)} ${firstPeriod}\u2013${formatTime(range.last)} ${lastPeriod}`;
 }
 
-
 // --- Component ---
 
 export default function TimeSlotRoundsDisplay({
@@ -231,7 +225,7 @@ export default function TimeSlotRoundsDisplay({
     return map;
   }, [allVoters, allRounds]);
 
-  const { roundsByNumber, totalRounds } = useMemo(() => {
+  const { roundsByNumber, totalRounds, winnerSlot } = useMemo(() => {
     const byNumber = allRounds.reduce((acc, slot) => {
       if (!acc[slot.round_number]) acc[slot.round_number] = [];
       acc[slot.round_number].push(slot);
@@ -240,15 +234,12 @@ export default function TimeSlotRoundsDisplay({
     return {
       roundsByNumber: byNumber,
       totalRounds: Math.max(...Object.keys(byNumber).map(Number)),
+      winnerSlot: allRounds.find(s => s.is_winner) || null,
     };
   }, [allRounds]);
 
-  // The winner slot (first slot in round 1 with is_winner=true)
-  const winnerSlot = useMemo(() => allRounds.find(s => s.is_winner) || null, [allRounds]);
-
   // Virtual "Result" page is totalRounds + 1, shown by default
   const resultPage = totalRounds + 1;
-  const totalPages = resultPage;
   const [currentPage, setCurrentPage] = useState(resultPage);
 
   const isResultPage = currentPage === resultPage;
@@ -257,17 +248,14 @@ export default function TimeSlotRoundsDisplay({
   const participantCount = currentSlots.length > 0 ? currentSlots[0].participant_count : 0;
   const totalSlotCount = currentSlots.length;
 
-  const groups = useMemo(() => buildGroups(currentSlots), [currentSlots]);
-
-  // Check if all groups share a single date so we can show it once as a header
-  const allDates = useMemo(() => {
+  const { groups, singleDate } = useMemo(() => {
+    const g = buildGroups(currentSlots);
     const dates = new Set<string>();
-    for (const g of groups) {
-      for (const dr of g.dateRanges) dates.add(dr.date);
+    for (const group of g) {
+      for (const dr of group.dateRanges) dates.add(dr.date);
     }
-    return [...dates].sort();
-  }, [groups]);
-  const singleDate = allDates.length === 1 ? allDates[0] : null;
+    return { groups: g, singleDate: dates.size === 1 ? [...dates][0] : null };
+  }, [currentSlots]);
 
   const COLLAPSED_GROUPS = 4;
   const needsCollapse = groups.length > COLLAPSED_GROUPS + 1;
@@ -418,7 +406,6 @@ export default function TimeSlotRoundsDisplay({
 
         <button
           onClick={() => currentPage === totalRounds ? setCurrentPage(resultPage) : setCurrentPage(p => p + 1)}
-          disabled={false}
           className="p-1.5 rounded text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900"
           aria-label={currentPage === totalRounds ? 'Back to result' : 'Next round'}
         >

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -288,6 +288,49 @@ export default function TimeSlotRoundsDisplay({
     </div>
   );
 
+  const isFinalRound = currentRound === totalRounds;
+
+  const renderFinalRoundSlot = (slot: TimeSlot) => (
+    <div className="bg-green-50 dark:bg-green-900/30 px-3 py-2.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+          </svg>
+          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {formatTimeRange(slot)}
+          </span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {formatDuration(slot.duration_hours)}
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {slot.participant_names.map((name, idx) => {
+            const voteId = slot.participant_vote_ids[idx];
+            const isCurrentUser = voteId === currentUserVoteId;
+            const colorClass = (voteId && colorMap.get(voteId)) || PARTICIPANT_COLORS[0];
+            const displayName = isCurrentUser
+              ? (name ? `You (${name})` : 'You')
+              : (name || 'Anonymous');
+            return (
+              <span
+                key={voteId || idx}
+                className={`inline-block px-2 py-0.5 rounded-full text-xs ${
+                  isCurrentUser ? 'font-bold ring-1 ring-blue-500 dark:ring-blue-400' : 'font-medium'
+                } ${colorClass}`}
+              >
+                {displayName}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+      <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 ml-6">
+        {formatDate(slot.slot_date)}
+      </div>
+    </div>
+  );
+
   const renderGroup = (group: SlotGroup, groupIdx: number) => {
     const hasWinner = !!group.winner_slot;
 
@@ -392,18 +435,24 @@ export default function TimeSlotRoundsDisplay({
       </div>
 
       <div className="border rounded-lg overflow-hidden dark:border-gray-700">
-        {visibleGroups.map((group, index) => renderGroup(group, index))}
+        {isFinalRound && totalRounds > 1 && currentSlots.find(s => s.is_winner) ? (
+          renderFinalRoundSlot(currentSlots.find(s => s.is_winner)!)
+        ) : (
+          <>
+            {visibleGroups.map((group, index) => renderGroup(group, index))}
 
-        {needsCollapse && (
-          <button
-            onClick={() => setExpanded(!expanded)}
-            className="w-full px-3 py-2 text-center text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-50 dark:hover:bg-gray-700 border-t border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800"
-          >
-            {expanded
-              ? 'Show less'
-              : `Show ${hiddenGroupCount} more group${hiddenGroupCount === 1 ? '' : 's'}`
-            }
-          </button>
+            {needsCollapse && (
+              <button
+                onClick={() => setExpanded(!expanded)}
+                className="w-full px-3 py-2 text-center text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-50 dark:hover:bg-gray-700 border-t border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800"
+              >
+                {expanded
+                  ? 'Show less'
+                  : `Show ${hiddenGroupCount} more group${hiddenGroupCount === 1 ? '' : 's'}`
+                }
+              </button>
+            )}
+          </>
         )}
       </div>
 

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -265,14 +265,6 @@ export default function TimeSlotRoundsDisplay({
   const visibleGroups = showAll ? groups : groups.slice(0, COLLAPSED_GROUPS);
   const hiddenGroupCount = groups.length - visibleGroups.length;
 
-  if (allRounds.length === 0) {
-    return (
-      <div className="text-center text-gray-600 dark:text-gray-400">
-        No time slots available
-      </div>
-    );
-  }
-
   const renderParticipantPills = (group: SlotGroup) => (
     <div className="flex flex-wrap gap-1">
       {group.participant_names.map((name, idx) => {
@@ -299,46 +291,49 @@ export default function TimeSlotRoundsDisplay({
 
   // (result page rendering handled separately below)
 
-  const renderFinalRoundSlot = (slot: TimeSlot) => (
-    <div className="bg-green-50 dark:bg-green-900/30 px-3 py-2.5">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-          </svg>
-          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-            {formatTimeRange(slot)}
-          </span>
-          <span className="text-xs text-gray-400 dark:text-gray-500">
-            {formatDuration(slot.duration_hours)}
-          </span>
-        </div>
-        <div className="flex flex-wrap gap-1">
-          {slot.participant_names.map((name, idx) => {
-            const voteId = slot.participant_vote_ids[idx];
-            const isCurrentUser = voteId === currentUserVoteId;
-            const colorClass = (voteId && colorMap.get(voteId)) || PARTICIPANT_COLORS[0];
-            const displayName = isCurrentUser
-              ? (name ? `You (${name})` : 'You')
-              : (name || 'Anonymous');
-            return (
-              <span
-                key={voteId || idx}
-                className={`inline-block px-2 py-0.5 rounded-full text-xs ${
-                  isCurrentUser ? 'font-bold ring-1 ring-blue-500 dark:ring-blue-400' : 'font-medium'
-                } ${colorClass}`}
-              >
-                {displayName}
-              </span>
-            );
-          })}
+  if (allRounds.length === 0) {
+    return (
+      <div className="text-center text-gray-600 dark:text-gray-400">
+        No time slots available
+      </div>
+    );
+  }
+
+  // Result page: simple labeled layout with a back arrow to see rounds
+  if (isResultPage && winnerSlot) {
+    return (
+      <div className="w-full max-w-2xl mx-auto">
+        <div className="border rounded-lg overflow-hidden dark:border-gray-700 bg-white dark:bg-gray-800">
+          <div className="px-4 py-2.5 flex items-start justify-between">
+            <div className="space-y-1">
+              <div>
+                <span className="text-xs text-gray-500 dark:text-gray-400">Time</span>
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {formatTimeRange(winnerSlot)} <span className="font-normal text-gray-400 dark:text-gray-500">{formatDuration(winnerSlot.duration_hours)}</span>
+                </div>
+              </div>
+              <div>
+                <span className="text-xs text-gray-500 dark:text-gray-400">Date</span>
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  {formatDate(winnerSlot.slot_date)}
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => setCurrentPage(totalRounds)}
+              className="p-1 rounded text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+              aria-label="View rounds"
+              title="View considered time slots"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
-      <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 ml-6">
-        {formatDate(slot.slot_date)}
-      </div>
-    </div>
-  );
+    );
+  }
 
   // Check if all groups share a single date so we can show it once as a header
   const allDates = useMemo(() => {
@@ -415,31 +410,19 @@ export default function TimeSlotRoundsDisplay({
         </button>
 
         <div className="text-center flex-1">
-          {isResultPage ? (
-            <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
-              Result
-            </div>
-          ) : (
-            <>
-              <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
-                Round {currentPage} of {totalRounds}
-              </div>
-              <div className="text-xs text-gray-500 dark:text-gray-400">
-                {participantCount} {participantCount === 1 ? 'participant' : 'participants'} &middot; {totalSlotCount} time slot{totalSlotCount !== 1 ? 's' : ''}
-              </div>
-            </>
-          )}
+          <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
+            Round {currentPage} of {totalRounds}
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            {participantCount} {participantCount === 1 ? 'participant' : 'participants'} &middot; {totalSlotCount} time slot{totalSlotCount !== 1 ? 's' : ''}
+          </div>
         </div>
 
         <button
-          onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
-          disabled={currentPage === totalPages}
-          className={`p-1.5 rounded ${
-            currentPage === totalPages
-              ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
-              : 'text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900'
-          }`}
-          aria-label="Next round"
+          onClick={() => currentPage === totalRounds ? setCurrentPage(resultPage) : setCurrentPage(p => p + 1)}
+          disabled={false}
+          className="p-1.5 rounded text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900"
+          aria-label={currentPage === totalRounds ? 'Back to result' : 'Next round'}
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -448,48 +431,25 @@ export default function TimeSlotRoundsDisplay({
       </div>
 
       <div className="border rounded-lg overflow-hidden dark:border-gray-700">
-        {isResultPage && winnerSlot ? (
-          renderFinalRoundSlot(winnerSlot)
-        ) : (
-          <>
-            {singleDate && (
-              <div className="px-3 py-1 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                {formatDate(singleDate)}
-              </div>
-            )}
-            {visibleGroups.map((group, index) => renderGroup(group, index))}
+        {singleDate && (
+          <div className="px-3 py-1 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+            {formatDate(singleDate)}
+          </div>
+        )}
+        {visibleGroups.map((group, index) => renderGroup(group, index))}
 
-            {needsCollapse && (
-              <button
-                onClick={() => setExpanded(!expanded)}
-                className="w-full px-3 py-2 text-center text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-50 dark:hover:bg-gray-700 border-t border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800"
-              >
-                {expanded
-                  ? 'Show less'
-                  : `Show ${hiddenGroupCount} more group${hiddenGroupCount === 1 ? '' : 's'}`
-                }
-              </button>
-            )}
-          </>
+        {needsCollapse && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="w-full px-3 py-2 text-center text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-50 dark:hover:bg-gray-700 border-t border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800"
+          >
+            {expanded
+              ? 'Show less'
+              : `Show ${hiddenGroupCount} more group${hiddenGroupCount === 1 ? '' : 's'}`
+            }
+          </button>
         )}
       </div>
-
-      {totalPages > 1 && (
-        <div className="flex justify-center gap-2 mt-3">
-          {Array.from({ length: totalPages }, (_, i) => i + 1).map((pageNum) => (
-            <button
-              key={pageNum}
-              onClick={() => setCurrentPage(pageNum)}
-              className={`w-2 h-2 rounded-full ${
-                pageNum === currentPage
-                  ? 'bg-blue-600 dark:bg-blue-400'
-                  : 'bg-gray-300 dark:bg-gray-600'
-              }`}
-              aria-label={pageNum === resultPage ? 'Go to result' : `Go to round ${pageNum}`}
-            />
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -331,61 +331,57 @@ export default function TimeSlotRoundsDisplay({
     </div>
   );
 
+  // Check if all groups share a single date so we can show it once as a header
+  const allDates = useMemo(() => {
+    const dates = new Set<string>();
+    for (const g of groups) {
+      for (const dr of g.dateRanges) dates.add(dr.date);
+    }
+    return [...dates].sort();
+  }, [groups]);
+  const singleDate = allDates.length === 1 ? allDates[0] : null;
+
+  const formatGroupRanges = (group: SlotGroup): string => {
+    return group.dateRanges.map(dr => {
+      const datePrefix = singleDate ? '' : `${formatDate(dr.date)}: `;
+      const ranges = dr.ranges.map(r => formatStartTimeRange(r)).join(', ');
+      return `${datePrefix}${ranges}`;
+    }).join(' · ');
+  };
+
   const renderGroup = (group: SlotGroup, groupIdx: number) => {
     const hasWinner = !!group.winner_slot;
 
     return (
       <div
         key={groupIdx}
-        className={`${groupIdx > 0 ? 'border-t border-gray-200 dark:border-gray-600' : ''} ${
+        className={`flex items-center px-3 py-1.5 ${groupIdx > 0 ? 'border-t border-gray-100 dark:border-gray-700' : ''} ${
           hasWinner ? 'bg-green-50 dark:bg-green-900/30' : 'bg-white dark:bg-gray-800'
         }`}
       >
-        {/* Header: duration, slot count, participants */}
-        <div className="px-3 pt-2.5 pb-1">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              {hasWinner && (
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                </svg>
-              )}
-              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                {formatDuration(group.duration_hours)}
-              </span>
-              <span className="text-xs text-gray-400 dark:text-gray-500">
-                {group.slotCount} slot{group.slotCount !== 1 ? 's' : ''}
-              </span>
-            </div>
-            {renderParticipantPills(group)}
-          </div>
-
-          {/* Winner callout */}
-          {hasWinner && group.winner_slot && (
-            <div className="mt-1 text-xs font-medium text-green-700 dark:text-green-300">
-              Winner: {formatTimeRange(group.winner_slot)}, {formatDate(group.winner_slot.slot_date)}
-            </div>
+        <div className="w-5 flex-shrink-0">
+          {hasWinner && (
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+            </svg>
           )}
         </div>
 
-        {/* Date + start time ranges */}
-        <div className="px-3 pb-2.5">
-          {group.dateRanges.map((dr) => (
-            <div key={dr.date} className="mt-1">
-              <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                {formatDate(dr.date)}
-              </span>
-              <div className="text-sm text-gray-900 dark:text-gray-100 ml-1 mt-0.5">
-                <span className="text-xs text-gray-400 dark:text-gray-500">Starts: </span>
-                {dr.ranges.map((r, i) => (
-                  <span key={i}>
-                    {i > 0 && <span className="text-gray-400 dark:text-gray-500">,{' '}</span>}
-                    {formatStartTimeRange(r)}
-                  </span>
-                ))}
-              </div>
-            </div>
-          ))}
+        <div className={`flex-1 min-w-0 ${hasWinner ? 'font-semibold' : ''}`}>
+          <span className="text-sm text-gray-900 dark:text-gray-100">
+            {formatDuration(group.duration_hours)}
+          </span>
+          <span className="text-xs text-gray-400 dark:text-gray-500 mx-1.5">&middot;</span>
+          <span className="text-sm text-gray-900 dark:text-gray-100">
+            {formatGroupRanges(group)}
+          </span>
+          <span className="text-xs text-gray-400 dark:text-gray-500 ml-1.5">
+            {group.slotCount} slot{group.slotCount !== 1 ? 's' : ''}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-1 justify-end ml-2">
+          {renderParticipantPills(group)}
         </div>
       </div>
     );
@@ -439,6 +435,11 @@ export default function TimeSlotRoundsDisplay({
           renderFinalRoundSlot(currentSlots.find(s => s.is_winner)!)
         ) : (
           <>
+            {singleDate && (
+              <div className="px-3 py-1 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                {formatDate(singleDate)}
+              </div>
+            )}
             {visibleGroups.map((group, index) => renderGroup(group, index))}
 
             {needsCollapse && (

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -203,14 +203,6 @@ function formatStartTimeRange(range: StartTimeRange): string {
   return `${formatTime(range.first)} ${firstPeriod}\u2013${formatTime(range.last)} ${lastPeriod}`;
 }
 
-function formatStep(minutes: number): string {
-  if (minutes <= 0) return '';
-  if (minutes >= 60 && minutes % 60 === 0) {
-    const hours = minutes / 60;
-    return hours === 1 ? 'every hr' : `every ${hours}h`;
-  }
-  return `every ${minutes}m`;
-}
 
 // --- Component ---
 
@@ -341,15 +333,11 @@ export default function TimeSlotRoundsDisplay({
                 {formatDate(dr.date)}
               </span>
               <div className="text-sm text-gray-900 dark:text-gray-100 ml-1 mt-0.5">
+                <span className="text-xs text-gray-400 dark:text-gray-500">Starts: </span>
                 {dr.ranges.map((r, i) => (
                   <span key={i}>
                     {i > 0 && <span className="text-gray-400 dark:text-gray-500">,{' '}</span>}
                     {formatStartTimeRange(r)}
-                    {r.count > 1 && r.step > 0 && (
-                      <span className="text-xs text-gray-400 dark:text-gray-500 ml-1">
-                        {formatStep(r.step)}
-                      </span>
-                    )}
                   </span>
                 ))}
               </div>

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -211,7 +211,6 @@ export default function TimeSlotRoundsDisplay({
   allVoters,
   currentUserVoteId,
 }: TimeSlotRoundsDisplayProps) {
-  const [currentRound, setCurrentRound] = useState(1);
   const [expanded, setExpanded] = useState(false);
 
   const colorMap = useMemo(() => {
@@ -244,7 +243,17 @@ export default function TimeSlotRoundsDisplay({
     };
   }, [allRounds]);
 
-  const currentSlots = roundsByNumber[currentRound] || [];
+  // The winner slot (first slot in round 1 with is_winner=true)
+  const winnerSlot = useMemo(() => allRounds.find(s => s.is_winner) || null, [allRounds]);
+
+  // Virtual "Result" page is totalRounds + 1, shown by default
+  const resultPage = totalRounds + 1;
+  const totalPages = resultPage;
+  const [currentPage, setCurrentPage] = useState(resultPage);
+
+  const isResultPage = currentPage === resultPage;
+  const currentRoundNumber = isResultPage ? totalRounds : currentPage;
+  const currentSlots = roundsByNumber[currentRoundNumber] || [];
   const participantCount = currentSlots.length > 0 ? currentSlots[0].participant_count : 0;
   const totalSlotCount = currentSlots.length;
 
@@ -288,7 +297,7 @@ export default function TimeSlotRoundsDisplay({
     </div>
   );
 
-  const isFinalRound = currentRound === totalRounds;
+  // (result page rendering handled separately below)
 
   const renderFinalRoundSlot = (slot: TimeSlot) => (
     <div className="bg-green-50 dark:bg-green-900/30 px-3 py-2.5">
@@ -391,10 +400,10 @@ export default function TimeSlotRoundsDisplay({
     <div className="w-full max-w-2xl mx-auto">
       <div className="flex items-center justify-between mb-3">
         <button
-          onClick={() => setCurrentRound(r => Math.max(1, r - 1))}
-          disabled={currentRound === 1}
+          onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+          disabled={currentPage === 1}
           className={`p-1.5 rounded ${
-            currentRound === 1
+            currentPage === 1
               ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
               : 'text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900'
           }`}
@@ -406,19 +415,27 @@ export default function TimeSlotRoundsDisplay({
         </button>
 
         <div className="text-center flex-1">
-          <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
-            Round {currentRound} of {totalRounds}
-          </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400">
-            {participantCount} {participantCount === 1 ? 'participant' : 'participants'} &middot; {totalSlotCount} time slot{totalSlotCount !== 1 ? 's' : ''}
-          </div>
+          {isResultPage ? (
+            <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
+              Result
+            </div>
+          ) : (
+            <>
+              <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                Round {currentPage} of {totalRounds}
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                {participantCount} {participantCount === 1 ? 'participant' : 'participants'} &middot; {totalSlotCount} time slot{totalSlotCount !== 1 ? 's' : ''}
+              </div>
+            </>
+          )}
         </div>
 
         <button
-          onClick={() => setCurrentRound(r => Math.min(totalRounds, r + 1))}
-          disabled={currentRound === totalRounds}
+          onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+          disabled={currentPage === totalPages}
           className={`p-1.5 rounded ${
-            currentRound === totalRounds
+            currentPage === totalPages
               ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
               : 'text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900'
           }`}
@@ -431,8 +448,8 @@ export default function TimeSlotRoundsDisplay({
       </div>
 
       <div className="border rounded-lg overflow-hidden dark:border-gray-700">
-        {isFinalRound && currentSlots.find(s => s.is_winner) ? (
-          renderFinalRoundSlot(currentSlots.find(s => s.is_winner)!)
+        {isResultPage && winnerSlot ? (
+          renderFinalRoundSlot(winnerSlot)
         ) : (
           <>
             {singleDate && (
@@ -457,18 +474,18 @@ export default function TimeSlotRoundsDisplay({
         )}
       </div>
 
-      {totalRounds > 1 && (
+      {totalPages > 1 && (
         <div className="flex justify-center gap-2 mt-3">
-          {Array.from({ length: totalRounds }, (_, i) => i + 1).map((roundNum) => (
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((pageNum) => (
             <button
-              key={roundNum}
-              onClick={() => setCurrentRound(roundNum)}
+              key={pageNum}
+              onClick={() => setCurrentPage(pageNum)}
               className={`w-2 h-2 rounded-full ${
-                roundNum === currentRound
+                pageNum === currentPage
                   ? 'bg-blue-600 dark:bg-blue-400'
                   : 'bg-gray-300 dark:bg-gray-600'
               }`}
-              aria-label={`Go to round ${roundNum}`}
+              aria-label={pageNum === resultPage ? 'Go to result' : `Go to round ${pageNum}`}
             />
           ))}
         </div>

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -431,7 +431,7 @@ export default function TimeSlotRoundsDisplay({
       </div>
 
       <div className="border rounded-lg overflow-hidden dark:border-gray-700">
-        {isFinalRound && totalRounds > 1 && currentSlots.find(s => s.is_winner) ? (
+        {isFinalRound && currentSlots.find(s => s.is_winner) ? (
           renderFinalRoundSlot(currentSlots.find(s => s.is_winner)!)
         ) : (
           <>

--- a/components/TimeSlotRoundsDisplay.tsx
+++ b/components/TimeSlotRoundsDisplay.tsx
@@ -20,8 +20,6 @@ interface TimeSlotRoundsDisplayProps {
   currentUserVoteId: string | null;
 }
 
-const COLLAPSED_VISIBLE = 3;
-
 const PARTICIPANT_COLORS = [
   'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
   'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
@@ -42,11 +40,10 @@ function formatDate(dateStr: string): string {
   });
 }
 
-function formatTime(timeStr: string, showNextDay?: boolean): string {
+function formatTime(timeStr: string): string {
   const [hours, minutes] = timeStr.split(':').map(Number);
   const displayHours = hours % 12 || 12;
-  const suffix = showNextDay ? '+1' : '';
-  return `${displayHours}:${minutes.toString().padStart(2, '0')}${suffix}`;
+  return `${displayHours}:${minutes.toString().padStart(2, '0')}`;
 }
 
 function formatPeriod(timeStr: string): string {
@@ -63,19 +60,159 @@ function formatTimeRange(slot: TimeSlot): string {
   const isNextDay = slot.slot_end_time <= slot.slot_start_time;
   const endPeriod = formatPeriod(slot.slot_end_time);
   const start = formatTime(slot.slot_start_time);
-  const end = formatTime(slot.slot_end_time, isNextDay);
+  const endHours = slot.slot_end_time.split(':').map(Number);
+  const displayEnd = (endHours[0] % 12 || 12) + ':' + endHours[1].toString().padStart(2, '0') + (isNextDay ? '+1' : '');
 
   if (startPeriod === endPeriod && !isNextDay) {
-    return `${start}\u2013${end} ${endPeriod}`;
+    return `${start}\u2013${displayEnd} ${endPeriod}`;
   }
-  return `${start} ${startPeriod}\u2013${end} ${endPeriod}`;
+  return `${start} ${startPeriod}\u2013${displayEnd} ${endPeriod}`;
 }
 
-interface DisplaySlot {
-  slot: TimeSlot;
-  date: string;
-  isFirstInDate: boolean;
+// --- Grouping logic ---
+
+interface StartTimeRange {
+  first: string; // HH:MM
+  last: string;  // HH:MM
+  count: number;
+  step: number;  // minutes between consecutive slots
 }
+
+interface DateRanges {
+  date: string;
+  ranges: StartTimeRange[];
+}
+
+interface SlotGroup {
+  duration_hours: number;
+  participant_vote_ids: string[];
+  participant_names: string[];
+  participant_count: number;
+  winner_slot: TimeSlot | null;
+  dateRanges: DateRanges[];
+  slotCount: number;
+}
+
+function timeToMinutes(timeStr: string): number {
+  const [h, m] = timeStr.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function minutesToTimeStr(mins: number): string {
+  const h = Math.floor(mins / 60) % 24;
+  const m = mins % 60;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
+
+function findContiguousRanges(sortedMinutes: number[]): StartTimeRange[] {
+  if (sortedMinutes.length === 0) return [];
+  if (sortedMinutes.length === 1) {
+    return [{ first: minutesToTimeStr(sortedMinutes[0]), last: minutesToTimeStr(sortedMinutes[0]), count: 1, step: 0 }];
+  }
+
+  // Detect step as minimum positive gap
+  let minStep = Infinity;
+  for (let i = 1; i < sortedMinutes.length; i++) {
+    const diff = sortedMinutes[i] - sortedMinutes[i - 1];
+    if (diff > 0 && diff < minStep) minStep = diff;
+  }
+
+  const ranges: StartTimeRange[] = [];
+  let start = sortedMinutes[0];
+  let prev = sortedMinutes[0];
+  let count = 1;
+
+  for (let i = 1; i < sortedMinutes.length; i++) {
+    if (sortedMinutes[i] - prev === minStep) {
+      prev = sortedMinutes[i];
+      count++;
+    } else {
+      ranges.push({ first: minutesToTimeStr(start), last: minutesToTimeStr(prev), count, step: minStep });
+      start = sortedMinutes[i];
+      prev = sortedMinutes[i];
+      count = 1;
+    }
+  }
+  ranges.push({ first: minutesToTimeStr(start), last: minutesToTimeStr(prev), count, step: minStep });
+
+  return ranges;
+}
+
+function buildGroups(slots: TimeSlot[]): SlotGroup[] {
+  const groupMap = new Map<string, TimeSlot[]>();
+
+  for (const slot of slots) {
+    const key = `${slot.duration_hours}|${[...slot.participant_vote_ids].sort().join(',')}`;
+    if (!groupMap.has(key)) groupMap.set(key, []);
+    groupMap.get(key)!.push(slot);
+  }
+
+  const groups: SlotGroup[] = [];
+
+  for (const [, slotsInGroup] of groupMap) {
+    const first = slotsInGroup[0];
+
+    const byDate = new Map<string, string[]>();
+    let winnerSlot: TimeSlot | null = null;
+
+    for (const slot of slotsInGroup) {
+      if (!byDate.has(slot.slot_date)) byDate.set(slot.slot_date, []);
+      byDate.get(slot.slot_date)!.push(slot.slot_start_time);
+      if (slot.is_winner) winnerSlot = slot;
+    }
+
+    const dateRanges: DateRanges[] = [];
+    const sortedDates = [...byDate.keys()].sort();
+
+    for (const date of sortedDates) {
+      const startTimes = byDate.get(date)!;
+      const minutes = startTimes.map(timeToMinutes).sort((a, b) => a - b);
+      dateRanges.push({ date, ranges: findContiguousRanges(minutes) });
+    }
+
+    groups.push({
+      duration_hours: first.duration_hours,
+      participant_vote_ids: first.participant_vote_ids,
+      participant_names: first.participant_names,
+      participant_count: first.participant_count,
+      winner_slot: winnerSlot,
+      dateRanges,
+      slotCount: slotsInGroup.length,
+    });
+  }
+
+  // Sort: winner group first, then by slot count descending
+  groups.sort((a, b) => {
+    if (a.winner_slot && !b.winner_slot) return -1;
+    if (!a.winner_slot && b.winner_slot) return 1;
+    return b.slotCount - a.slotCount;
+  });
+
+  return groups;
+}
+
+function formatStartTimeRange(range: StartTimeRange): string {
+  if (range.first === range.last) {
+    return `${formatTime(range.first)} ${formatPeriod(range.first)}`;
+  }
+  const firstPeriod = formatPeriod(range.first);
+  const lastPeriod = formatPeriod(range.last);
+  if (firstPeriod === lastPeriod) {
+    return `${formatTime(range.first)}\u2013${formatTime(range.last)} ${lastPeriod}`;
+  }
+  return `${formatTime(range.first)} ${firstPeriod}\u2013${formatTime(range.last)} ${lastPeriod}`;
+}
+
+function formatStep(minutes: number): string {
+  if (minutes <= 0) return '';
+  if (minutes >= 60 && minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return hours === 1 ? 'every hr' : `every ${hours}h`;
+  }
+  return `every ${minutes}m`;
+}
+
+// --- Component ---
 
 export default function TimeSlotRoundsDisplay({
   allRounds,
@@ -85,13 +222,11 @@ export default function TimeSlotRoundsDisplay({
   const [currentRound, setCurrentRound] = useState(1);
   const [expanded, setExpanded] = useState(false);
 
-  // Build a vote ID -> color index map from allVoters (or fallback to stable ordering from data)
   const colorMap = useMemo(() => {
     const map = new Map<string, string>();
     if (allVoters.length > 0) {
       allVoters.forEach((v, i) => map.set(v.id, PARTICIPANT_COLORS[i % PARTICIPANT_COLORS.length]));
     } else {
-      // Derive unique vote IDs from all rounds in stable order
       const seen = new Set<string>();
       for (const slot of allRounds) {
         for (const id of slot.participant_vote_ids) {
@@ -119,45 +254,15 @@ export default function TimeSlotRoundsDisplay({
 
   const currentSlots = roundsByNumber[currentRound] || [];
   const participantCount = currentSlots.length > 0 ? currentSlots[0].participant_count : 0;
+  const totalSlotCount = currentSlots.length;
 
-  const { allDisplaySlots, winnerIdx } = useMemo(() => {
-    const slots: DisplaySlot[] = [];
-    let winner = -1;
-    // Group by date and flatten in one pass
-    let prevDate = '';
-    for (const slot of currentSlots) {
-      const isFirst = slot.slot_date !== prevDate;
-      if (slot.is_winner) winner = slots.length;
-      slots.push({ slot, date: slot.slot_date, isFirstInDate: isFirst });
-      prevDate = slot.slot_date;
-    }
-    return { allDisplaySlots: slots, winnerIdx: winner };
-  }, [currentSlots]);
+  const groups = useMemo(() => buildGroups(currentSlots), [currentSlots]);
 
-  const needsCollapse = allDisplaySlots.length > COLLAPSED_VISIBLE + 1;
+  const COLLAPSED_GROUPS = 4;
+  const needsCollapse = groups.length > COLLAPSED_GROUPS + 1;
   const showAll = expanded || !needsCollapse;
-
-  const visibleSlots = useMemo(() => {
-    if (showAll) return allDisplaySlots;
-    // Show winner (if exists) + first COLLAPSED_VISIBLE other slots
-    const visible: DisplaySlot[] = [];
-    let added = 0;
-    for (let i = 0; i < allDisplaySlots.length && (added < COLLAPSED_VISIBLE || i === winnerIdx); i++) {
-      if (i === winnerIdx) {
-        visible.push(allDisplaySlots[i]);
-      } else if (added < COLLAPSED_VISIBLE) {
-        visible.push(allDisplaySlots[i]);
-        added++;
-      }
-    }
-    // Ensure winner is included even if beyond COLLAPSED_VISIBLE range
-    if (winnerIdx >= 0 && !visible.includes(allDisplaySlots[winnerIdx])) {
-      visible.push(allDisplaySlots[winnerIdx]);
-    }
-    return visible;
-  }, [allDisplaySlots, winnerIdx, showAll]);
-
-  const hiddenCount = allDisplaySlots.length - visibleSlots.length;
+  const visibleGroups = showAll ? groups : groups.slice(0, COLLAPSED_GROUPS);
+  const hiddenGroupCount = groups.length - visibleGroups.length;
 
   if (allRounds.length === 0) {
     return (
@@ -167,63 +272,91 @@ export default function TimeSlotRoundsDisplay({
     );
   }
 
-  const renderSlotRow = (item: DisplaySlot, index: number) => {
-    const { slot, date, isFirstInDate } = item;
-    const isWinner = slot.is_winner;
+  const renderParticipantPills = (group: SlotGroup) => (
+    <div className="flex flex-wrap gap-1">
+      {group.participant_names.map((name, idx) => {
+        const voteId = group.participant_vote_ids[idx];
+        const isCurrentUser = voteId === currentUserVoteId;
+        const colorClass = (voteId && colorMap.get(voteId)) || PARTICIPANT_COLORS[0];
+        const displayName = isCurrentUser
+          ? (name ? `You (${name})` : 'You')
+          : (name || 'Anonymous');
+
+        return (
+          <span
+            key={voteId || idx}
+            className={`inline-block px-2 py-0.5 rounded-full text-xs ${
+              isCurrentUser ? 'font-bold ring-1 ring-blue-500 dark:ring-blue-400' : 'font-medium'
+            } ${colorClass}`}
+          >
+            {displayName}
+          </span>
+        );
+      })}
+    </div>
+  );
+
+  const renderGroup = (group: SlotGroup, groupIdx: number) => {
+    const hasWinner = !!group.winner_slot;
+
     return (
-      <React.Fragment key={`${date}-${index}`}>
-        {isFirstInDate && (
-          <div className="px-3 py-1 bg-gray-50 dark:bg-gray-800 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide border-t border-gray-100 dark:border-gray-700 first:border-t-0">
-            {formatDate(date)}
-          </div>
-        )}
-        <div
-          className={`flex items-center px-3 py-1.5 border-t border-gray-100 dark:border-gray-700 ${
-            isWinner
-              ? 'bg-green-50 dark:bg-green-900/30'
-              : 'bg-white dark:bg-gray-800'
-          }`}
-        >
-          <div className="w-5 flex-shrink-0">
-            {isWinner && (
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-            )}
-          </div>
-
-          <div className={`flex-1 min-w-0 ${isWinner ? 'font-semibold' : ''}`}>
-            <span className="text-sm text-gray-900 dark:text-gray-100">
-              {formatTimeRange(slot)}
-            </span>
-            <span className="text-xs text-gray-400 dark:text-gray-500 ml-1.5">
-              {formatDuration(slot.duration_hours)}
-            </span>
+      <div
+        key={groupIdx}
+        className={`${groupIdx > 0 ? 'border-t border-gray-200 dark:border-gray-600' : ''} ${
+          hasWinner ? 'bg-green-50 dark:bg-green-900/30' : 'bg-white dark:bg-gray-800'
+        }`}
+      >
+        {/* Header: duration, slot count, participants */}
+        <div className="px-3 pt-2.5 pb-1">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {hasWinner && (
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              )}
+              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                {formatDuration(group.duration_hours)}
+              </span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {group.slotCount} slot{group.slotCount !== 1 ? 's' : ''}
+              </span>
+            </div>
+            {renderParticipantPills(group)}
           </div>
 
-          <div className="flex flex-wrap gap-1 justify-end ml-2">
-            {slot.participant_names.map((name, idx) => {
-              const voteId = slot.participant_vote_ids[idx];
-              const isCurrentUser = voteId === currentUserVoteId;
-              const colorClass = (voteId && colorMap.get(voteId)) || PARTICIPANT_COLORS[0];
-              const displayName = isCurrentUser
-                ? (name ? `You (${name})` : 'You')
-                : (name || 'Anonymous');
-
-              return (
-                <span
-                  key={voteId || idx}
-                  className={`inline-block px-2 py-0.5 rounded-full text-xs ${
-                    isCurrentUser ? 'font-bold ring-1 ring-blue-500 dark:ring-blue-400' : 'font-medium'
-                  } ${colorClass}`}
-                >
-                  {displayName}
-                </span>
-              );
-            })}
-          </div>
+          {/* Winner callout */}
+          {hasWinner && group.winner_slot && (
+            <div className="mt-1 text-xs font-medium text-green-700 dark:text-green-300">
+              Winner: {formatTimeRange(group.winner_slot)}, {formatDate(group.winner_slot.slot_date)}
+            </div>
+          )}
         </div>
-      </React.Fragment>
+
+        {/* Date + start time ranges */}
+        <div className="px-3 pb-2.5">
+          {group.dateRanges.map((dr) => (
+            <div key={dr.date} className="mt-1">
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                {formatDate(dr.date)}
+              </span>
+              <div className="text-sm text-gray-900 dark:text-gray-100 ml-1 mt-0.5">
+                {dr.ranges.map((r, i) => (
+                  <span key={i}>
+                    {i > 0 && <span className="text-gray-400 dark:text-gray-500">,{' '}</span>}
+                    {formatStartTimeRange(r)}
+                    {r.count > 1 && r.step > 0 && (
+                      <span className="text-xs text-gray-400 dark:text-gray-500 ml-1">
+                        {formatStep(r.step)}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     );
   };
 
@@ -250,7 +383,7 @@ export default function TimeSlotRoundsDisplay({
             Round {currentRound} of {totalRounds}
           </div>
           <div className="text-xs text-gray-500 dark:text-gray-400">
-            {participantCount} {participantCount === 1 ? 'participant' : 'participants'} &middot; {allDisplaySlots.length} time slots
+            {participantCount} {participantCount === 1 ? 'participant' : 'participants'} &middot; {totalSlotCount} time slot{totalSlotCount !== 1 ? 's' : ''}
           </div>
         </div>
 
@@ -271,7 +404,7 @@ export default function TimeSlotRoundsDisplay({
       </div>
 
       <div className="border rounded-lg overflow-hidden dark:border-gray-700">
-        {visibleSlots.map((item, index) => renderSlotRow(item, index))}
+        {visibleGroups.map((group, index) => renderGroup(group, index))}
 
         {needsCollapse && (
           <button
@@ -280,7 +413,7 @@ export default function TimeSlotRoundsDisplay({
           >
             {expanded
               ? 'Show less'
-              : `Show ${hiddenCount} more time slot${hiddenCount === 1 ? '' : 's'}`
+              : `Show ${hiddenGroupCount} more group${hiddenGroupCount === 1 ? '' : 's'}`
             }
           </button>
         )}


### PR DESCRIPTION
## Summary
- **Group time slots** by duration + participant set into compact single-row entries with start time ranges (e.g. "1.75h · 9:15–11:15 AM · 9 slots")
- **Add a Result page** as the default view showing just the winning time slot with labeled Time/Date rows and a back arrow to drill into candidate rounds
- **Compact participation result panels** — reduce padding, heading sizes, and pill spacing across all participation poll result variants
- **Code cleanup** — import shared `timeToMinutes`, remove dead `step` field, consolidate memos, remove redundant variables

## Test plan
- [ ] Create a participation poll with time windows, vote, close it, and verify the Result page shows just the winning time slot
- [ ] Click the back arrow on the Result page to verify round navigation works
- [ ] Verify grouped slots show correct start time ranges and participant pills
- [ ] Check participation result panels (participating, not participating, not happening) for compact spacing
- [ ] Verify no React hooks ordering errors in the console

https://claude.ai/code/session_01YUK65S1YTaCYWxD9NHq46P