### PR TITLE
Add detailed failure reasons to participation poll results

### DIFF
--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -231,17 +231,17 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     if (totalVotes === 0) return 'No responses received';
 
     if (totalYesVotes === 0) {
-      if (noCount > 0 && abstainCount > 0) return `${noCount} declined, ${abstainCount} abstained — no one volunteered`;
+      if (noCount > 0 && abstainCount > 0) return `${noCount} declined, ${abstainCount} abstained — no one said yes`;
       if (noCount > 0) return `All ${noCount} respondent${noCount !== 1 ? 's' : ''} declined`;
       if (abstainCount > 0) return `All ${abstainCount} respondent${abstainCount !== 1 ? 's' : ''} abstained`;
-      return 'No one volunteered';
+      return 'No one said yes';
     }
 
     if (yesCount === 0 && totalYesVotes > 0) {
       if (isCurrentUserYesVoter && totalYesVotes === 1) {
         const conds = formatConditions(userMinParticipants, userMaxParticipants);
-        if (conds) return `You wanted ${conds}, but you were the only volunteer`;
-        return 'You were the only volunteer, but your conditions couldn\u2019t be met';
+        if (conds) return `You wanted ${conds}, but no one else said yes`;
+        return 'No one else said yes, so your conditions couldn\u2019t be met';
       }
       if (isCurrentUserYesVoter) {
         const othersCount = totalYesVotes - 1;

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -160,6 +160,7 @@ function YesNoResults({ results, isPollClosed, userVoteData, onFollowUpClick }: 
 function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpClick }: { results: PollResults, isPollClosed?: boolean, userVoteData?: any, onFollowUpClick?: () => void }) {
   const yesCount = results.yes_count || 0;
   const noCount = results.no_count || 0;
+  const totalYesVotes = results.total_yes_votes ?? yesCount;
   const totalVotes = results.total_votes;
   const minParticipants = results.min_participants;
   const maxParticipants = results.max_participants;
@@ -209,21 +210,47 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
   // Determine if the event is happening based on participant count being in range
   let isHappening = yesCount > 0;
-  let statusMessage = '';
 
   if (minParticipants !== undefined && minParticipants !== null) {
     if (yesCount < minParticipants) {
       isHappening = false;
-      statusMessage = `Need at least ${minParticipants} participants`;
     }
   }
 
   if (maxParticipants !== undefined && maxParticipants !== null) {
     if (yesCount > maxParticipants) {
       isHappening = false;
-      statusMessage = `Maximum ${maxParticipants} participants exceeded`;
     }
   }
+
+  // Generate a detailed reason for why the event isn't happening
+  const getFailureReason = (): string => {
+    // Nobody responded at all
+    if (totalVotes === 0) return 'No responses received';
+
+    // People responded but nobody said yes
+    if (totalYesVotes === 0) {
+      if (noCount > 0) return `Everyone declined (${noCount} no${noCount !== 1 ? "'s" : ''})`;
+      return 'No one volunteered';
+    }
+
+    // People said yes but the algorithm couldn't form a compatible group
+    if (yesCount === 0 && totalYesVotes > 0) {
+      return `${totalYesVotes} wanted to participate but their conditions were incompatible`;
+    }
+
+    // Some participants selected but below minimum
+    if (minParticipants && yesCount < minParticipants) {
+      return `Only ${yesCount} of ${minParticipants} required participants`;
+    }
+
+    // Over maximum (shouldn't normally happen, but just in case)
+    if (maxParticipants && yesCount > maxParticipants) {
+      return `${yesCount} participants exceeded the maximum of ${maxParticipants}`;
+    }
+
+    return '';
+  };
 
   const userVotedYes = userVoteData?.yes_no_choice === 'yes';
   const userVotedNo = userVoteData?.yes_no_choice === 'no';
@@ -299,7 +326,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
       <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
         <div className="text-center">
           <div className="text-xl font-bold mb-1 text-red-800 dark:text-red-200">
-            Not happening
+            ✗ Not happening
           </div>
           <div className="text-sm text-red-700 dark:text-red-300">
             No responses received
@@ -364,11 +391,25 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
     // Scenario: Event IS happening, user voted YES but is NOT in participant list (needs weren't met)
     if (isHappening && userVotedYes && !userIsInParticipantList) {
+      // Explain why the user was excluded
+      const userExclusionReason = (() => {
+        if (userMaxParticipants !== null && userMaxParticipants !== undefined && yesCount > userMaxParticipants) {
+          return `Too many participants for your conditions (max ${userMaxParticipants})`;
+        }
+        if (userMinParticipants !== null && userMinParticipants !== undefined && yesCount < userMinParticipants) {
+          return `Not enough participants for your conditions (min ${userMinParticipants})`;
+        }
+        return 'Your conditions were incompatible with the group';
+      })();
+
       return (
         <div className="rounded-lg border-2 bg-yellow-100 dark:bg-yellow-900 border-yellow-400 dark:border-yellow-600 px-4 py-3">
           <div className="text-center">
             <div className="text-xl font-bold mb-1 text-yellow-800 dark:text-yellow-200">
               You&apos;re not participating
+            </div>
+            <div className="text-sm text-yellow-700 dark:text-yellow-300 mb-1">
+              {userExclusionReason}
             </div>
             <div className="flex flex-wrap items-center justify-center gap-1.5">
               <span className="text-sm text-yellow-700 dark:text-yellow-300">
@@ -436,18 +477,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
     // Scenario: Event NOT happening, user voted YES
     if (!isHappening && userVotedYes) {
-      // If no one is participating at all, use simplified message
-      if (yesCount === 0) {
-        return (
-          <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
-            <div className="text-center">
-              <div className="text-xl font-bold text-red-800 dark:text-red-200">
-                No one is participating
-              </div>
-            </div>
-          </div>
-        );
-      }
+      const failureReason = getFailureReason();
 
       const userNeedsText = userMinParticipants && userMaxParticipants
         ? `${userMinParticipants}-${userMaxParticipants}`
@@ -463,15 +493,14 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
             <div className="text-xl font-bold mb-1 text-red-800 dark:text-red-200">
               ✗ Not happening
             </div>
-            <div className="text-sm text-red-700 dark:text-red-300 mb-2">
-              Final: {yesCount} participant{yesCount !== 1 ? "s" : ""}
-              {(minParticipants || maxParticipants) && (
-                <> (needed {minParticipants && maxParticipants ? `${minParticipants}-${maxParticipants}` : minParticipants ? `${minParticipants}+` : `up to ${maxParticipants}`})</>
-              )}
-            </div>
-            {userNeedsText && (
+            {failureReason && (
+              <div className="text-sm text-red-700 dark:text-red-300 mb-1">
+                {failureReason}
+              </div>
+            )}
+            {!userIsInParticipantList && userNeedsText && (
               <div className="text-sm text-red-700 dark:text-red-300 opacity-75">
-                Your needs weren&apos;t met ({userNeedsText})
+                Your conditions weren&apos;t met ({userNeedsText} participants)
               </div>
             )}
           </div>
@@ -481,18 +510,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
     // Scenario: Event NOT happening, user voted NO or didn't vote
     if (!isHappening) {
-      // Check if there are no participants at all
-      if (yesCount === 0) {
-        return (
-          <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
-            <div className="text-center">
-              <div className="text-xl font-bold text-red-800 dark:text-red-200">
-                No one is participating
-              </div>
-            </div>
-          </div>
-        );
-      }
+      const failureReason = getFailureReason();
 
       return (
         <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
@@ -500,12 +518,11 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
             <div className="text-xl font-bold mb-1 text-red-800 dark:text-red-200">
               ✗ Not happening
             </div>
-            <div className="text-sm text-red-700 dark:text-red-300">
-              Final: {yesCount} participant{yesCount !== 1 ? "s" : ""}
-              {(minParticipants || maxParticipants) && (
-                <> (needed {minParticipants && maxParticipants ? `${minParticipants}-${maxParticipants}` : minParticipants ? `${minParticipants}+` : `up to ${maxParticipants}`})</>
-              )}
-            </div>
+            {failureReason && (
+              <div className="text-sm text-red-700 dark:text-red-300">
+                {failureReason}
+              </div>
+            )}
           </div>
         </div>
       );

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -210,20 +210,9 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     fetchParticipants();
   }, [results.poll_id]);
 
-  // Determine if the event is happening based on participant count being in range
-  let isHappening = yesCount > 0;
-
-  if (minParticipants !== undefined && minParticipants !== null) {
-    if (yesCount < minParticipants) {
-      isHappening = false;
-    }
-  }
-
-  if (maxParticipants !== undefined && maxParticipants !== null) {
-    if (yesCount > maxParticipants) {
-      isHappening = false;
-    }
-  }
+  const isHappening = yesCount > 0
+    && (minParticipants == null || yesCount >= minParticipants)
+    && (maxParticipants == null || yesCount <= maxParticipants);
 
   // Generate a detailed reason for why the event isn't happening
   // When isCurrentUserYesVoter is true, uses "you" language instead of third-person
@@ -291,10 +280,10 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
   // Build explanation for why the user specifically was excluded
   const getUserExclusionReason = (): string => {
-    if (userMaxParticipants !== null && userMaxParticipants !== undefined && yesCount > userMaxParticipants) {
+    if (userMaxParticipants != null && yesCount > userMaxParticipants) {
       return `You set a max of ${userMaxParticipants} participant${userMaxParticipants !== 1 ? 's' : ''}, but ${yesCount} were selected`;
     }
-    if (userMinParticipants !== null && userMinParticipants !== undefined && yesCount < userMinParticipants) {
+    if (userMinParticipants != null && yesCount < userMinParticipants) {
       return `You required at least ${userMinParticipants} participant${userMinParticipants !== 1 ? 's' : ''}, but only ${yesCount} ${yesCount !== 1 ? 'were' : 'was'} selected`;
     }
     return 'Your conditions were incompatible with the selected group';
@@ -303,13 +292,8 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
   const userVotedYes = userVoteData?.yes_no_choice === 'yes';
   const userVotedNo = userVoteData?.yes_no_choice === 'no';
 
-  // Check if user's personal conditions were met
   const userMinParticipants = userVoteData?.min_participants;
   const userMaxParticipants = userVoteData?.max_participants;
-  const userConditionsMet = userVotedYes && (
-    (userMinParticipants === null || userMinParticipants === undefined || yesCount >= userMinParticipants) &&
-    (userMaxParticipants === null || userMaxParticipants === undefined || yesCount <= userMaxParticipants)
-  );
 
   // Check if current user is in the participant list (by vote ID)
   const userVoteId = userVoteData?.id;

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -239,11 +239,16 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
     if (yesCount === 0 && totalYesVotes > 0) {
       if (isCurrentUserYesVoter && totalYesVotes === 1) {
+        const conds = formatConditions(userMinParticipants, userMaxParticipants);
+        if (conds) return `You wanted ${conds}, but you were the only volunteer`;
         return 'You were the only volunteer, but your conditions couldn\u2019t be met';
       }
       if (isCurrentUserYesVoter) {
         const othersCount = totalYesVotes - 1;
-        return `You and ${othersCount} other${othersCount !== 1 ? 's' : ''} wanted to join, but everyone\u2019s conditions were incompatible`;
+        const conds = formatConditions(userMinParticipants, userMaxParticipants);
+        const base = `You and ${othersCount} other${othersCount !== 1 ? 's' : ''} wanted to join, but everyone\u2019s conditions were incompatible`;
+        if (conds) return `${base} (you wanted ${conds})`;
+        return base;
       }
       if (totalYesVotes === 1) return '1 person wanted to join but their conditions couldn\u2019t be satisfied';
       return `${totalYesVotes} people wanted to join but their conditions were incompatible`;

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -226,7 +226,8 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
   }
 
   // Generate a detailed reason for why the event isn't happening
-  const getFailureReason = (): string => {
+  // When isCurrentUserYesVoter is true, uses "you" language instead of third-person
+  const getFailureReason = (isCurrentUserYesVoter: boolean = false): string => {
     if (totalVotes === 0) return 'No responses received';
 
     if (totalYesVotes === 0) {
@@ -237,6 +238,13 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     }
 
     if (yesCount === 0 && totalYesVotes > 0) {
+      if (isCurrentUserYesVoter && totalYesVotes === 1) {
+        return 'You were the only volunteer, but your conditions couldn\u2019t be met';
+      }
+      if (isCurrentUserYesVoter) {
+        const othersCount = totalYesVotes - 1;
+        return `You and ${othersCount} other${othersCount !== 1 ? 's' : ''} wanted to join, but everyone\u2019s conditions were incompatible`;
+      }
       if (totalYesVotes === 1) return '1 person wanted to join but their conditions couldn\u2019t be satisfied';
       return `${totalYesVotes} people wanted to join but their conditions were incompatible`;
     }
@@ -261,6 +269,19 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     if (abstainCount > 0) parts.push(`${abstainCount} abstain`);
     if (parts.length === 0) return '';
     return parts.join(', ');
+  };
+
+  // Format a min/max constraint as readable text
+  const formatConditions = (min: number | null | undefined, max: number | null | undefined): string | null => {
+    const hasMin = min !== null && min !== undefined;
+    const hasMax = max !== null && max !== undefined;
+    if (!hasMin && !hasMax) return null;
+    if (hasMin && hasMax) {
+      if (min === max) return `exactly ${min} participant${min !== 1 ? 's' : ''}`;
+      return `${min}–${max} participants`;
+    }
+    if (hasMin) return `at least ${min} participant${min !== 1 ? 's' : ''}`;
+    return `at most ${max} participant${max !== 1 ? 's' : ''}`;
   };
 
   // Build explanation for why the user specifically was excluded
@@ -522,19 +543,15 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
     // Scenario: Event NOT happening, user voted YES
     if (!isHappening && userVotedYes) {
-      const failureReason = getFailureReason();
+      const failureReason = getFailureReason(true);
       const breakdown = getVoteBreakdown();
+      const userConditionsText = formatConditions(userMinParticipants, userMaxParticipants);
 
-      // Show the user's own conditions if they had any
-      const userHadConditions = (userMinParticipants !== null && userMinParticipants !== undefined)
-        || (userMaxParticipants !== null && userMaxParticipants !== undefined);
-      const userConditionsLine = userHadConditions
-        ? `Your conditions: ${userMinParticipants && userMaxParticipants
-            ? `${userMinParticipants}–${userMaxParticipants} participants`
-            : userMinParticipants
-            ? `at least ${userMinParticipants} participant${userMinParticipants !== 1 ? 's' : ''}`
-            : `at most ${userMaxParticipants} participant${userMaxParticipants !== 1 ? 's' : ''}`}`
-        : null;
+      // Only show the user's conditions separately if the failure reason doesn't already
+      // explain them (i.e. it's a poll-level constraint failure, not a user-conditions failure)
+      const showUserConditions = userConditionsText
+        && yesCount > 0  // if yesCount === 0, the failure reason already covers conditions
+        && minParticipants && yesCount < minParticipants;  // poll-level min not met
 
       return (
         <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
@@ -547,9 +564,9 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
                 {failureReason}
               </div>
             )}
-            {userConditionsLine && (
+            {showUserConditions && (
               <div className="text-sm text-red-700 dark:text-red-300 opacity-75 mb-1">
-                {userConditionsLine}
+                Your conditions: {userConditionsText}
               </div>
             )}
             {breakdown && (

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -158,12 +158,14 @@ function YesNoResults({ results, isPollClosed, userVoteData, onFollowUpClick }: 
 
 
 function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpClick }: { results: PollResults, isPollClosed?: boolean, userVoteData?: any, onFollowUpClick?: () => void }) {
-  const yesCount = results.yes_count || 0;
+  const yesCount = results.yes_count || 0;        // participants selected by algorithm
   const noCount = results.no_count || 0;
-  const totalYesVotes = results.total_yes_votes ?? yesCount;
+  const abstainCount = results.abstain_count || 0;
+  const totalYesVotes = results.total_yes_votes ?? yesCount;  // raw yes votes before algorithm
   const totalVotes = results.total_votes;
   const minParticipants = results.min_participants;
   const maxParticipants = results.max_participants;
+  const excludedYesVoters = totalYesVotes - yesCount;  // said yes but didn't make the cut
 
   const [participants, setParticipants] = useState<{id: string, voter_name: string | null, vote_id?: string}[]>([]);
   const [allVoters, setAllVoters] = useState<{id: string, voter_name: string | null}[]>([]);
@@ -225,31 +227,51 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
   // Generate a detailed reason for why the event isn't happening
   const getFailureReason = (): string => {
-    // Nobody responded at all
     if (totalVotes === 0) return 'No responses received';
 
-    // People responded but nobody said yes
     if (totalYesVotes === 0) {
-      if (noCount > 0) return `Everyone declined (${noCount} no${noCount !== 1 ? "'s" : ''})`;
+      if (noCount > 0 && abstainCount > 0) return `${noCount} declined, ${abstainCount} abstained — no one volunteered`;
+      if (noCount > 0) return `All ${noCount} respondent${noCount !== 1 ? 's' : ''} declined`;
+      if (abstainCount > 0) return `All ${abstainCount} respondent${abstainCount !== 1 ? 's' : ''} abstained`;
       return 'No one volunteered';
     }
 
-    // People said yes but the algorithm couldn't form a compatible group
     if (yesCount === 0 && totalYesVotes > 0) {
-      return `${totalYesVotes} wanted to participate but their conditions were incompatible`;
+      if (totalYesVotes === 1) return '1 person wanted to join but their conditions couldn\u2019t be satisfied';
+      return `${totalYesVotes} people wanted to join but their conditions were incompatible`;
     }
 
-    // Some participants selected but below minimum
     if (minParticipants && yesCount < minParticipants) {
-      return `Only ${yesCount} of ${minParticipants} required participants`;
+      const shortBy = minParticipants - yesCount;
+      return `${yesCount} participant${yesCount !== 1 ? 's' : ''} — ${shortBy} short of the ${minParticipants} required`;
     }
 
-    // Over maximum (shouldn't normally happen, but just in case)
     if (maxParticipants && yesCount > maxParticipants) {
       return `${yesCount} participants exceeded the maximum of ${maxParticipants}`;
     }
 
     return '';
+  };
+
+  // Build a compact vote breakdown string
+  const getVoteBreakdown = (): string => {
+    const parts: string[] = [];
+    if (totalYesVotes > 0) parts.push(`${totalYesVotes} yes`);
+    if (noCount > 0) parts.push(`${noCount} no`);
+    if (abstainCount > 0) parts.push(`${abstainCount} abstain`);
+    if (parts.length === 0) return '';
+    return parts.join(', ');
+  };
+
+  // Build explanation for why the user specifically was excluded
+  const getUserExclusionReason = (): string => {
+    if (userMaxParticipants !== null && userMaxParticipants !== undefined && yesCount > userMaxParticipants) {
+      return `You set a max of ${userMaxParticipants} participant${userMaxParticipants !== 1 ? 's' : ''}, but ${yesCount} were selected`;
+    }
+    if (userMinParticipants !== null && userMinParticipants !== undefined && yesCount < userMinParticipants) {
+      return `You required at least ${userMinParticipants} participant${userMinParticipants !== 1 ? 's' : ''}, but only ${yesCount} ${yesCount !== 1 ? 'were' : 'was'} selected`;
+    }
+    return 'Your conditions were incompatible with the selected group';
   };
 
   const userVotedYes = userVoteData?.yes_no_choice === 'yes';
@@ -346,6 +368,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
         (!p.voter_name || p.voter_name.trim() === '') && p.vote_id !== userVoteId
       ).length;
       const isAlone = participants.length === 1;
+      const breakdown = getVoteBreakdown();
 
       return (
         <div className="rounded-lg border-2 bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 px-4 py-3">
@@ -355,7 +378,8 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
             </div>
             {isAlone ? (
               <div className="text-sm text-green-700 dark:text-green-300">
-                😢 All alone
+                Just you so far
+                {excludedYesVoters > 0 && ` — ${excludedYesVoters} other${excludedYesVoters !== 1 ? 's' : ''} wanted to but couldn\u2019t`}
               </div>
             ) : (
               <div>
@@ -382,6 +406,16 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
                     </div>
                   )}
                 </div>
+                {excludedYesVoters > 0 && (
+                  <div className="text-xs text-green-600 dark:text-green-400 opacity-75 mt-1">
+                    {excludedYesVoters} other{excludedYesVoters !== 1 ? 's' : ''} wanted to join but couldn&apos;t
+                  </div>
+                )}
+              </div>
+            )}
+            {breakdown && (
+              <div className="text-xs text-green-600 dark:text-green-400 opacity-75 mt-1">
+                Responses: {breakdown}
               </div>
             )}
           </div>
@@ -391,16 +425,8 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
     // Scenario: Event IS happening, user voted YES but is NOT in participant list (needs weren't met)
     if (isHappening && userVotedYes && !userIsInParticipantList) {
-      // Explain why the user was excluded
-      const userExclusionReason = (() => {
-        if (userMaxParticipants !== null && userMaxParticipants !== undefined && yesCount > userMaxParticipants) {
-          return `Too many participants for your conditions (max ${userMaxParticipants})`;
-        }
-        if (userMinParticipants !== null && userMinParticipants !== undefined && yesCount < userMinParticipants) {
-          return `Not enough participants for your conditions (min ${userMinParticipants})`;
-        }
-        return 'Your conditions were incompatible with the group';
-      })();
+      const exclusionReason = getUserExclusionReason();
+      const breakdown = getVoteBreakdown();
 
       return (
         <div className="rounded-lg border-2 bg-yellow-100 dark:bg-yellow-900 border-yellow-400 dark:border-yellow-600 px-4 py-3">
@@ -408,12 +434,12 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
             <div className="text-xl font-bold mb-1 text-yellow-800 dark:text-yellow-200">
               You&apos;re not participating
             </div>
-            <div className="text-sm text-yellow-700 dark:text-yellow-300 mb-1">
-              {userExclusionReason}
+            <div className="text-sm text-yellow-700 dark:text-yellow-300 mb-2">
+              {exclusionReason}
             </div>
-            <div className="flex flex-wrap items-center justify-center gap-1.5">
+            <div className="flex flex-wrap items-center justify-center gap-1.5 mb-2">
               <span className="text-sm text-yellow-700 dark:text-yellow-300">
-                but these are
+                Going without you:
               </span>
               {/* Named participants */}
               {namedParticipants.map((participant) => (
@@ -434,6 +460,12 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
                 </div>
               )}
             </div>
+            {breakdown && (
+              <div className="text-xs text-yellow-600 dark:text-yellow-400 opacity-75">
+                Responses: {breakdown}
+                {excludedYesVoters > 0 && ` (${excludedYesVoters} other${excludedYesVoters !== 1 ? 's' : ''} also excluded)`}
+              </div>
+            )}
           </div>
         </div>
       );
@@ -441,16 +473,24 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
 
     // Scenario: Event IS happening, user voted NO or didn't vote
     if (isHappening && (userVotedNo || !userVoteData)) {
+      const breakdown = getVoteBreakdown();
+      const userAbstained = userVoteData?.is_abstain;
+      const statusLine = userAbstained
+        ? 'You abstained'
+        : userVotedNo
+        ? 'You declined'
+        : 'You didn\u2019t vote';
+
       return (
         <div className="rounded-lg border-2 bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 px-4 py-3">
           <div className="text-center">
             <div className="text-xl font-bold mb-1 text-green-800 dark:text-green-200">
-              You&apos;re not participating
+              It&apos;s happening!
             </div>
-            <div className="flex flex-wrap items-center justify-center gap-1.5">
-              <span className="text-sm text-green-700 dark:text-green-300">
-                but these are
-              </span>
+            <div className="text-sm text-green-700 dark:text-green-300 mb-1">
+              {statusLine} — {yesCount} participant{yesCount !== 1 ? 's' : ''} going
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-1.5 mb-2">
               {/* Named participants */}
               {namedParticipants.map((participant) => (
                 <span
@@ -470,6 +510,11 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
                 </div>
               )}
             </div>
+            {breakdown && (
+              <div className="text-xs text-green-600 dark:text-green-400 opacity-75">
+                Responses: {breakdown}
+              </div>
+            )}
           </div>
         </div>
       );
@@ -478,13 +523,17 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     // Scenario: Event NOT happening, user voted YES
     if (!isHappening && userVotedYes) {
       const failureReason = getFailureReason();
+      const breakdown = getVoteBreakdown();
 
-      const userNeedsText = userMinParticipants && userMaxParticipants
-        ? `${userMinParticipants}-${userMaxParticipants}`
-        : userMinParticipants
-        ? `${userMinParticipants}+`
-        : userMaxParticipants
-        ? `up to ${userMaxParticipants}`
+      // Show the user's own conditions if they had any
+      const userHadConditions = (userMinParticipants !== null && userMinParticipants !== undefined)
+        || (userMaxParticipants !== null && userMaxParticipants !== undefined);
+      const userConditionsLine = userHadConditions
+        ? `Your conditions: ${userMinParticipants && userMaxParticipants
+            ? `${userMinParticipants}–${userMaxParticipants} participants`
+            : userMinParticipants
+            ? `at least ${userMinParticipants} participant${userMinParticipants !== 1 ? 's' : ''}`
+            : `at most ${userMaxParticipants} participant${userMaxParticipants !== 1 ? 's' : ''}`}`
         : null;
 
       return (
@@ -498,9 +547,14 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
                 {failureReason}
               </div>
             )}
-            {!userIsInParticipantList && userNeedsText && (
-              <div className="text-sm text-red-700 dark:text-red-300 opacity-75">
-                Your conditions weren&apos;t met ({userNeedsText} participants)
+            {userConditionsLine && (
+              <div className="text-sm text-red-700 dark:text-red-300 opacity-75 mb-1">
+                {userConditionsLine}
+              </div>
+            )}
+            {breakdown && (
+              <div className="text-xs text-red-600 dark:text-red-400 opacity-75">
+                Responses: {breakdown}
               </div>
             )}
           </div>
@@ -511,6 +565,7 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
     // Scenario: Event NOT happening, user voted NO or didn't vote
     if (!isHappening) {
       const failureReason = getFailureReason();
+      const breakdown = getVoteBreakdown();
 
       return (
         <div className="rounded-lg border-2 bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 px-4 py-3">
@@ -519,8 +574,13 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
               ✗ Not happening
             </div>
             {failureReason && (
-              <div className="text-sm text-red-700 dark:text-red-300">
+              <div className="text-sm text-red-700 dark:text-red-300 mb-1">
                 {failureReason}
+              </div>
+            )}
+            {breakdown && (
+              <div className="text-xs text-red-600 dark:text-red-400 opacity-75">
+                Responses: {breakdown}
               </div>
             )}
           </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -142,6 +142,7 @@ function toPollResults(data: any): PollResults & { ranked_choice_rounds?: ApiRan
     options: data.options ?? undefined,
     yes_count: data.yes_count ?? undefined,
     no_count: data.no_count ?? undefined,
+    total_yes_votes: data.total_yes_votes ?? undefined,
     total_votes: data.total_votes,
     yes_percentage: data.yes_percentage ?? undefined,
     no_percentage: data.no_percentage ?? undefined,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -142,6 +142,7 @@ function toPollResults(data: any): PollResults & { ranked_choice_rounds?: ApiRan
     options: data.options ?? undefined,
     yes_count: data.yes_count ?? undefined,
     no_count: data.no_count ?? undefined,
+    abstain_count: data.abstain_count ?? undefined,
     total_yes_votes: data.total_yes_votes ?? undefined,
     total_votes: data.total_votes,
     yes_percentage: data.yes_percentage ?? undefined,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -107,6 +107,7 @@ export interface PollResults {
   options?: string[];
   yes_count?: number;
   no_count?: number;
+  total_yes_votes?: number;
   total_votes: number;
   yes_percentage?: number;
   no_percentage?: number;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -107,6 +107,7 @@ export interface PollResults {
   options?: string[];
   yes_count?: number;
   no_count?: number;
+  abstain_count?: number;
   total_yes_votes?: number;
   total_votes: number;
   yes_percentage?: number;

--- a/server/models.py
+++ b/server/models.py
@@ -210,6 +210,7 @@ class PollResultsResponse(BaseModel):
     yes_count: int | None = None
     no_count: int | None = None
     abstain_count: int | None = None
+    total_yes_votes: int | None = None
     total_votes: int = 0
     yes_percentage: int | None = None
     no_percentage: int | None = None

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1011,6 +1011,7 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             yes_count=participating_count,
             no_count=no_count,
             abstain_count=abstain_count,
+            total_yes_votes=yes_count,
             total_votes=len(votes),
             min_participants=poll.get("min_participants"),
             max_participants=poll.get("max_participants"),


### PR DESCRIPTION
## Summary
- Replace bare "No one is participating" messages with specific failure reasons (everyone declined, conditions incompatible, below minimum, etc.)
- Add `total_yes_votes` and `abstain_count` fields to API response so the frontend can distinguish "nobody said yes" from "people said yes but constraints were incompatible"
- Show personalized "you" language when the current user voted yes (e.g. "You wanted exactly 2 participants, but no one else said yes")
- Show vote breakdown (X yes, Y no, Z abstain) on all result cards
- Explain exactly why a user was excluded when the event is happening without them (e.g. "You set a max of 3 participants, but 5 were selected")
- Handle edge cases: "exactly N" when min equals max, excluded voter counts, abstain-only polls

## Test plan
- [ ] Create participation poll, have no one respond, close → should show "✗ Not happening / No responses received"
- [ ] Create poll, all vote no, close → should show "All N respondents declined"
- [ ] Create poll, vote yes with min=2/max=2 as only voter, close → should show "You wanted exactly 2 participants, but no one else said yes"
- [ ] Create poll with multiple yes voters with incompatible conditions, close → should show "N people wanted to join but their conditions were incompatible"
- [ ] Create poll with poll-level min=5, only 2 compatible yes voters, close → should show "2 participants — 3 short of the 5 required"
- [ ] Vote yes with max=2 on a poll where 4 get selected → should show yellow card: "You set a max of 2 participants, but 4 were selected" with participant names
- [ ] Vote no on a happening poll → should show "It's happening! / You declined — N participants going"
- [ ] Don't vote on a happening poll → should show "It's happening! / You didn't vote — N participants going"

https://claude.ai/code/session_016A86dKavBiauFoTcuCHEsw