### PR TITLE
Fix poll-to-report back-links in social tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -924,6 +924,7 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Poll-to-report back-links require `SOCIAL_TEST_REPORT_URL` in the test subprocess environment.** `generate_report.py` derives it from `--site-url` (or `SOCIAL_TEST_API_URL` env var) + `/{REPORT_FILENAME}.html` and passes it to pytest. Without it, `conftest.py`'s `REPORT_URL` is empty and no back-link is injected into poll `details` fields.
 - **Report-to-poll forward links work independently** — they read `poll_id` from test results JSON after the run. Only the reverse direction (poll → report) requires the URL to be known at test time.
 - **The report filename is defined once** in `REPORT_FILENAME` constant in `generate_report.py`. Update it there if the filename changes.
+- **After deploying a report to a dev server, always verify it loads** by curling the URL and checking for a non-empty 200 response. Pipe-based base64 transfers can silently produce empty files. Then share the verified URL with the user.
 
 ### Yes/No Result Edge Cases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -919,6 +919,12 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Place detail modal**: Tapping a restaurant/location name opens `PlaceDetailModal` (map embed + metadata). Tapping the address opens an iOS-style action sheet (`AddressActionsModal`) with "Open in Maps" (Apple Maps), "Open in Google Maps", and "Copy Address". Don't use `geo:` URIs on iOS — they're unreliable (may open Google Earth or other random apps). Don't include the business name in maps queries — it triggers a search for multiple branches instead of navigating to the specific address.
 - **`line-clamp-2` breaks flex layouts**: Don't apply `line-clamp-*` to containers with flex children (like `OptionLabel`). The CSS treats flex items as flowing text and truncates unexpectedly. Use `overflow-hidden` instead and let inner components handle their own truncation.
 
+### Social Test Report Bidirectional Linking
+
+- **Poll-to-report back-links require `SOCIAL_TEST_REPORT_URL` in the test subprocess environment.** `generate_report.py` derives it from `--site-url` (or `SOCIAL_TEST_API_URL` env var) + `/{REPORT_FILENAME}.html` and passes it to pytest. Without it, `conftest.py`'s `REPORT_URL` is empty and no back-link is injected into poll `details` fields.
+- **Report-to-poll forward links work independently** — they read `poll_id` from test results JSON after the run. Only the reverse direction (poll → report) requires the URL to be known at test time.
+- **The report filename is defined once** in `REPORT_FILENAME` constant in `generate_report.py`. Update it there if the filename changes.
+
 ### Yes/No Result Edge Cases
 
 - **All-abstain polls return `winner=None`, not `"tie"`.** In `server/algorithms/yes_no.py`, when `yes_count == 0 and no_count == 0` (but `total_votes > 0` due to abstains), the winner is `None`. A tie means competing sides got equal votes; all-abstain means no decision was made. The `total_votes == 0` early return handles the no-votes-at-all case separately.

--- a/social_tests/generate_report.py
+++ b/social_tests/generate_report.py
@@ -25,14 +25,15 @@ RESULTS_PATH = Path("/tmp/social_test_results.json")
 REPORT_DIR = Path(__file__).parent / "reports"
 STRATEGY_PATH = Path(__file__).parent / "testing_strategy.md"
 CRITIQUE_PATH = REPORT_DIR / "previous_critique.json"
+REPORT_FILENAME = "social_test_report"
 
 
-def run_tests(site_url: str = "") -> list[dict]:
+def run_tests(site_url: str | None = None) -> list[dict]:
     """Execute pytest and return collected results."""
     env = os.environ.copy()
     env["SOCIAL_TEST_RESULTS_PATH"] = str(RESULTS_PATH)
     if site_url:
-        env["SOCIAL_TEST_REPORT_URL"] = f"{site_url.rstrip('/')}/social_test_report.html"
+        env["SOCIAL_TEST_REPORT_URL"] = f"{site_url.rstrip('/')}/{REPORT_FILENAME}.html"
 
     print("Running social tests...")
     proc = subprocess.run(
@@ -513,12 +514,12 @@ def main():
 
     # Step 3: Build report
     md_content = build_markdown(results, critique_map, site_url=args.site_url)
-    md_path = REPORT_DIR / "social_test_report.md"
+    md_path = REPORT_DIR / f"{REPORT_FILENAME}.md"
     md_path.write_text(md_content)
     print(f"Markdown report: {md_path}")
 
     html_content = build_html(md_content)
-    html_path = REPORT_DIR / "social_test_report.html"
+    html_path = REPORT_DIR / f"{REPORT_FILENAME}.html"
     html_path.write_text(html_content)
     print(f"HTML report: {html_path}")
 

--- a/social_tests/generate_report.py
+++ b/social_tests/generate_report.py
@@ -27,10 +27,12 @@ STRATEGY_PATH = Path(__file__).parent / "testing_strategy.md"
 CRITIQUE_PATH = REPORT_DIR / "previous_critique.json"
 
 
-def run_tests() -> list[dict]:
+def run_tests(site_url: str = "") -> list[dict]:
     """Execute pytest and return collected results."""
     env = os.environ.copy()
     env["SOCIAL_TEST_RESULTS_PATH"] = str(RESULTS_PATH)
+    if site_url:
+        env["SOCIAL_TEST_REPORT_URL"] = f"{site_url.rstrip('/')}/social_test_report.html"
 
     print("Running social tests...")
     proc = subprocess.run(
@@ -494,7 +496,7 @@ def main():
             results = json.load(f)
         print(f"Using cached results: {len(results)} tests")
     else:
-        results = run_tests()
+        results = run_tests(site_url=args.site_url)
         print(f"Collected {len(results)} test results")
 
     if not results:


### PR DESCRIPTION
## Summary
- `generate_report.py` was not passing `SOCIAL_TEST_REPORT_URL` to the pytest subprocess, so polls created during social tests never got back-links to their section in the report
- Now derives the report URL from `--site-url` and passes it via env var
- Extracted `REPORT_FILENAME` constant to avoid hardcoding the filename in 3 places
- Used `str | None` instead of empty string default for cleaner optional parameter

## Test plan
- [x] Regenerated social test report with `--site-url` — all 33 tests pass
- [x] Verified new polls have `details` field with report back-link URL
- [x] Verified report still has forward "view poll" links to polls
- [x] Confirmed bidirectional navigation works on dev server

https://claude.ai/code/session_014rqEJAokTAXwNPWUhq87vf