### PR TITLE
Fix poll validation message and 2-option ranked choice voting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,7 @@ The sections below contain mandatory rules. Follow them exactly.
   3. **Rebase on main** (`git fetch origin main && git rebase origin/main`) to ensure the branch merges cleanly. Force-push if needed after rebase.
   4. Create the PR.
   5. **Wait for PR checks to pass AND verify mergeability** before showing the PR link. Poll **both** the check-runs API (`/commits/{sha}/check-runs`) AND the commit statuses API (`/commits/{sha}/statuses`) every 15s until all checks complete — GitHub Actions results appear in check-runs, but Vercel build status appears in commit statuses. Also confirm `mergeable: true` on the PR. Report the link only after both succeed, or report failures.
+- **Demo after every change**: After pushing a fix or feature, wait for the dev server to finish rebuilding (poll the dev API health endpoint until it returns 200), then use the API to create a realistic demonstration that showcases the new behavior. Create polls, cast votes with realistic names, set up whatever scenario best highlights the change. Think creatively — make names, options, and poll titles feel like real people making real decisions. Use a generous expiration buffer (e.g., 7 days) unless the demo specifically requires an imminent deadline. Share the dev server link to the demo poll with the user so they can see the change in action.
 
 ### Python Tooling: uv (Mandatory)
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -398,7 +398,7 @@ function CreatePollContent() {
   const getValidationError = (): string | null => {
     // Check title first
     if (!title.trim()) {
-      return "Please enter a title.";
+      return isAutoTitle ? "Please enter a category or title." : "Please enter a title.";
     }
     
     if (title.length > 100) {

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -2116,8 +2116,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                               onClick={(e) => {
                                 // Don't trigger vote when clicking the restaurant/place name (opens detail modal instead)
                                 if ((e.target as HTMLElement).closest?.('[data-place-name]')) return;
-                                const other = pollOptions.find((o: string) => o !== option)!;
-                                handleRankingChange([option, other]);
+                                handleRankingChange([option]);
                                 setIsAbstaining(false);
                               }}
                               disabled={isSubmitting}

--- a/tests/e2e/specs/poll-creation.spec.ts
+++ b/tests/e2e/specs/poll-creation.spec.ts
@@ -122,7 +122,7 @@ test.describe('Poll Creation', () => {
     await expect(submitButton).toBeDisabled();
     
     // Verify the validation message appears (match actual error text from UI)
-    const errorMsg = page.locator('text="Please enter a poll title."');
+    const errorMsg = page.locator('text="Please enter a category or title."');
     await expect(errorMsg).toBeVisible();
     
     await page.screenshot({ path: 'test-results/validation-error.png' });


### PR DESCRIPTION
## Summary
- **Validation message**: When auto-title is active and no category or title is entered, the error now says "Please enter a category or title." instead of just "Please enter a title." — since selecting a category would also resolve the issue by auto-generating a title.
- **2-option ranked choice**: When a user taps their choice in a 2-option poll, only that option is ranked. Previously both options were auto-ranked (selected as #1, other as #2), so results always showed 100% of votes distributed. Now results show only explicit votes for each option.
- **CLAUDE.md**: Added demo-after-every-change rule.

## Test plan
- [ ] Create a poll without selecting a category or title — verify error says "Please enter a category or title."
- [ ] Switch to manual title mode (click the title label) and leave blank — verify error says "Please enter a title."
- [ ] Create a 2-option ranked choice poll, vote for one option — verify only that option is ranked in "Your choice" display
- [ ] Close the poll — verify results show vote counts per option (not all votes on both)

https://claude.ai/code/session_01EWpdGooSd29g6nwdwqC3o1