### PR TITLE
Fix ranking display for polls with fewer than 2 options

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1993,7 +1993,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                         ))}
                         <div className="text-sm text-gray-500 dark:text-gray-400 mt-2">{pollOptions.length === 2 ? 'Loading your choice...' : 'Loading your ranking...'}</div>
                       </div>
-                    ) : pollOptions.length > 2 ? (
+                    ) : pollOptions.length !== 2 ? (
                       /* 2-option choice is shown inline in the header */
                       <div className="space-y-2">
                         {userVoteData?.is_abstain || isAbstaining ? (


### PR DESCRIPTION
The 'Your ranking:' section was empty for ranked choice polls with 1 option
because the condition checked pollOptions.length > 2. Polls with exactly 2
options show the choice inline, but 0 or 1 option polls fell through to null.
Changed condition to pollOptions.length !== 2 so all non-2-option polls show
the ranking list.

https://claude.ai/code/session_01K9hMpFVBYb7Yao5bMWbMg6