### PR TITLE
Add min responses threshold and expiration conditions for preference polls

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1454,7 +1454,7 @@ function CreatePollContent() {
                           <span className="text-xs text-gray-400 dark:text-gray-500 font-normal">or</span>
                         )}
                         {voteLabel && (
-                          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+                          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
                             {voteLabel}
                           </span>
                         )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -245,7 +245,7 @@ function CreatePollContent() {
     if (isPreferencePoll) {
       // Switching to preference/suggestion poll: default to 4 weeks
       if (BASE_DEADLINE_OPTIONS.some(o => o.value === deadlineOption)) {
-        setDeadlineOption('4weeks');
+        setDeadlineOption('1month');
       }
     } else {
       // Switching away: revert to inline default if it's an expiration modal option

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1429,18 +1429,42 @@ function CreatePollContent() {
                 type="button"
                 onClick={() => setShowExpirationModal(true)}
                 disabled={isLoading}
-                className="w-full py-3 px-4 rounded-lg border-2 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                className="w-full py-3 px-4 rounded-lg border-2 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                Expiration Conditions
-                <span className="text-xs text-gray-500 dark:text-gray-400 font-normal">
-                  ({deadlineOption === 'none' ? 'none' :
-                    EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
-                    deadlineOptions.find(o => o.value === deadlineOption)?.label ||
-                    deadlineOption}{autoCloseAfter ? ` + ${autoCloseAfter} votes` : ''})
-                </span>
+                <div className="flex items-center justify-center gap-2">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  Expiration Conditions
+                </div>
+                {(() => {
+                  const timeLabel = deadlineOption !== 'none'
+                    ? (EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
+                       deadlineOptions.find(o => o.value === deadlineOption)?.label ||
+                       deadlineOption)
+                    : null;
+                  const voteLabel = autoCloseAfter ? `${autoCloseAfter} votes` : null;
+                  if (!timeLabel && !voteLabel) return (
+                    <span className="text-xs text-gray-400 dark:text-gray-500 font-normal mt-1">none</span>
+                  );
+                  return (
+                    <div className="flex items-center justify-center gap-1.5 mt-1.5 flex-wrap">
+                      {timeLabel && (
+                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                          {timeLabel}
+                        </span>
+                      )}
+                      {timeLabel && voteLabel && (
+                        <span className="text-xs text-gray-400 dark:text-gray-500 font-normal">or</span>
+                      )}
+                      {voteLabel && (
+                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+                          {voteLabel}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })()}
               </button>
             </>
           )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1429,10 +1429,10 @@ function CreatePollContent() {
                 type="button"
                 onClick={() => setShowExpirationModal(true)}
                 disabled={isLoading}
-                className="w-full py-2.5 px-4 rounded-lg border-2 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-sm text-gray-700 dark:text-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-left"
+                className="block text-sm font-medium text-left"
               >
-                <div className="flex items-center gap-1.5 flex-wrap">
-                  <span className="font-medium whitespace-nowrap">Expire after</span>
+                <span className="inline-flex items-center gap-1.5 flex-wrap">
+                  <span className="whitespace-nowrap">Expiration:</span>
                   {(() => {
                     const timeLabel = deadlineOption !== 'none'
                       ? (EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
@@ -1441,7 +1441,7 @@ function CreatePollContent() {
                       : null;
                     const voteLabel = autoCloseAfter ? `${autoCloseAfter} votes` : null;
                     if (!timeLabel && !voteLabel) return (
-                      <span className="text-xs text-gray-400 dark:text-gray-500 font-normal italic">none</span>
+                      <span className="font-normal text-blue-600 dark:text-blue-400">none</span>
                     );
                     return (
                       <>
@@ -1461,7 +1461,7 @@ function CreatePollContent() {
                       </>
                     );
                   })()}
-                </div>
+                </span>
               </button>
             </>
           )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -245,7 +245,7 @@ function CreatePollContent() {
     if (isPreferencePoll) {
       // Switching to preference/suggestion poll: default to 4 weeks
       if (BASE_DEADLINE_OPTIONS.some(o => o.value === deadlineOption)) {
-        setDeadlineOption('1month');
+        setDeadlineOption('1week');
       }
     } else {
       // Switching away: revert to inline default if it's an expiration modal option

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -13,9 +13,11 @@ import ConfirmationModal from "@/components/ConfirmationModal";
 import FollowUpHeader from "@/components/FollowUpHeader";
 import ForkHeader from "@/components/ForkHeader";
 import { triggerDiscoveryIfNeeded } from "@/lib/pollDiscovery";
-import { getUserName, saveUserName } from "@/lib/userProfile";
+import { getUserName, saveUserName, getUserMinResponses, saveUserMinResponses } from "@/lib/userProfile";
 import { debugLog } from "@/lib/debugLogger";
 import OptionsInput from "@/components/OptionsInput";
+import CompactMinResponsesField from "@/components/CompactMinResponsesField";
+import ExpirationConditionsModal, { EXPIRATION_DEADLINE_OPTIONS } from "@/components/ExpirationConditionsModal";
 import MinMaxCounter from "@/components/MinMaxCounter";
 import ParticipationConditions, { DayTimeWindow } from "@/components/ParticipationConditions";
 import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
@@ -124,6 +126,10 @@ function CreatePollContent() {
   const [refLongitude, setRefLongitude] = useState<number | undefined>(undefined);
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
+  // Minimum responses / preliminary results / expiration modal
+  const [minResponses, setMinResponses] = useState<number>(1);
+  const [showPreliminaryResults, setShowPreliminaryResults] = useState(true);
+  const [showExpirationModal, setShowExpirationModal] = useState(false);
 
   const hasNoOptions = options.filter(o => o.trim()).length === 0;
   const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && hasNoOptions;
@@ -230,6 +236,25 @@ function CreatePollContent() {
     }
   }, []);
 
+  // Set default deadline based on poll type
+  const isPreferencePoll = pollType === 'poll' && category !== 'yes_no';
+  const prevIsPreferencePollRef = useRef(isPreferencePoll);
+  useEffect(() => {
+    if (isPreferencePoll === prevIsPreferencePollRef.current) return;
+    prevIsPreferencePollRef.current = isPreferencePoll;
+    if (isPreferencePoll) {
+      // Switching to preference/suggestion poll: default to 4 weeks
+      if (BASE_DEADLINE_OPTIONS.some(o => o.value === deadlineOption)) {
+        setDeadlineOption('4weeks');
+      }
+    } else {
+      // Switching away: revert to inline default if it's an expiration modal option
+      if (EXPIRATION_DEADLINE_OPTIONS.some(o => o.value === deadlineOption) && deadlineOption !== 'custom') {
+        setDeadlineOption('10min');
+      }
+    }
+  }, [isPreferencePoll, deadlineOption]);
+
   // Save poll type preference separately (persists across submissions)
   const savePollTypePreference = useCallback((type: 'poll' | 'participation') => {
     if (typeof window !== 'undefined') {
@@ -257,11 +282,13 @@ function CreatePollContent() {
         durationMaxValue,
         durationMinEnabled,
         durationMaxEnabled,
-        dayTimeWindows
+        dayTimeWindows,
+        minResponses,
+        showPreliminaryResults,
       };
       localStorage.setItem('pollFormState', JSON.stringify(formState));
     }
-  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows]);
+  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows, minResponses, showPreliminaryResults]);
 
   // Get default date/time values (client-side only to avoid hydration mismatch)
   const getDefaultDateTime = () => {
@@ -322,6 +349,8 @@ function CreatePollContent() {
           if (formState.durationMinEnabled !== undefined) setDurationMinEnabled(formState.durationMinEnabled);
           if (formState.durationMaxEnabled !== undefined) setDurationMaxEnabled(formState.durationMaxEnabled);
           if (formState.dayTimeWindows !== undefined) setDayTimeWindows(formState.dayTimeWindows);
+          if (formState.minResponses !== undefined) setMinResponses(formState.minResponses);
+          if (formState.showPreliminaryResults !== undefined) setShowPreliminaryResults(formState.showPreliminaryResults);
 
           return formState;
         } catch (error) {
@@ -500,6 +529,10 @@ function CreatePollContent() {
     if (savedName) {
       setCreatorName(savedName);
     }
+    const savedMinResponses = getUserMinResponses();
+    if (savedMinResponses !== null) {
+      setMinResponses(savedMinResponses);
+    }
 
     if (!followUpToParam && !forkOfParam && !duplicateOfParam && !voteFromSuggestionParam) {
       const savedFormState = loadFormState();
@@ -617,6 +650,8 @@ function CreatePollContent() {
           if (forkData.options_metadata) {
             setOptionsMetadata(forkData.options_metadata);
           }
+          if (forkData.min_responses != null) setMinResponses(forkData.min_responses);
+          if (forkData.show_preliminary_results != null) setShowPreliminaryResults(forkData.show_preliminary_results);
         } catch (error) {
           console.error('Error loading fork data:', error);
         }
@@ -707,6 +742,8 @@ function CreatePollContent() {
           if (duplicateData.options_metadata) {
             setOptionsMetadata(duplicateData.options_metadata);
           }
+          if (duplicateData.min_responses != null) setMinResponses(duplicateData.min_responses);
+          if (duplicateData.show_preliminary_results != null) setShowPreliminaryResults(duplicateData.show_preliminary_results);
 
           // Don't clean up the duplicate data yet - keep it until poll is created
           // so that refresh doesn't lose the data
@@ -852,23 +889,28 @@ function CreatePollContent() {
 
   const calculateDeadline = () => {
     const now = new Date();
-    
+
+    // No deadline if disabled via expiration modal
+    if (deadlineOption === "none") return null;
+
     if (deadlineOption === "custom") {
       if (!customDate || !customTime) return null;
       const dateTimeString = `${customDate}T${customTime}`;
       const customDateTime = new Date(dateTimeString);
-      
+
       // Check if the selected time is in the past
       if (customDateTime <= now) {
         return null; // Will be caught by validation
       }
-      
+
       return customDateTime.toISOString();
     }
-    
-    const option = deadlineOptions.find(opt => opt.value === deadlineOption);
+
+    // Check both inline deadline options and expiration modal options
+    const option = deadlineOptions.find(opt => opt.value === deadlineOption)
+      || EXPIRATION_DEADLINE_OPTIONS.find(opt => opt.value === deadlineOption);
     if (!option) return null;
-    
+
     const deadline = new Date(now.getTime() + option.minutes * 60 * 1000);
     return deadline.toISOString();
   };
@@ -1132,6 +1174,12 @@ function CreatePollContent() {
         pollData.auto_close_after = autoCloseAfter;
       }
 
+      // Add min_responses and show_preliminary_results for preference/suggestion polls
+      if (dbPollType === 'ranked_choice' || dbPollType === 'suggestion') {
+        pollData.min_responses = minResponses;
+        pollData.show_preliminary_results = showPreliminaryResults;
+      }
+
       // Check for duplicate follow-up poll before creating
       if (followUpTo) {
         try {
@@ -1354,90 +1402,137 @@ function CreatePollContent() {
             </>
           )}
 
-          {/* Auto-close + Response Deadline */}
-          <div>
-            <label className="block text-sm font-medium mb-1">Close After</label>
-            <div className="flex items-center gap-2 min-w-0">
-              <input
-                type="number"
-                min="1"
-                value={autoCloseAfter ?? ''}
-                onChange={(e) => {
-                  const val = e.target.value;
-                  setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val, 10) || 1));
+          {/* Preference/suggestion polls: min responses, preliminary results, expiration modal */}
+          {isPreferencePoll && (
+            <>
+              <CompactMinResponsesField
+                value={minResponses}
+                setValue={(val) => {
+                  setMinResponses(val);
+                  saveUserMinResponses(val);
                 }}
                 disabled={isLoading}
-                placeholder="—"
-                className="w-16 shrink-0 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
               />
-              <span className="text-sm text-gray-600 dark:text-gray-400 shrink-0">votes or</span>
-              <select
-                id="deadline"
-                value={deadlineOption}
-                onChange={(e) => setDeadlineOption(e.target.value)}
-                disabled={isLoading}
-                className="min-w-0 flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm truncate"
-              >
-                {deadlineOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {isClient ? getTimeLabel(option.value) : option.label}
-                  </option>
-                ))}
-              </select>
-              {autoCloseAfter !== null && (
-                <button
-                  type="button"
-                  onClick={() => setAutoCloseAfter(null)}
-                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0"
-                  title="Disable auto-close"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              )}
-            </div>
-          </div>
-
-          {deadlineOption === "custom" && (
-            <div>
-              <label className="block text-sm font-medium mb-1">
-                Custom Deadline<span className="text-gray-500 font-normal">{getCustomDeadlineDisplay()}</span>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={showPreliminaryResults}
+                  onChange={(e) => setShowPreliminaryResults(e.target.checked)}
+                  disabled={isLoading}
+                  className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Show preliminary results
+                </span>
               </label>
-              <div className="flex justify-between gap-2">
-                <div className="w-auto">
-                  <label htmlFor="customDate" className="block text-xs text-gray-500 mb-1">
-                    Date
-                  </label>
+              <button
+                type="button"
+                onClick={() => setShowExpirationModal(true)}
+                disabled={isLoading}
+                className="w-full py-3 px-4 rounded-lg border-2 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Expiration Conditions
+                <span className="text-xs text-gray-500 dark:text-gray-400 font-normal">
+                  ({deadlineOption === 'none' ? 'none' :
+                    EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
+                    deadlineOptions.find(o => o.value === deadlineOption)?.label ||
+                    deadlineOption}{autoCloseAfter ? ` + ${autoCloseAfter} votes` : ''})
+                </span>
+              </button>
+            </>
+          )}
+
+          {/* Auto-close + Response Deadline (for yes_no and participation polls) */}
+          {!isPreferencePoll && (
+            <>
+              <div>
+                <label className="block text-sm font-medium mb-1">Close After</label>
+                <div className="flex items-center gap-2 min-w-0">
                   <input
-                    type="date"
-                    id="customDate"
-                    value={customDate}
-                    onChange={(e) => setCustomDate(e.target.value)}
+                    type="number"
+                    min="1"
+                    value={autoCloseAfter ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val, 10) || 1));
+                    }}
                     disabled={isLoading}
-                    min={isClient ? getTodayDate() : ''}
-                    className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
-                    style={{ fontSize: '14px' }}
-                    required
+                    placeholder="—"
+                    className="w-16 shrink-0 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
                   />
-                </div>
-                <div className="w-auto">
-                  <label htmlFor="customTime" className="block text-xs text-gray-500 mb-1 text-right">
-                    Time
-                  </label>
-                  <input
-                    type="time"
-                    id="customTime"
-                    value={customTime}
-                    onChange={(e) => setCustomTime(e.target.value)}
+                  <span className="text-sm text-gray-600 dark:text-gray-400 shrink-0">votes or</span>
+                  <select
+                    id="deadline"
+                    value={deadlineOption}
+                    onChange={(e) => setDeadlineOption(e.target.value)}
                     disabled={isLoading}
-                    className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
-                    style={{ fontSize: '14px' }}
-                    required
-                  />
+                    className="min-w-0 flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm truncate"
+                  >
+                    {deadlineOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {isClient ? getTimeLabel(option.value) : option.label}
+                      </option>
+                    ))}
+                  </select>
+                  {autoCloseAfter !== null && (
+                    <button
+                      type="button"
+                      onClick={() => setAutoCloseAfter(null)}
+                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0"
+                      title="Disable auto-close"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  )}
                 </div>
               </div>
-            </div>
+
+              {deadlineOption === "custom" && (
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    Custom Deadline<span className="text-gray-500 font-normal">{getCustomDeadlineDisplay()}</span>
+                  </label>
+                  <div className="flex justify-between gap-2">
+                    <div className="w-auto">
+                      <label htmlFor="customDate" className="block text-xs text-gray-500 mb-1">
+                        Date
+                      </label>
+                      <input
+                        type="date"
+                        id="customDate"
+                        value={customDate}
+                        onChange={(e) => setCustomDate(e.target.value)}
+                        disabled={isLoading}
+                        min={isClient ? getTodayDate() : ''}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                        required
+                      />
+                    </div>
+                    <div className="w-auto">
+                      <label htmlFor="customTime" className="block text-xs text-gray-500 mb-1 text-right">
+                        Time
+                      </label>
+                      <input
+                        type="time"
+                        id="customTime"
+                        value={customTime}
+                        onChange={(e) => setCustomTime(e.target.value)}
+                        disabled={isLoading}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                        required
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </>
           )}
 
           {/* Auto-create preferences poll checkbox - shown when no options provided (suggestion mode) */}
@@ -1645,6 +1740,21 @@ function CreatePollContent() {
         message={`Are you sure you want to create "${title}"?`}
         confirmText="Create"
         cancelText="Cancel"
+      />
+
+      <ExpirationConditionsModal
+        isOpen={showExpirationModal}
+        onClose={() => setShowExpirationModal(false)}
+        deadlineOption={deadlineOption}
+        setDeadlineOption={setDeadlineOption}
+        customDate={customDate}
+        setCustomDate={setCustomDate}
+        customTime={customTime}
+        setCustomTime={setCustomTime}
+        autoCloseAfter={autoCloseAfter}
+        setAutoCloseAfter={setAutoCloseAfter}
+        isClient={isClient}
+        disabled={isLoading}
       />
 
     </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1429,42 +1429,39 @@ function CreatePollContent() {
                 type="button"
                 onClick={() => setShowExpirationModal(true)}
                 disabled={isLoading}
-                className="w-full py-3 px-4 rounded-lg border-2 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full py-2.5 px-4 rounded-lg border-2 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 text-sm text-gray-700 dark:text-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-left"
               >
-                <div className="flex items-center justify-center gap-2">
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                  Expiration Conditions
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  <span className="font-medium whitespace-nowrap">Expire after</span>
+                  {(() => {
+                    const timeLabel = deadlineOption !== 'none'
+                      ? (EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
+                         deadlineOptions.find(o => o.value === deadlineOption)?.label ||
+                         deadlineOption)
+                      : null;
+                    const voteLabel = autoCloseAfter ? `${autoCloseAfter} votes` : null;
+                    if (!timeLabel && !voteLabel) return (
+                      <span className="text-xs text-gray-400 dark:text-gray-500 font-normal italic">none</span>
+                    );
+                    return (
+                      <>
+                        {timeLabel && (
+                          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                            {timeLabel}
+                          </span>
+                        )}
+                        {timeLabel && voteLabel && (
+                          <span className="text-xs text-gray-400 dark:text-gray-500 font-normal">or</span>
+                        )}
+                        {voteLabel && (
+                          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+                            {voteLabel}
+                          </span>
+                        )}
+                      </>
+                    );
+                  })()}
                 </div>
-                {(() => {
-                  const timeLabel = deadlineOption !== 'none'
-                    ? (EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
-                       deadlineOptions.find(o => o.value === deadlineOption)?.label ||
-                       deadlineOption)
-                    : null;
-                  const voteLabel = autoCloseAfter ? `${autoCloseAfter} votes` : null;
-                  if (!timeLabel && !voteLabel) return (
-                    <span className="text-xs text-gray-400 dark:text-gray-500 font-normal mt-1">none</span>
-                  );
-                  return (
-                    <div className="flex items-center justify-center gap-1.5 mt-1.5 flex-wrap">
-                      {timeLabel && (
-                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-                          {timeLabel}
-                        </span>
-                      )}
-                      {timeLabel && voteLabel && (
-                        <span className="text-xs text-gray-400 dark:text-gray-500 font-normal">or</span>
-                      )}
-                      {voteLabel && (
-                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
-                          {voteLabel}
-                        </span>
-                      )}
-                    </div>
-                  );
-                })()}
               </button>
             </>
           )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1411,20 +1411,10 @@ function CreatePollContent() {
                   setMinResponses(val);
                   saveUserMinResponses(val);
                 }}
+                showPreliminary={showPreliminaryResults}
+                setShowPreliminary={setShowPreliminaryResults}
                 disabled={isLoading}
               />
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={showPreliminaryResults}
-                  onChange={(e) => setShowPreliminaryResults(e.target.checked)}
-                  disabled={isLoading}
-                  className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Show preliminary results
-                </span>
-              </label>
               <button
                 type="button"
                 onClick={() => setShowExpirationModal(true)}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -202,10 +202,21 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const isPollClosed = useMemo(() => {
     // If manually reopened, stay open regardless of deadline
     if (manuallyReopened && !pollClosed) return false;
-    
+
     // Otherwise, use normal logic: manual close OR deadline expiration
     return pollClosed || isPollExpired;
   }, [pollClosed, isPollExpired, manuallyReopened]);
+
+  // Track response count for preliminary results
+  const [responseCount, setResponseCount] = useState<number>(poll.response_count ?? 0);
+
+  // Whether preliminary results should be shown (open poll, threshold met)
+  const showPrelimResults = useMemo(() => {
+    if (isPollClosed) return false; // Closed polls show results via the normal path
+    if (!poll.show_preliminary_results) return false;
+    const minResp = poll.min_responses ?? 1;
+    return responseCount >= minResp;
+  }, [isPollClosed, poll.show_preliminary_results, poll.min_responses, responseCount]);
 
   // Check if user has voted on this poll (stored in localStorage)
   const hasVotedOnPoll = useCallback((pollId: string): boolean => {
@@ -385,6 +396,13 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       fetchPollResults();
     }
   }, [poll.poll_type, fetchPollResults]);
+
+  // Fetch preliminary results when threshold is met
+  useEffect(() => {
+    if (showPrelimResults && !pollResults) {
+      fetchPollResults();
+    }
+  }, [showPrelimResults, pollResults, fetchPollResults]);
 
   // Load existing suggestions from other votes
   const loadExistingSuggestions = async (excludeUserVote = false) => {
@@ -737,6 +755,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           setPollClosed(true);
           setManuallyReopened(false); // Reset flag when closed
           fetchPollResults();
+        }
+        // Update response count for preliminary results
+        if (pollData?.response_count != null) {
+          setResponseCount(pollData.response_count);
         }
       } catch (error) {
         console.error('Polling error:', error);
@@ -1223,6 +1245,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       setHasVoted(true);
       setUserVoteId(voteId ?? null);
 
+      // Update response count for preliminary results
+      if (!isEditingVote) {
+        setResponseCount(prev => prev + 1);
+      }
+
       // Merge submitted metadata into local state so it's available immediately
       if (suggestionMetadata && Object.keys(suggestionMetadata).length > 0) {
         setOptionsMetadataLocal(prev => ({ ...prev, ...suggestionMetadata }));
@@ -1274,8 +1301,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         await fetchSuggestions();
       }
 
-      // If the poll is closed, fetch results immediately after voting
-      if (isPollClosed && !isEditingVote) {
+      // If the poll is closed or preliminary results threshold met, fetch results
+      if ((isPollClosed || showPrelimResults) && !isEditingVote) {
         await fetchPollResults();
       }
     } catch (error) {
@@ -1398,6 +1425,25 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           return null;
         })()}
         
+        {/* Preliminary results for open polls that have met the threshold */}
+        {showPrelimResults && !isPollClosed && (
+          <div className="pt-2.5">
+            <div className="mb-2 text-xs text-gray-500 dark:text-gray-400 text-center font-medium uppercase tracking-wide">
+              Preliminary Results
+            </div>
+            {loadingResults ? (
+              <div className="flex justify-center items-center py-3">
+                <svg className="animate-spin h-8 w-8 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+              </div>
+            ) : pollResults ? (
+              <PollResultsDisplay results={pollResults} isPollClosed={false} userVoteData={userVoteData} optionsMetadata={optionsMetadataLocal} />
+            ) : null}
+          </div>
+        )}
+
         {/* For closed polls, show results first */}
         {isPollClosed && (
           <div className="pt-2.5">

--- a/components/CompactMinResponsesField.tsx
+++ b/components/CompactMinResponsesField.tsx
@@ -58,6 +58,7 @@ export default function CompactMinResponsesField({ value, setValue, showPrelimin
         Min Responses: <span className="font-normal text-blue-600 dark:text-blue-400">{value}</span>
       </button>
       <label htmlFor={checkboxId} className="flex items-center gap-1.5 cursor-pointer">
+        <span className="text-xs text-gray-500 dark:text-gray-400">then show results</span>
         <input
           type="checkbox"
           id={checkboxId}
@@ -66,7 +67,6 @@ export default function CompactMinResponsesField({ value, setValue, showPrelimin
           disabled={disabled}
           className="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
         />
-        <span className="text-xs text-gray-500 dark:text-gray-400">Show preliminary</span>
       </label>
     </div>
   );

--- a/components/CompactMinResponsesField.tsx
+++ b/components/CompactMinResponsesField.tsx
@@ -5,13 +5,16 @@ import { useState, useRef, useEffect, useId } from 'react';
 interface CompactMinResponsesFieldProps {
   value: number;
   setValue: (value: number) => void;
+  showPreliminary: boolean;
+  setShowPreliminary: (value: boolean) => void;
   disabled?: boolean;
 }
 
-export default function CompactMinResponsesField({ value, setValue, disabled = false }: CompactMinResponsesFieldProps) {
+export default function CompactMinResponsesField({ value, setValue, showPreliminary, setShowPreliminary, disabled = false }: CompactMinResponsesFieldProps) {
   const [isEditing, setIsEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const id = useId();
+  const checkboxId = useId();
 
   useEffect(() => {
     if (isEditing) {
@@ -24,7 +27,7 @@ export default function CompactMinResponsesField({ value, setValue, disabled = f
     return (
       <div>
         <label htmlFor={id} className="block text-sm font-medium mb-1">
-          Minimum Responses
+          Min Responses
         </label>
         <input
           ref={inputRef}
@@ -46,12 +49,25 @@ export default function CompactMinResponsesField({ value, setValue, disabled = f
   }
 
   return (
-    <button
-      type="button"
-      onClick={() => setIsEditing(true)}
-      className="block text-sm font-medium text-left"
-    >
-      Minimum Responses: <span className="font-normal text-blue-600 dark:text-blue-400">{value}</span>
-    </button>
+    <div className="flex items-center justify-between">
+      <button
+        type="button"
+        onClick={() => setIsEditing(true)}
+        className="text-sm font-medium text-left"
+      >
+        Min Responses: <span className="font-normal text-blue-600 dark:text-blue-400">{value}</span>
+      </button>
+      <label htmlFor={checkboxId} className="flex items-center gap-1.5 cursor-pointer">
+        <input
+          type="checkbox"
+          id={checkboxId}
+          checked={showPreliminary}
+          onChange={(e) => setShowPreliminary(e.target.checked)}
+          disabled={disabled}
+          className="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        />
+        <span className="text-xs text-gray-500 dark:text-gray-400">Show preliminary</span>
+      </label>
+    </div>
   );
 }

--- a/components/CompactMinResponsesField.tsx
+++ b/components/CompactMinResponsesField.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useRef, useEffect, useId } from 'react';
+
+interface CompactMinResponsesFieldProps {
+  value: number;
+  setValue: (value: number) => void;
+  disabled?: boolean;
+}
+
+export default function CompactMinResponsesField({ value, setValue, disabled = false }: CompactMinResponsesFieldProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const id = useId();
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  if (isEditing) {
+    return (
+      <div>
+        <label htmlFor={id} className="block text-sm font-medium mb-1">
+          Minimum Responses
+        </label>
+        <input
+          ref={inputRef}
+          type="number"
+          id={id}
+          min={1}
+          value={value}
+          onChange={(e) => {
+            const num = parseInt(e.target.value, 10);
+            if (!isNaN(num) && num >= 1) setValue(num);
+          }}
+          onBlur={() => setIsEditing(false)}
+          onKeyDown={(e) => { if (e.key === 'Enter') setIsEditing(false); }}
+          disabled={disabled}
+          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setIsEditing(true)}
+      className="block text-sm font-medium text-left"
+    >
+      Minimum Responses: <span className="font-normal text-blue-600 dark:text-blue-400">{value}</span>
+    </button>
+  );
+}

--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -196,7 +196,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
           
           visualizations.push({
             roundNumber: roundNum,
-            title: roundNum === totalRounds ? 'Final Result' : `Round ${roundNum} of ${totalRounds}`,
+            title: roundNum === totalRounds ? 'Final Round' : `Round ${roundNum} of ${totalRounds}`,
             candidates,
             eliminatedCandidates,
             userPreference,

--- a/components/ExpirationConditionsModal.tsx
+++ b/components/ExpirationConditionsModal.tsx
@@ -3,16 +3,20 @@
 import { useState, useEffect, useCallback } from 'react';
 import ModalPortal from '@/components/ModalPortal';
 
-// Rescaled deadline options with 4 weeks in the middle
+// Deadline options starting small and scaling up to 1 month
 const EXPIRATION_DEADLINE_OPTIONS = [
+  { value: "5min", label: "5 min", minutes: 5 },
+  { value: "10min", label: "10 min", minutes: 10 },
+  { value: "15min", label: "15 min", minutes: 15 },
+  { value: "30min", label: "30 min", minutes: 30 },
+  { value: "1hr", label: "1 hr", minutes: 60 },
+  { value: "2hr", label: "2 hr", minutes: 120 },
+  { value: "4hr", label: "4 hr", minutes: 240 },
   { value: "1day", label: "1 day", minutes: 1440 },
   { value: "3days", label: "3 days", minutes: 4320 },
   { value: "1week", label: "1 week", minutes: 10080 },
   { value: "2weeks", label: "2 weeks", minutes: 20160 },
-  { value: "4weeks", label: "4 weeks", minutes: 40320 },
-  { value: "2months", label: "2 months", minutes: 87840 },
-  { value: "3months", label: "3 months", minutes: 131400 },
-  { value: "6months", label: "6 months", minutes: 262800 },
+  { value: "1month", label: "1 month", minutes: 43200 },
   { value: "custom", label: "Custom", minutes: 0 },
 ];
 
@@ -97,7 +101,7 @@ export default function ExpirationConditionsModal({
                     // Clear deadline - set to a sentinel value
                     setDeadlineOption('none');
                   } else {
-                    setDeadlineOption('4weeks');
+                    setDeadlineOption('1month');
                   }
                 }}
                 disabled={disabled}

--- a/components/ExpirationConditionsModal.tsx
+++ b/components/ExpirationConditionsModal.tsx
@@ -101,7 +101,7 @@ export default function ExpirationConditionsModal({
                     // Clear deadline - set to a sentinel value
                     setDeadlineOption('none');
                   } else {
-                    setDeadlineOption('1month');
+                    setDeadlineOption('1week');
                   }
                 }}
                 disabled={disabled}

--- a/components/ExpirationConditionsModal.tsx
+++ b/components/ExpirationConditionsModal.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import ModalPortal from '@/components/ModalPortal';
+
+// Rescaled deadline options with 4 weeks in the middle
+const EXPIRATION_DEADLINE_OPTIONS = [
+  { value: "1day", label: "1 day", minutes: 1440 },
+  { value: "3days", label: "3 days", minutes: 4320 },
+  { value: "1week", label: "1 week", minutes: 10080 },
+  { value: "2weeks", label: "2 weeks", minutes: 20160 },
+  { value: "4weeks", label: "4 weeks", minutes: 40320 },
+  { value: "2months", label: "2 months", minutes: 87840 },
+  { value: "3months", label: "3 months", minutes: 131400 },
+  { value: "6months", label: "6 months", minutes: 262800 },
+  { value: "custom", label: "Custom", minutes: 0 },
+];
+
+export { EXPIRATION_DEADLINE_OPTIONS };
+
+interface ExpirationConditionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  deadlineOption: string;
+  setDeadlineOption: (value: string) => void;
+  customDate: string;
+  setCustomDate: (value: string) => void;
+  customTime: string;
+  setCustomTime: (value: string) => void;
+  autoCloseAfter: number | null;
+  setAutoCloseAfter: (value: number | null) => void;
+  isClient: boolean;
+  disabled?: boolean;
+}
+
+function getTodayDate(): string {
+  if (typeof window === 'undefined') return '';
+  const today = new Date();
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+}
+
+export default function ExpirationConditionsModal({
+  isOpen,
+  onClose,
+  deadlineOption,
+  setDeadlineOption,
+  customDate,
+  setCustomDate,
+  customTime,
+  setCustomTime,
+  autoCloseAfter,
+  setAutoCloseAfter,
+  isClient,
+  disabled = false,
+}: ExpirationConditionsModalProps) {
+  const [deadlineEnabled, setDeadlineEnabled] = useState(true);
+  const [voteCountEnabled, setVoteCountEnabled] = useState(autoCloseAfter !== null);
+
+  // Sync local state with props
+  useEffect(() => {
+    setVoteCountEnabled(autoCloseAfter !== null);
+  }, [autoCloseAfter]);
+
+  const getDeadlineLabel = useCallback((optionValue: string): string => {
+    if (optionValue === 'custom') return 'Custom';
+    const opt = EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === optionValue);
+    if (!opt) return optionValue;
+    if (!isClient) return opt.label;
+    const now = new Date();
+    const deadline = new Date(now.getTime() + opt.minutes * 60 * 1000);
+    return `${opt.label} (${deadline.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })})`;
+  }, [isClient]);
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalPortal>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      >
+        <div className="bg-white dark:bg-gray-900 rounded-xl p-6 mx-4 max-w-sm w-full shadow-xl">
+          <h3 className="text-lg font-semibold mb-4">Expiration Conditions</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+            The poll will close when any of these conditions are met.
+          </p>
+
+          {/* Deadline condition */}
+          <div className="mb-4">
+            <label className="flex items-center gap-2 cursor-pointer mb-2">
+              <input
+                type="checkbox"
+                checked={deadlineEnabled}
+                onChange={(e) => {
+                  setDeadlineEnabled(e.target.checked);
+                  if (!e.target.checked) {
+                    // Clear deadline - set to a sentinel value
+                    setDeadlineOption('none');
+                  } else {
+                    setDeadlineOption('4weeks');
+                  }
+                }}
+                disabled={disabled}
+                className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-sm font-medium">Time limit</span>
+            </label>
+            {deadlineEnabled && (
+              <div className="ml-6 space-y-2">
+                <select
+                  value={deadlineOption}
+                  onChange={(e) => setDeadlineOption(e.target.value)}
+                  disabled={disabled}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 text-sm"
+                >
+                  {EXPIRATION_DEADLINE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {getDeadlineLabel(option.value)}
+                    </option>
+                  ))}
+                </select>
+                {deadlineOption === 'custom' && (
+                  <div className="flex gap-2">
+                    <input
+                      type="date"
+                      value={customDate}
+                      onChange={(e) => setCustomDate(e.target.value)}
+                      disabled={disabled}
+                      min={isClient ? getTodayDate() : ''}
+                      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white text-sm"
+                    />
+                    <input
+                      type="time"
+                      value={customTime}
+                      onChange={(e) => setCustomTime(e.target.value)}
+                      disabled={disabled}
+                      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white text-sm"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Vote count condition */}
+          <div className="mb-6">
+            <label className="flex items-center gap-2 cursor-pointer mb-2">
+              <input
+                type="checkbox"
+                checked={voteCountEnabled}
+                onChange={(e) => {
+                  setVoteCountEnabled(e.target.checked);
+                  if (e.target.checked) {
+                    setAutoCloseAfter(autoCloseAfter ?? 10);
+                  } else {
+                    setAutoCloseAfter(null);
+                  }
+                }}
+                disabled={disabled}
+                className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-sm font-medium">Close after N responses</span>
+            </label>
+            {voteCountEnabled && (
+              <div className="ml-6">
+                <input
+                  type="number"
+                  min={1}
+                  value={autoCloseAfter ?? ''}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val, 10) || 1));
+                  }}
+                  disabled={disabled}
+                  placeholder="Number of responses"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 text-sm"
+                />
+              </div>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full py-2.5 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/database/migrations/083_add_min_responses_and_show_preliminary_results_down.sql
+++ b/database/migrations/083_add_min_responses_and_show_preliminary_results_down.sql
@@ -1,0 +1,3 @@
+-- Remove min_responses and show_preliminary_results columns
+ALTER TABLE polls DROP COLUMN IF EXISTS min_responses;
+ALTER TABLE polls DROP COLUMN IF EXISTS show_preliminary_results;

--- a/database/migrations/083_add_min_responses_and_show_preliminary_results_up.sql
+++ b/database/migrations/083_add_min_responses_and_show_preliminary_results_up.sql
@@ -1,0 +1,3 @@
+-- Add min_responses and show_preliminary_results columns for preference/suggestion polls
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS min_responses integer DEFAULT 1;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS show_preliminary_results boolean DEFAULT true;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -128,6 +128,8 @@ function toPoll(data: any): Poll {
     reference_latitude: data.reference_latitude ?? undefined,
     reference_longitude: data.reference_longitude ?? undefined,
     reference_location_label: data.reference_location_label ?? undefined,
+    min_responses: data.min_responses ?? undefined,
+    show_preliminary_results: data.show_preliminary_results ?? true,
     response_count: data.response_count ?? undefined,
   };
 }
@@ -204,6 +206,8 @@ export async function apiCreatePoll(params: {
   reference_latitude?: number;
   reference_longitude?: number;
   reference_location_label?: string;
+  min_responses?: number;
+  show_preliminary_results?: boolean;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',

--- a/lib/pollCreator.ts
+++ b/lib/pollCreator.ts
@@ -93,6 +93,8 @@ export function buildPollSnapshot(poll: Poll) {
     category: poll.category,
     options_metadata: poll.options_metadata,
     is_auto_title: poll.is_auto_title,
+    min_responses: poll.min_responses,
+    show_preliminary_results: poll.show_preliminary_results,
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,6 +64,8 @@ export interface Poll {
   reference_longitude?: number | null;
   reference_location_label?: string | null;
   is_auto_title?: boolean;
+  min_responses?: number | null;
+  show_preliminary_results?: boolean;
   response_count?: number | null;
   results?: PollResults | null;
 }

--- a/lib/userProfile.ts
+++ b/lib/userProfile.ts
@@ -1,5 +1,6 @@
 const USER_NAME_KEY = 'whoeverwants_user_name';
 const USER_LOCATION_KEY = 'whoeverwants_user_location';
+const USER_MIN_RESPONSES_KEY = 'whoeverwants_min_responses';
 
 export interface UserLocation {
   latitude: number;
@@ -45,6 +46,19 @@ export function getUserLocation(): UserLocation | null {
 export function clearUserLocation() {
   if (typeof window === 'undefined') return;
   localStorage.removeItem(USER_LOCATION_KEY);
+}
+
+export function saveUserMinResponses(value: number) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(USER_MIN_RESPONSES_KEY, String(value));
+}
+
+export function getUserMinResponses(): number | null {
+  if (typeof window === 'undefined') return null;
+  const stored = localStorage.getItem(USER_MIN_RESPONSES_KEY);
+  if (!stored) return null;
+  const num = parseInt(stored, 10);
+  return isNaN(num) ? null : num;
 }
 
 export function getUserInitials(name: string | null): string {

--- a/server/models.py
+++ b/server/models.py
@@ -61,6 +61,10 @@ class CreatePollRequest(BaseModel):
     reference_latitude: float | None = None
     reference_longitude: float | None = None
     reference_location_label: str | None = None
+    # Minimum responses before results are shown (preference/suggestion polls)
+    min_responses: int | None = None
+    # Whether to show preliminary results once min_responses is met
+    show_preliminary_results: bool = True
 
 
 class SubmitVoteRequest(BaseModel):
@@ -162,6 +166,8 @@ class PollResponse(BaseModel):
     reference_longitude: float | None = None
     reference_location_label: str | None = None
     is_auto_title: bool = False
+    min_responses: int | None = None
+    show_preliminary_results: bool = True
     response_count: int | None = None
     results: "PollResultsResponse | None" = None
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -254,6 +254,8 @@ def _row_to_poll(row: dict) -> PollResponse:
         reference_longitude=row.get("reference_longitude"),
         reference_location_label=row.get("reference_location_label"),
         is_auto_title=row.get("is_auto_title", False),
+        min_responses=row.get("min_responses"),
+        show_preliminary_results=row.get("show_preliminary_results", True),
     )
 
 
@@ -480,6 +482,7 @@ def create_poll(req: CreatePollRequest):
                                reference_latitude, reference_longitude,
                                reference_location_label,
                                is_auto_title,
+                               min_responses, show_preliminary_results,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
@@ -498,6 +501,7 @@ def create_poll(req: CreatePollRequest):
                     %(reference_latitude)s, %(reference_longitude)s,
                     %(reference_location_label)s,
                     %(is_auto_title)s,
+                    %(min_responses)s, %(show_preliminary_results)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -536,6 +540,8 @@ def create_poll(req: CreatePollRequest):
                 "reference_longitude": req.reference_longitude,
                 "reference_location_label": req.reference_location_label,
                 "is_auto_title": req.is_auto_title,
+                "min_responses": req.min_responses,
+                "show_preliminary_results": req.show_preliminary_results,
                 "now": now,
             },
         ).fetchone()
@@ -647,9 +653,17 @@ def get_poll(poll_id: str):
             "SELECT * FROM polls WHERE id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()
-    if not row:
-        raise HTTPException(status_code=404, detail="Poll not found")
-    return _row_to_poll(row)
+        if not row:
+            raise HTTPException(status_code=404, detail="Poll not found")
+        poll_resp = _row_to_poll(row)
+        # Include response count for open polls (used for min_responses threshold)
+        if not row.get("is_closed", False):
+            count = conn.execute(
+                "SELECT COUNT(*) as cnt FROM votes WHERE poll_id = %(poll_id)s",
+                {"poll_id": poll_id},
+            ).fetchone()["cnt"]
+            poll_resp.response_count = count
+    return poll_resp
 
 
 # --- Voting ---
@@ -1190,7 +1204,7 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                 if pid in votes_by_poll:
                     votes_by_poll[pid].append(v)
 
-        # Count responses for open polls
+        # Count responses for open polls and fetch votes for those meeting min_responses
         response_counts: dict[str, int] = {}
         if open_poll_ids:
             count_rows = conn.execute(
@@ -1199,6 +1213,27 @@ def get_accessible_polls(req: AccessiblePollsRequest):
             ).fetchall()
             for cr in count_rows:
                 response_counts[str(cr["poll_id"])] = cr["cnt"]
+
+        # Identify open polls that qualify for preliminary results
+        preliminary_poll_ids = []
+        rows_by_id = {str(r["id"]): r for r in rows}
+        for pid in open_poll_ids:
+            r = rows_by_id[pid]
+            min_resp = r.get("min_responses")
+            show_prelim = r.get("show_preliminary_results", True)
+            if show_prelim and min_resp is not None and response_counts.get(pid, 0) >= min_resp:
+                preliminary_poll_ids.append(pid)
+
+        if preliminary_poll_ids:
+            prelim_vote_rows = conn.execute(
+                "SELECT * FROM votes WHERE poll_id = ANY(%(poll_ids)s)",
+                {"poll_ids": preliminary_poll_ids},
+            ).fetchall()
+            for v in prelim_vote_rows:
+                pid = str(v["poll_id"])
+                if pid not in votes_by_poll:
+                    votes_by_poll[pid] = []
+                votes_by_poll[pid].append(v)
 
     results = []
     for r in rows:


### PR DESCRIPTION
## Summary
- Add **minimum responses threshold** for ranked choice and suggestion polls — once N ballots are submitted, preliminary results are shown above the ballot form (poll stays open)
- Add **"show preliminary results" checkbox** inline with min responses field, checked by default
- Replace inline "Close After" control with **Expiration Conditions modal** for preference/suggestion polls, supporting two toggleable conditions: time limit (default 1 week) and close-after-N-responses (disabled by default), displayed as blue condition bubbles with "or" separator
- Time limit options range from 5 min to 1 month with custom date/time picker
- Min responses value persists in localStorage alongside user name
- Carries over in fork/duplicate/follow-up poll snapshots
- Rename "Final Result" to "Final Round" in ranked choice results to avoid confusion with preliminary results
- New database migration (083) adds `min_responses` and `show_preliminary_results` columns to polls table

## Test plan
- [ ] Create a ranked choice poll with min_responses=2, verify preliminary results appear after 2 votes
- [ ] Verify ballot form remains accessible below preliminary results
- [ ] Test expiration modal: toggle time limit and vote count conditions
- [ ] Verify condition bubbles display correctly with "or" separator
- [ ] Test custom date/time picker in expiration modal
- [ ] Create a suggestion poll and verify same behavior
- [ ] Fork/duplicate a poll with min_responses set, verify value carries over
- [ ] Verify "Final Round" label in ranked choice results