### PR TITLE
Merge suggestion polls into ranked choice as two-phase voting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -945,6 +945,15 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Poll data snapshots (fork/duplicate/follow-up)** are passed between pages via localStorage. When adding new poll fields, update `buildPollSnapshot()` in `lib/pollCreator.ts` — it's used by `FollowUpModal.tsx`, `DuplicateButton.tsx`, and `ForkButton.tsx`.
 - **PWA clients cache old JS bundles** — snapshot structure changes (new fields in `buildPollSnapshot`) won't take effect until users get new JS. Always add backward-compatible detection in the consumer (create-poll page) rather than relying solely on snapshot fields. The `is_auto_title` detection uses a ref-based comparison against `generateTitle()` output to handle old snapshots that lack the field.
 
+### Drag-to-Reorder & Tap-to-Move (RankableOptions)
+
+- **Delay drag start until pointer moves >8px.** On `pointerdown`, save intent in a ref (`pendingDragRef`) but don't call `startDrag`. On `pointermove`, if threshold exceeded, start the actual drag. On `pointerup`, if drag never started, it's a tap. This avoids React's async state update issue: `pointerup` fires before `isDragging` state is processed, leaving drag state stuck.
+- **Use FLIP animation for tap-to-reorder, not CSS `top` transitions.** Changing `top` values across React state updates doesn't reliably trigger CSS transitions (React 18 batching, Tailwind class conflicts). Instead: record old `getBoundingClientRect()` positions, apply the state change with `flushSync`, then apply inverse `transform: translateY(delta)` + forced reflow (`el.offsetHeight`) + transition removal. This is the standard FLIP (First, Last, Invert, Play) technique.
+- **Tailwind `transition-colors` overrides inline `transition: top`** because it sets `transition-property` to only color properties. Never mix Tailwind transition classes with inline `transition` shorthand on the same element — consolidate all transitions in one place.
+- **`touch-action: none` must only be on the drag handle, not the container.** Putting it on the outer container blocks all scrolling. Only the right-side handle element needs it.
+- **`setPointerCapture` routes events to the captured element.** Use it on `pointerdown` to prevent iOS SFSafariViewController's sheet dismiss gesture from intercepting downward drags.
+- **Handle tap zones extend beyond item bounds** via negative `top`/`bottom` offsets that account for both the item's padding (12px from `p-3`) and half the gap between items.
+
 ### Textarea Sizing & Inline-Block Gaps
 
 - **`<textarea>` defaults to `display: inline-block`** in most browsers, which causes a descender-space gap below it (based on parent `line-height`). Always add `display: block` (Tailwind `block` class) to textareas to eliminate this phantom spacing.

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -53,13 +53,7 @@ const BASE_DEADLINE_OPTIONS = [
 ];
 
 const SUGGESTION_CUTOFF_OPTIONS = [
-  { value: "5min", label: "5 min", minutes: 5 },
-  { value: "10min", label: "10 min", minutes: 10 },
-  { value: "15min", label: "15 min", minutes: 15 },
-  { value: "30min", label: "30 min", minutes: 30 },
-  { value: "1hr", label: "1 hr", minutes: 60 },
-  { value: "2hr", label: "2 hr", minutes: 120 },
-  { value: "4hr", label: "4 hr", minutes: 240 },
+  ...BASE_DEADLINE_OPTIONS.filter(o => o.value !== 'custom'),
   { value: "8hr", label: "8 hr", minutes: 480 },
   { value: "1day", label: "1 day", minutes: 1440 },
   { value: "3day", label: "3 days", minutes: 4320 },

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -52,6 +52,21 @@ const BASE_DEADLINE_OPTIONS = [
   { value: "custom", label: "Custom", minutes: 0 },
 ];
 
+const SUGGESTION_CUTOFF_OPTIONS = [
+  { value: "5min", label: "5 min", minutes: 5 },
+  { value: "10min", label: "10 min", minutes: 10 },
+  { value: "15min", label: "15 min", minutes: 15 },
+  { value: "30min", label: "30 min", minutes: 30 },
+  { value: "1hr", label: "1 hr", minutes: 60 },
+  { value: "2hr", label: "2 hr", minutes: 120 },
+  { value: "4hr", label: "4 hr", minutes: 240 },
+  { value: "8hr", label: "8 hr", minutes: 480 },
+  { value: "1day", label: "1 day", minutes: 1440 },
+  { value: "3day", label: "3 days", minutes: 4320 },
+  { value: "1week", label: "1 week", minutes: 10080 },
+  { value: "custom", label: "Custom", minutes: 0 },
+];
+
 const DEV_DEADLINE_OPTIONS = [
   { value: "10sec", label: "10 sec", minutes: 1/6 },
   ...BASE_DEADLINE_OPTIONS,
@@ -102,8 +117,8 @@ function CreatePollContent() {
   const titleInputRef = useRef<HTMLInputElement>(null);
   const loadedTitleRef = useRef<string | null>(null);
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
-  const [autoCreatePreferences, setAutoCreatePreferences] = useState(true);
-  const [autoPreferencesDeadline, setAutoPreferencesDeadline] = useState("10min");
+  const [suggestionCutoff, setSuggestionCutoff] = useState("2hr");
+  const [allowPreRanking, setAllowPreRanking] = useState(true);
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -381,15 +396,14 @@ function CreatePollContent() {
   };
 
   // Determine poll type based on form selection and options
-  const getPollType = (): 'yes_no' | 'ranked_choice' | 'suggestion' | 'participation' => {
+  const getPollType = (): 'yes_no' | 'ranked_choice' | 'participation' => {
     if (pollType === 'participation') {
       return 'participation';
     }
     if (category === 'yes_no') {
       return 'yes_no';
     }
-    const filledOptions = options.filter(opt => opt.trim() !== '');
-    return filledOptions.length === 0 ? 'suggestion' : 'ranked_choice';
+    return 'ranked_choice';
   };
 
 
@@ -598,7 +612,8 @@ function CreatePollContent() {
           if (forkData.poll_type === 'ranked_choice' && forkData.options) {
             setPollType('poll');
             setOptions(forkData.options);
-          } else if (forkData.poll_type === 'suggestion') {
+          } else if (forkData.poll_type === 'ranked_choice') {
+            // ranked_choice without options (e.g. suggestion phase poll)
             setPollType('poll');
             setOptions(['']);
           } else if (forkData.poll_type === 'participation') {
@@ -690,9 +705,6 @@ function CreatePollContent() {
           if (duplicateData.poll_type === 'ranked_choice') {
             setPollType('poll');
             setOptions(duplicateData.options || ['']);
-          } else if (duplicateData.poll_type === 'suggestion') {
-            setPollType('poll');
-            setOptions(['']);
           } else if (duplicateData.poll_type === 'participation') {
             setPollType('participation');
             setOptions(['']);
@@ -1084,8 +1096,8 @@ function CreatePollContent() {
         pollData.fork_of = forkOf;
       }
 
-      // Add category for suggestion and ranked_choice polls
-      if ((dbPollType === 'suggestion' || dbPollType === 'ranked_choice') && category !== 'custom') {
+      // Add category for ranked_choice polls
+      if (dbPollType === 'ranked_choice' && category !== 'custom') {
         pollData.category = category;
       }
 
@@ -1101,17 +1113,18 @@ function CreatePollContent() {
         pollData.options_metadata = optionsMetadata;
       }
 
-      // Add options for ranked choice polls only
-      // For suggestion polls, initial options become the creator's vote (not poll content)
-      if (dbPollType === 'ranked_choice') {
+      // Add options for ranked choice polls with pre-defined options
+      // (skip for suggestion mode — options will be populated from suggestions)
+      if (dbPollType === 'ranked_choice' && filledOptions.length > 0) {
         pollData.options = filledOptions;
       }
 
-      // Add auto-create preferences settings for suggestion polls
-      if (dbPollType === 'suggestion' && autoCreatePreferences) {
-        pollData.auto_create_preferences = true;
-        pollData.auto_preferences_deadline_minutes =
-          BASE_DEADLINE_OPTIONS.find(o => o.value === autoPreferencesDeadline)?.minutes || 10;
+      // Add suggestion deadline for polls with no options (suggestion phase)
+      if (isSuggestionMode) {
+        const cutoffMinutes = SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.minutes || 120;
+        const cutoffDate = new Date(new Date().getTime() + cutoffMinutes * 60 * 1000);
+        pollData.suggestion_deadline = cutoffDate.toISOString();
+        pollData.allow_pre_ranking = allowPreRanking;
       }
 
       // Add min/max participants for participation polls
@@ -1174,8 +1187,8 @@ function CreatePollContent() {
         pollData.auto_close_after = autoCloseAfter;
       }
 
-      // Add min_responses and show_preliminary_results for preference/suggestion polls
-      if (dbPollType === 'ranked_choice' || dbPollType === 'suggestion') {
+      // Add min_responses and show_preliminary_results for preference polls
+      if (dbPollType === 'ranked_choice') {
         pollData.min_responses = minResponses;
         pollData.show_preliminary_results = showPreliminaryResults;
       }
@@ -1390,7 +1403,6 @@ function CreatePollContent() {
                 options={options}
                 setOptions={setOptions}
                 isLoading={isLoading}
-                pollType="poll"
                 category={category}
                 optionsMetadata={optionsMetadata}
                 onMetadataChange={setOptionsMetadata}
@@ -1546,43 +1558,39 @@ function CreatePollContent() {
             </>
           )}
 
-          {/* Auto-create preferences poll checkbox - shown when no options provided (suggestion mode) */}
+          {/* Suggestions Cutoff - shown when no options provided (suggestion mode) */}
           {isSuggestionMode && (
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={autoCreatePreferences}
-                  onChange={(e) => setAutoCreatePreferences(e.target.checked)}
-                  disabled={isLoading}
-                  className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Ask for preferences when closed
-                </span>
-              </label>
-              {autoCreatePreferences && (
-                <div className="ml-6">
-                  <label htmlFor="autoPreferencesDeadline" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
-                    Preferences poll deadline
-                  </label>
-                  <select
-                    id="autoPreferencesDeadline"
-                    value={autoPreferencesDeadline}
-                    onChange={(e) => setAutoPreferencesDeadline(e.target.value)}
+            <div>
+              <div className="flex items-center justify-between">
+                <label className="block text-sm font-medium">
+                  <span>Suggestions Cutoff: </span>
+                  <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                    {SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.label || suggestionCutoff}
+                  </span>
+                </label>
+                <label className="flex items-center gap-1.5 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={allowPreRanking}
+                    onChange={(e) => setAllowPreRanking(e.target.checked)}
                     disabled={isLoading}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-                  >
-                    <option value="5min">5 minutes</option>
-                    <option value="10min">10 minutes</option>
-                    <option value="15min">15 minutes</option>
-                    <option value="30min">30 minutes</option>
-                    <option value="1hr">1 hour</option>
-                    <option value="2hr">2 hours</option>
-                    <option value="4hr">4 hours</option>
-                  </select>
-                </div>
-              )}
+                    className="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    allow pre-ranking
+                  </span>
+                </label>
+              </div>
+              <select
+                value={suggestionCutoff}
+                onChange={(e) => setSuggestionCutoff(e.target.value)}
+                disabled={isLoading}
+                className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+              >
+                {SUGGESTION_CUTOFF_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
             </div>
           )}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import Link from "next/link";
 import "./globals.css";
 import CommitInfo from "@/components/CommitInfo";
 import ResponsiveScaling from "@/components/ResponsiveScaling";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "WhoeverWants",
@@ -64,7 +56,7 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=M+PLUS+1+Code:wght@700&display=swap" rel="stylesheet" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
       >
         <CommitInfo showTimeBadge={process.env.NODE_ENV === 'development'} />
         <ResponsiveScaling>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1299,6 +1299,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
           // Case 4: Poll is still open and not expired - show countdown
           if (!isPollClosed && !isExpired && deadline) {
+            // During suggestion phase, show suggestion deadline instead of response deadline
+            if (inSuggestionPhase && poll.suggestion_deadline) {
+              return <Countdown deadline={poll.suggestion_deadline} label="Suggestions close" />;
+            }
             return <Countdown deadline={poll.response_deadline || null} />;
           }
 
@@ -1311,8 +1315,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           return null;
         })()}
         
-        {/* Preliminary results shown ABOVE ballot when user has already voted */}
-        {hasVoted && !isEditingVote && preliminaryResultsBlock("pt-2.5")}
+        {/* Preliminary results shown ABOVE ballot when user has already voted (hidden during suggestion phase) */}
+        {hasVoted && !isEditingVote && !inSuggestionPhase && preliminaryResultsBlock("pt-2.5")}
 
         {/* For closed polls, show results first */}
         {isPollClosed && (

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -920,11 +920,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       const filteredRankedChoices = rankedChoices.filter(choice => choice && choice.trim().length > 0);
       const filteredSuggestions = suggestionChoices.filter(choice => choice && choice.trim().length > 0);
       if (filteredRankedChoices.length === 0 && (!canSubmitSuggestions || filteredSuggestions.length === 0)) {
-        await logToServer('suggestion-vote', 'error', 'Ranked choice validation failed', { rankedChoices, suggestionChoices, isAbstaining, canSubmitSuggestions });
-        setVoteError(canSubmitSuggestions
-          ? "Please add or second at least one suggestion, or select Abstain"
-          : "Please rank at least one option or select Abstain");
-        return;
+        if (canSubmitSuggestions) {
+          // During suggestion phase, submitting with nothing selected is an implicit abstain
+          setIsAbstaining(true);
+        } else {
+          await logToServer('suggestion-vote', 'error', 'Ranked choice validation failed', { rankedChoices, suggestionChoices, isAbstaining, canSubmitSuggestions });
+          setVoteError("Please rank at least one option or select Abstain");
+          return;
+        }
       }
     }
 
@@ -1013,11 +1016,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         const filteredSuggestionsForValidation = suggestionChoices.filter(choice => choice && choice.trim().length > 0);
 
         if (filteredRankedChoices.length === 0 && !isAbstaining && (!canSubmitSuggestions || filteredSuggestionsForValidation.length === 0)) {
-          setVoteError(canSubmitSuggestions
-            ? "Please add or second at least one suggestion, or select Abstain"
-            : "Please rank at least one option or select Abstain");
-          setIsSubmitting(false);
-          return;
+          if (!canSubmitSuggestions) {
+            setVoteError("Please rank at least one option or select Abstain");
+            setIsSubmitting(false);
+            return;
+          }
+          // During suggestion phase, empty submission is treated as abstain (handled by finalAbstain below)
         }
         
         // Additional validation: ensure choices are valid poll options

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1886,8 +1886,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     />
                   )}
 
-                  {/* Suggestion phase disclaimer when pre-ranking is allowed */}
-                  {canSubmitSuggestions && canSubmitRankings && pollOptions.length > 0 && (
+                  {/* Suggestion phase disclaimer when pre-ranking is allowed and user has voted */}
+                  {canSubmitSuggestions && canSubmitRankings && hasVoted && !isEditingVote && pollOptions.length > 0 && (
                     <div className="mb-3 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg">
                       <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200 text-sm">
                         <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1901,8 +1901,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     </div>
                   )}
 
-                  {/* Ranking UI - shown when ranking is allowed and there are options */}
-                  {canSubmitRankings && pollOptions.length > 0 && (
+                  {/* Ranking UI - shown when ranking is allowed and there are options
+                       During suggestion phase with pre-ranking, only show after user has submitted suggestions */}
+                  {canSubmitRankings && pollOptions.length > 0 && (!canSubmitSuggestions || (hasVoted && !isEditingVote)) && (
                   <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
                     {pollOptions.length === 2 ? (
                       <>
@@ -1974,8 +1975,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     </div>
                   )}
 
-                  {/* Name field and submit - shown when not in suggestion-only mode (SuggestionVotingInterface has its own) */}
-                  {(!canSubmitSuggestions || canSubmitRankings) && (
+                  {/* Name field and submit - hidden during suggestion phase until user has submitted suggestions
+                       (SuggestionVotingInterface has its own name/submit for the initial suggestion submission) */}
+                  {(!canSubmitSuggestions || (canSubmitRankings && hasVoted && !isEditingVote)) && (
                   <>
                   <div className="mt-4">
                     <CompactNameField name={voterName} setName={setVoterName} />

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1059,13 +1059,19 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         // During suggestion phase with no rankings and no suggestions: abstain
         const hasRankings = filteredRankedChoices.length > 0;
         const hasSuggestions = filteredSuggestions && filteredSuggestions.length > 0;
-        const finalAbstain = isAbstaining || (!hasRankings && !hasSuggestions);
+        // If user has suggestions (from this or previous submission) but abstains from ranking,
+        // preserve suggestions — only full abstain when neither exists
+        const previousSuggestions = userVoteData?.suggestions;
+        const hasPreviousSuggestions = previousSuggestions && previousSuggestions.length > 0;
+        const finalAbstain = isAbstaining && !hasSuggestions && !hasPreviousSuggestions
+          ? true  // Full abstain: no suggestions at all
+          : !hasRankings && !hasSuggestions && !hasPreviousSuggestions;
 
         voteData = {
           poll_id: poll.id,
           vote_type: 'ranked_choice' as const,
-          ranked_choices: finalAbstain || !hasRankings ? null : filteredRankedChoices,
-          suggestions: finalAbstain || !hasSuggestions ? null : filteredSuggestions,
+          ranked_choices: isAbstaining || !hasRankings ? null : filteredRankedChoices,
+          suggestions: hasSuggestions ? filteredSuggestions : (hasPreviousSuggestions ? previousSuggestions : null),
           is_abstain: finalAbstain,
           voter_name: voterName.trim() || null,
           options_metadata: filteredMetadata && Object.keys(filteredMetadata).length > 0 ? filteredMetadata : null,

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1848,7 +1848,39 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                        During suggestion phase with pre-ranking, only show after user has submitted suggestions */}
                   {canSubmitRankings && pollOptions.length > 0 && (!canSubmitSuggestions || (hasVoted && !isEditingVote)) && (
                   <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
-                    {pollOptions.length === 2 ? (
+                    {/* Show ranking summary if user already submitted rankings during suggestion phase */}
+                    {canSubmitSuggestions && hasVoted && !isEditingVote && userVoteData?.ranked_choices?.length > 0 ? (
+                      <>
+                        <div className="flex items-center justify-between mb-2">
+                          <h4 className="text-base font-medium text-gray-900 dark:text-white">Your ranking:</h4>
+                          {editVoteButton}
+                        </div>
+                        <div className="space-y-2">
+                          {userVoteData.ranked_choices.map((choice: string, index: number) => (
+                            <div key={index} className="flex items-center gap-2">
+                              <div className="flex-shrink-0" style={{ width: '32px' }}>
+                                <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                                  {index + 1}
+                                </span>
+                              </div>
+                              <div className="flex-1 flex items-center p-2 bg-white dark:bg-gray-900 rounded min-w-0">
+                                <div className="min-w-0 overflow-hidden">
+                                  <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
+                                </div>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    ) : canSubmitSuggestions && hasVoted && !isEditingVote && (userVoteData?.is_abstain || isAbstaining) && !userVoteData?.ranked_choices?.length ? (
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <h4 className="text-base font-medium text-gray-900 dark:text-white">Ranking:</h4>
+                          <span className="text-sm text-gray-500 dark:text-gray-400">Not yet ranked</span>
+                        </div>
+                        {editVoteButton}
+                      </div>
+                    ) : pollOptions.length === 2 ? (
                       <>
                         <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
                           Select your preference
@@ -1895,15 +1927,20 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       </>
                     )}
                     
-                    <AbstainButton
-                      isAbstaining={isAbstaining}
-                      onClick={handleAbstain}
-                    />
-                    
-                    {voteError && (
-                      <div className="mt-4 p-3 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">
-                        {voteError}
-                      </div>
+                    {/* Hide abstain button and error when showing ranking summary */}
+                    {!(canSubmitSuggestions && hasVoted && !isEditingVote && (userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain)) && (
+                      <>
+                        <AbstainButton
+                          isAbstaining={isAbstaining}
+                          onClick={handleAbstain}
+                        />
+
+                        {voteError && (
+                          <div className="mt-4 p-3 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">
+                            {voteError}
+                          </div>
+                        )}
+                      </>
                     )}
                   </div>
                   )}
@@ -1926,8 +1963,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   )}
 
                   {/* Name field and submit - hidden during suggestion phase until user has submitted suggestions
-                       (SuggestionVotingInterface has its own name/submit for the initial suggestion submission) */}
-                  {(!canSubmitSuggestions || (canSubmitRankings && hasVoted && !isEditingVote)) && (
+                       (SuggestionVotingInterface has its own name/submit for the initial suggestion submission)
+                       Also hidden when showing ranking summary (user already submitted rankings) */}
+                  {(!canSubmitSuggestions || (canSubmitRankings && hasVoted && !isEditingVote)) && !(canSubmitSuggestions && hasVoted && !isEditingVote && userVoteData?.ranked_choices?.length > 0) && (
                   <>
                   <div className="mt-4">
                     <CompactNameField name={voterName} setName={setVoterName} />

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1143,6 +1143,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
       // Refresh suggestion list for polls with suggestion phase
       if (hasSuggestionPhase) {
+        // Reset abstain so the ranking ballot is usable after suggestion submission
+        // (abstaining from suggestions shouldn't block ranking)
+        if (isAbstaining && canSubmitRankings) {
+          setIsAbstaining(false);
+        }
         setTimeout(async () => {
           await loadExistingSuggestions(false);
           await fetchPollResults();

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -2009,8 +2009,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
 
 
-          {/* Preliminary results shown BELOW ballot when user hasn't voted yet */}
-          {(!hasVoted || isEditingVote) && preliminaryResultsBlock("mt-6")}
+          {/* Preliminary results shown BELOW ballot when user hasn't voted yet (hidden during suggestion phase) */}
+          {(!hasVoted || isEditingVote) && !inSuggestionPhase && preliminaryResultsBlock("mt-6")}
 
           {/* Follow ups to this poll section */}
           {followUpPolls.length > 0 && (

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -878,7 +878,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       suggestionChoicesData: suggestionChoices
     });
 
-    if (isSubmitting || (hasVoted && !isEditingVote) || isPollClosed) {
+    // During suggestion phase with pre-ranking, submitting rankings after the initial
+    // suggestion vote is an implicit edit (updating the existing vote with rankings)
+    const isImplicitEdit = hasVoted && !isEditingVote && canSubmitSuggestions && canSubmitRankings;
+    if (isImplicitEdit) {
+      setIsEditingVote(true);
+    }
+
+    if (isSubmitting || (hasVoted && !isEditingVote && !isImplicitEdit) || isPollClosed) {
       await logToServer('suggestion-vote', 'warn', 'handleVoteClick early return', {
         reason: isSubmitting ? 'isSubmitting' : (hasVoted && !isEditingVote) ? 'hasVoted and not editing' : 'isPollClosed'
       });

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1814,13 +1814,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     />
                   )}
 
-                  {/* Suggestion respondents */}
-                  {canSubmitSuggestions && hasVoted && !isEditingVote && !isLoadingVoteData && (
-                    <div className="mt-2 mb-3">
-                      <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Suggested" filter={suggestionsVoterFilter} />
-                    </div>
-                  )}
-
                   {/* Suggestion phase disclaimer when pre-ranking is allowed and user has voted */}
                   {canSubmitSuggestions && canSubmitRankings && hasVoted && !isEditingVote && pollOptions.length > 0 && (
                     <div className="mb-3 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg">

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1773,17 +1773,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     ) : null}
                   </div>
 
-                  {/* Voter lists for open ranked choice polls */}
-                  {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-4 space-y-2">
-                      {hasSuggestionPhase ? (
-                        <>
-                          <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Suggested" filter={suggestionsVoterFilter} />
-                          <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Ranked" filter={rankingsVoterFilter} />
-                        </>
-                      ) : (
-                        <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
-                      )}
+                  {/* Voter list for non-suggestion ranked choice polls */}
+                  {!isPollClosed && hasVoted && !isLoadingVoteData && !hasSuggestionPhase && (
+                    <div className="mt-4">
+                      <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
                     </div>
                   )}
                 </div>
@@ -1819,6 +1812,13 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       onSuggestionMetadataChange={setSuggestionMetadata}
                       optionsMetadata={optionsMetadataLocal}
                     />
+                  )}
+
+                  {/* Suggestion respondents */}
+                  {canSubmitSuggestions && hasVoted && !isEditingVote && !isLoadingVoteData && (
+                    <div className="mt-2 mb-3">
+                      <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Suggested" filter={suggestionsVoterFilter} />
+                    </div>
                   )}
 
                   {/* Suggestion phase disclaimer when pre-ranking is allowed and user has voted */}
@@ -1898,6 +1898,13 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       </div>
                     )}
                   </div>
+                  )}
+
+                  {/* Ranking respondents - shown under ranking UI during suggestion phase */}
+                  {hasSuggestionPhase && canSubmitRankings && hasVoted && !isEditingVote && !isLoadingVoteData && (
+                    <div className="mt-2 mb-3">
+                      <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Ranked" filter={rankingsVoterFilter} />
+                    </div>
                   )}
 
                   {/* Waiting for suggestions message when pre-ranking is disabled */}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 import { useAppPrefetch } from "@/lib/prefetch";
 import Countdown from "@/components/Countdown";
 import CompactNameField from "@/components/CompactNameField";
-import RankableOptions from "@/components/RankableOptions";
 import PollResultsDisplay from "@/components/PollResults";
 import SuggestionVotingInterface from "@/components/SuggestionVotingInterface";
+import RankingSection from "@/components/RankingSection";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import FloatingCopyLinkButton from "@/components/FloatingCopyLinkButton";
 import FollowUpHeader from "@/components/FollowUpHeader";
@@ -83,7 +83,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [userVoteId, setUserVoteId] = useState<string | null>(null);
   const [userVoteData, setUserVoteData] = useState<any>(null);
   const [isLoadingVoteData, setIsLoadingVoteData] = useState(false);
-  const [isEditingVote, setIsEditingVote] = useState(false);
+  const [isEditingVote, setIsEditingVote] = useState(false); // For suggestion editing
+  const [isEditingRanking, setIsEditingRanking] = useState(false); // For ranking editing (independent)
   const [showForgetConfirmModal, setShowForgetConfirmModal] = useState(false);
   const [hasPollDataState, setHasPollDataState] = useState(false);
   const [currentTime, setCurrentTime] = useState<Date | null>(null);
@@ -111,7 +112,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
   // Stable filter callbacks for VoterList
   const suggestionsVoterFilter = useCallback((v: ApiVote) => !!(v.suggestions && v.suggestions.length > 0), []);
-  const rankingsVoterFilter = useCallback((v: ApiVote) => !!(v.ranked_choices && v.ranked_choices.length > 0), []);
 
   const autoCloseTriggeredRef = useRef(false);
   const fetchResultsInFlight = useRef(false);
@@ -878,16 +878,19 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       suggestionChoicesData: suggestionChoices
     });
 
+    // Either suggestion editing or ranking editing counts as "editing"
+    const isAnyEditing = isEditingVote || isEditingRanking;
+
     // During suggestion phase with pre-ranking, submitting rankings after the initial
     // suggestion vote is an implicit edit (updating the existing vote with rankings)
-    const isImplicitEdit = hasVoted && !isEditingVote && canSubmitSuggestions && canSubmitRankings;
+    const isImplicitEdit = hasVoted && !isAnyEditing && canSubmitSuggestions && canSubmitRankings;
     if (isImplicitEdit) {
       setIsEditingVote(true);
     }
 
-    if (isSubmitting || (hasVoted && !isEditingVote && !isImplicitEdit) || isPollClosed) {
+    if (isSubmitting || (hasVoted && !isAnyEditing && !isImplicitEdit) || isPollClosed) {
       await logToServer('suggestion-vote', 'warn', 'handleVoteClick early return', {
-        reason: isSubmitting ? 'isSubmitting' : (hasVoted && !isEditingVote) ? 'hasVoted and not editing' : 'isPollClosed'
+        reason: isSubmitting ? 'isSubmitting' : (hasVoted && !isAnyEditing) ? 'hasVoted and not editing' : 'isPollClosed'
       });
       return;
     }
@@ -965,9 +968,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
     setShowVoteConfirmModal(false);
 
-    if (isSubmitting || (hasVoted && !isEditingVote) || isPollClosed) {
+    const isAnyEditingForSubmit = isEditingVote || isEditingRanking;
+    if (isSubmitting || (hasVoted && !isAnyEditingForSubmit) || isPollClosed) {
       await logToServer('suggestion-vote', 'warn', 'submitVote early return', {
-        reason: isSubmitting ? 'isSubmitting' : (hasVoted && !isEditingVote) ? 'hasVoted and not editing' : 'isPollClosed'
+        reason: isSubmitting ? 'isSubmitting' : (hasVoted && !isAnyEditingForSubmit) ? 'hasVoted and not editing' : 'isPollClosed'
       });
       return;
     }
@@ -1072,7 +1076,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       let error: any; // eslint-disable-line
 
 
-      if (isEditingVote && userVoteId) {
+      if ((isEditingVote || isEditingRanking) && userVoteId) {
 
         // Create update data with only the vote choice (don't update vote_type or poll_id)
         // Use the same filtered data that was prepared in voteData to ensure consistency
@@ -1179,9 +1183,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       }
       
       setIsEditingVote(false);
-      
+      setIsEditingRanking(false);
+
       // Refresh results after editing votes with suggestions
-      if (hasSuggestionPhase && isEditingVote) {
+      if (hasSuggestionPhase && (isEditingVote || isEditingRanking)) {
         await fetchPollResults();
       }
 
@@ -1833,153 +1838,36 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     />
                   )}
 
-                  {/* Early voting section header during suggestion phase */}
-                  {canSubmitSuggestions && canSubmitRankings && hasVoted && !isEditingVote && pollOptions.length > 0 && (
-                    <>
-                      <h3 className="text-lg font-semibold text-center text-gray-900 dark:text-white mt-4 mb-1">Early Voting</h3>
-                      <Countdown deadline={poll.response_deadline || null} label="Preferences closing" />
-                      <p className="text-center text-xs text-amber-700 dark:text-amber-300 mb-3">
-                        Options may change until suggestions cutoff!
-                      </p>
-                    </>
-                  )}
-
-                  {/* Ranking UI - shown when ranking is allowed and there are options
-                       During suggestion phase with pre-ranking, only show after user has submitted suggestions */}
-                  {canSubmitRankings && pollOptions.length > 0 && (!canSubmitSuggestions || (hasVoted && !isEditingVote)) && (
-                  <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
-                    {/* Show ranking summary if user already submitted rankings during suggestion phase */}
-                    {canSubmitSuggestions && hasVoted && !isEditingVote && userVoteData?.ranked_choices?.length > 0 ? (
-                      <>
-                        <div className="flex items-center justify-between mb-2">
-                          <h4 className="text-base font-medium text-gray-900 dark:text-white">Your ranking:</h4>
-                          {editVoteButton}
-                        </div>
-                        <div className="space-y-2">
-                          {userVoteData.ranked_choices.map((choice: string, index: number) => (
-                            <div key={index} className="flex items-center gap-2">
-                              <div className="flex-shrink-0" style={{ width: '32px' }}>
-                                <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                                  {index + 1}
-                                </span>
-                              </div>
-                              <div className="flex-1 flex items-center p-2 bg-white dark:bg-gray-900 rounded min-w-0">
-                                <div className="min-w-0 overflow-hidden">
-                                  <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
-                                </div>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    ) : canSubmitSuggestions && hasVoted && !isEditingVote && (userVoteData?.is_abstain || isAbstaining) && !userVoteData?.ranked_choices?.length ? (
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <h4 className="text-base font-medium text-gray-900 dark:text-white">Ranking:</h4>
-                          <span className="text-sm text-gray-500 dark:text-gray-400">Not yet ranked</span>
-                        </div>
-                        {editVoteButton}
-                      </div>
-                    ) : pollOptions.length === 2 ? (
-                      <>
-                        <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
-                          Select your preference
-                        </h4>
-                        <div className="flex gap-2">
-                          {twoOptionDisplayOrder.map((option: string) => (
-                            <button
-                              key={option}
-                              onClick={(e) => {
-                                // Don't trigger vote when clicking the restaurant/place name (opens detail modal instead)
-                                if ((e.target as HTMLElement).closest?.('[data-place-name]')) return;
-                                handleRankingChange([option]);
-                                setIsAbstaining(false);
-                              }}
-                              disabled={isSubmitting}
-                              className={`flex-1 min-w-0 py-3 px-3 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                                rankedChoices[0] === option
-                                  ? 'bg-blue-200 dark:bg-blue-800 text-blue-900 dark:text-blue-100 border-2 border-blue-400 dark:border-blue-600 active:bg-blue-300 dark:active:bg-blue-700'
-                                  : 'bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 text-blue-800 dark:text-blue-200 border-2 border-transparent active:bg-blue-300 dark:active:bg-blue-700'
-                              }`}
-                            >
-                              <OptionLabel text={option} metadata={optionsMetadataLocal?.[option]} layout="stacked" />
-                            </button>
-                          ))}
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <h4 className="text-base font-medium text-gray-900 dark:text-white mb-3">
-                          Reorder from most to least preferred
-                        </h4>
-
-                        {pollOptions.length > 0 && (
-                          <RankableOptions
-                            key={isEditingVote ? 'editing' : 'new'}
-                            options={pollOptions}
-                            onRankingChange={handleRankingChange}
-                            disabled={isSubmitting || (isAbstaining && !canSubmitSuggestions)}
-                            storageKey={pollId ? `poll-ranking-${pollId}` : undefined}
-                            initialRanking={isEditingVote && userVoteData?.ranked_choices ? userVoteData.ranked_choices : undefined}
-                            optionsMetadata={optionsMetadataLocal}
-                          />
-                        )}
-                      </>
-                    )}
-                    
-                    {/* Hide abstain button and error when showing ranking summary */}
-                    {!(canSubmitSuggestions && hasVoted && !isEditingVote && (userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain)) && (
-                      <>
-                        <AbstainButton
-                          isAbstaining={isAbstaining}
-                          onClick={handleAbstain}
-                        />
-
-                        {voteError && (
-                          <div className="mt-4 p-3 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">
-                            {voteError}
-                          </div>
-                        )}
-                      </>
-                    )}
-                  </div>
-                  )}
-
-                  {/* Ranking respondents - shown under ranking UI during suggestion phase */}
-                  {hasSuggestionPhase && canSubmitRankings && hasVoted && !isEditingVote && !isLoadingVoteData && (
-                    <div className="mt-2 mb-3">
-                      <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Ranked" filter={rankingsVoterFilter} />
-                    </div>
-                  )}
-
-                  {/* Waiting for suggestions message when pre-ranking is disabled */}
-                  {!canSubmitRankings && canSubmitSuggestions && (
-                    <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
-                      <p className="text-blue-800 dark:text-blue-200 text-sm">
-                        Ranking will open after suggestions cutoff in{' '}
-                        <Countdown deadline={poll.suggestion_deadline!} onExpire={() => setCurrentTime(new Date())} />
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Name field and submit - hidden during suggestion phase until user has submitted suggestions
-                       (SuggestionVotingInterface has its own name/submit for the initial suggestion submission)
-                       Also hidden when showing ranking summary (user already submitted rankings) */}
-                  {(!canSubmitSuggestions || (canSubmitRankings && hasVoted && !isEditingVote)) && !(canSubmitSuggestions && hasVoted && !isEditingVote && userVoteData?.ranked_choices?.length > 0) && (
-                  <>
-                  <div className="mt-4">
-                    <CompactNameField name={voterName} setName={setVoterName} />
-                  </div>
-
-                  <button
-                    onClick={handleVoteClick}
-                    disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0)}
-                    className="w-full mt-4 py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
-                  >
-                    {isSubmitting ? 'Submitting...' : 'Submit Vote'}
-                  </button>
-                  </>
-                  )}
+                  {/* Ranking section — independent component with its own edit state */}
+                  <RankingSection
+                    poll={poll}
+                    pollId={pollId}
+                    pollOptions={pollOptions}
+                    rankedChoices={rankedChoices}
+                    handleRankingChange={handleRankingChange}
+                    isAbstaining={isAbstaining}
+                    setIsAbstaining={setIsAbstaining}
+                    handleAbstain={handleAbstain}
+                    isSubmitting={isSubmitting}
+                    isPollClosed={!!isPollClosed}
+                    hasVoted={hasVoted}
+                    isEditingRanking={isEditingRanking}
+                    setIsEditingRanking={setIsEditingRanking}
+                    userVoteData={userVoteData}
+                    isLoadingVoteData={isLoadingVoteData}
+                    voterName={voterName}
+                    setVoterName={setVoterName}
+                    handleVoteClick={handleVoteClick}
+                    voteError={voteError}
+                    voterListRefresh={voterListRefresh}
+                    optionsMetadata={optionsMetadataLocal}
+                    canSubmitSuggestions={canSubmitSuggestions}
+                    canSubmitRankings={canSubmitRankings}
+                    hasSuggestionPhase={hasSuggestionPhase}
+                    suggestionChoices={suggestionChoices}
+                    justCancelledAbstain={justCancelledAbstain}
+                    twoOptionDisplayOrder={twoOptionDisplayOrder}
+                  />
 
                   {/* Show follow-up/fork header after submit button */}
                   <div className="mt-4">

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -916,9 +916,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
     if (poll.poll_type === 'ranked_choice' && !isAbstaining) {
       const filteredRankedChoices = rankedChoices.filter(choice => choice && choice.trim().length > 0);
-      if (filteredRankedChoices.length === 0) {
-        await logToServer('suggestion-vote', 'error', 'Ranked choice validation failed', { rankedChoices, isAbstaining });
-        setVoteError("Please rank at least one option or select Abstain");
+      const filteredSuggestions = suggestionChoices.filter(choice => choice && choice.trim().length > 0);
+      if (filteredRankedChoices.length === 0 && (!canSubmitSuggestions || filteredSuggestions.length === 0)) {
+        await logToServer('suggestion-vote', 'error', 'Ranked choice validation failed', { rankedChoices, suggestionChoices, isAbstaining, canSubmitSuggestions });
+        setVoteError(canSubmitSuggestions
+          ? "Please add or second at least one suggestion, or select Abstain"
+          : "Please rank at least one option or select Abstain");
         return;
       }
     }
@@ -1005,9 +1008,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       } else if (poll.poll_type === 'ranked_choice') {
         // Filter and validate ranked choices (No Preference items already filtered by RankableOptions)
         const filteredRankedChoices = rankedChoices.filter(choice => choice && choice.trim().length > 0);
-        
-        if (filteredRankedChoices.length === 0 && !isAbstaining) {
-          setVoteError("Please rank at least one option or select Abstain");
+        const filteredSuggestionsForValidation = suggestionChoices.filter(choice => choice && choice.trim().length > 0);
+
+        if (filteredRankedChoices.length === 0 && !isAbstaining && (!canSubmitSuggestions || filteredSuggestionsForValidation.length === 0)) {
+          setVoteError(canSubmitSuggestions
+            ? "Please add or second at least one suggestion, or select Abstain"
+            : "Please rank at least one option or select Abstain");
           setIsSubmitting(false);
           return;
         }

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -23,8 +23,8 @@ import OptionLabel from "@/components/OptionLabel";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults, OptionsMetadata, DayTimeWindow } from "@/lib/types";
-import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, apiFindDuplicatePoll, ApiVote } from "@/lib/api";
-import VoteOnItModal from "@/components/VoteOnItModal";
+import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
+
 import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
 import { getUserName, saveUserName } from "@/lib/userProfile";
@@ -88,6 +88,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [hasPollDataState, setHasPollDataState] = useState(false);
   const [currentTime, setCurrentTime] = useState<Date | null>(null);
 
+  // Suggestion phase helpers: a ranked_choice poll with suggestion_deadline
+  // has an optional suggestion collection phase before ranking begins
+  const hasSuggestionPhase = poll.poll_type === 'ranked_choice' && !!poll.suggestion_deadline;
+  const inSuggestionPhase = hasSuggestionPhase && currentTime
+    ? currentTime < new Date(poll.suggestion_deadline!)
+    : hasSuggestionPhase; // Before currentTime is set, assume suggestion phase if deadline exists
+  const canSubmitSuggestions = hasSuggestionPhase && inSuggestionPhase;
+  const canSubmitRankings = poll.poll_type === 'ranked_choice' && (
+    !hasSuggestionPhase || !inSuggestionPhase || poll.allow_pre_ranking !== false
+  );
+
   // Debug logging utility (output captured by CommitInfo Logs tab)
   const logToServer = (_logType: string, level: string, message: string, data: unknown = {}) => {
     const fn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
@@ -98,9 +109,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [voterName, setVoterName] = useState<string>("");
   const [voterListRefresh, setVoterListRefresh] = useState(0);
   const [showFollowUpModal, setShowFollowUpModal] = useState(false);
-  const [showVoteOnItModal, setShowVoteOnItModal] = useState(false);
-  const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [loadingSuggestions, setLoadingSuggestions] = useState(false);
+
+
   const autoCloseTriggeredRef = useRef(false);
   const fetchResultsInFlight = useRef(false);
   const fetchResultsLastCall = useRef(0);
@@ -314,25 +324,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       // ONLY use votes from this browser's localStorage - no cross-browser contamination
       const allVotes = [...userVotes];
 
-      if (poll.poll_type === 'suggestion') {
-        // For suggestions, use only the LATEST vote (not aggregated)
-        // When a user edits their vote, the vote record is updated in place
-        // So we should only use the most recent version, not combine multiple votes
-        const sortedVotes = allVotes.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-        const latestVote = sortedVotes[0];
-        
-        const aggregatedVoteData = {
-          ...latestVote,
-          suggestions: latestVote.suggestions || [],
-          aggregatedFrom: 1
-        };
-
-        return aggregatedVoteData;
-      } else {
-        // For non-suggestion polls, just return the most recent vote
-        const sortedVotes = allVotes.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-        return sortedVotes[0];
-      }
+      // Return the most recent vote
+      const sortedVotes = allVotes.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+      return sortedVotes[0];
     } catch (error) {
       console.error('Error fetching aggregated vote data:', error);
       return null;
@@ -389,8 +383,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   useEffect(() => {
     setCurrentTime(new Date());
 
-    // Load existing suggestions for suggestion polls
-    if (poll.poll_type === 'suggestion') {
+    // Load existing suggestions for polls with suggestion phase
+    if (hasSuggestionPhase) {
       loadExistingSuggestions();
       // Also fetch results to show vote counts for suggestion polls
       fetchPollResults();
@@ -524,9 +518,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       const voteId = getStoredVoteId(poll.id);
       setUserVoteId(voteId);
       
-      // Fetch vote data from database if we have a vote ID
-      // OR if this is a suggestion poll (to handle creator votes and aggregation)
-      if (voteId || poll.poll_type === 'suggestion' || poll.poll_type === 'participation') {
+      // Fetch vote data from database if we have a vote ID or for specific poll types
+      if (voteId || hasSuggestionPhase || poll.poll_type === 'participation') {
         setIsLoadingVoteData(true);
 
         // For participation polls without a stored vote ID, find the vote via participant name match
@@ -540,9 +533,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         };
 
         let fetchPromise;
-        if (poll.poll_type === 'suggestion') {
-          fetchPromise = fetchAggregatedVoteData(poll.id);
-        } else if (voteId) {
+        if (voteId) {
           fetchPromise = fetchVoteData(voteId);
         } else if (poll.poll_type === 'participation') {
           fetchPromise = fetchParticipationVoteByName(poll.id);
@@ -568,8 +559,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               } catch (e) { /* ignore */ }
             }
 
-            // For suggestion polls, fetch results to show vote counts even when poll is open
-            if (poll.poll_type === 'suggestion' && !isPollClosed) {
+            // For polls with suggestion phase, fetch results to show vote counts even when poll is open
+            if (hasSuggestionPhase && !isPollClosed) {
               fetchPollResults();
             }
             
@@ -602,10 +593,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                 if (minEnabled !== undefined) setDurationMinEnabled(minEnabled);
                 if (maxEnabled !== undefined) setDurationMaxEnabled(maxEnabled);
               }
-            } else if (poll.poll_type === 'ranked_choice' && voteData.ranked_choices) {
-              setRankedChoices(voteData.ranked_choices);
-            } else if (poll.poll_type === 'suggestion' && voteData.suggestions) {
-              setSuggestionChoices(voteData.suggestions);
+            } else if (poll.poll_type === 'ranked_choice') {
+              if (voteData.ranked_choices) setRankedChoices(voteData.ranked_choices);
+              if (voteData.suggestions) setSuggestionChoices(voteData.suggestions);
             }
           } else {
           }
@@ -656,45 +646,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     fetchFollowUpPolls();
   }, [poll.id]);
 
-  // Fetch suggestions for suggestion polls to show "Vote on it" button
-  const fetchSuggestions = useCallback(async () => {
-    if (poll.poll_type !== 'suggestion') {
-      setSuggestions([]);
-      return;
-    }
-
-    setLoadingSuggestions(true);
-    try {
-      const allVotes = await apiGetVotes(poll.id);
-      const suggestionVotes = allVotes.filter(v =>
-        v.vote_type === 'suggestion' && !v.is_abstain && v.suggestions && v.suggestions.length > 0
-      );
-
-      // Collect all unique suggestions
-      const suggestionSet = new Set<string>();
-      suggestionVotes.forEach(vote => {
-        if (vote.suggestions && Array.isArray(vote.suggestions)) {
-          vote.suggestions.forEach((sug: any) => {
-            const sugString = typeof sug === 'string' ? sug : sug?.option || sug?.toString() || '';
-            if (sugString) {
-              suggestionSet.add(sugString);
-            }
-          });
-        }
-      });
-
-      setSuggestions(Array.from(suggestionSet));
-    } catch (error) {
-      console.error('Error loading suggestions:', error);
-      setSuggestions([]);
-    } finally {
-      setLoadingSuggestions(false);
-    }
-  }, [poll.poll_type, poll.id]);
-
-  useEffect(() => {
-    fetchSuggestions();
-  }, [fetchSuggestions]);
 
   // Real-time timer to check for poll expiration
   useEffect(() => {
@@ -708,27 +659,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       setCurrentTime(now);
 
       // If poll just expired, automatically fetch results.
-      // For suggestion polls with auto_create_preferences, the server-side
-      // get_results endpoint auto-closes and activates the preferences poll.
       if (now >= deadline && !isPollClosed) {
         fetchPollResults();
-
-        if (
-          poll.poll_type === 'suggestion' &&
-          poll.auto_create_preferences &&
-          !autoCloseTriggeredRef.current
-        ) {
-          autoCloseTriggeredRef.current = true;
-          setPollClosed(true);
-          apiFindDuplicatePoll(poll.title, poll.id)
-            .then((followUp) => {
-              if (followUp && (!followUp.is_closed || followUp.close_reason === 'uncontested')) {
-                const shortId = followUp.short_id || followUp.id;
-                router.push(`/p/${shortId}`);
-              }
-            })
-            .catch(() => {});
-        }
       }
     };
 
@@ -739,7 +671,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     const interval = setInterval(updateTimer, 1000);
 
     return () => clearInterval(interval);
-  }, [poll.response_deadline, pollClosed, isPollClosed, fetchPollResults, poll.poll_type, poll.auto_create_preferences, poll.id, poll.title, router]);
+  }, [poll.response_deadline, pollClosed, isPollClosed, fetchPollResults, poll.poll_type, poll.id]);
 
   // Real-time subscription to listen for poll status changes (with polling fallback)
   useEffect(() => {
@@ -787,10 +719,16 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   }, [justCancelledAbstain]);
 
   // Memoize parsed options to prevent re-parsing on every render
+  // During suggestion phase (poll.options is null), derive options from suggestion_counts
   const pollOptions = useMemo(() => {
-    if (!poll.options) return [];
-    return typeof poll.options === 'string' ? JSON.parse(poll.options) : poll.options;
-  }, [poll.options]);
+    if (poll.options) {
+      return typeof poll.options === 'string' ? JSON.parse(poll.options) : poll.options;
+    }
+    if (hasSuggestionPhase && pollResults?.suggestion_counts) {
+      return pollResults.suggestion_counts.map((sc: { option: string }) => sc.option);
+    }
+    return [];
+  }, [poll.options, hasSuggestionPhase, pollResults?.suggestion_counts]);
 
   // Randomize display order for 2-option polls (client-only to avoid hydration mismatch)
   const [twoOptionDisplayOrder, setTwoOptionDisplayOrder] = useState<string[]>([]);
@@ -817,10 +755,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       // Clear previous choices when abstaining
       if (poll.poll_type === 'ranked_choice') {
         setRankedChoices([]);
+        setSuggestionChoices([]);
       } else if (poll.poll_type === 'yes_no') {
         setYesNoChoice(null); // Clear yes/no choice to prevent both appearing selected
-      } else if (poll.poll_type === 'suggestion') {
-        setSuggestionChoices([]);
       }
     } else {
       // Cancelling abstain
@@ -880,21 +817,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         setPollClosed(true);
         setManuallyReopened(false); // Reset manually reopened flag when closing
         await fetchPollResults();
-
-        // If this suggestion poll had auto_create_preferences, find and navigate
-        // to the activated preferences poll.
-        if (poll.poll_type === 'suggestion' && poll.auto_create_preferences) {
-          try {
-            const followUp = await apiFindDuplicatePoll(poll.title, poll.id);
-            if (followUp && (!followUp.is_closed || followUp.close_reason === 'uncontested')) {
-              if (creatorSecret) recordPollCreation(followUp.id, creatorSecret);
-              const shortId = followUp.short_id || followUp.id;
-              router.push(`/p/${shortId}`);
-            }
-          } catch {
-            // Non-critical — user can still find it via follow-up links
-          }
-        }
       } else {
         alert('Failed to close poll. Please try again.');
       }
@@ -1001,46 +923,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       }
     }
 
-    if (poll.poll_type === 'suggestion') {
-      const filteredSuggestions = suggestionChoices.filter(choice => choice && choice.trim().length > 0);
-      await logToServer('suggestion-vote', 'info', 'Suggestion validation check', {
-        originalSuggestions: suggestionChoices,
-        filteredSuggestions,
-        willAbstain: filteredSuggestions.length === 0
-      });
-      // No validation error - empty suggestions will be treated as abstain
-    }
-
-    await logToServer('suggestion-vote', 'info', 'handleVoteClick validation passed, showing confirmation modal', {
+    await logToServer('vote', 'info', 'handleVoteClick validation passed, showing confirmation modal', {
       pollType: poll.poll_type,
       isAbstaining,
-      choicesReady: poll.poll_type === 'suggestion' ? suggestionChoices.filter(choice => choice && choice.trim().length > 0).length : 'n/a'
+      hasSuggestionPhase,
     });
 
     setVoteError(null);
     setShowVoteConfirmModal(true);
   };
 
-  const handleVoteOnSuggestionsClick = async () => {
-    // Check if a follow-up preference poll already exists with the same title
-    setLoadingSuggestions(true);
-    try {
-      const existing = await apiFindDuplicatePoll(poll.title, poll.id);
-      if (existing) {
-        // Navigate directly to the existing poll
-        const shortId = existing.short_id || existing.id;
-        router.push(`/p/${shortId}`);
-        return;
-      }
-    } catch {
-      // If the check fails, fall through to show the modal
-    } finally {
-      setLoadingSuggestions(false);
-    }
 
-    // No duplicate found — show the creation modal
-    setShowVoteOnItModal(true);
-  };
 
   const submitVote = async () => {
     await logToServer('suggestion-vote', 'info', 'submitVote started', {
@@ -1129,48 +1022,28 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           return;
         }
         
+        // Include suggestions if poll has a suggestion phase
+        const filteredSuggestions = hasSuggestionPhase
+          ? suggestionChoices.filter(choice => choice && choice.trim().length > 0)
+          : null;
+        const filteredMetadata = hasSuggestionPhase && filteredSuggestions && filteredSuggestions.length > 0 && Object.keys(suggestionMetadata).length > 0
+          ? Object.fromEntries(Object.entries(suggestionMetadata).filter(([key]) => filteredSuggestions.includes(key)))
+          : null;
+
+        // During suggestion phase with no rankings and no suggestions: abstain
+        const hasRankings = filteredRankedChoices.length > 0;
+        const hasSuggestions = filteredSuggestions && filteredSuggestions.length > 0;
+        const finalAbstain = isAbstaining || (!hasRankings && !hasSuggestions);
+
         voteData = {
           poll_id: poll.id,
           vote_type: 'ranked_choice' as const,
-          ranked_choices: isAbstaining ? null : filteredRankedChoices,
-          is_abstain: isAbstaining,
-          voter_name: voterName.trim() || null
-        };
-      } else if (poll.poll_type === 'suggestion') {
-        const filteredSuggestions = suggestionChoices.filter(choice => choice && choice.trim().length > 0);
-
-        await logToServer('suggestion-vote', 'info', 'Processing suggestion vote data', {
-          originalSuggestions: suggestionChoices,
-          filteredSuggestions,
-          isAbstaining
-        });
-
-        // Empty suggestions will be treated as abstain
-        const willAbstain = filteredSuggestions.length === 0;
-        await logToServer('suggestion-vote', 'info', 'Suggestion vote processing', {
-          suggestionChoices,
-          filteredSuggestions,
-          willAbstain,
-          isAbstaining
-        });
-
-        // Send null for suggestions when abstaining, array with suggestions when voting
-        // Abstain if explicitly set OR if no suggestions provided
-        const finalAbstain = isAbstaining || willAbstain;
-        // Filter metadata to only include nominated options
-        const filteredMetadata = Object.keys(suggestionMetadata).length > 0
-          ? Object.fromEntries(Object.entries(suggestionMetadata).filter(([key]) => filteredSuggestions.includes(key)))
-          : null;
-        voteData = {
-          poll_id: poll.id,
-          vote_type: 'suggestion' as const,
-          suggestions: finalAbstain ? null : filteredSuggestions,
+          ranked_choices: finalAbstain || !hasRankings ? null : filteredRankedChoices,
+          suggestions: finalAbstain || !hasSuggestions ? null : filteredSuggestions,
           is_abstain: finalAbstain,
           voter_name: voterName.trim() || null,
-          options_metadata: !finalAbstain && filteredMetadata && Object.keys(filteredMetadata).length > 0 ? filteredMetadata : null,
+          options_metadata: filteredMetadata && Object.keys(filteredMetadata).length > 0 ? filteredMetadata : null,
         };
-
-        await logToServer('suggestion-vote', 'info', 'Suggestion voteData created', voteData);
       }
 
       let voteId: string | undefined;
@@ -1185,9 +1058,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null }
           : poll.poll_type === 'participation'
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null, min_participants: voterMinParticipants, max_participants: voterMaxEnabled ? voterMaxParticipants : null, voter_day_time_windows: voterDayTimeWindows.length > 0 ? voterDayTimeWindows : null, voter_duration: (durationMinEnabled || durationMaxEnabled) ? { minValue: durationMinValue, maxValue: durationMaxValue, minEnabled: durationMinEnabled, maxEnabled: durationMaxEnabled } : null }
-          : poll.poll_type === 'ranked_choice'
-          ? { ranked_choices: isAbstaining ? null : rankedChoices, is_abstain: isAbstaining, voter_name: voterName.trim() || null }
-          : { suggestions: voteData.suggestions, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null };
+          : { ranked_choices: voteData.ranked_choices, suggestions: voteData.suggestions, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null };
         
         
         
@@ -1258,16 +1129,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       // Trigger voter list refresh immediately
       setVoterListRefresh(prev => prev + 1);
 
-      // Refresh suggestion list for suggestion polls with a small delay to ensure DB update is complete
-      if (poll.poll_type === 'suggestion') {
-        // Add a small delay to ensure the database update is fully committed
+      // Refresh suggestion list for polls with suggestion phase
+      if (hasSuggestionPhase) {
         setTimeout(async () => {
-          // Refresh suggestions after DB update is complete
           await loadExistingSuggestions(false);
-          // Also fetch poll results to show vote counts
           await fetchPollResults();
-          // Fetch suggestions to update "Vote on it" button visibility
-          await fetchSuggestions();
         }, 500);
       }
       
@@ -1287,18 +1153,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       
       setIsEditingVote(false);
       
-      // Refetch vote data for suggestion polls to ensure UI shows latest data
-      if (poll.poll_type === 'suggestion' && isEditingVote) {
-        const updatedVoteData = await fetchAggregatedVoteData(poll.id);
-        if (updatedVoteData) {
-          setUserVoteData(updatedVoteData);
-        }
-
-        // CRITICAL FIX: Always refresh results after editing suggestions
-        // This ensures that deleted suggestions (abstained votes) are removed from display
+      // Refresh results after editing votes with suggestions
+      if (hasSuggestionPhase && isEditingVote) {
         await fetchPollResults();
-        // Fetch suggestions to update "Vote on it" button visibility
-        await fetchSuggestions();
       }
 
       // If the poll is closed or preliminary results threshold met, fetch results
@@ -1500,30 +1357,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                 </svg>
                 <span className="font-semibold">Follow up</span>
               </GradientBorderButton>
-            {poll.poll_type === 'suggestion' && suggestions.length >= 2 && (
-              <GradientBorderButton
-                onClick={handleVoteOnSuggestionsClick}
-                disabled={loadingSuggestions}
-                gradient="red-orange"
-              >
-                {loadingSuggestions ? (
-                  <>
-                    <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    <span className="font-semibold">Loading...</span>
-                  </>
-                ) : (
-                  <>
-                    <span className="font-semibold">Vote on it</span>
-                    <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={4}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M21 10H11a8 8 0 00-8 8v2M21 10l-6 6m6-6l-6-6" />
-                    </svg>
-                  </>
-                )}
-              </GradientBorderButton>
-            )}
           </div>
         )}
 
@@ -1893,40 +1726,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                 </>
               )}
             </div>
-          ) : poll.poll_type === 'suggestion' ? (
-            <SuggestionVotingInterface
-              poll={poll}
-              existingSuggestions={existingSuggestions}
-              suggestionChoices={suggestionChoices}
-              setSuggestionChoices={setSuggestionChoices}
-              isAbstaining={isAbstaining}
-              handleAbstain={handleAbstain}
-              voteError={voteError}
-              voterName={voterName}
-              setVoterName={setVoterName}
-              handleVoteClick={handleVoteClick}
-              isSubmitting={isSubmitting}
-              isPollClosed={!!isPollClosed}
-              isCreator={isCreator}
-              handleCloseClick={handleCloseClick}
-              isClosingPoll={isClosingPoll}
-              hasVoted={hasVoted}
-              isEditingVote={isEditingVote}
-              setIsEditingVote={setIsEditingVote}
-              userVoteData={userVoteData}
-              isLoadingVoteData={isLoadingVoteData}
-              pollResults={pollResults}
-              loadingResults={loadingResults}
-              loadExistingSuggestions={loadExistingSuggestions}
-              onFollowUpClick={() => setShowFollowUpModal(true)}
-              suggestions={suggestions}
-              loadingSuggestions={loadingSuggestions}
-              onVoteOnSuggestionsClick={handleVoteOnSuggestionsClick}
-              autoCreatePreferences={poll.auto_create_preferences}
-              suggestionMetadata={suggestionMetadata}
-              onSuggestionMetadataChange={setSuggestionMetadata}
-              optionsMetadata={optionsMetadataLocal}
-            />
           ) : (
             <div>
               {isPollClosed ? (
@@ -2054,6 +1853,56 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                 </div>
               ) : (
                 <>
+                  {/* Suggestion phase UI for polls with suggestion deadline */}
+                  {canSubmitSuggestions && (
+                    <SuggestionVotingInterface
+                      poll={poll}
+                      existingSuggestions={existingSuggestions}
+                      suggestionChoices={suggestionChoices}
+                      setSuggestionChoices={setSuggestionChoices}
+                      isAbstaining={isAbstaining}
+                      handleAbstain={handleAbstain}
+                      voteError={voteError}
+                      voterName={voterName}
+                      setVoterName={setVoterName}
+                      handleVoteClick={handleVoteClick}
+                      isSubmitting={isSubmitting}
+                      isPollClosed={!!isPollClosed}
+                      isCreator={isCreator}
+                      handleCloseClick={handleCloseClick}
+                      isClosingPoll={isClosingPoll}
+                      hasVoted={hasVoted}
+                      isEditingVote={isEditingVote}
+                      setIsEditingVote={setIsEditingVote}
+                      userVoteData={userVoteData}
+                      isLoadingVoteData={isLoadingVoteData}
+                      pollResults={pollResults}
+                      loadingResults={loadingResults}
+                      loadExistingSuggestions={loadExistingSuggestions}
+                      onFollowUpClick={() => setShowFollowUpModal(true)}
+                      suggestionMetadata={suggestionMetadata}
+                      onSuggestionMetadataChange={setSuggestionMetadata}
+                      optionsMetadata={optionsMetadataLocal}
+                    />
+                  )}
+
+                  {/* Suggestion phase disclaimer when pre-ranking is allowed */}
+                  {canSubmitSuggestions && canSubmitRankings && pollOptions.length > 0 && (
+                    <div className="mb-3 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg">
+                      <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200 text-sm">
+                        <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                        </svg>
+                        <span>
+                          Options can still be added! Suggestions close in{' '}
+                          <Countdown deadline={poll.suggestion_deadline!} onExpire={() => setCurrentTime(new Date())} />
+                        </span>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Ranking UI - shown when ranking is allowed and there are options */}
+                  {canSubmitRankings && pollOptions.length > 0 && (
                   <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
                     {pollOptions.length === 2 ? (
                       <>
@@ -2113,18 +1962,34 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       </div>
                     )}
                   </div>
+                  )}
 
+                  {/* Waiting for suggestions message when pre-ranking is disabled */}
+                  {!canSubmitRankings && canSubmitSuggestions && (
+                    <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
+                      <p className="text-blue-800 dark:text-blue-200 text-sm">
+                        Ranking will open when suggestions close in{' '}
+                        <Countdown deadline={poll.suggestion_deadline!} onExpire={() => setCurrentTime(new Date())} />
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Name field and submit - shown when not in suggestion-only mode (SuggestionVotingInterface has its own) */}
+                  {(!canSubmitSuggestions || canSubmitRankings) && (
+                  <>
                   <div className="mt-4">
                     <CompactNameField name={voterName} setName={setVoterName} />
                   </div>
-                  
+
                   <button
                     onClick={handleVoteClick}
-                    disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0)}
+                    disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0)}
                     className="w-full mt-4 py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
                   >
                     {isSubmitting ? 'Submitting...' : 'Submit Vote'}
                   </button>
+                  </>
+                  )}
 
                   {/* Show follow-up/fork header after submit button */}
                   <div className="mt-4">
@@ -2176,12 +2041,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           ? (isAbstaining 
               ? `Are you sure you want to abstain from this vote?`
               : `Are you sure you want to vote "${yesNoChoice?.toUpperCase()}"?`)
-          : poll.poll_type === 'suggestion'
-          ? (isAbstaining
-              ? `Are you sure you want to abstain from this vote?`
-              : isEditingVote
-                ? `Are you sure you want to update your suggestions?`
-                : `Are you sure you want to submit your suggestions?`)
           : (isAbstaining
               ? `Are you sure you want to abstain from this vote?`
               : `Are you sure you want to submit your ranking?`)}
@@ -2235,14 +2094,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         totalVotes={pollResults?.total_votes}
       />
 
-      {/* Vote on It Modal */}
-      <VoteOnItModal
-        isOpen={showVoteOnItModal}
-        pollId={poll.id}
-        pollTitle={poll.title}
-        suggestions={suggestions}
-        onClose={() => setShowVoteOnItModal(false)}
-      />
+
 
     </>
   );

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1847,7 +1847,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   {/* Ranking section — independent component with its own edit state */}
                   <RankingSection
                     poll={poll}
-                    pollId={pollId}
+                    pollId={pollId || ''}
                     pollOptions={pollOptions}
                     rankedChoices={rankedChoices}
                     handleRankingChange={handleRankingChange}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -15,10 +15,10 @@ import FollowUpHeader from "@/components/FollowUpHeader";
 import ForkHeader from "@/components/ForkHeader";
 import PollList from "@/components/PollList";
 import ProfileButton from "@/components/ProfileButton";
-import FollowUpModal from "@/components/FollowUpModal";
+
 import VoterList from "@/components/VoterList";
 import PollManagementButtons from "@/components/PollManagementButtons";
-import GradientBorderButton from "@/components/GradientBorderButton";
+
 import OptionLabel from "@/components/OptionLabel";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
@@ -108,7 +108,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [loadingFollowUps, setLoadingFollowUps] = useState(false);
   const [voterName, setVoterName] = useState<string>("");
   const [voterListRefresh, setVoterListRefresh] = useState(0);
-  const [showFollowUpModal, setShowFollowUpModal] = useState(false);
 
 
   const autoCloseTriggeredRef = useRef(false);
@@ -1355,22 +1354,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           </div>
         )}
 
-        {/* Follow-up button for closed polls - always shown after results */}
-        {isPollClosed && (
-          <div className="my-4 flex justify-between items-center">
-              <GradientBorderButton
-                onClick={() => setShowFollowUpModal(true)}
-                gradient="blue-purple"
-              >
-                <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={4}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-                </svg>
-                <span className="font-semibold">Follow up</span>
-              </GradientBorderButton>
-          </div>
-        )}
-
-        {/* Show follow-up/fork header after Follow up button for closed polls */}
+        {/* Show follow-up/fork header for closed polls */}
         {isPollClosed && (
           <div className="mt-4">
             {poll.follow_up_to && <FollowUpHeader followUpToPollId={poll.follow_up_to} />}
@@ -1464,30 +1448,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     )}
                   </div>
 
-                  {/* Follow Up Button row - shown when poll is open and user has voted */}
-                  {!isPollClosed && !isLoadingVoteData && (
-                    <div className="my-4 flex justify-between items-center">
-                      <GradientBorderButton
-                          onClick={() => setShowFollowUpModal(true)}
-                          gradient="blue-purple"
-                        >
-                          <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={4}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-                          </svg>
-                          <span className="font-semibold">Follow up</span>
-                        </GradientBorderButton>
-                    </div>
-                  )}
-
-                  {/* Show follow-up/fork header after Follow up button when voted */}
-                  {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-4">
-                      {poll.follow_up_to && <FollowUpHeader followUpToPollId={poll.follow_up_to} />}
-                      {poll.fork_of && <ForkHeader forkOfPollId={poll.fork_of} />}
-                    </div>
-                  )}
-
-                  {/* Voter list for open yes/no polls - shown after Follow-up button when voted */}
+                  {/* Voter list for open yes/no polls */}
                   {!isPollClosed && hasVoted && !isLoadingVoteData && (
                     <div className="mt-4">
                       <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
@@ -1620,28 +1581,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       </>
                     )}
                   </div>
-
-                  {!isPollClosed && !isLoadingVoteData && (
-                    <div className="my-4 flex justify-between items-center">
-                      <GradientBorderButton
-                          onClick={() => setShowFollowUpModal(true)}
-                          gradient="blue-purple"
-                        >
-                          <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={4}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-                          </svg>
-                          <span className="font-semibold">Follow up</span>
-                        </GradientBorderButton>
-                    </div>
-                  )}
-
-                  {/* Show follow-up/fork header after Follow up button when voted */}
-                  {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-4">
-                      {poll.follow_up_to && <FollowUpHeader followUpToPollId={poll.follow_up_to} />}
-                      {poll.fork_of && <ForkHeader forkOfPollId={poll.fork_of} />}
-                    </div>
-                  )}
 
                   {!isPollClosed && hasVoted && !isLoadingVoteData && (
                     <div className="mt-4">
@@ -1831,30 +1770,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     ) : null}
                   </div>
 
-                  {/* Follow Up Button row - shown when poll is open and user has voted */}
-                  {!isPollClosed && !isLoadingVoteData && (
-                    <div className="my-4 flex justify-between items-center">
-                      <GradientBorderButton
-                          onClick={() => setShowFollowUpModal(true)}
-                          gradient="blue-purple"
-                        >
-                          <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={4}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-                          </svg>
-                          <span className="font-semibold">Follow up</span>
-                        </GradientBorderButton>
-                    </div>
-                  )}
-
-                  {/* Show follow-up/fork header after Follow up button when voted */}
-                  {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-4">
-                      {poll.follow_up_to && <FollowUpHeader followUpToPollId={poll.follow_up_to} />}
-                      {poll.fork_of && <ForkHeader forkOfPollId={poll.fork_of} />}
-                    </div>
-                  )}
-
-                  {/* Voter list for open ranked choice polls - shown after Follow-up button when voted */}
+                  {/* Voter list for open ranked choice polls */}
                   {!isPollClosed && hasVoted && !isLoadingVoteData && (
                     <div className="mt-4">
                       <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
@@ -1889,7 +1805,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       pollResults={pollResults}
                       loadingResults={loadingResults}
                       loadExistingSuggestions={loadExistingSuggestions}
-                      onFollowUpClick={() => setShowFollowUpModal(true)}
                       suggestionMetadata={suggestionMetadata}
                       onSuggestionMetadataChange={setSuggestionMetadata}
                       optionsMetadata={optionsMetadataLocal}
@@ -2098,13 +2013,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
       />
 
-      {/* Follow-up Modal */}
-      <FollowUpModal
-        isOpen={showFollowUpModal}
-        poll={poll}
-        onClose={() => setShowFollowUpModal(false)}
-        totalVotes={pollResults?.total_votes}
-      />
 
 
 

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1767,7 +1767,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     </div>
                   )}
                 </div>
-              ) : hasVoted && !isEditingVote ? (
+              ) : hasVoted && !isEditingVote && !canSubmitSuggestions ? (
                 <div className="text-center py-3">
                   <div className="text-left">
                     <div className="flex items-center justify-between mb-2">

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -565,9 +565,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             if (hasSuggestionPhase && !isPollClosed) {
               fetchPollResults();
             }
-            
+
             // Set UI state based on vote data from database columns
-            setIsAbstaining(voteData.is_abstain || false);
+            // During suggestion phase with pre-ranking, don't restore abstain from server —
+            // the abstain only applied to suggestions, user should still be able to rank
+            const shouldRestoreAbstain = voteData.is_abstain && !(hasSuggestionPhase && canSubmitRankings);
+            setIsAbstaining(shouldRestoreAbstain);
             if (voteData.is_abstain) {
               // Don't set choices for abstain votes
             } else if (poll.poll_type === 'yes_no' && voteData.yes_no_choice) {
@@ -1876,7 +1879,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             key={isEditingVote ? 'editing' : 'new'}
                             options={pollOptions}
                             onRankingChange={handleRankingChange}
-                            disabled={isSubmitting || isAbstaining}
+                            disabled={isSubmitting || (isAbstaining && !canSubmitSuggestions)}
                             storageKey={pollId ? `poll-ranking-${pollId}` : undefined}
                             initialRanking={isEditingVote && userVoteData?.ranked_choices ? userVoteData.ranked_choices : undefined}
                             optionsMetadata={optionsMetadataLocal}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1309,7 +1309,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           if (!isPollClosed && !isExpired && deadline) {
             // During suggestion phase, show suggestion deadline instead of response deadline
             if (inSuggestionPhase && poll.suggestion_deadline) {
-              return <Countdown deadline={poll.suggestion_deadline} label="Suggestions close" />;
+              return <Countdown deadline={poll.suggestion_deadline} label="Suggestions cutoff" />;
             }
             return <Countdown deadline={poll.response_deadline || null} />;
           }
@@ -1816,17 +1816,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
                   {/* Suggestion phase disclaimer when pre-ranking is allowed and user has voted */}
                   {canSubmitSuggestions && canSubmitRankings && hasVoted && !isEditingVote && pollOptions.length > 0 && (
-                    <div className="mb-3 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg">
-                      <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200 text-sm">
-                        <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
-                        </svg>
-                        <span>
-                          Options can still be added! Suggestions close in{' '}
-                          <Countdown deadline={poll.suggestion_deadline!} onExpire={() => setCurrentTime(new Date())} />
-                        </span>
+                    <>
+                      <div className="mb-2 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg">
+                        <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200 text-sm">
+                          <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                          </svg>
+                          <span>Options can still be added until suggestions cutoff!</span>
+                        </div>
                       </div>
-                    </div>
+                      <Countdown deadline={poll.response_deadline || null} label="Preferences closing" />
+                    </>
                   )}
 
                   {/* Ranking UI - shown when ranking is allowed and there are options
@@ -1904,7 +1904,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   {!canSubmitRankings && canSubmitSuggestions && (
                     <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
                       <p className="text-blue-800 dark:text-blue-200 text-sm">
-                        Ranking will open when suggestions close in{' '}
+                        Ranking will open after suggestions cutoff in{' '}
                         <Countdown deadline={poll.suggestion_deadline!} onExpire={() => setCurrentTime(new Date())} />
                       </p>
                     </div>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1814,18 +1814,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     />
                   )}
 
-                  {/* Suggestion phase disclaimer when pre-ranking is allowed and user has voted */}
+                  {/* Early voting section header during suggestion phase */}
                   {canSubmitSuggestions && canSubmitRankings && hasVoted && !isEditingVote && pollOptions.length > 0 && (
                     <>
-                      <div className="mb-2 p-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg">
-                        <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200 text-sm">
-                          <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
-                          </svg>
-                          <span>Options can still be added until suggestions cutoff!</span>
-                        </div>
-                      </div>
+                      <h3 className="text-lg font-semibold text-center text-gray-900 dark:text-white mt-4 mb-1">Early Voting</h3>
                       <Countdown deadline={poll.response_deadline || null} label="Preferences closing" />
+                      <p className="text-center text-xs text-amber-700 dark:text-amber-300 mb-3">
+                        Options may change until suggestions cutoff!
+                      </p>
                     </>
                   )}
 

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -109,6 +109,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [voterName, setVoterName] = useState<string>("");
   const [voterListRefresh, setVoterListRefresh] = useState(0);
 
+  // Stable filter callbacks for VoterList
+  const suggestionsVoterFilter = useCallback((v: ApiVote) => !!(v.suggestions && v.suggestions.length > 0), []);
+  const rankingsVoterFilter = useCallback((v: ApiVote) => !!(v.ranked_choices && v.ranked_choices.length > 0), []);
 
   const autoCloseTriggeredRef = useRef(false);
   const fetchResultsInFlight = useRef(false);
@@ -1770,10 +1773,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     ) : null}
                   </div>
 
-                  {/* Voter list for open ranked choice polls */}
+                  {/* Voter lists for open ranked choice polls */}
                   {!isPollClosed && hasVoted && !isLoadingVoteData && (
-                    <div className="mt-4">
-                      <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
+                    <div className="mt-4 space-y-2">
+                      {hasSuggestionPhase ? (
+                        <>
+                          <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Suggested" filter={suggestionsVoterFilter} />
+                          <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Ranked" filter={rankingsVoterFilter} />
+                        </>
+                      ) : (
+                        <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
+                      )}
                     </div>
                   )}
                 </div>

--- a/components/Countdown.tsx
+++ b/components/Countdown.tsx
@@ -4,9 +4,11 @@ import { useState, useEffect } from "react";
 
 interface CountdownProps {
   deadline: string | null;
+  label?: string;
+  onExpire?: () => void;
 }
 
-export default function Countdown({ deadline }: CountdownProps) {
+export default function Countdown({ deadline, label, onExpire }: CountdownProps) {
   const [timeLeft, setTimeLeft] = useState<string>("");
   const [isExpired, setIsExpired] = useState(false);
   const [isClient, setIsClient] = useState(false);
@@ -26,6 +28,7 @@ export default function Countdown({ deadline }: CountdownProps) {
       if (difference <= 0) {
         setIsExpired(true);
         setTimeLeft("Completed");
+        onExpire?.();
         return;
       }
 
@@ -89,7 +92,7 @@ export default function Countdown({ deadline }: CountdownProps) {
         ? 'text-red-700 dark:text-red-300' 
         : 'text-blue-700 dark:text-blue-300'
       }`}>
-        {isExpired ? `Poll Ended` : `Closing in ${timeLeft}`}
+        {isExpired ? (label ? `${label} ended` : `Poll Ended`) : `${label || 'Closing'} in ${timeLeft}`}
       </span>
     </div>
   );

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -12,7 +12,6 @@ interface OptionsInputProps {
   options: string[];
   setOptions: (options: string[]) => void;
   isLoading?: boolean;
-  pollType?: 'poll' | 'suggestion';
   label?: React.ReactNode;
   placeholder?: string;
   category?: PollCategory;
@@ -27,7 +26,6 @@ export default function OptionsInput({
   options,
   setOptions,
   isLoading = false,
-  pollType = 'poll',
   label,
   placeholder,
   category = 'custom',
@@ -141,11 +139,6 @@ export default function OptionsInput({
         return filledOptions.length === 0 ? "Search for a restaurant..." : "Add another restaurant...";
       }
       return `Restaurant ${index + 1}`;
-    } else if (pollType === 'suggestion') {
-      if (isLastField) {
-        return filledOptions.length === 0 ? "Add a suggestion" : "Add another suggestion...";
-      }
-      return `Suggestion ${index + 1}`;
     } else {
       if (isLastField) {
         return filledOptions.length === 0 ? "Add an option" : "Add another option...";

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -10,7 +10,6 @@ import { getBuiltInType } from "@/components/TypeFieldInput";
 
 const POLL_TYPE_SYMBOLS: Record<string, string> = {
   yes_no: '☐',
-  suggestion: '💡',
   ranked_choice: '🗳️',
   participation: '🙋',
 };
@@ -144,13 +143,6 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined, use
         return { text: getOptionDisplayName(results.winner, poll), emoji: '👑', color: 'green' };
       }
       return { text: 'No winner', emoji: '—', color: 'gray' };
-    }
-    case 'suggestion': {
-      if (results.suggestion_counts && results.suggestion_counts.length > 0) {
-        const top = results.suggestion_counts[0];
-        return { text: getOptionDisplayName(top.option, poll), emoji: '👑', color: 'green' };
-      }
-      return { text: 'No suggestions', emoji: '—', color: 'gray' };
     }
     case 'participation': {
       const participatingCount = results.yes_count || 0;

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { PollResults, OptionsMetadata } from "@/lib/types";
 import { apiGetVotes, apiGetParticipants } from "@/lib/api";
 import CompactRankedChoiceResults from "./CompactRankedChoiceResults";
-import SuggestionsList from "./SuggestionsList";
+
 
 interface PollResultsProps {
   results: PollResults;
@@ -25,10 +25,6 @@ export default function PollResultsDisplay({ results, isPollClosed, userVoteData
 
   if (results.poll_type === 'ranked_choice') {
     return <CompactRankedChoiceResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} optionsMetadata={optionsMetadata} />;
-  }
-
-  if (results.poll_type === 'suggestion') {
-    return <SuggestionResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} optionsMetadata={optionsMetadata} />;
   }
 
   return null;
@@ -605,40 +601,3 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
   );
 }
 
-function SuggestionResults({ results, isPollClosed, userVoteData, onFollowUpClick, optionsMetadata }: { results: PollResults, isPollClosed?: boolean, userVoteData?: any, onFollowUpClick?: () => void, optionsMetadata?: OptionsMetadata | null }) {
-  // Use server-side suggestion counts from the results endpoint
-  const suggestions = results.suggestion_counts || [];
-
-  const totalVoters = results.total_votes;
-  
-  // Count of unique suggestion items
-  const uniqueSuggestionCount = suggestions.length;
-
-  if (totalVoters === 0) {
-    return (
-      <div className="text-center">
-        <p className="text-gray-600 dark:text-gray-400">No Voters</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-4">
-      <div className="space-y-3">
-        {suggestions.length === 0 ? (
-          <p className="text-gray-600 dark:text-gray-400 text-center py-4">
-            No suggestions available.
-          </p>
-        ) : (
-          <SuggestionsList
-            suggestions={suggestions}
-            userSuggestions={userVoteData?.suggestions || []}
-            showVoteCounts={true}
-            showUserIndicator={true}
-            optionsMetadata={optionsMetadata}
-          />
-        )}
-      </div>
-    </div>
-  );
-}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -837,28 +837,45 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     }
   }, [disabled, mainList, noPreferenceList, keyboardMode, focusedItemId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Helper function to move items within the same list (with animation)
+  // FLIP animation helper: records positions, applies state change, then animates
+  const animateWithFLIP = useCallback((callback: () => void) => {
+    // FIRST: Record current DOM positions of all items
+    const oldPositions: Record<string, number> = {};
+    for (const [id, el] of Object.entries(elementRefs.current)) {
+      if (el) {
+        oldPositions[id] = el.getBoundingClientRect().top;
+      }
+    }
+
+    // LAST: Apply the state change synchronously
+    flushSync(callback);
+
+    // INVERT + PLAY: Calculate deltas and animate
+    for (const [id, el] of Object.entries(elementRefs.current)) {
+      if (el && oldPositions[id] !== undefined) {
+        const newPos = el.getBoundingClientRect().top;
+        const delta = oldPositions[id] - newPos;
+        if (Math.abs(delta) > 1) {
+          // INVERT: Snap to old position via transform
+          el.style.transition = 'none';
+          el.style.transform = `translateY(${delta}px)`;
+
+          // Force reflow so the browser registers the old position
+          el.offsetHeight; // eslint-disable-line @typescript-eslint/no-unused-expressions
+
+          // PLAY: Animate to new position
+          el.style.transition = 'transform 0.3s ease';
+          el.style.transform = '';
+        }
+      }
+    }
+  }, []);
+
+  // Helper function to move items within the same list (with FLIP animation)
   const moveItemInList = useCallback((listType: 'main' | 'noPreference', fromIndex: number, toIndex: number) => {
     const setter = listType === 'main' ? setMainList : setNoPreferenceList;
 
-    // Step 1: Update top positions WITHOUT reordering the array.
-    // flushSync forces React to commit to DOM immediately so the browser
-    // can start CSS transitions before we reorder the array.
-    flushSync(() => {
-      setter(prev => prev.map((item, i) => {
-        if (i === fromIndex) return { ...item, top: toIndex * totalItemHeight };
-        if (fromIndex < toIndex && i > fromIndex && i <= toIndex) {
-          return { ...item, top: (i - 1) * totalItemHeight };
-        }
-        if (fromIndex > toIndex && i >= toIndex && i < fromIndex) {
-          return { ...item, top: (i + 1) * totalItemHeight };
-        }
-        return item;
-      }));
-    });
-
-    // Step 2: After the transition starts, reorder the array to match.
-    requestAnimationFrame(() => {
+    animateWithFLIP(() => {
       setter(prev => {
         const newList = [...prev];
         const [item] = newList.splice(fromIndex, 1);
@@ -866,9 +883,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         return updateItemPositions(newList);
       });
     });
-  }, [updateItemPositions, totalItemHeight]);
+  }, [updateItemPositions, animateWithFLIP]);
 
-  // Helper function to move items between lists (with animation)
+  // Helper function to move items between lists (with FLIP animation)
   const moveItemBetweenLists = useCallback((
     itemId: string,
     sourceList: 'main' | 'noPreference',
@@ -884,22 +901,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     const sourceSetter = sourceList === 'main' ? setMainList : setNoPreferenceList;
     const targetSetter = targetList === 'main' ? setMainList : setNoPreferenceList;
 
-    // Step 1: Animate positions — shift items in source list up to close gap,
-    // shift items in target list down to make room.
-    // flushSync forces DOM commit so CSS transitions start before array reorder.
-    flushSync(() => {
-      sourceSetter(prev => prev.map((it, i) => {
-        if (i > sourceIndex) return { ...it, top: (i - 1) * totalItemHeight };
-        return it;
-      }));
-      targetSetter(prev => prev.map((it, i) => {
-        if (i >= targetIndex) return { ...it, top: (i + 1) * totalItemHeight };
-        return it;
-      }));
-    });
-
-    // Step 2: After transitions start, do the actual array reorder
-    requestAnimationFrame(() => {
+    animateWithFLIP(() => {
       sourceSetter(prev => {
         const newList = [...prev];
         newList.splice(sourceIndex, 1);
@@ -911,7 +913,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         return updateItemPositions(newList);
       });
     });
-  }, [mainList, noPreferenceList, updateItemPositions]);
+  }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP]);
 
   // Render a single list container (main or no preference)
   const renderListContainer = (
@@ -1060,7 +1062,6 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                         onPointerUp={!disabled ? (e) => {
                           // If drag never started (pointer moved <8px), it's a tap
                           const pending = pendingDragRef.current;
-                          console.log('[TAP] pointerUp, pending:', !!pending, 'started:', pending?.started, 'id match:', pending?.id === option.id);
                           if (pending && !pending.started && pending.id === option.id) {
                             pendingDragRef.current = null; // Clear before document handler runs
 
@@ -1068,22 +1069,16 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                             const relativeY = e.clientY - rect.top;
                             const half = rect.height / 2;
 
-                            console.log('[TAP] detected tap on', option.text, 'listType:', listType, 'index:', index, 'relativeY:', relativeY.toFixed(0), 'half:', half.toFixed(0));
-
                             if (listType === 'noPreference') {
-                              console.log('[TAP] moving from noPreference to main');
                               moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
                             } else if (relativeY < half) {
                               if (index > 0) {
-                                console.log('[TAP] moving UP from', index, 'to', index - 1);
                                 moveItemInList(listType, index, index - 1);
                               }
                             } else {
                               if (index < listItems.length - 1) {
-                                console.log('[TAP] moving DOWN from', index, 'to', index + 1);
                                 moveItemInList(listType, index, index + 1);
                               } else {
-                                console.log('[TAP] moving to noPreference (was last in main)');
                                 moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
                               }
                             }

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1016,7 +1016,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                     />
 
                     {/* Center content - not grabbable */}
-                    <div className={`flex-1 flex items-center pr-10 min-w-0 ${
+                    <div className={`flex-1 flex items-center pr-12 min-w-0 ${
                       disabled
                         ? 'text-gray-500 dark:text-gray-400'
                         : 'text-gray-900 dark:text-white'
@@ -1024,45 +1024,103 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />
                     </div>
 
-                    {/* Right side: up/down arrow buttons for tap-based reordering */}
+                    {/* Right side: combined drag handle with tap zones for reordering */}
                     {!disabled && (
-                      <div className="absolute right-1 top-1/2 -translate-y-1/2 flex flex-col gap-0.5" style={{ zIndex: 2 }}>
-                        <button
-                          type="button"
-                          onClick={(e) => {
+                      <div
+                        className="absolute -right-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
+                        style={{
+                          width: 'calc(20% + 0.75rem)',
+                          touchAction: 'none',
+                          zIndex: 2
+                        }}
+                        onPointerDown={!disabled ? (e) => {
+                          // Determine if the tap is in the top or bottom third
+                          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                          const relativeY = e.clientY - rect.top;
+                          const third = rect.height / 3;
+
+                          if (listType === 'noPreference') {
+                            // In exclusion area: any tap moves to bottom of main list
+                            e.preventDefault();
                             e.stopPropagation();
-                            if (index > 0) moveItemInList(listType, index, index - 1);
-                          }}
-                          disabled={index === 0}
-                          className={`w-7 h-7 flex items-center justify-center rounded transition-colors ${
-                            index === 0
-                              ? 'text-gray-300 dark:text-gray-600'
-                              : 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 active:bg-gray-300 dark:active:bg-gray-600'
-                          }`}
-                          aria-label="Move up"
-                        >
-                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                            <polyline points="18 15 12 9 6 15" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          onClick={(e) => {
+                            moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
+                            return;
+                          }
+
+                          if (relativeY < third) {
+                            // Top third: move up (or do nothing if already at top)
+                            e.preventDefault();
                             e.stopPropagation();
-                            if (index < listItems.length - 1) moveItemInList(listType, index, index + 1);
-                          }}
-                          disabled={index === listItems.length - 1}
-                          className={`w-7 h-7 flex items-center justify-center rounded transition-colors ${
-                            index === listItems.length - 1
-                              ? 'text-gray-300 dark:text-gray-600'
-                              : 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 active:bg-gray-300 dark:active:bg-gray-600'
-                          }`}
-                          aria-label="Move down"
-                        >
-                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                            <polyline points="6 9 12 15 18 9" />
-                          </svg>
-                        </button>
+                            if (index > 0) {
+                              moveItemInList(listType, index, index - 1);
+                            }
+                            return;
+                          } else if (relativeY > third * 2) {
+                            // Bottom third: move down, or to exclusion area if at bottom
+                            e.preventDefault();
+                            e.stopPropagation();
+                            if (index < listItems.length - 1) {
+                              moveItemInList(listType, index, index + 1);
+                            } else {
+                              // At bottom of main list: move to exclusion area
+                              moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
+                            }
+                            return;
+                          }
+
+                          // Middle third: start drag
+                          handlePointerStart(e, option.id);
+                        } : undefined}
+                        title=""
+                      >
+                        {/* Visual: arrows + drag handle */}
+                        <div className="absolute right-4 top-1/2 -translate-y-1/2 flex flex-col items-center justify-center gap-0">
+                          {listType === 'main' ? (
+                            <>
+                              {/* Up arrow */}
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                                className={index === 0 ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400 dark:text-gray-500'}
+                              >
+                                <polyline points="18 15 12 9 6 15" />
+                              </svg>
+                              {/* Drag handle lines */}
+                              <div className="flex flex-col items-center justify-center my-0.5">
+                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
+                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
+                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
+                              </div>
+                              {/* Down arrow */}
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                                className="text-gray-400 dark:text-gray-500"
+                              >
+                                <polyline points="6 9 12 15 18 9" />
+                              </svg>
+                            </>
+                          ) : (
+                            <>
+                              {/* Plus symbol above */}
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                                className="text-green-500 dark:text-green-400"
+                              >
+                                <line x1="12" y1="5" x2="12" y2="19" />
+                                <line x1="5" y1="12" x2="19" y2="12" />
+                              </svg>
+                              {/* Drag handle lines */}
+                              <div className="flex flex-col items-center justify-center my-0.5">
+                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
+                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
+                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
+                              </div>
+                              {/* Plus symbol below */}
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                                className="text-green-500 dark:text-green-400"
+                              >
+                                <line x1="12" y1="5" x2="12" y2="19" />
+                                <line x1="5" y1="12" x2="19" y2="12" />
+                              </svg>
+                            </>
+                          )}
+                        </div>
                       </div>
                     )}
                   </div>

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -417,17 +417,26 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       }
     };
 
-    // During active drag, suppress native touch gestures globally.
-    // This prevents SFSafariViewController's sheet dismiss gesture
-    // (and similar in-app browser overlays) from intercepting vertical drags.
+    // During active drag, completely freeze the page to prevent
+    // SFSafariViewController's sheet dismiss gesture from firing.
+    // The sheet's dismiss is triggered by overscroll at the top of the page,
+    // so we lock the body in place and block all scroll/overscroll propagation.
     const handleTouchMove = (e: TouchEvent) => {
       if (dragState.isDragging) {
         e.preventDefault();
       }
     };
 
+    let savedScrollY = 0;
     if (dragState.isDragging) {
+      savedScrollY = window.scrollY;
       document.body.style.touchAction = 'none';
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${savedScrollY}px`;
+      document.body.style.left = '0';
+      document.body.style.right = '0';
+      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overscrollBehavior = 'none';
       document.addEventListener('touchmove', handleTouchMove, { passive: false });
     }
 
@@ -443,6 +452,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       document.removeEventListener('touchmove', handleTouchMove);
       if (dragState.isDragging) {
         document.body.style.touchAction = '';
+        document.body.style.position = '';
+        document.body.style.top = '';
+        document.body.style.left = '';
+        document.body.style.right = '';
+        document.body.style.overflow = '';
+        document.documentElement.style.overscrollBehavior = '';
+        window.scrollTo(0, savedScrollY);
       }
     };
   }, [dragState.isDragging, handleDragMove, finishDrag]);

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1016,12 +1016,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                     ${disabled ? 'cursor-not-allowed bg-gray-200 dark:bg-gray-600' : 'cursor-grab active:cursor-grabbing bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800'}
                     ${keyboardMode && focusedItemId === option.id ? 'ring-2 ring-blue-500 ring-offset-2' : ''}
                     border border-gray-300 dark:border-gray-500 p-3 select-none
-                    transition-colors duration-150
                   `}
                   style={{
                     top: `${option.top}px`,
                     height: `${itemHeight}px`,
-                    transition: dragState.isDragging ? 'top 0.2s ease' : 'top 0.3s ease',
+                    transition: dragState.isDragging
+                      ? 'top 0.2s ease, background-color 0.15s, color 0.15s'
+                      : 'top 0.3s ease, background-color 0.15s, color 0.15s',
                     zIndex: 1
                   }}
                   onKeyDown={!disabled ? (e) => handleKeyDown(e, option.id) : undefined}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -110,11 +110,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   const noPreferenceContainerRef = useRef<HTMLDivElement>(null);
   const elementRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  // Synchronous refs for tap/drag disambiguation (React state is async,
-  // so pointerup can fire before re-render and miss the drag state)
-  const dragStartPosRef = useRef<{ x: number; y: number } | null>(null);
-  const draggedIdForTapRef = useRef<string | null>(null);
-  const tapHandledRef = useRef(false);
+  // Pending drag ref: tracks pointer-down state before drag actually starts.
+  // Drag only starts after the pointer moves >8px — taps never enter drag state.
+  const pendingDragRef = useRef<{
+    id: string;
+    startX: number;
+    startY: number;
+    started: boolean; // true once movement threshold exceeded and startDrag called
+  } | null>(null);
 
   // Update positions of all items based on current order
   const updateItemPositions = useCallback((itemList: RankableOption[]) => {
@@ -176,19 +179,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     return null;
   }, [getIndexFromY, mainList.length, noPreferenceList.length, dragState.sourceList]);
 
-  // Get coordinates from either mouse or touch event
-  const getEventCoords = useCallback((e: React.PointerEvent | PointerEvent) => {
-    return { x: e.clientX, y: e.clientY };
-  }, []);
-
-  // Start dragging an item
-  const startDrag = useCallback((e: React.PointerEvent, id: string) => {
+  // Start dragging an item (called after pointer has moved beyond threshold)
+  const startDrag = useCallback((clientX: number, clientY: number, id: string) => {
     if (disabled || dragState.isDragging) return;
 
     // Find the item in either list
     let itemIndex = mainList.findIndex(item => item.id === id);
     let sourceList: 'main' | 'noPreference' = 'main';
-    
+
     if (itemIndex === -1) {
       itemIndex = noPreferenceList.findIndex(item => item.id === id);
       sourceList = 'noPreference';
@@ -199,7 +197,6 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     if (!element) return;
 
     const rect = element.getBoundingClientRect();
-    const coords = getEventCoords(e);
 
     // Store drag state
     setDragState({
@@ -210,19 +207,19 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       sourceList,
       targetList: sourceList,
       mouseOffset: {
-        x: coords.x - rect.left,
-        y: coords.y - rect.top
+        x: clientX - rect.left,
+        y: clientY - rect.top
       },
-      mousePosition: coords
+      mousePosition: { x: clientX, y: clientY }
     });
-  }, [disabled, dragState.isDragging, mainList, noPreferenceList, getEventCoords]);
+  }, [disabled, dragState.isDragging, mainList, noPreferenceList]);
 
   // Handle drag movement
   const handleDragMove = useCallback((e: PointerEvent) => {
     if (!dragState.isDragging) return;
 
     e.preventDefault();
-    const coords = getEventCoords(e);
+    const coords = { x: e.clientX, y: e.clientY };
     const dropTarget = getDropTarget(coords.x, coords.y);
 
     let newTargetList = dragState.targetList;
@@ -322,7 +319,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         }
       });
     }
-  }, [dragState, getEventCoords, getDropTarget, totalItemHeight]);
+  }, [dragState, getDropTarget, totalItemHeight]);
 
   // Complete the drag operation
   const finishDrag = useCallback(() => {
@@ -412,19 +409,29 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   // Set up event listeners
   useEffect(() => {
     const handleMove = (e: PointerEvent) => {
+      // Check for pending drag that hasn't started yet
+      const pending = pendingDragRef.current;
+      if (pending && !pending.started) {
+        const dx = Math.abs(e.clientX - pending.startX);
+        const dy = Math.abs(e.clientY - pending.startY);
+        if (dx > 8 || dy > 8) {
+          // Movement exceeded threshold — start the actual drag
+          pending.started = true;
+          startDrag(pending.startX, pending.startY, pending.id);
+        }
+        return; // Don't process as drag move until next event after startDrag re-renders
+      }
+
       if (dragState.isDragging) {
         handleDragMove(e);
       }
     };
 
     const handleEnd = () => {
-      if (dragState.isDragging && !tapHandledRef.current) {
+      if (dragState.isDragging) {
         finishDrag();
       }
-      // Clear refs on any pointer end
-      dragStartPosRef.current = null;
-      draggedIdForTapRef.current = null;
-      tapHandledRef.current = false;
+      pendingDragRef.current = null;
     };
 
     // During active drag, completely freeze the page to prevent
@@ -471,7 +478,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         window.scrollTo(0, savedScrollY);
       }
     };
-  }, [dragState.isDragging, handleDragMove, finishDrag]);
+  }, [dragState.isDragging, handleDragMove, finishDrag, startDrag]);
 
   // Track if component has mounted
   const hasMountedRef = useRef(false);
@@ -723,13 +730,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     // from intercepting the touch as a dismiss gesture.
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
 
-    // Set refs synchronously so pointerup can detect taps even before React re-renders
-    dragStartPosRef.current = { x: e.clientX, y: e.clientY };
-    draggedIdForTapRef.current = id;
-    tapHandledRef.current = false;
-
-    startDrag(e, id);
-  }, [disabled, startDrag]);
+    // Only record intent — actual drag starts after pointer moves >8px
+    pendingDragRef.current = {
+      id,
+      startX: e.clientX,
+      startY: e.clientY,
+      started: false
+    };
+  }, [disabled]);
 
   // Handle keyboard navigation
   const handleKeyDown = useCallback((e: React.KeyboardEvent, id: string) => {
@@ -1055,34 +1063,26 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                           handlePointerStart(e, option.id);
                         } : undefined}
                         onPointerUp={!disabled ? (e) => {
-                          // Use refs for tap detection (React state may not have updated yet)
-                          const startPos = dragStartPosRef.current;
-                          const draggedId = draggedIdForTapRef.current;
-                          if (startPos && draggedId === option.id) {
-                            const dx = Math.abs(e.clientX - startPos.x);
-                            const dy = Math.abs(e.clientY - startPos.y);
-                            if (dx < 8 && dy < 8) {
-                              // It was a tap, not a drag — mark as handled so document handler skips finishDrag
-                              tapHandledRef.current = true;
-                              // Cancel the drag without applying drag-based repositioning
-                              finishDrag();
+                          // If drag never started (pointer moved <8px), it's a tap
+                          const pending = pendingDragRef.current;
+                          if (pending && !pending.started && pending.id === option.id) {
+                            pendingDragRef.current = null; // Clear before document handler runs
 
-                              const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                              const relativeY = e.clientY - rect.top;
-                              const half = rect.height / 2;
+                            const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                            const relativeY = e.clientY - rect.top;
+                            const half = rect.height / 2;
 
-                              if (listType === 'noPreference') {
-                                moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
-                              } else if (relativeY < half) {
-                                if (index > 0) {
-                                  moveItemInList(listType, index, index - 1);
-                                }
+                            if (listType === 'noPreference') {
+                              moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
+                            } else if (relativeY < half) {
+                              if (index > 0) {
+                                moveItemInList(listType, index, index - 1);
+                              }
+                            } else {
+                              if (index < listItems.length - 1) {
+                                moveItemInList(listType, index, index + 1);
                               } else {
-                                if (index < listItems.length - 1) {
-                                  moveItemInList(listType, index, index + 1);
-                                } else {
-                                  moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
-                                }
+                                moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
                               }
                             }
                           }

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -836,75 +836,82 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     }
   }, [disabled, mainList, noPreferenceList, keyboardMode, focusedItemId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Helper function to move items within the same list
+  // Helper function to move items within the same list (with animation)
   const moveItemInList = useCallback((listType: 'main' | 'noPreference', fromIndex: number, toIndex: number) => {
-    if (listType === 'main') {
-      setMainList(prev => {
-        const newList = [...prev];
-        const [item] = newList.splice(fromIndex, 1);
-        newList.splice(toIndex, 0, item);
-        const updatedList = updateItemPositions(newList);
-        
-        // Parent notification will be handled by useEffect
-        
-        return updatedList;
+    const setter = listType === 'main' ? setMainList : setNoPreferenceList;
+
+    // Step 1: Update top positions WITHOUT reordering the array.
+    // This triggers CSS transition on the displaced items.
+    setter(prev => {
+      const updated = prev.map((item, i) => {
+        if (i === fromIndex) return { ...item, top: toIndex * totalItemHeight };
+        // Shift items between fromIndex and toIndex
+        if (fromIndex < toIndex && i > fromIndex && i <= toIndex) {
+          return { ...item, top: (i - 1) * totalItemHeight };
+        }
+        if (fromIndex > toIndex && i >= toIndex && i < fromIndex) {
+          return { ...item, top: (i + 1) * totalItemHeight };
+        }
+        return item;
       });
-    } else {
-      setNoPreferenceList(prev => {
+      return updated;
+    });
+
+    // Step 2: After the transition starts, reorder the array to match.
+    requestAnimationFrame(() => {
+      setter(prev => {
         const newList = [...prev];
         const [item] = newList.splice(fromIndex, 1);
         newList.splice(toIndex, 0, item);
         return updateItemPositions(newList);
       });
-    }
-  }, [updateItemPositions]);
+    });
+  }, [updateItemPositions, totalItemHeight]);
 
-  // Helper function to move items between lists
+  // Helper function to move items between lists (with animation)
   const moveItemBetweenLists = useCallback((
-    itemId: string, 
-    sourceList: 'main' | 'noPreference', 
-    sourceIndex: number, 
-    targetList: 'main' | 'noPreference', 
+    itemId: string,
+    sourceList: 'main' | 'noPreference',
+    sourceIndex: number,
+    targetList: 'main' | 'noPreference',
     targetIndex: number
   ) => {
     const sourceListRef = sourceList === 'main' ? mainList : noPreferenceList;
     const item = sourceListRef[sourceIndex];
-    
+
     if (!item) return;
 
-    // Remove from source list
-    if (sourceList === 'main') {
-      setMainList(prev => {
-        const newList = [...prev];
-        newList.splice(sourceIndex, 1);
-        return updateItemPositions(newList);
-      });
-    } else {
-      setNoPreferenceList(prev => {
-        const newList = [...prev];
-        newList.splice(sourceIndex, 1);
-        return updateItemPositions(newList);
-      });
-    }
+    const sourceSetter = sourceList === 'main' ? setMainList : setNoPreferenceList;
+    const targetSetter = targetList === 'main' ? setMainList : setNoPreferenceList;
 
-    // Add to target list
-    if (targetList === 'main') {
-      setMainList(prev => {
-        const newList = [...prev];
-        newList.splice(targetIndex, 0, item);
-        const updatedList = updateItemPositions(newList);
-        
-        // Parent notification will be handled by useEffect
-        
-        return updatedList;
+    // Step 1: Animate positions — shift items in source list up to close gap,
+    // shift items in target list down to make room, then do the actual splice in rAF.
+    sourceSetter(prev => {
+      return prev.map((it, i) => {
+        if (i > sourceIndex) return { ...it, top: (i - 1) * totalItemHeight };
+        return it;
       });
-    } else {
-      setNoPreferenceList(prev => {
+    });
+    targetSetter(prev => {
+      return prev.map((it, i) => {
+        if (i >= targetIndex) return { ...it, top: (i + 1) * totalItemHeight };
+        return it;
+      });
+    });
+
+    // Step 2: After transitions start, do the actual array reorder
+    requestAnimationFrame(() => {
+      sourceSetter(prev => {
+        const newList = [...prev];
+        newList.splice(sourceIndex, 1);
+        return updateItemPositions(newList);
+      });
+      targetSetter(prev => {
         const newList = [...prev];
         newList.splice(targetIndex, 0, item);
         return updateItemPositions(newList);
       });
-    }
+    });
   }, [mainList, noPreferenceList, updateItemPositions]);
 
   // Render a single list container (main or no preference)

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -417,6 +417,20 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       }
     };
 
+    // During active drag, suppress native touch gestures globally.
+    // This prevents SFSafariViewController's sheet dismiss gesture
+    // (and similar in-app browser overlays) from intercepting vertical drags.
+    const handleTouchMove = (e: TouchEvent) => {
+      if (dragState.isDragging) {
+        e.preventDefault();
+      }
+    };
+
+    if (dragState.isDragging) {
+      document.body.style.touchAction = 'none';
+      document.addEventListener('touchmove', handleTouchMove, { passive: false });
+    }
+
     // Add event listeners to document for better capture
     document.addEventListener('pointermove', handleMove);
     document.addEventListener('pointerup', handleEnd);
@@ -426,6 +440,10 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       document.removeEventListener('pointermove', handleMove);
       document.removeEventListener('pointerup', handleEnd);
       document.removeEventListener('pointercancel', handleEnd);
+      document.removeEventListener('touchmove', handleTouchMove);
+      if (dragState.isDragging) {
+        document.body.style.touchAction = '';
+      }
     };
   }, [dragState.isDragging, handleDragMove, finishDrag]);
 

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -702,9 +702,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
 
   const handlePointerStart = useCallback((e: React.PointerEvent, id: string) => {
     if (disabled) return;
-    
+
     e.preventDefault();
     e.stopPropagation();
+    // Capture the pointer to this element — routes all subsequent pointer events
+    // here and prevents the hosting view (e.g. SFSafariViewController sheet)
+    // from intercepting the touch as a dismiss gesture.
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
     startDrag(e, id);
   }, [disabled, startDrag]);
 
@@ -1054,7 +1058,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   };
 
   const renderRankableInterface = () => (
-    <div>
+    <div style={{ touchAction: 'none' }}>
       {/* Main ranking list */}
       {renderListContainer(
         mainList,

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1027,19 +1027,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                   aria-describedby={`${option.id}-instructions`}
                 >
                   <div className="flex items-center justify-between h-full relative">
-                    {/* Left drag handle with grabbable region */}
-                    <div
-                      className="absolute -left-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
-                      style={{
-                        width: 'calc(20% + 0.75rem)',
-                        touchAction: 'none',
-                        zIndex: 2
-                      }}
-                      onPointerDown={!disabled ? (e) => handlePointerStart(e, option.id) : undefined}
-                      title=""
-                    />
-
-                    {/* Center content - not grabbable */}
+                    {/* Content area - not draggable, allows normal scrolling */}
                     <div className={`flex-1 flex items-center pr-12 min-w-0 ${
                       disabled
                         ? 'text-gray-500 dark:text-gray-400'
@@ -1156,7 +1144,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   };
 
   const renderRankableInterface = () => (
-    <div style={{ touchAction: 'none' }}>
+    <div>
       {/* Main ranking list */}
       {renderListContainer(
         mainList,

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1055,7 +1055,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                           top: `-${gapSize / 2}px`,
                           bottom: `-${gapSize / 2}px`,
                           touchAction: 'none',
-                          zIndex: 2
+                          zIndex: 2,
+                          border: '2px solid red',
+                          background: 'rgba(255,0,0,0.1)'
                         }}
                         onPointerDown={!disabled ? (e) => {
                           // Always start drag — tap detection happens on pointerup

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -629,10 +629,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
             <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="min-w-0 overflow-hidden" />
           </div>
-          <div className="w-6 h-6 flex flex-col items-center justify-center ml-2">
-            <div className="w-4 h-0.5 bg-gray-600 mb-1"></div>
-            <div className="w-4 h-0.5 bg-gray-600 mb-1"></div>
-            <div className="w-4 h-0.5 bg-gray-600"></div>
+          <div className="flex flex-col items-center justify-center ml-2 text-gray-500">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="18 15 12 9 6 15" />
+            </svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
           </div>
         </div>
       </div>
@@ -1013,7 +1016,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                     />
 
                     {/* Center content - not grabbable */}
-                    <div className={`flex-1 flex items-center pr-12 min-w-0 ${
+                    <div className={`flex-1 flex items-center pr-10 min-w-0 ${
                       disabled
                         ? 'text-gray-500 dark:text-gray-400'
                         : 'text-gray-900 dark:text-white'
@@ -1021,24 +1024,45 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />
                     </div>
 
-                    {/* Right drag handle with grabbable region */}
+                    {/* Right side: up/down arrow buttons for tap-based reordering */}
                     {!disabled && (
-                      <div
-                        className="absolute -right-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
-                        style={{
-                          width: 'calc(20% + 0.75rem)',
-                          touchAction: 'none',
-                          zIndex: 2
-                        }}
-                        onPointerDown={(e) => handlePointerStart(e, option.id)}
-                        title=""
-                      >
-                        {/* Visual hamburger menu - positioned within the grabbable area */}
-                        <div className="absolute right-5 top-1/2 -translate-y-1/2 w-6 h-6 flex flex-col items-center justify-center">
-                          <div className="w-4 h-0.5 bg-gray-400 mb-1"></div>
-                          <div className="w-4 h-0.5 bg-gray-400 mb-1"></div>
-                          <div className="w-4 h-0.5 bg-gray-400"></div>
-                        </div>
+                      <div className="absolute right-1 top-1/2 -translate-y-1/2 flex flex-col gap-0.5" style={{ zIndex: 2 }}>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (index > 0) moveItemInList(listType, index, index - 1);
+                          }}
+                          disabled={index === 0}
+                          className={`w-7 h-7 flex items-center justify-center rounded transition-colors ${
+                            index === 0
+                              ? 'text-gray-300 dark:text-gray-600'
+                              : 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 active:bg-gray-300 dark:active:bg-gray-600'
+                          }`}
+                          aria-label="Move up"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                            <polyline points="18 15 12 9 6 15" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (index < listItems.length - 1) moveItemInList(listType, index, index + 1);
+                          }}
+                          disabled={index === listItems.length - 1}
+                          className={`w-7 h-7 flex items-center justify-center rounded transition-colors ${
+                            index === listItems.length - 1
+                              ? 'text-gray-300 dark:text-gray-600'
+                              : 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 active:bg-gray-300 dark:active:bg-gray-600'
+                          }`}
+                          aria-label="Move down"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
+                        </button>
                       </div>
                     )}
                   </div>

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1060,6 +1060,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                         onPointerUp={!disabled ? (e) => {
                           // If drag never started (pointer moved <8px), it's a tap
                           const pending = pendingDragRef.current;
+                          console.log('[TAP] pointerUp, pending:', !!pending, 'started:', pending?.started, 'id match:', pending?.id === option.id);
                           if (pending && !pending.started && pending.id === option.id) {
                             pendingDragRef.current = null; // Clear before document handler runs
 
@@ -1067,16 +1068,22 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                             const relativeY = e.clientY - rect.top;
                             const half = rect.height / 2;
 
+                            console.log('[TAP] detected tap on', option.text, 'listType:', listType, 'index:', index, 'relativeY:', relativeY.toFixed(0), 'half:', half.toFixed(0));
+
                             if (listType === 'noPreference') {
+                              console.log('[TAP] moving from noPreference to main');
                               moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
                             } else if (relativeY < half) {
                               if (index > 0) {
+                                console.log('[TAP] moving UP from', index, 'to', index - 1);
                                 moveItemInList(listType, index, index - 1);
                               }
                             } else {
                               if (index < listItems.length - 1) {
+                                console.log('[TAP] moving DOWN from', index, 'to', index + 1);
                                 moveItemInList(listType, index, index + 1);
                               } else {
+                                console.log('[TAP] moving to noPreference (was last in main)');
                                 moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
                               }
                             }

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1052,8 +1052,8 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                         className="absolute -right-3 cursor-grab active:cursor-grabbing"
                         style={{
                           width: 'calc(20% + 0.75rem)',
-                          top: `-${gapSize / 2}px`,
-                          bottom: `-${gapSize / 2}px`,
+                          top: `-${12 + gapSize / 2}px`,
+                          bottom: `-${12 + gapSize / 2}px`,
                           touchAction: 'none',
                           zIndex: 2,
                           border: '2px solid red',

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1049,9 +1049,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                          Drag starts on pointerdown; if released without moving, treated as tap */}
                     {!disabled && (
                       <div
-                        className="absolute -right-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
+                        className="absolute -right-3 cursor-grab active:cursor-grabbing"
                         style={{
                           width: 'calc(20% + 0.75rem)',
+                          top: `-${gapSize / 2}px`,
+                          bottom: `-${gapSize / 2}px`,
                           touchAction: 'none',
                           zIndex: 2
                         }}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -110,6 +110,12 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   const noPreferenceContainerRef = useRef<HTMLDivElement>(null);
   const elementRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
+  // Synchronous refs for tap/drag disambiguation (React state is async,
+  // so pointerup can fire before re-render and miss the drag state)
+  const dragStartPosRef = useRef<{ x: number; y: number } | null>(null);
+  const draggedIdForTapRef = useRef<string | null>(null);
+  const tapHandledRef = useRef(false);
+
   // Update positions of all items based on current order
   const updateItemPositions = useCallback((itemList: RankableOption[]) => {
     return itemList.map((item, index) => ({
@@ -412,9 +418,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     };
 
     const handleEnd = () => {
-      if (dragState.isDragging) {
+      if (dragState.isDragging && !tapHandledRef.current) {
         finishDrag();
       }
+      // Clear refs on any pointer end
+      dragStartPosRef.current = null;
+      draggedIdForTapRef.current = null;
+      tapHandledRef.current = false;
     };
 
     // During active drag, completely freeze the page to prevent
@@ -712,6 +722,12 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     // here and prevents the hosting view (e.g. SFSafariViewController sheet)
     // from intercepting the touch as a dismiss gesture.
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
+
+    // Set refs synchronously so pointerup can detect taps even before React re-renders
+    dragStartPosRef.current = { x: e.clientX, y: e.clientY };
+    draggedIdForTapRef.current = id;
+    tapHandledRef.current = false;
+
     startDrag(e, id);
   }, [disabled, startDrag]);
 
@@ -1024,7 +1040,8 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />
                     </div>
 
-                    {/* Right side: combined drag handle with tap zones for reordering */}
+                    {/* Right side: combined drag handle with tap zones for reordering
+                         Drag starts on pointerdown; if released without moving, treated as tap */}
                     {!disabled && (
                       <div
                         className="absolute -right-3 top-0 bottom-0 cursor-grab active:cursor-grabbing"
@@ -1034,42 +1051,41 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                           zIndex: 2
                         }}
                         onPointerDown={!disabled ? (e) => {
-                          // Determine if the tap is in the top or bottom third
-                          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                          const relativeY = e.clientY - rect.top;
-                          const third = rect.height / 3;
-
-                          if (listType === 'noPreference') {
-                            // In exclusion area: any tap moves to bottom of main list
-                            e.preventDefault();
-                            e.stopPropagation();
-                            moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
-                            return;
-                          }
-
-                          if (relativeY < third) {
-                            // Top third: move up (or do nothing if already at top)
-                            e.preventDefault();
-                            e.stopPropagation();
-                            if (index > 0) {
-                              moveItemInList(listType, index, index - 1);
-                            }
-                            return;
-                          } else if (relativeY > third * 2) {
-                            // Bottom third: move down, or to exclusion area if at bottom
-                            e.preventDefault();
-                            e.stopPropagation();
-                            if (index < listItems.length - 1) {
-                              moveItemInList(listType, index, index + 1);
-                            } else {
-                              // At bottom of main list: move to exclusion area
-                              moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
-                            }
-                            return;
-                          }
-
-                          // Middle third: start drag
+                          // Always start drag — tap detection happens on pointerup
                           handlePointerStart(e, option.id);
+                        } : undefined}
+                        onPointerUp={!disabled ? (e) => {
+                          // Use refs for tap detection (React state may not have updated yet)
+                          const startPos = dragStartPosRef.current;
+                          const draggedId = draggedIdForTapRef.current;
+                          if (startPos && draggedId === option.id) {
+                            const dx = Math.abs(e.clientX - startPos.x);
+                            const dy = Math.abs(e.clientY - startPos.y);
+                            if (dx < 8 && dy < 8) {
+                              // It was a tap, not a drag — mark as handled so document handler skips finishDrag
+                              tapHandledRef.current = true;
+                              // Cancel the drag without applying drag-based repositioning
+                              finishDrag();
+
+                              const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                              const relativeY = e.clientY - rect.top;
+                              const half = rect.height / 2;
+
+                              if (listType === 'noPreference') {
+                                moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
+                              } else if (relativeY < half) {
+                                if (index > 0) {
+                                  moveItemInList(listType, index, index - 1);
+                                }
+                              } else {
+                                if (index < listItems.length - 1) {
+                                  moveItemInList(listType, index, index + 1);
+                                } else {
+                                  moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
+                                }
+                              }
+                            }
+                          }
                         } : undefined}
                         title=""
                       >

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { flushSync } from 'react-dom';
 import { ClientOnlyDragDrop } from './ClientOnly';
 import type { OptionsMetadata } from '@/lib/types';
 import OptionLabel, { isLocationEntry } from './OptionLabel';
@@ -841,11 +842,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     const setter = listType === 'main' ? setMainList : setNoPreferenceList;
 
     // Step 1: Update top positions WITHOUT reordering the array.
-    // This triggers CSS transition on the displaced items.
-    setter(prev => {
-      const updated = prev.map((item, i) => {
+    // flushSync forces React to commit to DOM immediately so the browser
+    // can start CSS transitions before we reorder the array.
+    flushSync(() => {
+      setter(prev => prev.map((item, i) => {
         if (i === fromIndex) return { ...item, top: toIndex * totalItemHeight };
-        // Shift items between fromIndex and toIndex
         if (fromIndex < toIndex && i > fromIndex && i <= toIndex) {
           return { ...item, top: (i - 1) * totalItemHeight };
         }
@@ -853,8 +854,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           return { ...item, top: (i + 1) * totalItemHeight };
         }
         return item;
-      });
-      return updated;
+      }));
     });
 
     // Step 2: After the transition starts, reorder the array to match.
@@ -885,18 +885,17 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     const targetSetter = targetList === 'main' ? setMainList : setNoPreferenceList;
 
     // Step 1: Animate positions — shift items in source list up to close gap,
-    // shift items in target list down to make room, then do the actual splice in rAF.
-    sourceSetter(prev => {
-      return prev.map((it, i) => {
+    // shift items in target list down to make room.
+    // flushSync forces DOM commit so CSS transitions start before array reorder.
+    flushSync(() => {
+      sourceSetter(prev => prev.map((it, i) => {
         if (i > sourceIndex) return { ...it, top: (i - 1) * totalItemHeight };
         return it;
-      });
-    });
-    targetSetter(prev => {
-      return prev.map((it, i) => {
+      }));
+      targetSetter(prev => prev.map((it, i) => {
         if (i >= targetIndex) return { ...it, top: (i + 1) * totalItemHeight };
         return it;
-      });
+      }));
     });
 
     // Step 2: After transitions start, do the actual array reorder

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1056,8 +1056,6 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                           bottom: `-${12 + gapSize / 2}px`,
                           touchAction: 'none',
                           zIndex: 2,
-                          border: '2px solid red',
-                          background: 'rgba(255,0,0,0.1)'
                         }}
                         onPointerDown={!disabled ? (e) => {
                           // Always start drag — tap detection happens on pointerup

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useCallback } from "react";
+import Countdown from "@/components/Countdown";
+import RankableOptions from "@/components/RankableOptions";
+import AbstainButton from "@/components/AbstainButton";
+import CompactNameField from "@/components/CompactNameField";
+import OptionLabel from "@/components/OptionLabel";
+import VoterList from "@/components/VoterList";
+import type { OptionsMetadata } from "@/lib/types";
+import type { ApiVote } from "@/lib/api";
+
+interface RankingSectionProps {
+  poll: any;
+  pollId: string;
+  pollOptions: string[];
+  rankedChoices: string[];
+  handleRankingChange: (choices: string[]) => void;
+  isAbstaining: boolean;
+  setIsAbstaining: (val: boolean) => void;
+  handleAbstain: () => void;
+  isSubmitting: boolean;
+  isPollClosed: boolean;
+  hasVoted: boolean;
+  isEditingRanking: boolean;
+  setIsEditingRanking: (val: boolean) => void;
+  userVoteData: any;
+  isLoadingVoteData: boolean;
+  voterName: string;
+  setVoterName: (name: string) => void;
+  handleVoteClick: () => void;
+  voteError: string | null;
+  voterListRefresh: number;
+  optionsMetadata: OptionsMetadata | null;
+  canSubmitSuggestions: boolean;
+  canSubmitRankings: boolean;
+  hasSuggestionPhase: boolean;
+  suggestionChoices: string[];
+  justCancelledAbstain: boolean;
+  twoOptionDisplayOrder: string[];
+}
+
+const rankingsVoterFilter = (v: ApiVote) => !!(v.ranked_choices && v.ranked_choices.length > 0);
+
+export default function RankingSection({
+  poll,
+  pollId,
+  pollOptions,
+  rankedChoices,
+  handleRankingChange,
+  isAbstaining,
+  setIsAbstaining,
+  handleAbstain,
+  isSubmitting,
+  isPollClosed,
+  hasVoted,
+  isEditingRanking,
+  setIsEditingRanking,
+  userVoteData,
+  isLoadingVoteData,
+  voterName,
+  setVoterName,
+  handleVoteClick,
+  voteError,
+  voterListRefresh,
+  optionsMetadata,
+  canSubmitSuggestions,
+  canSubmitRankings,
+  hasSuggestionPhase,
+  suggestionChoices,
+  justCancelledAbstain,
+  twoOptionDisplayOrder,
+}: RankingSectionProps) {
+  const hasSubmittedRankings = hasVoted && userVoteData?.ranked_choices?.length > 0;
+  const abstainedNoRanking = hasVoted && !userVoteData?.ranked_choices?.length && (userVoteData?.is_abstain || isAbstaining);
+
+  // During suggestion phase: show summary when user has voted and isn't editing rankings
+  const showSummary = canSubmitSuggestions && hasVoted && !isEditingRanking && (hasSubmittedRankings || abstainedNoRanking);
+  const showBallot = !showSummary;
+
+  const editButton = !isPollClosed && !isLoadingVoteData ? (
+    <button
+      onClick={() => setIsEditingRanking(true)}
+      className="px-3 py-1 bg-yellow-400 hover:bg-yellow-500 text-yellow-900 font-medium text-sm rounded-md transition-colors flex-shrink-0"
+    >
+      Edit
+    </button>
+  ) : null;
+
+  const handleSubmit = useCallback(() => {
+    handleVoteClick();
+  }, [handleVoteClick]);
+
+  if (!canSubmitRankings || pollOptions.length === 0) {
+    if (!canSubmitRankings && canSubmitSuggestions) {
+      return (
+        <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
+          <p className="text-blue-800 dark:text-blue-200 text-sm">
+            Ranking will open after suggestions cutoff in{' '}
+            <Countdown deadline={poll.suggestion_deadline!} onExpire={() => {}} />
+          </p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  // During suggestion phase, only show after user has submitted suggestions
+  if (canSubmitSuggestions && !hasVoted) return null;
+
+  return (
+    <>
+      {/* Early voting header during suggestion phase */}
+      {canSubmitSuggestions && !isEditingRanking && (
+        <>
+          <h3 className="text-lg font-semibold text-center text-gray-900 dark:text-white mt-4 mb-1">Early Voting</h3>
+          <Countdown deadline={poll.response_deadline || null} label="Preferences closing" />
+          <p className="text-center text-xs text-amber-700 dark:text-amber-300 mb-3">
+            Options may change until suggestions cutoff!
+          </p>
+        </>
+      )}
+
+      <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
+        {showSummary && hasSubmittedRankings && (
+          <>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-base font-medium text-gray-900 dark:text-white">Your ranking:</h4>
+              {editButton}
+            </div>
+            <div className="space-y-2">
+              {userVoteData.ranked_choices.map((choice: string, index: number) => (
+                <div key={index} className="flex items-center gap-2">
+                  <div className="flex-shrink-0" style={{ width: '32px' }}>
+                    <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                      {index + 1}
+                    </span>
+                  </div>
+                  <div className="flex-1 flex items-center p-2 bg-white dark:bg-gray-900 rounded min-w-0">
+                    <div className="min-w-0 overflow-hidden">
+                      <OptionLabel text={choice} metadata={optionsMetadata?.[choice]} />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {showSummary && abstainedNoRanking && !hasSubmittedRankings && (
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <h4 className="text-base font-medium text-gray-900 dark:text-white">Ranking:</h4>
+              <span className="text-sm text-gray-500 dark:text-gray-400">Not yet ranked</span>
+            </div>
+            {editButton}
+          </div>
+        )}
+
+        {showBallot && (
+          <>
+            {pollOptions.length === 2 ? (
+              <>
+                <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
+                  Select your preference
+                </h4>
+                <div className="flex gap-2">
+                  {twoOptionDisplayOrder.map((option: string) => (
+                    <button
+                      key={option}
+                      onClick={(e) => {
+                        if ((e.target as HTMLElement).closest?.('[data-place-name]')) return;
+                        handleRankingChange([option]);
+                        setIsAbstaining(false);
+                      }}
+                      disabled={isSubmitting}
+                      className={`flex-1 min-w-0 py-3 px-3 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                        rankedChoices[0] === option
+                          ? 'bg-blue-200 dark:bg-blue-800 text-blue-900 dark:text-blue-100 border-2 border-blue-400 dark:border-blue-600 active:bg-blue-300 dark:active:bg-blue-700'
+                          : 'bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 text-blue-800 dark:text-blue-200 border-2 border-transparent active:bg-blue-300 dark:active:bg-blue-700'
+                      }`}
+                    >
+                      <OptionLabel text={option} metadata={optionsMetadata?.[option]} layout="stacked" />
+                    </button>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <>
+                <h4 className="text-base font-medium text-gray-900 dark:text-white mb-3">
+                  Reorder from most to least preferred
+                </h4>
+                {pollOptions.length > 0 && (
+                  <RankableOptions
+                    key={isEditingRanking ? 'editing' : 'new'}
+                    options={pollOptions}
+                    onRankingChange={handleRankingChange}
+                    disabled={isSubmitting || (isAbstaining && !canSubmitSuggestions)}
+                    storageKey={pollId ? `poll-ranking-${pollId}` : undefined}
+                    initialRanking={isEditingRanking && userVoteData?.ranked_choices ? userVoteData.ranked_choices : undefined}
+                    optionsMetadata={optionsMetadata}
+                  />
+                )}
+              </>
+            )}
+
+            <AbstainButton
+              isAbstaining={isAbstaining}
+              onClick={handleAbstain}
+            />
+
+            {voteError && (
+              <div className="mt-4 p-3 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">
+                {voteError}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Ranking respondents */}
+      {hasSuggestionPhase && hasVoted && !isEditingRanking && !isLoadingVoteData && (
+        <div className="mt-2 mb-3">
+          <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Ranked" filter={rankingsVoterFilter} />
+        </div>
+      )}
+
+      {/* Name field and submit button */}
+      {showBallot && (
+        <>
+          <div className="mt-4">
+            <CompactNameField name={voterName} setName={setVoterName} />
+          </div>
+          <button
+            onClick={handleSubmit}
+            disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0)}
+            className="w-full mt-4 py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
+          >
+            {isSubmitting ? 'Submitting...' : 'Submit Vote'}
+          </button>
+        </>
+      )}
+    </>
+  );
+}

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -151,7 +151,9 @@ export default function RankingSection({
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <h4 className="text-base font-medium text-gray-900 dark:text-white">Ranking:</h4>
-              <span className="text-sm text-gray-500 dark:text-gray-400">Not yet ranked</span>
+              <span className="inline-flex items-center px-3 py-1 bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded-full text-sm font-medium">
+                Abstained
+              </span>
             </div>
             {editButton}
           </div>

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -98,7 +98,7 @@ export default function RankingSection({
         <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
           <p className="text-blue-800 dark:text-blue-200 text-sm">
             Ranking will open after suggestions cutoff in{' '}
-            <Countdown deadline={poll.suggestion_deadline!} onExpire={() => {}} />
+            <Countdown deadline={poll.suggestion_deadline!} />
           </p>
         </div>
       );

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCallback } from "react";
 import Countdown from "@/components/Countdown";
 import RankableOptions from "@/components/RankableOptions";
 import AbstainButton from "@/components/AbstainButton";
@@ -93,10 +92,6 @@ export default function RankingSection({
     </button>
   ) : null;
 
-  const handleSubmit = useCallback(() => {
-    handleVoteClick();
-  }, [handleVoteClick]);
-
   if (!canSubmitRankings || pollOptions.length === 0) {
     if (!canSubmitRankings && canSubmitSuggestions) {
       return (
@@ -116,7 +111,6 @@ export default function RankingSection({
 
   return (
     <>
-      {/* Early voting header during suggestion phase */}
       {canSubmitSuggestions && !isEditingRanking && (
         <>
           <h3 className="text-lg font-semibold text-center text-gray-900 dark:text-white mt-4 mb-1">Early Voting</h3>
@@ -226,21 +220,19 @@ export default function RankingSection({
         )}
       </div>
 
-      {/* Ranking respondents */}
       {hasSuggestionPhase && hasVoted && !isEditingRanking && !isLoadingVoteData && (
         <div className="mt-2 mb-3">
           <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} label="Ranked" filter={rankingsVoterFilter} />
         </div>
       )}
 
-      {/* Name field and submit button */}
       {showBallot && (
         <>
           <div className="mt-4">
             <CompactNameField name={voterName} setName={setVoterName} />
           </div>
           <button
-            onClick={handleSubmit}
+            onClick={handleVoteClick}
             disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0)}
             className="w-full mt-4 py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
           >

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -80,7 +80,13 @@ export default function RankingSection({
 
   const editButton = !isPollClosed && !isLoadingVoteData ? (
     <button
-      onClick={() => setIsEditingRanking(true)}
+      onClick={() => {
+        // Restore abstain state if user previously abstained from ranking
+        if (abstainedNoRanking && !hasSubmittedRankings) {
+          setIsAbstaining(true);
+        }
+        setIsEditingRanking(true);
+      }}
       className="px-3 py-1 bg-yellow-400 hover:bg-yellow-500 text-yellow-900 font-medium text-sm rounded-md transition-colors flex-shrink-0"
     >
       Edit
@@ -166,7 +172,7 @@ export default function RankingSection({
                 <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
                   Select your preference
                 </h4>
-                <div className="flex gap-2">
+                <div className={`flex gap-2 transition-opacity ${isAbstaining ? 'opacity-40 pointer-events-none' : ''}`}>
                   {twoOptionDisplayOrder.map((option: string) => (
                     <button
                       key={option}
@@ -175,7 +181,7 @@ export default function RankingSection({
                         handleRankingChange([option]);
                         setIsAbstaining(false);
                       }}
-                      disabled={isSubmitting}
+                      disabled={isSubmitting || isAbstaining}
                       className={`flex-1 min-w-0 py-3 px-3 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                         rankedChoices[0] === option
                           ? 'bg-blue-200 dark:bg-blue-800 text-blue-900 dark:text-blue-100 border-2 border-blue-400 dark:border-blue-600 active:bg-blue-300 dark:active:bg-blue-700'
@@ -197,7 +203,7 @@ export default function RankingSection({
                     key={isEditingRanking ? 'editing' : 'new'}
                     options={pollOptions}
                     onRankingChange={handleRankingChange}
-                    disabled={isSubmitting || (isAbstaining && !canSubmitSuggestions)}
+                    disabled={isSubmitting || isAbstaining}
                     storageKey={pollId ? `poll-ranking-${pollId}` : undefined}
                     initialRanking={isEditingRanking && userVoteData?.ranked_choices ? userVoteData.ranked_choices : undefined}
                     optionsMetadata={optionsMetadata}

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -230,7 +230,7 @@ export default function SuggestionVotingInterface({
 
         {/* Suggestion respondents */}
         {!isPollClosed && !isLoadingVoteData && (
-          <div className="mt-3">
+          <div className="mt-5">
             <VoterList pollId={poll.id} refreshTrigger={0} label="Suggested" filter={hasSuggestions} />
           </div>
         )}

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -38,10 +38,6 @@ interface SuggestionVotingInterfaceProps {
   loadingResults: boolean;
   loadExistingSuggestions: () => void;
   onFollowUpClick: () => void;
-  suggestions: string[];
-  loadingSuggestions: boolean;
-  onVoteOnSuggestionsClick: () => void;
-  autoCreatePreferences?: boolean;
   suggestionMetadata?: OptionsMetadata;
   onSuggestionMetadataChange?: (metadata: OptionsMetadata) => void;
   optionsMetadata?: OptionsMetadata | null;
@@ -72,10 +68,6 @@ export default function SuggestionVotingInterface({
   loadingResults,
   loadExistingSuggestions,
   onFollowUpClick,
-  suggestions,
-  loadingSuggestions,
-  onVoteOnSuggestionsClick,
-  autoCreatePreferences,
   suggestionMetadata,
   onSuggestionMetadataChange,
   optionsMetadata,
@@ -248,37 +240,7 @@ export default function SuggestionVotingInterface({
               </svg>
               <span className="font-semibold">Follow up</span>
             </GradientBorderButton>
-            {suggestions.length >= 2 && !autoCreatePreferences && (
-              <GradientBorderButton
-                onClick={onVoteOnSuggestionsClick}
-                disabled={loadingSuggestions}
-                gradient="red-orange"
-              >
-                {loadingSuggestions ? (
-                  <>
-                    <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 718-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    <span className="font-semibold">Loading...</span>
-                  </>
-                ) : (
-                  <>
-                    <span className="font-semibold">Vote on it</span>
-                    <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={4}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M21 10H11a8 8 0 00-8 8v2M21 10l-6 6m6-6l-6-6" />
-                    </svg>
-                  </>
-                )}
-              </GradientBorderButton>
-            )}
           </div>
-        )}
-
-        {!isPollClosed && !isLoadingVoteData && autoCreatePreferences && (
-          <p className="mt-3 px-3 py-2 text-xs text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
-            A preferences poll will be created automatically when this poll closes.
-          </p>
         )}
 
         {/* Show follow-up/fork header after Follow up button when voted */}
@@ -363,7 +325,6 @@ export default function SuggestionVotingInterface({
             options={newSuggestions}
             setOptions={setNewSuggestions}
             isLoading={isSubmitting}
-            pollType="suggestion"
             label={isEditingVote ? "Add new suggestions:" : "Add new suggestions:"}
             category={poll.category || 'custom'}
             optionsMetadata={suggestionMetadata}

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -9,7 +9,6 @@ import CompactNameField from "@/components/CompactNameField";
 import OptionLabel from "@/components/OptionLabel";
 import PollManagementButtons from "@/components/PollManagementButtons";
 import VoterList from "@/components/VoterList";
-import GradientBorderButton from "@/components/GradientBorderButton";
 import FollowUpHeader from "@/components/FollowUpHeader";
 import ForkHeader from "@/components/ForkHeader";
 
@@ -37,7 +36,6 @@ interface SuggestionVotingInterfaceProps {
   pollResults: any;
   loadingResults: boolean;
   loadExistingSuggestions: () => void;
-  onFollowUpClick: () => void;
   suggestionMetadata?: OptionsMetadata;
   onSuggestionMetadataChange?: (metadata: OptionsMetadata) => void;
   optionsMetadata?: OptionsMetadata | null;
@@ -67,7 +65,6 @@ export default function SuggestionVotingInterface({
   pollResults,
   loadingResults,
   loadExistingSuggestions,
-  onFollowUpClick,
   suggestionMetadata,
   onSuggestionMetadataChange,
   optionsMetadata,
@@ -228,30 +225,7 @@ export default function SuggestionVotingInterface({
           )}
         </div>
 
-        {/* Follow Up Button - shown when poll is open and user has voted */}
-        {!isPollClosed && !isLoadingVoteData && (
-          <div className="mt-4 flex justify-between items-center">
-            <GradientBorderButton
-              onClick={onFollowUpClick}
-              gradient="blue-purple"
-            >
-              <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={4}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-              </svg>
-              <span className="font-semibold">Follow up</span>
-            </GradientBorderButton>
-          </div>
-        )}
-
-        {/* Show follow-up/fork header after Follow up button when voted */}
-        {!isPollClosed && !isLoadingVoteData && (
-          <div className="mt-4">
-            {poll.follow_up_to && <FollowUpHeader followUpToPollId={poll.follow_up_to} />}
-            {poll.fork_of && <ForkHeader forkOfPollId={poll.fork_of} />}
-          </div>
-        )}
-
-        {/* Voter list for open suggestion polls - shown after Follow-up button when voted */}
+        {/* Voter list for open suggestion polls */}
         {!isPollClosed && !isLoadingVoteData && (
           <div className="mt-8">
             <VoterList pollId={poll.id} refreshTrigger={0} />

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -7,7 +7,6 @@ import { isLocationLikeCategory } from "@/components/TypeFieldInput";
 import type { ApiVote } from "@/lib/api";
 
 const hasSuggestions = (v: ApiVote) => !!(v.suggestions && v.suggestions.length > 0);
-const hasRankings = (v: ApiVote) => !!(v.ranked_choices && v.ranked_choices.length > 0);
 import SuggestionsList from "@/components/SuggestionsList";
 import CompactNameField from "@/components/CompactNameField";
 import OptionLabel from "@/components/OptionLabel";
@@ -229,11 +228,10 @@ export default function SuggestionVotingInterface({
           )}
         </div>
 
-        {/* Voter lists for suggestion polls */}
+        {/* Suggestion respondents */}
         {!isPollClosed && !isLoadingVoteData && (
-          <div className="mt-4 space-y-2">
+          <div className="mt-3">
             <VoterList pollId={poll.id} refreshTrigger={0} label="Suggested" filter={hasSuggestions} />
-            <VoterList pollId={poll.id} refreshTrigger={0} label="Ranked" filter={hasRankings} />
           </div>
         )}
       </div>

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -5,14 +5,14 @@ import PollResultsDisplay from "@/components/PollResults";
 import OptionsInput, { type OptionsMetadata } from "@/components/OptionsInput";
 import { isLocationLikeCategory } from "@/components/TypeFieldInput";
 import type { ApiVote } from "@/lib/api";
-
-const hasSuggestions = (v: ApiVote) => !!(v.suggestions && v.suggestions.length > 0);
 import SuggestionsList from "@/components/SuggestionsList";
 import CompactNameField from "@/components/CompactNameField";
 import OptionLabel from "@/components/OptionLabel";
 import PollManagementButtons from "@/components/PollManagementButtons";
 import VoterList from "@/components/VoterList";
 import FollowUpHeader from "@/components/FollowUpHeader";
+
+const hasSuggestions = (v: ApiVote) => !!(v.suggestions && v.suggestions.length > 0);
 import ForkHeader from "@/components/ForkHeader";
 
 interface SuggestionVotingInterfaceProps {

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -4,6 +4,10 @@ import { useState, useRef, useEffect, Dispatch, SetStateAction } from "react";
 import PollResultsDisplay from "@/components/PollResults";
 import OptionsInput, { type OptionsMetadata } from "@/components/OptionsInput";
 import { isLocationLikeCategory } from "@/components/TypeFieldInput";
+import type { ApiVote } from "@/lib/api";
+
+const hasSuggestions = (v: ApiVote) => !!(v.suggestions && v.suggestions.length > 0);
+const hasRankings = (v: ApiVote) => !!(v.ranked_choices && v.ranked_choices.length > 0);
 import SuggestionsList from "@/components/SuggestionsList";
 import CompactNameField from "@/components/CompactNameField";
 import OptionLabel from "@/components/OptionLabel";
@@ -225,10 +229,11 @@ export default function SuggestionVotingInterface({
           )}
         </div>
 
-        {/* Voter list for open suggestion polls */}
+        {/* Voter lists for suggestion polls */}
         {!isPollClosed && !isLoadingVoteData && (
-          <div className="mt-8">
-            <VoterList pollId={poll.id} refreshTrigger={0} />
+          <div className="mt-4 space-y-2">
+            <VoterList pollId={poll.id} refreshTrigger={0} label="Suggested" filter={hasSuggestions} />
+            <VoterList pollId={poll.id} refreshTrigger={0} label="Ranked" filter={hasRankings} />
           </div>
         )}
       </div>

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -62,7 +62,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger, labe
 
   if (initialLoading) {
     return (
-      <div className={`flex flex-wrap items-center gap-1.5 ${className}`}>
+      <div className={`flex flex-wrap items-center gap-1.5 ml-2 ${className}`}>
         <span className="text-sm text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>👥</span>
         {[1, 2, 3].map((i) => (
           <div
@@ -128,9 +128,9 @@ export default function VoterList({ pollId, className = "", refreshTrigger, labe
   };
 
   return (
-    <div className={`flex flex-wrap items-center gap-1.5 ${className}`}>
+    <div className={`flex flex-wrap items-center gap-1.5 ml-2 ${className}`}>
       <span className="text-sm text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>
-        👥 {voters.length}
+        {voters.length} 👥
       </span>
 
       {namedVoters.map((voter, index) => {

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { apiGetVotes } from '@/lib/api';
+import { apiGetVotes, ApiVote } from '@/lib/api';
 
 interface Voter {
   id: string;
@@ -11,12 +11,12 @@ interface Voter {
 interface VoterListProps {
   pollId: string;
   className?: string;
-  refreshTrigger?: number; // Optional prop to trigger refresh
+  refreshTrigger?: number;
+  label?: string;
+  filter?: (vote: ApiVote) => boolean;
 }
 
-const CARD_CLASS = "bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm";
-
-export default function VoterList({ pollId, className = "", refreshTrigger }: VoterListProps) {
+export default function VoterList({ pollId, className = "", refreshTrigger, label, filter }: VoterListProps) {
   const [voters, setVoters] = useState<Voter[]>([]);
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -25,10 +25,10 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
   const fetchVoters = useCallback(async () => {
     try {
-      const votes = await apiGetVotes(pollId);
+      let votes = await apiGetVotes(pollId);
+      if (filter) votes = votes.filter(filter);
       const voterData: Voter[] = votes.map(v => ({ id: v.id, voter_name: v.voter_name }));
 
-      // Skip state updates if voter list hasn't changed
       const newKey = voterData.map(v => `${v.id}:${v.voter_name ?? ''}`).join(',');
       if (newKey !== voterIdsRef.current) {
         voterIdsRef.current = newKey;
@@ -44,7 +44,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
     } finally {
       setInitialLoading(false);
     }
-  }, [pollId]);
+  }, [pollId, filter]);
 
   useEffect(() => {
     if (pollId) {
@@ -62,37 +62,20 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
 
   if (initialLoading) {
     return (
-      <div className={`${CARD_CLASS} ${className}`}>
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
-          {/* Shimmer effect for loading voter bubbles */}
-          {[1, 2, 3, 4, 5].map((i) => (
-            <div
-              key={i}
-              className="animate-pulse inline-block px-3 py-1 rounded-full bg-gray-200 dark:bg-gray-700"
-              style={{
-                width: `${60 + (i * 15) % 40}px`,
-                height: '28px'
-              }}
-            />
-          ))}
-        </div>
+      <div className={`flex flex-wrap items-center gap-1.5 ${className}`}>
+        <span className="text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>✓</span>
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="animate-pulse inline-block px-2.5 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700"
+            style={{ width: `${50 + (i * 12) % 30}px`, height: '24px' }}
+          />
+        ))}
       </div>
     );
   }
 
-  if (error) {
-    return (
-      <div className={`${CARD_CLASS} ${className}`}>
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">Respondents</span>
-          <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
-        </div>
-      </div>
-    );
-  }
-
-  if (voters.length === 0) {
+  if (error || voters.length === 0) {
     return null;
   }
 
@@ -102,48 +85,34 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
     try {
       const pollVoteIds = JSON.parse(localStorage.getItem('pollVoteIds') || '{}');
       return pollVoteIds[pollId] || null;
-    } catch (error) {
-      console.error('Error getting vote ID:', error);
+    } catch {
       return null;
     }
   };
 
   const currentUserVoteId = getUserVoteId();
-
-  // Check if current user is in the voter list (could be named or anonymous)
   const currentUserVote = currentUserVoteId
     ? voters.find(v => v.id === currentUserVoteId)
     : null;
 
-  // Get named voters (excluding anonymous ones and current user if anonymous)
   let allNamedVoters = voters
     .filter(vote => vote.voter_name && vote.voter_name.trim() !== '')
-    .sort((a, b) => {
-      const nameA = (a.voter_name || '').toLowerCase();
-      const nameB = (b.voter_name || '').toLowerCase();
-      return nameA.localeCompare(nameB);
-    });
+    .sort((a, b) => (a.voter_name || '').toLowerCase().localeCompare((b.voter_name || '').toLowerCase()));
 
-  // Separate current user from other named voters
   const currentUserIsNamed = currentUserVote && currentUserVote.voter_name && currentUserVote.voter_name.trim() !== '';
 
   const otherVoters = currentUserIsNamed
     ? allNamedVoters.filter(v => v.id !== currentUserVote.id)
     : allNamedVoters;
 
-  // Combine: current user first (if named or exists), then others
-  const namedVoters = currentUserIsNamed
+  const namedVoters = currentUserVote
     ? [currentUserVote, ...otherVoters]
-    : currentUserVote
-      ? [currentUserVote, ...otherVoters]  // Include anonymous current user
-      : otherVoters;
+    : otherVoters;
 
-  // Adjust anonymous count to exclude current user if they voted anonymously
   const adjustedAnonymousCount = currentUserVote && !currentUserIsNamed
     ? anonymousCount - 1
     : anonymousCount;
 
-  // Generate consistent colors for voter bubbles
   const getVoterColor = (index: number) => {
     const colors = [
       'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
@@ -159,38 +128,34 @@ export default function VoterList({ pollId, className = "", refreshTrigger }: Vo
   };
 
   return (
-    <div className={`${CARD_CLASS} ${className}`}>
-      <div className="flex flex-wrap items-center gap-1.5">
-        <span className="text-lg font-bold text-gray-900 dark:text-white mr-1">
-          Respondents ({voters.length})
-        </span>
+    <div className={`flex flex-wrap items-center gap-1.5 ${className}`}>
+      <span className="text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>
+        ✓ {voters.length}
+      </span>
 
-        {/* Named voters - displayed as colored bubbles in a flowing layout */}
-        {namedVoters.map((voter, index) => {
-          const isCurrentUser = currentUserVote && voter.id === currentUserVote.id;
-          const displayName = isCurrentUser
-            ? (voter.voter_name ? `You (${voter.voter_name})` : 'You')
-            : voter.voter_name;
+      {namedVoters.map((voter, index) => {
+        const isCurrentUser = currentUserVote && voter.id === currentUserVote.id;
+        const displayName = isCurrentUser
+          ? (voter.voter_name ? `You (${voter.voter_name})` : 'You')
+          : voter.voter_name;
 
-          return (
-            <span
-              key={voter.id}
-              className={`inline-block px-3 py-1 rounded-full text-sm ${
-                isCurrentUser ? 'font-bold ring-2 ring-blue-500 dark:ring-blue-400' : 'font-medium'
-              } ${getVoterColor(index)}`}
-            >
-              {displayName}
-            </span>
-          );
-        })}
-
-        {/* Anonymous voters count */}
-        {adjustedAnonymousCount > 0 && (
-          <span className="inline-block px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600 text-sm text-gray-600 dark:text-gray-300 italic">
-            {adjustedAnonymousCount} × Anonymous
+        return (
+          <span
+            key={voter.id}
+            className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${
+              isCurrentUser ? 'font-bold ring-2 ring-blue-500 dark:ring-blue-400' : 'font-medium'
+            } ${getVoterColor(index)}`}
+          >
+            {displayName}
           </span>
-        )}
-      </div>
+        );
+      })}
+
+      {adjustedAnonymousCount > 0 && (
+        <span className="inline-block px-2.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded-full border border-gray-300 dark:border-gray-600 text-xs text-gray-600 dark:text-gray-300 italic">
+          {adjustedAnonymousCount} × Anon
+        </span>
+      )}
     </div>
   );
 }

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -62,7 +62,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger, labe
 
   if (initialLoading) {
     return (
-      <div className={`flex flex-wrap items-center gap-1.5 ml-2 ${className}`}>
+      <div className={`flex flex-wrap items-center justify-center gap-1.5 ${className}`}>
         <span className="text-sm text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>👥</span>
         {[1, 2, 3].map((i) => (
           <div
@@ -128,7 +128,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger, labe
   };
 
   return (
-    <div className={`flex flex-wrap items-center gap-1.5 ml-2 ${className}`}>
+    <div className={`flex flex-wrap items-center justify-center gap-1.5 ${className}`}>
       <span className="text-sm text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>
         {voters.length} 👥
       </span>

--- a/components/VoterList.tsx
+++ b/components/VoterList.tsx
@@ -63,7 +63,7 @@ export default function VoterList({ pollId, className = "", refreshTrigger, labe
   if (initialLoading) {
     return (
       <div className={`flex flex-wrap items-center gap-1.5 ${className}`}>
-        <span className="text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>✓</span>
+        <span className="text-sm text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>👥</span>
         {[1, 2, 3].map((i) => (
           <div
             key={i}
@@ -129,8 +129,8 @@ export default function VoterList({ pollId, className = "", refreshTrigger, labe
 
   return (
     <div className={`flex flex-wrap items-center gap-1.5 ${className}`}>
-      <span className="text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>
-        ✓ {voters.length}
+      <span className="text-sm text-gray-500 dark:text-gray-400 mr-0.5" title={label || "Respondents"}>
+        👥 {voters.length}
       </span>
 
       {namedVoters.map((voter, index) => {

--- a/database/migrations/084_merge_suggestion_into_ranked_choice_down.sql
+++ b/database/migrations/084_merge_suggestion_into_ranked_choice_down.sql
@@ -1,0 +1,50 @@
+-- Rollback: restore suggestion as a separate poll type
+
+-- 1. Restore vote_structure_valid constraint (suggestion-exclusive)
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_structure_valid;
+ALTER TABLE votes ADD CONSTRAINT vote_structure_valid CHECK (
+    (vote_type = 'yes_no' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'participation' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'ranked_choice' AND
+     yes_no_choice IS NULL AND
+     ((ranked_choices IS NOT NULL AND is_abstain = false) OR (ranked_choices IS NULL AND is_abstain = true)) AND
+     suggestions IS NULL) OR
+    (vote_type = 'suggestion' AND
+     yes_no_choice IS NULL AND
+     ranked_choices IS NULL AND
+     ((suggestions IS NOT NULL AND array_length(suggestions, 1) > 0 AND is_abstain = false) OR
+      ((suggestions IS NULL OR array_length(suggestions, 1) IS NULL) AND is_abstain = true)))
+);
+
+-- 2. Restore vote_type constraint (with 'suggestion')
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS votes_vote_type_check;
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_type_check;
+ALTER TABLE votes ADD CONSTRAINT votes_vote_type_check
+    CHECK (vote_type IN ('yes_no', 'ranked_choice', 'suggestion', 'participation'));
+
+-- 3. Restore poll_type constraint (with 'suggestion')
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_type_check;
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS poll_type_check;
+ALTER TABLE polls ADD CONSTRAINT polls_poll_type_check
+    CHECK (poll_type IN ('yes_no', 'ranked_choice', 'suggestion', 'participation'));
+
+-- 4. Restore suggestion votes
+UPDATE votes SET vote_type = 'suggestion'
+WHERE vote_type = 'ranked_choice'
+  AND suggestions IS NOT NULL
+  AND ranked_choices IS NULL;
+
+-- 5. Restore suggestion polls
+UPDATE polls SET poll_type = 'suggestion'
+WHERE poll_type = 'ranked_choice'
+  AND suggestion_deadline IS NOT NULL;
+
+-- 6. Remove new columns
+ALTER TABLE polls DROP COLUMN IF EXISTS suggestion_deadline;
+ALTER TABLE polls DROP COLUMN IF EXISTS allow_pre_ranking;

--- a/database/migrations/084_merge_suggestion_into_ranked_choice_up.sql
+++ b/database/migrations/084_merge_suggestion_into_ranked_choice_up.sql
@@ -1,0 +1,79 @@
+-- Merge suggestion polls into ranked_choice polls.
+-- Suggestion is now an optional first phase of a ranked_choice poll,
+-- controlled by a suggestion_deadline column.
+
+-- 1. Add suggestion_deadline and allow_pre_ranking to polls
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS suggestion_deadline TIMESTAMPTZ;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS allow_pre_ranking BOOLEAN DEFAULT true;
+
+-- 2. Migrate existing suggestion polls to ranked_choice with suggestion_deadline
+-- For open suggestion polls: move response_deadline → suggestion_deadline,
+-- set a new response_deadline based on auto_preferences_deadline_minutes (or default 2hr)
+UPDATE polls
+SET poll_type = 'ranked_choice',
+    suggestion_deadline = response_deadline,
+    response_deadline = CASE
+      WHEN auto_preferences_deadline_minutes IS NOT NULL
+        THEN response_deadline + (auto_preferences_deadline_minutes || ' minutes')::interval
+      ELSE response_deadline + interval '2 hours'
+    END
+WHERE poll_type = 'suggestion'
+  AND is_closed = false;
+
+-- For closed suggestion polls: set suggestion_deadline to when they closed (response_deadline)
+-- and keep response_deadline as-is (poll is already done)
+UPDATE polls
+SET poll_type = 'ranked_choice',
+    suggestion_deadline = response_deadline
+WHERE poll_type = 'suggestion'
+  AND is_closed = true;
+
+-- 3. Delete reserved placeholder preference polls (they're no longer needed)
+-- These are closed ranked_choice polls with NULL options that were created as follow-ups
+-- to suggestion polls via auto_create_preferences
+DELETE FROM polls
+WHERE poll_type = 'ranked_choice'
+  AND is_closed = true
+  AND options IS NULL
+  AND follow_up_to IS NOT NULL
+  AND follow_up_to IN (
+    SELECT id FROM polls WHERE suggestion_deadline IS NOT NULL
+  );
+
+-- 4. Migrate existing suggestion votes to ranked_choice
+UPDATE votes SET vote_type = 'ranked_choice' WHERE vote_type = 'suggestion';
+
+-- 5. Update poll_type constraint (remove 'suggestion')
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_type_check;
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS poll_type_check;
+ALTER TABLE polls ADD CONSTRAINT polls_poll_type_check
+    CHECK (poll_type IN ('yes_no', 'ranked_choice', 'participation'));
+
+-- 6. Update vote_type constraint (remove 'suggestion')
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS votes_vote_type_check;
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_type_check;
+ALTER TABLE votes ADD CONSTRAINT votes_vote_type_check
+    CHECK (vote_type IN ('yes_no', 'ranked_choice', 'participation'));
+
+-- 7. Update vote_structure_valid: allow ranked_choice votes to have suggestions
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_structure_valid;
+ALTER TABLE votes ADD CONSTRAINT vote_structure_valid CHECK (
+    (vote_type = 'yes_no' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'participation' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'ranked_choice' AND
+     yes_no_choice IS NULL AND
+     (
+       -- Standard ranked_choice: has rankings, no suggestions
+       ((ranked_choices IS NOT NULL AND is_abstain = false) OR (ranked_choices IS NULL AND is_abstain = true)) OR
+       -- Suggestion phase: has suggestions (rankings optional)
+       (suggestions IS NOT NULL AND array_length(suggestions, 1) > 0 AND is_abstain = false) OR
+       -- Suggestion phase abstain
+       (is_abstain = true AND ranked_choices IS NULL AND (suggestions IS NULL OR array_length(suggestions, 1) IS NULL))
+     ))
+);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -103,8 +103,8 @@ function toPoll(data: any): Poll {
     min_participants: data.min_participants ?? undefined,
     max_participants: data.max_participants ?? undefined,
     short_id: data.short_id ?? undefined,
-    auto_create_preferences: data.auto_create_preferences ?? undefined,
-    auto_preferences_deadline_minutes: data.auto_preferences_deadline_minutes ?? undefined,
+    suggestion_deadline: data.suggestion_deadline ?? undefined,
+    allow_pre_ranking: data.allow_pre_ranking ?? true,
     details: data.details ?? undefined,
     location_mode: data.location_mode ?? undefined,
     location_value: data.location_value ?? undefined,
@@ -185,8 +185,8 @@ export async function apiCreatePoll(params: {
   fork_of?: string;
   min_participants?: number;
   max_participants?: number;
-  auto_create_preferences?: boolean;
-  auto_preferences_deadline_minutes?: number;
+  suggestion_deadline?: string;
+  allow_pre_ranking?: boolean;
   auto_close_after?: number;
   details?: string;
   location_mode?: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,7 +22,7 @@ export type OptionsMetadata = Record<string, OptionMetadataEntry>;
 export interface Poll {
   id: string;
   title: string;
-  poll_type: 'yes_no' | 'ranked_choice' | 'suggestion' | 'participation';
+  poll_type: 'yes_no' | 'ranked_choice' | 'participation';
   options?: string[];
   response_deadline?: string;
   created_at: string;
@@ -36,8 +36,8 @@ export interface Poll {
   min_participants?: number;
   max_participants?: number;
   short_id?: string;
-  auto_create_preferences?: boolean;
-  auto_preferences_deadline_minutes?: number;
+  suggestion_deadline?: string | null;
+  allow_pre_ranking?: boolean;
   auto_close_after?: number;
   details?: string;
   // Location/time fields for participation polls
@@ -103,7 +103,7 @@ export interface SuggestionCount {
 export interface PollResults {
   poll_id: string;
   title: string;
-  poll_type: 'yes_no' | 'ranked_choice' | 'suggestion' | 'participation';
+  poll_type: 'yes_no' | 'ranked_choice' | 'participation';
   created_at: string;
   response_deadline?: string;
   options?: string[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@ncdai/react-wheel-picker": "^1.0.17",
+        "geist": "^1.7.0",
         "next": "^16.2.0",
         "pushover-notifications": "^1.2.3",
         "react": "^19.2.4",
@@ -5333,6 +5334,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
+      "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:validate": "node tests/run-specific-tests.js all --coverage",
     "debug:console": "node scripts/debug-console.cjs",
     "debug:react": "node scripts/debug-react-state.cjs",
-"test:e2e": "playwright test --config=tests/e2e/config/playwright.config.ts",
+    "test:e2e": "playwright test --config=tests/e2e/config/playwright.config.ts",
     "test:e2e:verbose": "playwright test --config=tests/e2e/config/playwright.config.ts --reporter=line",
     "test:e2e:report": "playwright show-report",
     "test:e2e:codegen": "playwright codegen http://localhost:3000",
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@ncdai/react-wheel-picker": "^1.0.17",
+    "geist": "^1.7.0",
     "next": "^16.2.0",
     "pushover-notifications": "^1.2.3",
     "react": "^19.2.4",

--- a/server/algorithms/vote_validation.py
+++ b/server/algorithms/vote_validation.py
@@ -2,13 +2,13 @@
 
 Enforces that each vote contains exactly the fields required for its poll type
 and no fields belonging to other poll types. Mirrors the database CHECK constraint
-from migration 053.
+from migration 084.
 
 Rules:
 - yes_no: requires yes_no_choice ("yes" or "no"), forbids ranked_choices/suggestions
 - participation: same structure as yes_no (yes_no_choice required)
-- ranked_choice: requires non-empty ranked_choices array, forbids yes_no_choice/suggestions
-- suggestion: requires non-empty suggestions array, forbids yes_no_choice/ranked_choices
+- ranked_choice: requires ranked_choices and/or suggestions (suggestions allowed
+  for polls with a suggestion phase). Forbids yes_no_choice.
 - All types: is_abstain=True relaxes the "required" field constraint
 """
 
@@ -25,8 +25,13 @@ def validate_vote(
     ranked_choices: list[str] | None = None,
     suggestions: list[str] | None = None,
     is_abstain: bool = False,
+    has_suggestion_phase: bool = False,
 ) -> None:
     """Validate vote structure for a given poll type.
+
+    Args:
+        has_suggestion_phase: If True, the ranked_choice poll has a suggestion
+            phase and suggestions are allowed in the vote.
 
     Raises VoteValidationError if the vote is invalid.
     """
@@ -41,9 +46,10 @@ def validate_vote(
     if poll_type == "yes_no" or poll_type == "participation":
         _validate_yes_no_vote(yes_no_choice, ranked_choices, suggestions, is_abstain)
     elif poll_type == "ranked_choice":
-        _validate_ranked_choice_vote(yes_no_choice, ranked_choices, suggestions, is_abstain)
-    elif poll_type == "suggestion":
-        _validate_suggestion_vote(yes_no_choice, ranked_choices, suggestions, is_abstain)
+        _validate_ranked_choice_vote(
+            yes_no_choice, ranked_choices, suggestions, is_abstain,
+            has_suggestion_phase,
+        )
     else:
         raise VoteValidationError(f"Unknown poll type: {poll_type}")
 
@@ -76,36 +82,23 @@ def _validate_ranked_choice_vote(
     ranked_choices: list[str] | None,
     suggestions: list[str] | None,
     is_abstain: bool,
+    has_suggestion_phase: bool = False,
 ) -> None:
     if yes_no_choice:
         raise VoteValidationError("yes_no_choice not allowed for ranked choice polls")
-    if suggestions:
-        raise VoteValidationError("suggestions not allowed for ranked choice polls")
+
+    # Suggestions are only allowed on polls with a suggestion phase
+    if suggestions and not has_suggestion_phase:
+        raise VoteValidationError("suggestions not allowed for ranked choice polls without a suggestion phase")
 
     if is_abstain:
         return
 
-    if not ranked_choices or len(ranked_choices) == 0:
+    # Must have at least one of ranked_choices or suggestions
+    has_rankings = ranked_choices and len(ranked_choices) > 0
+    has_suggestions = suggestions and len(suggestions) > 0
+
+    if not has_rankings and not has_suggestions:
         raise VoteValidationError(
-            "ranked_choices is required and must be non-empty for ranked choice polls"
-        )
-
-
-def _validate_suggestion_vote(
-    yes_no_choice: str | None,
-    ranked_choices: list[str] | None,
-    suggestions: list[str] | None,
-    is_abstain: bool,
-) -> None:
-    if yes_no_choice:
-        raise VoteValidationError("yes_no_choice not allowed for suggestion polls")
-    if ranked_choices:
-        raise VoteValidationError("ranked_choices not allowed for suggestion polls")
-
-    if is_abstain:
-        return
-
-    if not suggestions or len(suggestions) == 0:
-        raise VoteValidationError(
-            "suggestions is required and must be non-empty for suggestion polls"
+            "ranked_choices or suggestions is required for ranked choice polls"
         )

--- a/server/models.py
+++ b/server/models.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, Field
 class PollType(str, Enum):
     yes_no = "yes_no"
     ranked_choice = "ranked_choice"
-    suggestion = "suggestion"
     participation = "participation"
 
 
@@ -33,8 +32,8 @@ class CreatePollRequest(BaseModel):
     fork_of: str | None = None
     min_participants: int | None = None
     max_participants: int | None = None
-    auto_create_preferences: bool = False
-    auto_preferences_deadline_minutes: int | None = None
+    suggestion_deadline: str | None = None
+    allow_pre_ranking: bool = True
     auto_close_after: int | None = None
     details: str | None = None
     # Location/time fields for participation polls
@@ -138,8 +137,8 @@ class PollResponse(BaseModel):
     min_participants: int | None = None
     max_participants: int | None = None
     short_id: str | None = None
-    auto_create_preferences: bool = False
-    auto_preferences_deadline_minutes: int | None = None
+    suggestion_deadline: str | None = None
+    allow_pre_ranking: bool = True
     auto_close_after: int | None = None
     details: str | None = None
     # Location/time fields

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -540,7 +540,7 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
     with get_db() as conn:
         # Verify poll exists and is open
         poll = conn.execute(
-            "SELECT id, is_closed, poll_type, suggestion_deadline FROM polls WHERE id = %(poll_id)s",
+            "SELECT id, is_closed, poll_type, suggestion_deadline, allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()
         if not poll:
@@ -561,13 +561,8 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
                 raise HTTPException(status_code=400, detail="Suggestions cutoff has passed")
 
             # Reject rankings before cutoff if pre-ranking is disabled
-            # (check allow_pre_ranking only when needed)
             if in_suggestion_phase and req.ranked_choices:
-                allow = conn.execute(
-                    "SELECT allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
-                    {"poll_id": poll_id},
-                ).fetchone()
-                if not allow["allow_pre_ranking"]:
+                if not poll["allow_pre_ranking"]:
                     raise HTTPException(status_code=400, detail="Rankings not allowed until suggestions cutoff")
 
         # Validate vote structure

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -41,7 +41,7 @@ def _check_auto_close(conn, poll_id: str) -> None:
     """Auto-close a poll based on auto_close_after (respondent count) or max_participants."""
     poll = conn.execute(
         """SELECT id, poll_type, is_closed, auto_close_after, max_participants,
-                  auto_create_preferences, auto_preferences_deadline_minutes,
+                  suggestion_deadline, allow_pre_ranking,
                   sub_poll_role, parent_participation_poll_id, options
            FROM polls WHERE id = %(poll_id)s""",
         {"poll_id": poll_id},
@@ -83,31 +83,21 @@ def _check_auto_close(conn, poll_id: str) -> None:
             closed = True
 
     if closed:
-        # If we just closed a suggestion poll, activate the reserved preferences poll
-        if poll.get("auto_create_preferences"):
-            now = datetime.now(timezone.utc)
-            _activate_reserved_preferences_poll(conn, dict(poll), now)
-
         # If we just closed a ranked_choice sub-poll, resolve the winner to parent
         if poll["poll_type"] == "ranked_choice" and poll.get("sub_poll_role"):
             _resolve_sub_poll_winner(conn, dict(poll))
 
 
-def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -> None:
-    """Activate the reserved ranked_choice follow-up when a suggestion poll closes.
+def _finalize_suggestion_options(conn, poll_id: str, now: datetime) -> None:
+    """Finalize options for a ranked_choice poll after its suggestion_deadline passes.
 
-    Collects all suggestions from votes, finds the reserved placeholder poll,
-    and updates it with the suggestions as options, a deadline, and opens it.
+    Collects all unique suggestions from votes and writes them to the poll's options column.
     """
     import json
 
-    parent_id = str(parent_row["id"])
-    deadline_minutes = parent_row.get("auto_preferences_deadline_minutes") or 10
-
-    # Collect unique suggestions from all votes on the parent poll
     votes = conn.execute(
         "SELECT suggestions FROM votes WHERE poll_id = %(poll_id)s AND suggestions IS NOT NULL",
-        {"poll_id": parent_id},
+        {"poll_id": poll_id},
     ).fetchall()
 
     all_suggestions: list[str] = []
@@ -119,93 +109,17 @@ def _activate_reserved_preferences_poll(conn, parent_row: dict, now: datetime) -
                 seen.add(lower)
                 all_suggestions.append(sug.strip())
 
-    if len(all_suggestions) == 0:
-        return
-
-    # Find the reserved placeholder poll
-    reserved = conn.execute(
-        """
-        SELECT id FROM polls
-        WHERE follow_up_to = %(parent_id)s
-          AND poll_type = 'ranked_choice'
-          AND is_closed = true
-          AND options IS NULL
-        ORDER BY created_at ASC
-        LIMIT 1
-        """,
-        {"parent_id": parent_id},
-    ).fetchone()
-
-    if not reserved:
-        return  # No reserved poll found (shouldn't happen)
-
-    # Propagate options_metadata from parent for matching suggestions
-    parent_metadata = parent_row.get("options_metadata") or {}
-    child_metadata = {sug: parent_metadata[sug] for sug in all_suggestions if sug in parent_metadata} or None
-
-    if len(all_suggestions) == 1:
-        # Single suggestion: activate as already closed with uncontested winner
+    if all_suggestions:
         conn.execute(
-            """
-            UPDATE polls
-            SET options = %(options)s::jsonb,
-                is_closed = true,
-                close_reason = 'uncontested',
-                updated_at = %(now)s,
-                options_metadata = %(options_metadata)s::jsonb,
-                is_sub_poll = COALESCE(%(is_sub_poll)s, is_sub_poll),
-                sub_poll_role = COALESCE(%(sub_poll_role)s, sub_poll_role),
-                parent_participation_poll_id = COALESCE(%(parent_id)s, parent_participation_poll_id)
-            WHERE id = %(reserved_id)s
-            """,
+            """UPDATE polls SET options = %(options)s::jsonb, updated_at = %(now)s
+               WHERE id = %(poll_id)s""",
             {
                 "options": json.dumps(all_suggestions),
                 "now": now,
-                "reserved_id": str(reserved["id"]),
-                "options_metadata": json.dumps(child_metadata) if child_metadata else None,
-                "is_sub_poll": parent_row.get("is_sub_poll") or None,
-                "sub_poll_role": None,
-                "parent_id": str(parent_row["parent_participation_poll_id"]) if parent_row.get("parent_participation_poll_id") else None,
+                "poll_id": poll_id,
             },
         )
-        # Resolve winner to parent if this is a sub-poll
-        reserved_poll = conn.execute(
-            "SELECT * FROM polls WHERE id = %(id)s",
-            {"id": str(reserved["id"])},
-        ).fetchone()
-        if reserved_poll and reserved_poll.get("sub_poll_role"):
-            _resolve_sub_poll_winner(conn, dict(reserved_poll))
-        return
 
-    # 2+ suggestions: activate as open ranked choice poll
-    from datetime import timedelta
-    deadline = now + timedelta(minutes=deadline_minutes)
-
-    # Activate the reserved poll (propagate sub-poll metadata if present)
-    conn.execute(
-        """
-        UPDATE polls
-        SET options = %(options)s::jsonb,
-            response_deadline = %(deadline)s,
-            is_closed = false,
-            updated_at = %(now)s,
-            options_metadata = %(options_metadata)s::jsonb,
-            is_sub_poll = COALESCE(%(is_sub_poll)s, is_sub_poll),
-            sub_poll_role = COALESCE(%(sub_poll_role)s, sub_poll_role),
-            parent_participation_poll_id = COALESCE(%(parent_id)s, parent_participation_poll_id)
-        WHERE id = %(reserved_id)s
-        """,
-        {
-            "options": json.dumps(all_suggestions),
-            "deadline": deadline.isoformat(),
-            "now": now,
-            "reserved_id": str(reserved["id"]),
-            "options_metadata": json.dumps(child_metadata) if child_metadata else None,
-            "is_sub_poll": parent_row.get("is_sub_poll") or None,
-            "sub_poll_role": None,  # Already set at creation for sub-polls
-            "parent_id": str(parent_row["parent_participation_poll_id"]) if parent_row.get("parent_participation_poll_id") else None,
-        },
-    )
 
 
 def _row_to_poll(row: dict) -> PollResponse:
@@ -227,8 +141,8 @@ def _row_to_poll(row: dict) -> PollResponse:
         min_participants=row.get("min_participants"),
         max_participants=row.get("max_participants"),
         short_id=row.get("short_id"),
-        auto_create_preferences=row.get("auto_create_preferences", False),
-        auto_preferences_deadline_minutes=row.get("auto_preferences_deadline_minutes"),
+        suggestion_deadline=row["suggestion_deadline"].isoformat() if row.get("suggestion_deadline") else None,
+        allow_pre_ranking=row.get("allow_pre_ranking", True),
         auto_close_after=row.get("auto_close_after"),
         details=row.get("details"),
         location_mode=row.get("location_mode"),
@@ -325,58 +239,33 @@ def _create_sub_polls_for_field(
         )
 
     elif mode == "suggestions":
-        # Create a suggestion sub-poll
+        # Create a ranked_choice sub-poll with a suggestion phase
         sug_deadline_mins = suggestions_deadline_minutes or 10
         sug_deadline = now + timedelta(minutes=sug_deadline_mins)
-        sug_row = conn.execute(
+        pref_deadline_mins = preferences_deadline_minutes or 10
+        pref_deadline = sug_deadline + timedelta(minutes=pref_deadline_mins)
+        conn.execute(
             """
             INSERT INTO polls (title, poll_type, response_deadline,
+                               suggestion_deadline,
                                creator_secret, creator_name,
                                is_sub_poll, sub_poll_role,
                                parent_participation_poll_id,
-                               auto_create_preferences,
-                               auto_preferences_deadline_minutes,
                                is_closed, created_at, updated_at)
-            VALUES (%(title)s, 'suggestion', %(deadline)s,
+            VALUES (%(title)s, 'ranked_choice', %(pref_deadline)s,
+                    %(sug_deadline)s,
                     %(creator_secret)s, %(creator_name)s,
                     true, %(sub_poll_role)s,
                     %(parent_id)s,
-                    true, %(pref_deadline_mins)s,
                     false, %(now)s, %(now)s)
-            RETURNING id
             """,
             {
                 "title": sub_title,
-                "deadline": sug_deadline.isoformat(),
+                "pref_deadline": pref_deadline.isoformat(),
+                "sug_deadline": sug_deadline.isoformat(),
                 "creator_secret": creator_secret,
                 "creator_name": creator_name,
                 "sub_poll_role": f"{field}_suggestions",
-                "parent_id": parent_id,
-                "pref_deadline_mins": preferences_deadline_minutes or 10,
-                "now": now,
-            },
-        ).fetchone()
-
-        # Create a reserved ranked_choice sub-poll (placeholder)
-        conn.execute(
-            """
-            INSERT INTO polls (title, poll_type, is_closed, follow_up_to,
-                               creator_secret, creator_name,
-                               is_sub_poll, sub_poll_role,
-                               parent_participation_poll_id,
-                               created_at, updated_at)
-            VALUES (%(title)s, 'ranked_choice', true, %(sug_id)s,
-                    %(creator_secret)s, %(creator_name)s,
-                    true, %(sub_poll_role)s,
-                    %(parent_id)s,
-                    %(now)s, %(now)s)
-            """,
-            {
-                "title": sub_title,
-                "sug_id": str(sug_row["id"]),
-                "creator_secret": creator_secret,
-                "creator_name": creator_name,
-                "sub_poll_role": f"{field}_preferences",
                 "parent_id": parent_id,
                 "now": now,
             },
@@ -468,7 +357,7 @@ def create_poll(req: CreatePollRequest):
             INSERT INTO polls (title, poll_type, options, response_deadline,
                                creator_secret, creator_name, follow_up_to,
                                fork_of, min_participants, max_participants,
-                               auto_create_preferences, auto_preferences_deadline_minutes,
+                               suggestion_deadline, allow_pre_ranking,
                                auto_close_after, details,
                                location_mode, location_value, resolved_location,
                                time_mode, time_value, resolved_time,
@@ -487,7 +376,7 @@ def create_poll(req: CreatePollRequest):
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
                     %(fork_of)s, %(min_participants)s, %(max_participants)s,
-                    %(auto_create_preferences)s, %(auto_preferences_deadline_minutes)s,
+                    %(suggestion_deadline)s, %(allow_pre_ranking)s,
                     %(auto_close_after)s, %(details)s,
                     %(location_mode)s, %(location_value)s, %(resolved_location)s,
                     %(time_mode)s, %(time_value)s, %(resolved_time)s,
@@ -516,8 +405,8 @@ def create_poll(req: CreatePollRequest):
                 "fork_of": req.fork_of,
                 "min_participants": req.min_participants,
                 "max_participants": req.max_participants,
-                "auto_create_preferences": req.auto_create_preferences,
-                "auto_preferences_deadline_minutes": req.auto_preferences_deadline_minutes,
+                "suggestion_deadline": req.suggestion_deadline,
+                "allow_pre_ranking": req.allow_pre_ranking,
                 "auto_close_after": req.auto_close_after,
                 "details": req.details,
                 "location_mode": req.location_mode,
@@ -547,31 +436,6 @@ def create_poll(req: CreatePollRequest):
         ).fetchone()
 
         parent_id = str(row["id"])
-
-        # If this is a suggestion poll with auto_create_preferences, reserve a
-        # placeholder ranked_choice follow-up poll so no one else can create a
-        # conflicting follow-up with the same title.
-        if req.poll_type == PollType.suggestion and req.auto_create_preferences:
-            conn.execute(
-                """
-                INSERT INTO polls (title, poll_type, is_closed, follow_up_to,
-                                   creator_secret, creator_name,
-                                   category,
-                                   created_at, updated_at)
-                VALUES (%(title)s, 'ranked_choice', true, %(parent_id)s,
-                        %(creator_secret)s, %(creator_name)s,
-                        %(category)s,
-                        %(now)s, %(now)s)
-                """,
-                {
-                    "title": req.title,
-                    "parent_id": parent_id,
-                    "creator_secret": req.creator_secret,
-                    "creator_name": req.creator_name,
-                    "category": req.category or "custom",
-                    "now": now,
-                },
-            )
 
         # Create sub-polls for location/time fields
         _create_sub_polls_for_field(
@@ -676,13 +540,35 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
     with get_db() as conn:
         # Verify poll exists and is open
         poll = conn.execute(
-            "SELECT id, is_closed, poll_type FROM polls WHERE id = %(poll_id)s",
+            "SELECT id, is_closed, poll_type, suggestion_deadline FROM polls WHERE id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()
         if not poll:
             raise HTTPException(status_code=404, detail="Poll not found")
         if poll["is_closed"]:
             raise HTTPException(status_code=400, detail="Poll is closed")
+
+        has_suggestion_phase = poll.get("suggestion_deadline") is not None
+
+        # Enforce suggestion phase timing
+        if has_suggestion_phase:
+            now_check = datetime.now(timezone.utc)
+            cutoff = poll["suggestion_deadline"]
+            in_suggestion_phase = now_check < cutoff
+
+            # Reject new suggestions after cutoff
+            if not in_suggestion_phase and req.suggestions:
+                raise HTTPException(status_code=400, detail="Suggestions cutoff has passed")
+
+            # Reject rankings before cutoff if pre-ranking is disabled
+            # (check allow_pre_ranking only when needed)
+            if in_suggestion_phase and req.ranked_choices:
+                allow = conn.execute(
+                    "SELECT allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
+                    {"poll_id": poll_id},
+                ).fetchone()
+                if not allow["allow_pre_ranking"]:
+                    raise HTTPException(status_code=400, detail="Rankings not allowed until suggestions cutoff")
 
         # Validate vote structure
         try:
@@ -693,6 +579,7 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
                 ranked_choices=req.ranked_choices,
                 suggestions=req.suggestions,
                 is_abstain=req.is_abstain,
+                has_suggestion_phase=has_suggestion_phase,
             )
         except VoteValidationError as e:
             raise HTTPException(status_code=400, detail=str(e))
@@ -778,13 +665,53 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
         if not existing:
             raise HTTPException(status_code=404, detail="Vote not found")
 
-        # Check poll is still open
+        # Check poll is still open and get suggestion phase info
         poll = conn.execute(
-            "SELECT is_closed FROM polls WHERE id = %(poll_id)s",
+            "SELECT is_closed, poll_type, suggestion_deadline, allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()
         if poll and poll["is_closed"]:
             raise HTTPException(status_code=400, detail="Poll is closed")
+
+        has_suggestion_phase = poll.get("suggestion_deadline") is not None
+        if has_suggestion_phase:
+            now_check = datetime.now(timezone.utc)
+            cutoff = poll["suggestion_deadline"]
+            in_suggestion_phase = now_check < cutoff
+
+            # Reject new suggestions after cutoff
+            if not in_suggestion_phase and req.suggestions:
+                raise HTTPException(status_code=400, detail="Suggestions cutoff has passed")
+
+            # Reject rankings before cutoff if pre-ranking is disabled
+            if in_suggestion_phase and req.ranked_choices and not poll["allow_pre_ranking"]:
+                raise HTTPException(status_code=400, detail="Rankings not allowed until suggestions cutoff")
+
+            # Prevent unsuggesting options that others have ranked
+            if in_suggestion_phase and req.suggestions is not None:
+                old_vote = conn.execute(
+                    "SELECT suggestions FROM votes WHERE id = %(vote_id)s",
+                    {"vote_id": vote_id},
+                ).fetchone()
+                if old_vote and old_vote["suggestions"]:
+                    removed = set(old_vote["suggestions"]) - set(req.suggestions)
+                    if removed:
+                        # Check if any other voter has ranked any of the removed suggestions
+                        ranked_by_others = conn.execute(
+                            """SELECT DISTINCT unnest(ranked_choices) as opt
+                               FROM votes
+                               WHERE poll_id = %(poll_id)s
+                                 AND id != %(vote_id)s
+                                 AND ranked_choices IS NOT NULL""",
+                            {"poll_id": poll_id, "vote_id": vote_id},
+                        ).fetchall()
+                        ranked_set = {r["opt"] for r in ranked_by_others}
+                        blocked = removed & ranked_set
+                        if blocked:
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"Cannot remove suggestions that others have ranked: {', '.join(sorted(blocked))}",
+                            )
 
         import json
         row = conn.execute(
@@ -837,23 +764,21 @@ def get_results(poll_id: str):
         if not poll:
             raise HTTPException(status_code=404, detail="Poll not found")
 
-        # Auto-close suggestion polls with auto_create_preferences when deadline
-        # has passed. This activates the reserved preferences poll server-side
-        # regardless of which client fetches results first.
+        # For ranked_choice polls with suggestion phase: finalize options when
+        # suggestion_deadline passes (populate options from collected suggestions)
         if (
-            poll["poll_type"] == "suggestion"
-            and poll.get("auto_create_preferences")
+            poll["poll_type"] == "ranked_choice"
+            and poll.get("suggestion_deadline")
             and not poll["is_closed"]
-            and poll.get("response_deadline")
-            and poll["response_deadline"] <= now
+            and poll["suggestion_deadline"] <= now
+            and not poll.get("options")  # Not yet finalized
         ):
-            result = conn.execute(
-                """UPDATE polls SET is_closed = true, close_reason = 'deadline', updated_at = %(now)s
-                   WHERE id = %(poll_id)s AND is_closed = false""",
-                {"poll_id": poll_id, "now": now},
-            )
-            if result.rowcount == 1:
-                _activate_reserved_preferences_poll(conn, dict(poll), now)
+            _finalize_suggestion_options(conn, poll_id, now)
+            # Re-read poll to get updated options
+            poll = conn.execute(
+                "SELECT * FROM polls WHERE id = %(poll_id)s",
+                {"poll_id": poll_id},
+            ).fetchone()
 
         # Auto-close ranked_choice sub-polls when deadline passes, and resolve winner
         if (
@@ -903,37 +828,26 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             max_participants=poll.get("max_participants"),
         )
 
-    if poll_type == "suggestion":
-        import json
-        raw_options = poll.get("options")
-        poll_options = None
-        if raw_options:
-            poll_options = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
-
-        result = count_suggestion_votes(votes, poll_options=poll_options)
-        return PollResultsResponse(
-            poll_id=str(poll["id"]),
-            title=poll["title"],
-            poll_type=poll_type,
-            created_at=poll["created_at"].isoformat() if isinstance(poll["created_at"], datetime) else str(poll["created_at"]),
-            response_deadline=poll["response_deadline"].isoformat() if poll.get("response_deadline") else None,
-            options=poll_options,
-            total_votes=result.total_votes,
-            abstain_count=result.abstain_count,
-            min_participants=poll.get("min_participants"),
-            max_participants=poll.get("max_participants"),
-            suggestion_counts=[
-                {"option": sc.option, "count": sc.count}
-                for sc in result.suggestion_counts
-            ],
-        )
-
     if poll_type == "ranked_choice":
         import json
         raw_options = poll.get("options")
         poll_options = None
         if raw_options:
             poll_options = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
+
+        has_suggestion_phase = poll.get("suggestion_deadline") is not None
+
+        # Compute suggestion counts if this poll has a suggestion phase
+        suggestion_counts_data = None
+        if has_suggestion_phase:
+            sug_result = count_suggestion_votes(votes, poll_options=poll_options)
+            suggestion_counts_data = [
+                {"option": sc.option, "count": sc.count}
+                for sc in sug_result.suggestion_counts
+            ]
+            # During suggestion phase (options not yet finalized), derive options from suggestions
+            if not poll_options and suggestion_counts_data:
+                poll_options = [sc["option"] for sc in suggestion_counts_data]
 
         # Uncontested: single option wins automatically
         if poll.get("close_reason") == "uncontested" and poll_options and len(poll_options) == 1:
@@ -957,22 +871,27 @@ def _compute_results(poll, votes) -> PollResultsResponse:
                     borda_score=0.0,
                     tie_broken_by_borda=False,
                 )],
+                suggestion_counts=suggestion_counts_data,
             )
 
-        result = calculate_ranked_choice_winner(votes, poll_options or [])
-
-        # Build round response objects
+        # Only compute ranked choice results if there are options to rank
         rc_rounds = []
-        for round_idx, round_entries in enumerate(result.rounds):
-            for entry in round_entries:
-                rc_rounds.append(RankedChoiceRoundResponse(
-                    round_number=round_idx + 1,
-                    option_name=entry.option_name,
-                    vote_count=entry.vote_count,
-                    is_eliminated=entry.is_eliminated,
-                    borda_score=entry.borda_score,
-                    tie_broken_by_borda=entry.tie_broken_by_borda,
-                ))
+        rc_winner = None
+        ranking_votes = [v for v in votes if v.get("ranked_choices")]
+        if poll_options and len(poll_options) >= 2 and ranking_votes:
+            result = calculate_ranked_choice_winner(ranking_votes, poll_options)
+            rc_winner = result.winner
+
+            for round_idx, round_entries in enumerate(result.rounds):
+                for entry in round_entries:
+                    rc_rounds.append(RankedChoiceRoundResponse(
+                        round_number=round_idx + 1,
+                        option_name=entry.option_name,
+                        vote_count=entry.vote_count,
+                        is_eliminated=entry.is_eliminated,
+                        borda_score=entry.borda_score,
+                        tie_broken_by_borda=entry.tie_broken_by_borda,
+                    ))
 
         return PollResultsResponse(
             poll_id=str(poll["id"]),
@@ -984,9 +903,10 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             total_votes=len(votes),
             min_participants=poll.get("min_participants"),
             max_participants=poll.get("max_participants"),
-            winner=result.winner,
-            ranked_choice_winner=result.winner,
-            ranked_choice_rounds=rc_rounds,
+            winner=rc_winner,
+            ranked_choice_winner=rc_winner,
+            ranked_choice_rounds=rc_rounds if rc_rounds else None,
+            suggestion_counts=suggestion_counts_data,
         )
 
     if poll_type == "participation":
@@ -1114,10 +1034,9 @@ def close_poll(poll_id: str, req: ClosePollRequest):
         if not row:
             raise HTTPException(status_code=403, detail="Invalid creator secret or poll not found")
 
-        # If this is a suggestion poll with auto_create_preferences, activate
-        # the reserved ranked_choice follow-up poll.
-        if row["poll_type"] == "suggestion" and row.get("auto_create_preferences"):
-            _activate_reserved_preferences_poll(conn, row, now)
+        # If closing a ranked_choice poll with suggestion phase, finalize options
+        if row["poll_type"] == "ranked_choice" and row.get("suggestion_deadline"):
+            _finalize_suggestion_options(conn, poll_id, now)
 
         # If this is a ranked_choice sub-poll, resolve the winner to parent
         if row["poll_type"] == "ranked_choice" and row.get("sub_poll_role"):
@@ -1164,17 +1083,6 @@ def get_accessible_polls(req: AccessiblePollsRequest):
             """SELECT * FROM polls
                WHERE id = ANY(%(poll_ids)s)
                  AND (is_sub_poll = false OR is_sub_poll IS NULL)
-                 AND NOT (
-                   poll_type = 'suggestion'
-                   AND auto_create_preferences = true
-                   AND is_closed = true
-                   AND EXISTS (
-                     SELECT 1 FROM polls p2
-                     WHERE p2.follow_up_to = polls.id
-                       AND p2.poll_type = 'ranked_choice'
-                       AND p2.options IS NOT NULL
-                   )
-                 )
                ORDER BY created_at DESC""",
             {"poll_ids": req.poll_ids},
         ).fetchall()

--- a/server/tests/test_vote_validation.py
+++ b/server/tests/test_vote_validation.py
@@ -36,7 +36,7 @@ class TestYesNoValidation:
 
     def test_wrong_vote_type(self):
         with pytest.raises(VoteValidationError, match="does not match"):
-            validate_vote("yes_no", "suggestion", yes_no_choice="yes")
+            validate_vote("yes_no", "ranked_choice", yes_no_choice="yes")
 
 
 class TestParticipationValidation:
@@ -60,7 +60,7 @@ class TestParticipationValidation:
 
     def test_wrong_vote_type(self):
         with pytest.raises(VoteValidationError, match="does not match"):
-            validate_vote("participation", "suggestion")
+            validate_vote("participation", "ranked_choice")
 
 
 class TestRankedChoiceValidation:
@@ -71,51 +71,52 @@ class TestRankedChoiceValidation:
         validate_vote("ranked_choice", "ranked_choice", is_abstain=True)
 
     def test_missing_rankings(self):
-        with pytest.raises(VoteValidationError, match="ranked_choices is required"):
+        with pytest.raises(VoteValidationError, match="ranked_choices or suggestions is required"):
             validate_vote("ranked_choice", "ranked_choice")
 
     def test_empty_rankings(self):
-        with pytest.raises(VoteValidationError, match="ranked_choices is required"):
+        with pytest.raises(VoteValidationError, match="ranked_choices or suggestions is required"):
             validate_vote("ranked_choice", "ranked_choice", ranked_choices=[])
 
     def test_yes_no_choice_forbidden(self):
         with pytest.raises(VoteValidationError, match="yes_no_choice not allowed"):
             validate_vote("ranked_choice", "ranked_choice", yes_no_choice="yes", ranked_choices=["a"])
 
-    def test_suggestions_forbidden(self):
+    def test_suggestions_forbidden_without_suggestion_phase(self):
         with pytest.raises(VoteValidationError, match="suggestions not allowed"):
             validate_vote("ranked_choice", "ranked_choice", ranked_choices=["a"], suggestions=["b"])
 
+    def test_suggestions_allowed_with_suggestion_phase(self):
+        """Suggestions are allowed when the poll has a suggestion phase."""
+        validate_vote(
+            "ranked_choice", "ranked_choice",
+            suggestions=["a", "b"],
+            has_suggestion_phase=True,
+        )
 
-class TestSuggestionValidation:
-    def test_valid_suggestions(self):
-        validate_vote("suggestion", "suggestion", suggestions=["Alice", "Bob"])
+    def test_suggestions_and_rankings_with_suggestion_phase(self):
+        """Both suggestions and rankings can coexist during suggestion phase."""
+        validate_vote(
+            "ranked_choice", "ranked_choice",
+            ranked_choices=["a", "b"],
+            suggestions=["a", "b", "c"],
+            has_suggestion_phase=True,
+        )
 
-    def test_valid_single_suggestion(self):
-        validate_vote("suggestion", "suggestion", suggestions=["Alice"])
+    def test_suggestions_only_is_valid_with_suggestion_phase(self):
+        """Suggestions without rankings is valid during suggestion phase."""
+        validate_vote(
+            "ranked_choice", "ranked_choice",
+            suggestions=["x"],
+            has_suggestion_phase=True,
+        )
 
-    def test_valid_abstain(self):
-        validate_vote("suggestion", "suggestion", is_abstain=True)
-
-    def test_missing_suggestions(self):
-        with pytest.raises(VoteValidationError, match="suggestions is required"):
-            validate_vote("suggestion", "suggestion")
-
-    def test_empty_suggestions(self):
-        with pytest.raises(VoteValidationError, match="suggestions is required"):
-            validate_vote("suggestion", "suggestion", suggestions=[])
-
-    def test_yes_no_choice_forbidden(self):
-        with pytest.raises(VoteValidationError, match="yes_no_choice not allowed"):
-            validate_vote("suggestion", "suggestion", yes_no_choice="yes", suggestions=["a"])
-
-    def test_ranked_choices_forbidden(self):
-        with pytest.raises(VoteValidationError, match="ranked_choices not allowed"):
-            validate_vote("suggestion", "suggestion", ranked_choices=["a"], suggestions=["b"])
-
-    def test_wrong_vote_type(self):
-        with pytest.raises(VoteValidationError, match="does not match"):
-            validate_vote("suggestion", "yes_no", suggestions=["a"])
+    def test_abstain_with_suggestion_phase(self):
+        validate_vote(
+            "ranked_choice", "ranked_choice",
+            is_abstain=True,
+            has_suggestion_phase=True,
+        )
 
 
 class TestUnknownPollType:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -33,7 +33,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "next-env.d.ts",
-    "out/types/**/*.ts"
+    "out/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- Merge the `suggestion` poll type into `ranked_choice` with an optional suggestion phase controlled by `suggestion_deadline`
- During suggestion phase, users submit suggestions first, then optionally pre-rank (if `allow_pre_ranking` is enabled)
- After suggestion cutoff, the poll transitions to a standard ranked choice vote with all collected options
- Redesigned ranking handle with tap-to-move (top half = up, bottom half = down) and drag-to-reorder, using FLIP animation for smooth transitions
- Extracted `RankingSection` as an independent component with its own editing state separate from suggestions
- Fixed iOS SFSafariViewController drag conflict via `setPointerCapture` + tap-based alternative
- Fixed abstain flow: suggestion abstain doesn't block ranking, ranking abstain grays out the ballot
- Centered respondents component, separate voter lists for suggestions vs rankings
- Removed the standalone `suggestion` poll type and `Follow Up` button

## Test plan
- [ ] Create a ranked choice poll with suggestion phase — verify suggestions, cutoff transition, and ranking work
- [ ] Test tap-to-move on ranking items (top half = up, bottom half = down, bottom of last = exclude)
- [ ] Test drag-to-reorder on ranking items
- [ ] Test abstain flows: abstain suggestions then rank, abstain rankings (grayed out ballot)
- [ ] Test edit button reopens correct section (suggestions vs rankings independently)
- [ ] Test pre-ranking during suggestion phase when enabled
- [ ] Verify scrolling works normally outside the handle area

https://claude.ai/code/session_01W5vT6kNxPh4BpahrCnRczd