### PR TITLE
Fix voting state persistence for time windows

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -146,7 +146,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     draftRestoredRef.current = true;
     if (poll.poll_type !== 'participation') return;
     // Don't restore draft if user already voted (DB values will be loaded instead)
-    if (hasVotedOnPoll(poll.id)) return;
+    try {
+      const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
+      if (votedPolls[poll.id]) return;
+    } catch { /* ignore */ }
     const draft = loadBallotDraft(poll.id);
     if (!draft) return;
     if (draft.yesNoChoice) setYesNoChoice(draft.yesNoChoice);
@@ -159,7 +162,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     if (draft.durationMaxValue !== undefined) setDurationMaxValue(draft.durationMaxValue);
     if (draft.durationMinEnabled !== undefined) setDurationMinEnabled(draft.durationMinEnabled);
     if (draft.durationMaxEnabled !== undefined) setDurationMaxEnabled(draft.durationMaxEnabled);
-  }, [poll.id, poll.poll_type, hasVotedOnPoll]);
+  }, [poll.id, poll.poll_type]);
 
   // Persist ballot draft state to localStorage whenever it changes (participation polls)
   useEffect(() => {

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -41,10 +41,35 @@ interface PollPageClientProps {
   pollId: string | null;
 }
 
+// Load a saved ballot draft from localStorage for a given poll
+function loadBallotDraft(pollId: string): Record<string, any> | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(`ballotDraft:${pollId}`);
+    return raw ? JSON.parse(raw) : null;
+  } catch { return null; }
+}
+
+// Save ballot draft to localStorage
+function saveBallotDraft(pollId: string, draft: Record<string, any>) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(`ballotDraft:${pollId}`, JSON.stringify(draft));
+  } catch { /* ignore quota errors */ }
+}
+
+// Clear ballot draft from localStorage
+function clearBallotDraft(pollId: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(`ballotDraft:${pollId}`);
+  } catch { /* ignore */ }
+}
+
 export default function PollPageClient({ poll, createdDate, pollId }: PollPageClientProps) {
   // Set the page title in the template header
   usePageTitle(poll.title);
-  
+
   const router = useRouter();
   const { prefetch } = useAppPrefetch();
   const searchParams = useSearchParams();
@@ -104,7 +129,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const fetchResultsInFlight = useRef(false);
   const fetchResultsLastCall = useRef(0);
 
-  // Participation poll voter conditions - initialize with poll's constraints
+  // Participation poll voter conditions - initialized with poll's constraints, draft restored in useEffect
   const [voterMinParticipants, setVoterMinParticipants] = useState<number | null>(poll.min_participants ?? 1);
   const [voterMaxParticipants, setVoterMaxParticipants] = useState<number | null>(poll.max_participants ?? null);
   const [voterMaxEnabled, setVoterMaxEnabled] = useState(poll.max_participants !== null && poll.max_participants !== undefined);
@@ -113,6 +138,48 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [durationMaxValue, setDurationMaxValue] = useState<number | null>(poll.duration_window?.maxValue ?? 2);
   const [durationMinEnabled, setDurationMinEnabled] = useState(poll.duration_window?.minEnabled ?? false);
   const [durationMaxEnabled, setDurationMaxEnabled] = useState(poll.duration_window?.maxEnabled ?? false);
+
+  // Restore ballot draft from localStorage on mount (participation polls only)
+  const draftRestoredRef = useRef(false);
+  useEffect(() => {
+    if (draftRestoredRef.current) return;
+    draftRestoredRef.current = true;
+    if (poll.poll_type !== 'participation') return;
+    // Don't restore draft if user already voted (DB values will be loaded instead)
+    if (hasVotedOnPoll(poll.id)) return;
+    const draft = loadBallotDraft(poll.id);
+    if (!draft) return;
+    if (draft.yesNoChoice) setYesNoChoice(draft.yesNoChoice);
+    if (draft.isAbstaining) setIsAbstaining(draft.isAbstaining);
+    if (draft.voterMinParticipants !== undefined) setVoterMinParticipants(draft.voterMinParticipants);
+    if (draft.voterMaxParticipants !== undefined) setVoterMaxParticipants(draft.voterMaxParticipants);
+    if (draft.voterMaxEnabled !== undefined) setVoterMaxEnabled(draft.voterMaxEnabled);
+    if (draft.voterDayTimeWindows) setVoterDayTimeWindows(draft.voterDayTimeWindows);
+    if (draft.durationMinValue !== undefined) setDurationMinValue(draft.durationMinValue);
+    if (draft.durationMaxValue !== undefined) setDurationMaxValue(draft.durationMaxValue);
+    if (draft.durationMinEnabled !== undefined) setDurationMinEnabled(draft.durationMinEnabled);
+    if (draft.durationMaxEnabled !== undefined) setDurationMaxEnabled(draft.durationMaxEnabled);
+  }, [poll.id, poll.poll_type, hasVotedOnPoll]);
+
+  // Persist ballot draft state to localStorage whenever it changes (participation polls)
+  useEffect(() => {
+    if (poll.poll_type !== 'participation' || hasVoted) return;
+    saveBallotDraft(poll.id, {
+      yesNoChoice,
+      isAbstaining,
+      voterMinParticipants,
+      voterMaxParticipants,
+      voterMaxEnabled,
+      voterDayTimeWindows,
+      durationMinValue,
+      durationMaxValue,
+      durationMinEnabled,
+      durationMaxEnabled,
+    });
+  }, [poll.id, poll.poll_type, hasVoted, yesNoChoice, isAbstaining,
+      voterMinParticipants, voterMaxParticipants, voterMaxEnabled,
+      voterDayTimeWindows, durationMinValue, durationMaxValue,
+      durationMinEnabled, durationMaxEnabled]);
 
   const isPollExpired = useMemo(() => {
     // Use server-safe check
@@ -1206,6 +1273,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         // Update hasPollData state
         setHasPollDataState(true);
       }
+      // Clear ballot draft now that vote is saved to the database
+      clearBallotDraft(poll.id);
       
       // Save the user's name if they provided one
       if (voterName.trim()) {

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -33,37 +33,13 @@ import ParticipationConditions from "@/components/ParticipationConditions";
 import TimeSlotRoundsDisplay from "@/components/TimeSlotRoundsDisplay";
 import PollDetails from "@/components/PollDetails";
 import SubPollField from "@/components/SubPollField";
+import { loadBallotDraft, saveBallotDraft, clearBallotDraft, BallotDraft } from "@/lib/ballotDraft";
 import { windowDurationMinutes, formatDurationLabel } from "@/lib/timeUtils";
 
 interface PollPageClientProps {
   poll: Poll;
   createdDate: string;
   pollId: string | null;
-}
-
-// Load a saved ballot draft from localStorage for a given poll
-function loadBallotDraft(pollId: string): Record<string, any> | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const raw = localStorage.getItem(`ballotDraft:${pollId}`);
-    return raw ? JSON.parse(raw) : null;
-  } catch { return null; }
-}
-
-// Save ballot draft to localStorage
-function saveBallotDraft(pollId: string, draft: Record<string, any>) {
-  if (typeof window === 'undefined') return;
-  try {
-    localStorage.setItem(`ballotDraft:${pollId}`, JSON.stringify(draft));
-  } catch { /* ignore quota errors */ }
-}
-
-// Clear ballot draft from localStorage
-function clearBallotDraft(pollId: string) {
-  if (typeof window === 'undefined') return;
-  try {
-    localStorage.removeItem(`ballotDraft:${pollId}`);
-  } catch { /* ignore */ }
 }
 
 export default function PollPageClient({ poll, createdDate, pollId }: PollPageClientProps) {
@@ -145,40 +121,38 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     if (draftRestoredRef.current) return;
     draftRestoredRef.current = true;
     if (poll.poll_type !== 'participation') return;
-    // Don't restore draft if user already voted (DB values will be loaded instead)
     try {
       const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
       if (votedPolls[poll.id]) return;
     } catch { /* ignore */ }
     const draft = loadBallotDraft(poll.id);
     if (!draft) return;
-    if (draft.yesNoChoice) setYesNoChoice(draft.yesNoChoice);
-    if (draft.isAbstaining) setIsAbstaining(draft.isAbstaining);
+    if (draft.yesNoChoice !== undefined) setYesNoChoice(draft.yesNoChoice ?? null);
+    if (draft.isAbstaining !== undefined) setIsAbstaining(draft.isAbstaining);
     if (draft.voterMinParticipants !== undefined) setVoterMinParticipants(draft.voterMinParticipants);
     if (draft.voterMaxParticipants !== undefined) setVoterMaxParticipants(draft.voterMaxParticipants);
     if (draft.voterMaxEnabled !== undefined) setVoterMaxEnabled(draft.voterMaxEnabled);
-    if (draft.voterDayTimeWindows) setVoterDayTimeWindows(draft.voterDayTimeWindows);
+    if (draft.voterDayTimeWindows !== undefined) setVoterDayTimeWindows(draft.voterDayTimeWindows);
     if (draft.durationMinValue !== undefined) setDurationMinValue(draft.durationMinValue);
     if (draft.durationMaxValue !== undefined) setDurationMaxValue(draft.durationMaxValue);
     if (draft.durationMinEnabled !== undefined) setDurationMinEnabled(draft.durationMinEnabled);
     if (draft.durationMaxEnabled !== undefined) setDurationMaxEnabled(draft.durationMaxEnabled);
   }, [poll.id, poll.poll_type]);
 
-  // Persist ballot draft state to localStorage whenever it changes (participation polls)
+  // Persist ballot draft to localStorage (debounced to avoid rapid writes during wheel/counter interactions)
+  const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     if (poll.poll_type !== 'participation' || hasVoted) return;
-    saveBallotDraft(poll.id, {
-      yesNoChoice,
-      isAbstaining,
-      voterMinParticipants,
-      voterMaxParticipants,
-      voterMaxEnabled,
-      voterDayTimeWindows,
-      durationMinValue,
-      durationMaxValue,
-      durationMinEnabled,
-      durationMaxEnabled,
-    });
+    if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
+    draftTimerRef.current = setTimeout(() => {
+      saveBallotDraft(poll.id, {
+        yesNoChoice, isAbstaining,
+        voterMinParticipants, voterMaxParticipants, voterMaxEnabled,
+        voterDayTimeWindows,
+        durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled,
+      });
+    }, 300);
+    return () => { if (draftTimerRef.current) clearTimeout(draftTimerRef.current); };
   }, [poll.id, poll.poll_type, hasVoted, yesNoChoice, isAbstaining,
       voterMinParticipants, voterMaxParticipants, voterMaxEnabled,
       voterDayTimeWindows, durationMinValue, durationMaxValue,

--- a/components/ParticipationConditions.tsx
+++ b/components/ParticipationConditions.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import MinMaxCounter from './MinMaxCounter';
 import DaysSelector from './DaysSelector';
 import DayTimeWindowsInput from './DayTimeWindowsInput';
@@ -72,6 +72,8 @@ export default function ParticipationConditions({
   isCreationForm = false,
 }: ParticipationConditionsProps) {
   const [isDaysPickerOpen, setIsDaysPickerOpen] = useState(false);
+  // Cache windows for removed days so they can be restored on re-add
+  const removedDaysCache = useRef<Record<string, TimeWindow[]>>({});
 
   const enforcedMinLimit = pollMinParticipants ?? 1;
   const enforcedMaxLimit = pollMaxParticipants ?? undefined;
@@ -85,12 +87,23 @@ export default function ParticipationConditions({
     if (!onDayTimeWindowsChange) return;
 
     const existingDays = dayTimeWindows.map(dtw => dtw.day);
+    const removedDays = existingDays.filter(day => !newDays.includes(day));
+
+    // Cache windows for removed days before discarding them
+    for (const day of removedDays) {
+      const dtw = dayTimeWindows.find(d => d.day === day);
+      if (dtw && dtw.windows.length > 0) {
+        removedDaysCache.current[day] = dtw.windows;
+      }
+    }
+
     const addedDays = newDays.filter(day => !existingDays.includes(day));
     const newEntries: DayTimeWindow[] = addedDays.map(day => ({
       day,
-      windows: []
+      // Restore cached windows if this day was previously removed
+      windows: removedDaysCache.current[day] || []
     }));
-    const removedDays = existingDays.filter(day => !newDays.includes(day));
+
     const updated = [
       ...dayTimeWindows.filter(dtw => !removedDays.includes(dtw.day)),
       ...newEntries

--- a/components/ParticipationConditions.tsx
+++ b/components/ParticipationConditions.tsx
@@ -98,11 +98,11 @@ export default function ParticipationConditions({
     }
 
     const addedDays = newDays.filter(day => !existingDays.includes(day));
-    const newEntries: DayTimeWindow[] = addedDays.map(day => ({
-      day,
-      // Restore cached windows if this day was previously removed
-      windows: removedDaysCache.current[day] || []
-    }));
+    const newEntries: DayTimeWindow[] = addedDays.map(day => {
+      const cached = removedDaysCache.current[day];
+      if (cached) delete removedDaysCache.current[day];
+      return { day, windows: cached || [] };
+    });
 
     const updated = [
       ...dayTimeWindows.filter(dtw => !removedDays.includes(dtw.day)),

--- a/lib/ballotDraft.ts
+++ b/lib/ballotDraft.ts
@@ -1,0 +1,39 @@
+// Ballot draft persistence — saves in-progress vote state to localStorage
+// so it survives page navigation. Keyed by poll ID.
+
+const PREFIX = 'ballotDraft:';
+
+export interface BallotDraft {
+  yesNoChoice?: 'yes' | 'no' | null;
+  isAbstaining?: boolean;
+  voterMinParticipants?: number | null;
+  voterMaxParticipants?: number | null;
+  voterMaxEnabled?: boolean;
+  voterDayTimeWindows?: any[];
+  durationMinValue?: number | null;
+  durationMaxValue?: number | null;
+  durationMinEnabled?: boolean;
+  durationMaxEnabled?: boolean;
+}
+
+export function loadBallotDraft(pollId: string): BallotDraft | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(PREFIX + pollId);
+    return raw ? JSON.parse(raw) : null;
+  } catch { return null; }
+}
+
+export function saveBallotDraft(pollId: string, draft: BallotDraft): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(PREFIX + pollId, JSON.stringify(draft));
+  } catch { /* ignore quota errors */ }
+}
+
+export function clearBallotDraft(pollId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(PREFIX + pollId);
+  } catch { /* ignore */ }
+}


### PR DESCRIPTION
## Summary
- Cache removed day windows in ParticipationConditions so deselecting then reselecting a day restores original time windows and checkbox states
- Persist participation poll ballot draft (yes/no choice, time windows, duration, participant conditions) to localStorage so navigating away and back preserves all voter selections
- Debounce localStorage writes (300ms) to avoid rapid I/O during wheel/counter interactions
- Extract ballot draft helpers to `lib/ballotDraft.ts` with typed `BallotDraft` interface

## Test plan
- [ ] Open a participation poll with time windows
- [ ] Select days, configure time windows, toggle checkboxes
- [ ] Deselect a day and reselect it — verify windows and checkbox states are restored
- [ ] Navigate away from the poll page and back — verify all ballot state is preserved
- [ ] Submit a vote — verify draft is cleared from localStorage
- [ ] Verify already-voted users still load state from DB, not stale draft

https://claude.ai/code/session_016fCT75LLZQJ3VwAo4wZgWW