### PR TITLE
Fix all-abstain returning tie instead of no winner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -919,6 +919,10 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Place detail modal**: Tapping a restaurant/location name opens `PlaceDetailModal` (map embed + metadata). Tapping the address opens an iOS-style action sheet (`AddressActionsModal`) with "Open in Maps" (Apple Maps), "Open in Google Maps", and "Copy Address". Don't use `geo:` URIs on iOS — they're unreliable (may open Google Earth or other random apps). Don't include the business name in maps queries — it triggers a search for multiple branches instead of navigating to the specific address.
 - **`line-clamp-2` breaks flex layouts**: Don't apply `line-clamp-*` to containers with flex children (like `OptionLabel`). The CSS treats flex items as flowing text and truncates unexpectedly. Use `overflow-hidden` instead and let inner components handle their own truncation.
 
+### Yes/No Result Edge Cases
+
+- **All-abstain polls return `winner=None`, not `"tie"`.** In `server/algorithms/yes_no.py`, when `yes_count == 0 and no_count == 0` (but `total_votes > 0` due to abstains), the winner is `None`. A tie means competing sides got equal votes; all-abstain means no decision was made. The `total_votes == 0` early return handles the no-votes-at-all case separately.
+
 ### API Development Pitfalls
 
 - **Catch-all fallthrough in `get_results()`**: When adding new poll types, `server/routers/polls.py` has a catch-all return at the bottom returning `yes_count=None`. Any poll type without an explicit handler silently falls through and the frontend interprets `None` as `0`. Always add an explicit handler for each poll type.

--- a/server/algorithms/yes_no.py
+++ b/server/algorithms/yes_no.py
@@ -63,7 +63,9 @@ def count_yes_no_votes(votes: list[dict]) -> YesNoResult:
     yes_percentage = round((yes_count / total_votes) * 100)
     no_percentage = round((no_count / total_votes) * 100)
 
-    if yes_count > no_count:
+    if yes_count == 0 and no_count == 0:
+        winner = None
+    elif yes_count > no_count:
         winner = "yes"
     elif no_count > yes_count:
         winner = "no"

--- a/server/tests/test_yes_no.py
+++ b/server/tests/test_yes_no.py
@@ -88,7 +88,7 @@ class TestCountYesNoVotes:
         assert result.total_votes == 2
         assert result.yes_percentage == 0
         assert result.no_percentage == 0
-        assert result.winner == "tie"
+        assert result.winner is None
 
     def test_abstain_affects_percentages(self):
         """Abstain votes are in the denominator, lowering yes/no percentages."""

--- a/social_tests/tests/test_multi_stage.py
+++ b/social_tests/tests/test_multi_stage.py
@@ -246,8 +246,8 @@ class TestFollowUpChains:
         # Some people change their mind with new info
         api.vote(second_poll["id"], voter_name="A", vote_type="yes_no", yes_no_choice="yes")
         api.vote(second_poll["id"], voter_name="B", vote_type="yes_no", yes_no_choice="yes")
-        api.vote(second_poll["id"], voter_name="C", vote_type="yes_no", yes_no_choice="no")  # Changed
-        api.vote(second_poll["id"], voter_name="D", vote_type="yes_no", yes_no_choice="yes")  # Changed
+        api.vote(second_poll["id"], voter_name="C", vote_type="yes_no", yes_no_choice="yes")  # Changed with budget context
+        api.vote(second_poll["id"], voter_name="D", vote_type="yes_no", yes_no_choice="yes")  # Changed with budget context
         api.vote(second_poll["id"], voter_name="E", vote_type="yes_no", yes_no_choice="no")
         api.vote(second_poll["id"], voter_name="F", vote_type="yes_no", yes_no_choice="no")
 


### PR DESCRIPTION
## Summary
- Fix yes/no poll results: all-abstain now returns `winner=null` instead of `"tie"`. A tie implies competing sides with equal votes — all-abstain means no decision was made.
- Fix `test_follow_up_after_tie` social test: votes were 3-3 (another tie) instead of 4-2 to actually break the deadlock.
- Document the all-abstain behavior in CLAUDE.md.

## Test plan
- [x] Unit tests pass (`server/tests/test_yes_no.py` — 12/12)
- [x] Social tests pass (33/33) — report regenerated and deployed
- [x] Report verified at https://test-at-test-com.dev.whoeverwants.com/social_test_report.html

https://claude.ai/code/session_01QLC8iP8nFygoV1bjHaU9u7