### PR TITLE
Suggestion poll improvements: deferred deadlines, cutoff button, ranking flow fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,6 +848,16 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Creator secret propagation**: Sub-polls share the parent's `creator_secret`. The browser propagates it via `SubPollField` on page load since localStorage only stores secrets for directly-created polls.
 - **Column whitelist**: `_resolve_sub_poll_winner` uses an f-string for the column name — the field value MUST be validated against `("location", "time")` before interpolation.
 
+### Deferred Suggestion Deadline
+
+- **Suggestion deadlines are deferred until the first suggestion is submitted.** Poll creation stores `suggestion_deadline_minutes` (the duration) and sets `suggestion_deadline` to NULL. When the first vote with suggestions arrives, the backend sets `suggestion_deadline = now + minutes`. This prevents empty cutoffs where the deadline expires before anyone suggests anything.
+- **Custom deadlines bypass deferral.** When the creator picks "Custom" and sets an absolute date/time, `suggestion_deadline` is sent directly (not deferred). Only preset durations use `suggestion_deadline_minutes`.
+- **`hasSuggestionPhase` checks both fields**: `!!(poll.suggestion_deadline || poll.suggestion_deadline_minutes)`. A poll is "in suggestion phase" when the timer hasn't started yet OR when the deadline hasn't passed.
+- **Frontend starts the timer optimistically** after the first suggestion vote succeeds: `setSuggestionDeadlineOverride(new Date(Date.now() + minutes * 60000).toISOString())`. This avoids waiting for a page refresh to show the countdown.
+- **`hasCompletedRanking`** (computed in PollPageClient) distinguishes "voted with suggestions only" from "voted with rankings". Used to gate preliminary results display and the ranking summary view — prevents showing results before the user has ranked.
+- **Auto-finalization in `get_poll`**: When `suggestion_deadline` has passed but `options` is still NULL, the endpoint auto-calls `_finalize_suggestion_options()`. This handles the case where the deadline expires naturally without a manual cutoff.
+- **Manual cutoff requires suggestions**: The `cutoff-suggestions` endpoint rejects requests (400) when no suggestions have been submitted, enforced via an EXISTS subquery in the UPDATE.
+
 ### PWA / Pull-to-Refresh
 
 - **Native pull-to-refresh works everywhere except iOS PWA standalone mode.** Apple explicitly disables it. Don't use `overscroll-behavior: contain` globally — that blocks the native gesture on all platforms. Only use a custom touch-based pull-to-refresh for iOS PWA (detect with `navigator.standalone === true` — do NOT use UA sniffing).

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1113,11 +1113,11 @@ function CreatePollContent() {
         pollData.options = filledOptions;
       }
 
-      // Add suggestion deadline for polls with no options (suggestion phase)
+      // Add suggestion deadline duration for polls with no options (suggestion phase)
+      // The actual deadline is deferred until the first suggestion is submitted
       if (isSuggestionMode) {
         const cutoffMinutes = SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.minutes || 120;
-        const cutoffDate = new Date(new Date().getTime() + cutoffMinutes * 60 * 1000);
-        pollData.suggestion_deadline = cutoffDate.toISOString();
+        pollData.suggestion_deadline_minutes = cutoffMinutes;
         pollData.allow_pre_ranking = allowPreRanking;
       }
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -112,6 +112,9 @@ function CreatePollContent() {
   const loadedTitleRef = useRef<string | null>(null);
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
   const [suggestionCutoff, setSuggestionCutoff] = useState("2hr");
+  const [customSuggestionDate, setCustomSuggestionDate] = useState('');
+  const [customSuggestionTime, setCustomSuggestionTime] = useState('');
+  const suggestionCutoffSelectRef = useRef<HTMLSelectElement>(null);
   const [allowPreRanking, setAllowPreRanking] = useState(true);
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
@@ -511,6 +514,16 @@ function CreatePollContent() {
     const day = String(today.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   };
+
+  // Set default custom suggestion date/time when switching to custom
+  useEffect(() => {
+    if (suggestionCutoff === 'custom' && !customSuggestionDate && isClient) {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      setCustomSuggestionDate(`${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`);
+      setCustomSuggestionTime('12:00');
+    }
+  }, [suggestionCutoff, customSuggestionDate, isClient]);
 
   // Initialize state from URL params
   useEffect(() => {
@@ -1113,11 +1126,17 @@ function CreatePollContent() {
         pollData.options = filledOptions;
       }
 
-      // Add suggestion deadline duration for polls with no options (suggestion phase)
-      // The actual deadline is deferred until the first suggestion is submitted
+      // Add suggestion deadline for polls with no options (suggestion phase)
       if (isSuggestionMode) {
-        const cutoffMinutes = SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.minutes || 120;
-        pollData.suggestion_deadline_minutes = cutoffMinutes;
+        if (suggestionCutoff === 'custom' && customSuggestionDate && customSuggestionTime) {
+          // Custom: send absolute deadline (not deferred)
+          const cutoffDate = new Date(`${customSuggestionDate}T${customSuggestionTime}`);
+          pollData.suggestion_deadline = cutoffDate.toISOString();
+        } else {
+          // Preset: deferred until first suggestion
+          const cutoffMinutes = SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.minutes || 120;
+          pollData.suggestion_deadline_minutes = cutoffMinutes;
+        }
         pollData.allow_pre_ranking = allowPreRanking;
       }
 
@@ -1556,10 +1575,26 @@ function CreatePollContent() {
           {isSuggestionMode && (
             <div>
               <div className="flex items-center justify-between">
-                <label className="block text-sm font-medium">
+                <label className="block text-sm font-medium cursor-pointer">
                   <span>Suggestions Cutoff: </span>
-                  <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-                    {SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.label || suggestionCutoff}
+                  <span className="relative inline-flex">
+                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                      {suggestionCutoff === 'custom'
+                        ? 'Custom'
+                        : SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.label || suggestionCutoff}
+                    </span>
+                    <select
+                      ref={suggestionCutoffSelectRef}
+                      value={suggestionCutoff}
+                      onChange={(e) => setSuggestionCutoff(e.target.value)}
+                      disabled={isLoading}
+                      className="absolute inset-0 opacity-0 cursor-pointer"
+                      aria-label="Suggestions cutoff duration"
+                    >
+                      {SUGGESTION_CUTOFF_OPTIONS.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
                   </span>
                 </label>
                 <label className="flex items-center gap-1.5 cursor-pointer">
@@ -1575,16 +1610,42 @@ function CreatePollContent() {
                   </span>
                 </label>
               </div>
-              <select
-                value={suggestionCutoff}
-                onChange={(e) => setSuggestionCutoff(e.target.value)}
-                disabled={isLoading}
-                className="mt-1 w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-              >
-                {SUGGESTION_CUTOFF_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
+              {/* Custom date/time fields */}
+              {suggestionCutoff === 'custom' && (
+                <div className="mt-2 flex justify-between gap-2">
+                  <div className="w-auto">
+                    <label htmlFor="customSuggestionDate" className="block text-xs text-gray-500 mb-1">
+                      Date
+                    </label>
+                    <input
+                      type="date"
+                      id="customSuggestionDate"
+                      value={customSuggestionDate}
+                      onChange={(e) => setCustomSuggestionDate(e.target.value)}
+                      disabled={isLoading}
+                      min={isClient ? getTodayDate() : ''}
+                      className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                      style={{ fontSize: '14px' }}
+                      required
+                    />
+                  </div>
+                  <div className="w-auto">
+                    <label htmlFor="customSuggestionTime" className="block text-xs text-gray-500 mb-1 text-right">
+                      Time
+                    </label>
+                    <input
+                      type="time"
+                      id="customSuggestionTime"
+                      value={customSuggestionTime}
+                      onChange={(e) => setCustomSuggestionTime(e.target.value)}
+                      disabled={isLoading}
+                      className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                      style={{ fontSize: '14px' }}
+                      required
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1449,11 +1449,17 @@ function CreatePollContent() {
                 <span className="inline-flex items-center gap-1.5 flex-wrap">
                   <span className="whitespace-nowrap">Expiration:</span>
                   {(() => {
-                    const timeLabel = deadlineOption !== 'none'
-                      ? (EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
-                         deadlineOptions.find(o => o.value === deadlineOption)?.label ||
-                         deadlineOption)
-                      : null;
+                    let timeLabel: string | null = null;
+                    if (deadlineOption !== 'none') {
+                      if (deadlineOption === 'custom' && customDate && customTime) {
+                        const dt = new Date(`${customDate}T${customTime}`);
+                        timeLabel = dt.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+                      } else {
+                        timeLabel = EXPIRATION_DEADLINE_OPTIONS.find(o => o.value === deadlineOption)?.label ||
+                          deadlineOptions.find(o => o.value === deadlineOption)?.label ||
+                          deadlineOption;
+                      }
+                    }
                     const voteLabel = autoCloseAfter ? `${autoCloseAfter} votes` : null;
                     if (!timeLabel && !voteLabel) return (
                       <span className="font-normal text-blue-600 dark:text-blue-400">none</span>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -114,7 +114,6 @@ function CreatePollContent() {
   const [suggestionCutoff, setSuggestionCutoff] = useState("2hr");
   const [customSuggestionDate, setCustomSuggestionDate] = useState('');
   const [customSuggestionTime, setCustomSuggestionTime] = useState('');
-  const suggestionCutoffSelectRef = useRef<HTMLSelectElement>(null);
   const [allowPreRanking, setAllowPreRanking] = useState(true);
   const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
@@ -1590,7 +1589,6 @@ function CreatePollContent() {
                         : SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.label || suggestionCutoff}
                     </span>
                     <select
-                      ref={suggestionCutoffSelectRef}
                       value={suggestionCutoff}
                       onChange={(e) => setSuggestionCutoff(e.target.value)}
                       disabled={isLoading}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1138,7 +1138,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null }
           : poll.poll_type === 'participation'
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null, min_participants: voterMinParticipants, max_participants: voterMaxEnabled ? voterMaxParticipants : null, voter_day_time_windows: voterDayTimeWindows.length > 0 ? voterDayTimeWindows : null, voter_duration: (durationMinEnabled || durationMaxEnabled) ? { minValue: durationMinValue, maxValue: durationMaxValue, minEnabled: durationMinEnabled, maxEnabled: durationMaxEnabled } : null }
-          : { ranked_choices: voteData.ranked_choices, suggestions: voteData.suggestions, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null };
+          : { ranked_choices: voteData.ranked_choices, suggestions: canSubmitSuggestions ? voteData.suggestions : undefined, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null };
         
         
         

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -93,13 +93,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [hasPollDataState, setHasPollDataState] = useState(false);
   const [currentTime, setCurrentTime] = useState<Date | null>(null);
 
-  // Suggestion phase helpers: a ranked_choice poll with suggestion_deadline
-  // has an optional suggestion collection phase before ranking begins
-  const hasSuggestionPhase = poll.poll_type === 'ranked_choice' && !!poll.suggestion_deadline;
+  // Suggestion phase helpers: a ranked_choice poll with suggestion_deadline or suggestion_deadline_minutes
+  // has an optional suggestion collection phase before ranking begins.
+  // When suggestion_deadline_minutes is set but suggestion_deadline is null, the timer hasn't started yet
+  // (waiting for first suggestion). This is still considered "in suggestion phase".
+  const hasSuggestionPhase = poll.poll_type === 'ranked_choice' && !!(poll.suggestion_deadline || poll.suggestion_deadline_minutes);
   const effectiveSuggestionDeadline = suggestionDeadlineOverride || poll.suggestion_deadline;
-  const inSuggestionPhase = hasSuggestionPhase && currentTime
-    ? currentTime < new Date(effectiveSuggestionDeadline!)
-    : hasSuggestionPhase; // Before currentTime is set, assume suggestion phase if deadline exists
+  const suggestionTimerStarted = !!effectiveSuggestionDeadline;
+  const inSuggestionPhase = hasSuggestionPhase && (
+    !suggestionTimerStarted // Timer hasn't started yet (waiting for first suggestion)
+    || (currentTime ? currentTime < new Date(effectiveSuggestionDeadline!) : true)
+  );
   const canSubmitSuggestions = hasSuggestionPhase && inSuggestionPhase;
   const canSubmitRankings = poll.poll_type === 'ranked_choice' && (
     !hasSuggestionPhase || !inSuggestionPhase || poll.allow_pre_ranking !== false
@@ -1211,6 +1215,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
       // Refresh suggestion list for polls with suggestion phase
       if (hasSuggestionPhase) {
+        // If this is the first suggestion on a deferred-deadline poll, start the timer
+        if (!suggestionTimerStarted && poll.suggestion_deadline_minutes && !isEditingVote) {
+          const newDeadline = new Date(Date.now() + poll.suggestion_deadline_minutes * 60 * 1000);
+          setSuggestionDeadlineOverride(newDeadline.toISOString());
+        }
         // Reset abstain so the ranking ballot is usable after suggestion submission
         // (abstaining from suggestions shouldn't block ranking)
         if (isAbstaining && canSubmitRankings) {
@@ -1386,8 +1395,25 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           // Case 4: Poll is still open and not expired - show countdown
           if (!isPollClosed && !isExpired && deadline) {
             // During suggestion phase, show suggestion deadline instead of response deadline
-            if (inSuggestionPhase && poll.suggestion_deadline) {
-              return <Countdown deadline={poll.suggestion_deadline} label="Suggestions cutoff" />;
+            if (inSuggestionPhase) {
+              if (poll.suggestion_deadline) {
+                return <Countdown deadline={poll.suggestion_deadline} label="Suggestions cutoff" />;
+              }
+              // Deferred deadline: timer starts when first suggestion is submitted
+              if (poll.suggestion_deadline_minutes) {
+                const durationLabel = poll.suggestion_deadline_minutes >= 1440
+                  ? `${Math.round(poll.suggestion_deadline_minutes / 1440)}d`
+                  : poll.suggestion_deadline_minutes >= 60
+                    ? `${Math.round(poll.suggestion_deadline_minutes / 60)}h`
+                    : `${poll.suggestion_deadline_minutes}m`;
+                return (
+                  <div className="mb-3 text-center">
+                    <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">
+                      {durationLabel} cutoff starts after first suggestion
+                    </span>
+                  </div>
+                );
+              }
             }
             return <Countdown deadline={poll.response_deadline || null} />;
           }
@@ -1955,7 +1981,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
               <PollManagementButtons
                 showCloseButton={!isPollClosed && isCreator}
-                showCutoffSuggestionsButton={!isPollClosed && isCreator && canSubmitSuggestions}
+                showCutoffSuggestionsButton={!isPollClosed && isCreator && canSubmitSuggestions && existingSuggestions.length > 0}
                 showReopenButton={!!(isPollClosed && process.env.NODE_ENV === 'development')}
                 showForgetButton={hasPollDataState}
                 onCloseClick={handleCloseClick}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1409,7 +1409,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                 return (
                   <div className="mb-3 text-center">
                     <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">
-                      {durationLabel} cutoff starts after first suggestion
+                      Suggestions cutoff {durationLabel} after first suggestion
                     </span>
                   </div>
                 );

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -75,6 +75,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [isCuttingOffSuggestions, setIsCuttingOffSuggestions] = useState(false);
   const [showCutoffConfirmModal, setShowCutoffConfirmModal] = useState(false);
   const [suggestionDeadlineOverride, setSuggestionDeadlineOverride] = useState<string | null>(null);
+  const [optionsOverride, setOptionsOverride] = useState<string[] | null>(null);
   const [pollClosed, setPollClosed] = useState(poll.is_closed ?? false);
   // Don't automatically assume poll was reopened just because deadline passed
   // Only set manuallyReopened when explicitly reopened by creator action
@@ -730,6 +731,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   // Memoize parsed options to prevent re-parsing on every render
   // During suggestion phase (poll.options is null), derive options from suggestion_counts
   const pollOptions = useMemo(() => {
+    if (optionsOverride) {
+      return optionsOverride;
+    }
     if (poll.options) {
       return typeof poll.options === 'string' ? JSON.parse(poll.options) : poll.options;
     }
@@ -737,7 +741,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       return pollResults.suggestion_counts.map((sc: { option: string }) => sc.option);
     }
     return [];
-  }, [poll.options, hasSuggestionPhase, pollResults?.suggestion_counts]);
+  }, [optionsOverride, poll.options, hasSuggestionPhase, pollResults?.suggestion_counts]);
 
   // Randomize display order for 2-option polls (client-only to avoid hydration mismatch)
   const [twoOptionDisplayOrder, setTwoOptionDisplayOrder] = useState<string[]>([]);
@@ -859,6 +863,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       if (updatedPoll) {
         // Update the suggestion deadline so the UI exits suggestion phase
         setSuggestionDeadlineOverride(updatedPoll.suggestion_deadline || new Date().toISOString());
+        // Update options from the finalized poll so the ranking ballot can render
+        if (updatedPoll.options) {
+          const opts = typeof updatedPoll.options === 'string' ? JSON.parse(updatedPoll.options) : updatedPoll.options;
+          setOptionsOverride(opts);
+        }
       }
     } catch (error) {
       console.error('Error cutting off suggestions:', error);

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -926,8 +926,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     const isAnyEditing = isEditingVote || isEditingRanking;
 
     // During suggestion phase with pre-ranking, submitting rankings after the initial
-    // suggestion vote is an implicit edit (updating the existing vote with rankings)
-    const isImplicitEdit = hasVoted && !isAnyEditing && canSubmitSuggestions && canSubmitRankings;
+    // suggestion vote is an implicit edit (updating the existing vote with rankings).
+    // Also applies after suggestion cutoff: user submitted suggestions but hasn't ranked yet.
+    const hasOnlySuggestions = hasVoted && hasSuggestionPhase && !userVoteData?.ranked_choices?.length && !userVoteData?.is_abstain;
+    const isImplicitEdit = hasVoted && !isAnyEditing && (
+      (canSubmitSuggestions && canSubmitRankings) || hasOnlySuggestions
+    );
     if (isImplicitEdit) {
       setIsEditingVote(true);
     }

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1873,6 +1873,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     suggestionChoices={suggestionChoices}
                     justCancelledAbstain={justCancelledAbstain}
                     twoOptionDisplayOrder={twoOptionDisplayOrder}
+                    isEditingSuggestions={isEditingVote}
                   />
 
                   {/* Show follow-up/fork header after submit button */}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1398,7 +1398,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         })()}
         
         {/* Preliminary results shown ABOVE ballot when user has already voted (hidden during suggestion phase) */}
-        {hasVoted && !isEditingVote && !inSuggestionPhase && preliminaryResultsBlock("pt-2.5")}
+        {/* For suggestion-phase polls, only show after user has submitted rankings, not just suggestions */}
+        {hasVoted && !isEditingVote && !inSuggestionPhase && (!hasSuggestionPhase || userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain) && preliminaryResultsBlock("pt-2.5")}
 
         {/* For closed polls, show results first */}
         {isPollClosed && (
@@ -1933,7 +1934,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
 
           {/* Preliminary results shown BELOW ballot when user hasn't voted yet (hidden during suggestion phase) */}
-          {(!hasVoted || isEditingVote) && !inSuggestionPhase && preliminaryResultsBlock("mt-6")}
+          {/* For suggestion-phase polls, hide until user has submitted rankings */}
+          {(!hasVoted || isEditingVote) && !inSuggestionPhase && !hasSuggestionPhase && preliminaryResultsBlock("mt-6")}
 
           {/* Follow ups to this poll section */}
           {followUpPolls.length > 0 && (

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -108,6 +108,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const canSubmitRankings = poll.poll_type === 'ranked_choice' && (
     !hasSuggestionPhase || !inSuggestionPhase || poll.allow_pre_ranking !== false
   );
+  // Whether the user has completed ranking (or abstained) — for suggestion-phase polls,
+  // this distinguishes "voted with suggestions only" from "voted with rankings"
+  const hasCompletedRanking = !hasSuggestionPhase || userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain;
 
   // Debug logging utility (output captured by CommitInfo Logs tab)
   const logToServer = (_logType: string, level: string, message: string, data: unknown = {}) => {
@@ -872,6 +875,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           const opts = typeof updatedPoll.options === 'string' ? JSON.parse(updatedPoll.options) : updatedPoll.options;
           setOptionsOverride(opts);
         }
+        await fetchPollResults();
       }
     } catch (error) {
       console.error('Error cutting off suggestions:', error);
@@ -1401,11 +1405,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               }
               // Deferred deadline: timer starts when first suggestion is submitted
               if (poll.suggestion_deadline_minutes) {
-                const durationLabel = poll.suggestion_deadline_minutes >= 1440
-                  ? `${Math.round(poll.suggestion_deadline_minutes / 1440)}d`
-                  : poll.suggestion_deadline_minutes >= 60
-                    ? `${Math.round(poll.suggestion_deadline_minutes / 60)}h`
-                    : `${poll.suggestion_deadline_minutes}m`;
+                const durationLabel = formatDurationLabel(poll.suggestion_deadline_minutes);
                 return (
                   <div className="mb-3 text-center">
                     <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">
@@ -1429,7 +1429,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         
         {/* Preliminary results shown ABOVE ballot when user has already voted (hidden during suggestion phase) */}
         {/* For suggestion-phase polls, only show after user has submitted rankings, not just suggestions */}
-        {hasVoted && !isEditingVote && !inSuggestionPhase && (!hasSuggestionPhase || userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain) && preliminaryResultsBlock("pt-2.5")}
+        {hasVoted && !isEditingVote && !inSuggestionPhase && hasCompletedRanking && preliminaryResultsBlock("pt-2.5")}
 
         {/* For closed polls, show results first */}
         {isPollClosed && (
@@ -1814,7 +1814,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     </div>
                   )}
                 </div>
-              ) : hasVoted && !isEditingVote && !canSubmitSuggestions && (!hasSuggestionPhase || (userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain)) ? (
+              ) : hasVoted && !isEditingVote && !canSubmitSuggestions && hasCompletedRanking ? (
                 <div className="text-center py-3">
                   <div className="text-left">
                     <div className="flex items-center justify-between mb-2">

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1916,6 +1916,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       suggestionMetadata={suggestionMetadata}
                       onSuggestionMetadataChange={setSuggestionMetadata}
                       optionsMetadata={optionsMetadataLocal}
+                      showCutoffButton={!isPollClosed && isCreator && canSubmitSuggestions && existingSuggestions.length > 0}
+                      onCutoffClick={handleCutoffSuggestionsClick}
+                      isCuttingOff={isCuttingOffSuggestions}
                     />
                   )}
 
@@ -1981,15 +1984,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
               <PollManagementButtons
                 showCloseButton={!isPollClosed && isCreator}
-                showCutoffSuggestionsButton={!isPollClosed && isCreator && canSubmitSuggestions && existingSuggestions.length > 0}
                 showReopenButton={!!(isPollClosed && process.env.NODE_ENV === 'development')}
                 showForgetButton={hasPollDataState}
                 onCloseClick={handleCloseClick}
-                onCutoffSuggestionsClick={handleCutoffSuggestionsClick}
                 onReopenClick={handleReopenClick}
                 onForgetClick={() => setShowForgetConfirmModal(true)}
                 isClosingPoll={isClosingPoll}
-                isCuttingOffSuggestions={isCuttingOffSuggestions}
                 isReopeningPoll={isReopeningPoll}
               />
             </div>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -23,7 +23,7 @@ import OptionLabel from "@/components/OptionLabel";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults, OptionsMetadata, DayTimeWindow } from "@/lib/types";
-import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
+import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiCutoffSuggestions, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
 
 import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
@@ -72,6 +72,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [loadingResults, setLoadingResults] = useState(false);
   const [isClosingPoll, setIsClosingPoll] = useState(false);
   const [isReopeningPoll, setIsReopeningPoll] = useState(false);
+  const [isCuttingOffSuggestions, setIsCuttingOffSuggestions] = useState(false);
+  const [showCutoffConfirmModal, setShowCutoffConfirmModal] = useState(false);
+  const [suggestionDeadlineOverride, setSuggestionDeadlineOverride] = useState<string | null>(null);
   const [pollClosed, setPollClosed] = useState(poll.is_closed ?? false);
   // Don't automatically assume poll was reopened just because deadline passed
   // Only set manuallyReopened when explicitly reopened by creator action
@@ -92,8 +95,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   // Suggestion phase helpers: a ranked_choice poll with suggestion_deadline
   // has an optional suggestion collection phase before ranking begins
   const hasSuggestionPhase = poll.poll_type === 'ranked_choice' && !!poll.suggestion_deadline;
+  const effectiveSuggestionDeadline = suggestionDeadlineOverride || poll.suggestion_deadline;
   const inSuggestionPhase = hasSuggestionPhase && currentTime
-    ? currentTime < new Date(poll.suggestion_deadline!)
+    ? currentTime < new Date(effectiveSuggestionDeadline!)
     : hasSuggestionPhase; // Before currentTime is set, assume suggestion phase if deadline exists
   const canSubmitSuggestions = hasSuggestionPhase && inSuggestionPhase;
   const canSubmitRankings = poll.poll_type === 'ranked_choice' && (
@@ -830,6 +834,37 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       alert('Failed to close poll. Please try again.');
     } finally {
       setIsClosingPoll(false);
+    }
+  };
+
+  const handleCutoffSuggestionsClick = () => {
+    if (isCuttingOffSuggestions || !isCreator) return;
+    const creatorSecret = getCreatorSecret(poll.id);
+    if (!creatorSecret) {
+      alert('You do not have permission to cutoff suggestions.');
+      return;
+    }
+    setShowCutoffConfirmModal(true);
+  };
+
+  const handleCutoffSuggestions = async () => {
+    setShowCutoffConfirmModal(false);
+    if (isCuttingOffSuggestions || !isCreator) return;
+    const creatorSecret = getCreatorSecret(poll.id);
+    if (!creatorSecret) return;
+
+    setIsCuttingOffSuggestions(true);
+    try {
+      const updatedPoll = await apiCutoffSuggestions(poll.id, creatorSecret);
+      if (updatedPoll) {
+        // Update the suggestion deadline so the UI exits suggestion phase
+        setSuggestionDeadlineOverride(updatedPoll.suggestion_deadline || new Date().toISOString());
+      }
+    } catch (error) {
+      console.error('Error cutting off suggestions:', error);
+      alert('Failed to cutoff suggestions. Please try again.');
+    } finally {
+      setIsCuttingOffSuggestions(false);
     }
   };
 
@@ -1900,17 +1935,20 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           )}
 
 
-          {/* Poll Management Buttons - Close, Reopen, and Forget Poll */}
-          {(hasPollDataState || (isPollClosed && process.env.NODE_ENV === 'development') || (!isPollClosed && (isCreator || process.env.NODE_ENV === 'development'))) && (
+          {/* Poll Management Buttons - Close, Cutoff Suggestions, Reopen, and Forget Poll */}
+          {(hasPollDataState || (isPollClosed && process.env.NODE_ENV === 'development') || (!isPollClosed && isCreator)) && (
             <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
               <PollManagementButtons
-                showCloseButton={!isPollClosed && (isCreator || process.env.NODE_ENV === 'development')}
+                showCloseButton={!isPollClosed && isCreator}
+                showCutoffSuggestionsButton={!isPollClosed && isCreator && canSubmitSuggestions}
                 showReopenButton={!!(isPollClosed && process.env.NODE_ENV === 'development')}
                 showForgetButton={hasPollDataState}
                 onCloseClick={handleCloseClick}
+                onCutoffSuggestionsClick={handleCutoffSuggestionsClick}
                 onReopenClick={handleReopenClick}
                 onForgetClick={() => setShowForgetConfirmModal(true)}
                 isClosingPoll={isClosingPoll}
+                isCuttingOffSuggestions={isCuttingOffSuggestions}
                 isReopeningPoll={isReopeningPoll}
               />
             </div>
@@ -1945,6 +1983,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
       />
       
+      <ConfirmationModal
+        isOpen={showCutoffConfirmModal}
+        onConfirm={handleCutoffSuggestions}
+        onCancel={() => setShowCutoffConfirmModal(false)}
+        title="Cutoff Suggestions"
+        message="Are you sure you want to end the suggestion phase now? No more suggestions will be accepted and ranking will begin immediately."
+        confirmText="Cutoff Now"
+        cancelText="Cancel"
+        confirmButtonClass="bg-amber-500 hover:bg-amber-600 text-white"
+      />
+
       <ConfirmationModal
         isOpen={showReopenConfirmModal}
         onConfirm={handleReopenPoll}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -1783,7 +1783,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     </div>
                   )}
                 </div>
-              ) : hasVoted && !isEditingVote && !canSubmitSuggestions ? (
+              ) : hasVoted && !isEditingVote && !canSubmitSuggestions && (!hasSuggestionPhase || (userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain)) ? (
                 <div className="text-center py-3">
                   <div className="text-left">
                     <div className="flex items-center justify-between mb-2">

--- a/components/PollManagementButtons.tsx
+++ b/components/PollManagementButtons.tsx
@@ -4,30 +4,56 @@ interface PollManagementButtonsProps {
   showCloseButton: boolean;
   showReopenButton: boolean;
   showForgetButton: boolean;
+  showCutoffSuggestionsButton?: boolean;
   onCloseClick: () => void;
   onReopenClick?: () => void;
   onForgetClick?: () => void;
+  onCutoffSuggestionsClick?: () => void;
   isClosingPoll: boolean;
   isReopeningPoll?: boolean;
+  isCuttingOffSuggestions?: boolean;
 }
 
 export default function PollManagementButtons({
   showCloseButton,
   showReopenButton,
   showForgetButton,
+  showCutoffSuggestionsButton = false,
   onCloseClick,
   onReopenClick,
   onForgetClick,
+  onCutoffSuggestionsClick,
   isClosingPoll,
-  isReopeningPoll = false
+  isReopeningPoll = false,
+  isCuttingOffSuggestions = false,
 }: PollManagementButtonsProps) {
   // Don't render anything if no buttons should be shown
-  if (!showCloseButton && !showReopenButton && !showForgetButton) {
+  if (!showCloseButton && !showReopenButton && !showForgetButton && !showCutoffSuggestionsButton) {
     return null;
   }
 
   return (
     <div className="flex flex-wrap justify-center gap-3">
+      {showCutoffSuggestionsButton && onCutoffSuggestionsClick && (
+        <button
+          onClick={onCutoffSuggestionsClick}
+          disabled={isCuttingOffSuggestions}
+          className="inline-flex items-center px-4 py-2 bg-amber-500 hover:bg-amber-600 active:bg-amber-700 active:scale-95 disabled:bg-amber-300 text-white text-sm font-medium rounded-lg transition-all disabled:cursor-not-allowed"
+        >
+          {isCuttingOffSuggestions ? (
+            <>
+              <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Cutting off...
+            </>
+          ) : (
+            'Cutoff Suggestions Now'
+          )}
+        </button>
+      )}
+
       {showCloseButton && (
         <button
           onClick={onCloseClick}

--- a/components/PollManagementButtons.tsx
+++ b/components/PollManagementButtons.tsx
@@ -4,56 +4,30 @@ interface PollManagementButtonsProps {
   showCloseButton: boolean;
   showReopenButton: boolean;
   showForgetButton: boolean;
-  showCutoffSuggestionsButton?: boolean;
   onCloseClick: () => void;
   onReopenClick?: () => void;
   onForgetClick?: () => void;
-  onCutoffSuggestionsClick?: () => void;
   isClosingPoll: boolean;
   isReopeningPoll?: boolean;
-  isCuttingOffSuggestions?: boolean;
 }
 
 export default function PollManagementButtons({
   showCloseButton,
   showReopenButton,
   showForgetButton,
-  showCutoffSuggestionsButton = false,
   onCloseClick,
   onReopenClick,
   onForgetClick,
-  onCutoffSuggestionsClick,
   isClosingPoll,
   isReopeningPoll = false,
-  isCuttingOffSuggestions = false,
 }: PollManagementButtonsProps) {
   // Don't render anything if no buttons should be shown
-  if (!showCloseButton && !showReopenButton && !showForgetButton && !showCutoffSuggestionsButton) {
+  if (!showCloseButton && !showReopenButton && !showForgetButton) {
     return null;
   }
 
   return (
     <div className="flex flex-wrap justify-center gap-3">
-      {showCutoffSuggestionsButton && onCutoffSuggestionsClick && (
-        <button
-          onClick={onCutoffSuggestionsClick}
-          disabled={isCuttingOffSuggestions}
-          className="inline-flex items-center px-4 py-2 bg-amber-500 hover:bg-amber-600 active:bg-amber-700 active:scale-95 disabled:bg-amber-300 text-white text-sm font-medium rounded-lg transition-all disabled:cursor-not-allowed"
-        >
-          {isCuttingOffSuggestions ? (
-            <>
-              <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
-              Cutting off...
-            </>
-          ) : (
-            'Cutoff Suggestions Now'
-          )}
-        </button>
-      )}
-
       {showCloseButton && (
         <button
           onClick={onCloseClick}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1051,7 +1051,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       <div
                         className="absolute -right-3 cursor-grab active:cursor-grabbing"
                         style={{
-                          width: 'calc(20% + 0.75rem)',
+                          width: 'calc(14% + 0.525rem)',
                           top: `-${12 + gapSize / 2}px`,
                           bottom: `-${12 + gapSize / 2}px`,
                           touchAction: 'none',

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -106,6 +106,16 @@ export default function RankingSection({
         </div>
       );
     }
+    // Suggestion phase ended but no suggestions were submitted
+    if (hasSuggestionPhase && !canSubmitSuggestions && pollOptions.length === 0) {
+      return (
+        <div className="p-4 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-center">
+          <p className="text-gray-600 dark:text-gray-400 text-sm">
+            No suggestions were submitted. There are no options to rank.
+          </p>
+        </div>
+      );
+    }
     return null;
   }
 

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -37,6 +37,7 @@ interface RankingSectionProps {
   suggestionChoices: string[];
   justCancelledAbstain: boolean;
   twoOptionDisplayOrder: string[];
+  isEditingSuggestions: boolean;
 }
 
 const rankingsVoterFilter = (v: ApiVote) => !!(v.ranked_choices && v.ranked_choices.length > 0);
@@ -69,6 +70,7 @@ export default function RankingSection({
   suggestionChoices,
   justCancelledAbstain,
   twoOptionDisplayOrder,
+  isEditingSuggestions,
 }: RankingSectionProps) {
   const hasSubmittedRankings = hasVoted && userVoteData?.ranked_choices?.length > 0;
   const abstainedNoRanking = hasVoted && !userVoteData?.ranked_choices?.length && (userVoteData?.is_abstain || isAbstaining);
@@ -93,7 +95,7 @@ export default function RankingSection({
   ) : null;
 
   if (!canSubmitRankings || pollOptions.length === 0) {
-    if (!canSubmitRankings && canSubmitSuggestions) {
+    if (!canSubmitRankings && canSubmitSuggestions && !isEditingSuggestions) {
       return (
         <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
           <p className="text-blue-800 dark:text-blue-200 text-sm">

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -99,10 +99,10 @@ export default function RankingSection({
     if (canSubmitSuggestions && !isEditingSuggestions) {
       return (
         <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
-          <p className="text-blue-800 dark:text-blue-200 text-sm">
+          <div className="text-blue-800 dark:text-blue-200 text-sm">
             Ranking will open after suggestions cutoff in{' '}
             <Countdown deadline={poll.suggestion_deadline!} />
-          </p>
+          </div>
         </div>
       );
     }

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -95,7 +95,6 @@ export default function RankingSection({
   ) : null;
 
   if (!canSubmitRankings || pollOptions.length === 0) {
-    // Show countdown when ranking isn't available yet, or when there are no options to rank during suggestion phase
     if (canSubmitSuggestions && hasVoted && !isEditingSuggestions) {
       return (
         <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
@@ -109,7 +108,6 @@ export default function RankingSection({
         </div>
       );
     }
-    // Suggestion phase ended but no suggestions were submitted
     if (hasSuggestionPhase && !canSubmitSuggestions && pollOptions.length === 0) {
       return (
         <div className="p-4 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-center">

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -100,8 +100,11 @@ export default function RankingSection({
       return (
         <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
           <div className="text-blue-800 dark:text-blue-200 text-sm">
-            Ranking will open after suggestions cutoff in{' '}
-            <Countdown deadline={poll.suggestion_deadline!} />
+            {poll.suggestion_deadline ? (
+              <>Ranking will open after suggestions cutoff in{' '}<Countdown deadline={poll.suggestion_deadline} /></>
+            ) : (
+              <>Ranking will open after suggestions cutoff</>
+            )}
           </div>
         </div>
       );

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -95,7 +95,8 @@ export default function RankingSection({
   ) : null;
 
   if (!canSubmitRankings || pollOptions.length === 0) {
-    if (!canSubmitRankings && canSubmitSuggestions && !isEditingSuggestions) {
+    // Show countdown when ranking isn't available yet, or when there are no options to rank during suggestion phase
+    if (canSubmitSuggestions && !isEditingSuggestions) {
       return (
         <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
           <p className="text-blue-800 dark:text-blue-200 text-sm">

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -96,7 +96,7 @@ export default function RankingSection({
 
   if (!canSubmitRankings || pollOptions.length === 0) {
     // Show countdown when ranking isn't available yet, or when there are no options to rank during suggestion phase
-    if (canSubmitSuggestions && !isEditingSuggestions) {
+    if (canSubmitSuggestions && hasVoted && !isEditingSuggestions) {
       return (
         <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg text-center">
           <div className="text-blue-800 dark:text-blue-200 text-sm">

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -42,6 +42,9 @@ interface SuggestionVotingInterfaceProps {
   suggestionMetadata?: OptionsMetadata;
   onSuggestionMetadataChange?: (metadata: OptionsMetadata) => void;
   optionsMetadata?: OptionsMetadata | null;
+  showCutoffButton?: boolean;
+  onCutoffClick?: () => void;
+  isCuttingOff?: boolean;
 }
 
 export default function SuggestionVotingInterface({
@@ -71,6 +74,9 @@ export default function SuggestionVotingInterface({
   suggestionMetadata,
   onSuggestionMetadataChange,
   optionsMetadata,
+  showCutoffButton = false,
+  onCutoffClick,
+  isCuttingOff = false,
 }: SuggestionVotingInterfaceProps) {
   const [newSuggestions, setNewSuggestions] = useState<string[]>([""]);
   const [filteredExistingSuggestions, setFilteredExistingSuggestions] = useState<string[]>([]);
@@ -232,6 +238,29 @@ export default function SuggestionVotingInterface({
         {!isPollClosed && !isLoadingVoteData && (
           <div className="mt-5">
             <VoterList pollId={poll.id} refreshTrigger={0} label="Suggested" filter={hasSuggestions} />
+          </div>
+        )}
+
+        {/* Cutoff suggestions button - shown to creator after suggestions exist */}
+        {showCutoffButton && onCutoffClick && (
+          <div className="mt-4 flex justify-center">
+            <button
+              onClick={onCutoffClick}
+              disabled={isCuttingOff}
+              className="inline-flex items-center px-4 py-2 bg-amber-500 hover:bg-amber-600 active:bg-amber-700 active:scale-95 disabled:bg-amber-300 text-white text-sm font-medium rounded-lg transition-all disabled:cursor-not-allowed"
+            >
+              {isCuttingOff ? (
+                <>
+                  <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  Cutting off...
+                </>
+              ) : (
+                'Cutoff Suggestions Now'
+              )}
+            </button>
           </div>
         )}
       </div>

--- a/database/migrations/085_add_suggestion_deadline_minutes_down.sql
+++ b/database/migrations/085_add_suggestion_deadline_minutes_down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE polls DROP COLUMN IF EXISTS suggestion_deadline_minutes;
+DELETE FROM _migrations WHERE name = '085_add_suggestion_deadline_minutes';

--- a/database/migrations/085_add_suggestion_deadline_minutes_up.sql
+++ b/database/migrations/085_add_suggestion_deadline_minutes_up.sql
@@ -1,0 +1,7 @@
+-- Add suggestion_deadline_minutes to store the original duration.
+-- The suggestion_deadline timestamp is now set when the first suggestion is submitted,
+-- not at poll creation time.
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS suggestion_deadline_minutes INT;
+
+-- Record in migrations table
+INSERT INTO _migrations (name) VALUES ('085_add_suggestion_deadline_minutes') ON CONFLICT DO NOTHING;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -309,6 +309,14 @@ export async function apiClosePoll(pollId: string, creatorSecret: string, closeR
   return toPoll(data);
 }
 
+export async function apiCutoffSuggestions(pollId: string, creatorSecret: string): Promise<Poll> {
+  const data = await apiFetch(`/${encodeURIComponent(pollId)}/cutoff-suggestions`, {
+    method: 'POST',
+    body: JSON.stringify({ creator_secret: creatorSecret }),
+  });
+  return toPoll(data);
+}
+
 export async function apiReopenPoll(pollId: string, creatorSecret: string): Promise<Poll> {
   const data = await apiFetch(`/${encodeURIComponent(pollId)}/reopen`, {
     method: 'POST',

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -104,6 +104,7 @@ function toPoll(data: any): Poll {
     max_participants: data.max_participants ?? undefined,
     short_id: data.short_id ?? undefined,
     suggestion_deadline: data.suggestion_deadline ?? undefined,
+    suggestion_deadline_minutes: data.suggestion_deadline_minutes ?? undefined,
     allow_pre_ranking: data.allow_pre_ranking ?? true,
     details: data.details ?? undefined,
     location_mode: data.location_mode ?? undefined,

--- a/lib/timeUtils.ts
+++ b/lib/timeUtils.ts
@@ -16,8 +16,11 @@ export function windowDurationMinutes(w: { min: string; max: string }): number {
 
 /** Format a duration in minutes as a compact label (e.g. "2h 30m", "45m", "1h") */
 export function formatDurationLabel(minutes: number): string {
-  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
   const mins = minutes % 60;
+  if (days > 0 && hours > 0) return `${days}d ${hours}h`;
+  if (days > 0) return `${days}d`;
   if (hours > 0 && mins > 0) return `${hours}h ${mins}m`;
   if (hours > 0) return `${hours}h`;
   return `${mins}m`;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,7 @@ export interface Poll {
   max_participants?: number;
   short_id?: string;
   suggestion_deadline?: string | null;
+  suggestion_deadline_minutes?: number | null;
   allow_pre_ranking?: boolean;
   auto_close_after?: number;
   details?: string;

--- a/server/models.py
+++ b/server/models.py
@@ -33,6 +33,7 @@ class CreatePollRequest(BaseModel):
     min_participants: int | None = None
     max_participants: int | None = None
     suggestion_deadline: str | None = None
+    suggestion_deadline_minutes: int | None = None
     allow_pre_ranking: bool = True
     auto_close_after: int | None = None
     details: str | None = None
@@ -142,6 +143,7 @@ class PollResponse(BaseModel):
     max_participants: int | None = None
     short_id: str | None = None
     suggestion_deadline: str | None = None
+    suggestion_deadline_minutes: int | None = None
     allow_pre_ranking: bool = True
     auto_close_after: int | None = None
     details: str | None = None

--- a/server/models.py
+++ b/server/models.py
@@ -102,6 +102,10 @@ class ReopenPollRequest(BaseModel):
     creator_secret: str
 
 
+class CutoffSuggestionsRequest(BaseModel):
+    creator_secret: str
+
+
 class AccessiblePollsRequest(BaseModel):
     poll_ids: list[str]
     include_results: bool = False

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -520,6 +520,21 @@ def get_poll(poll_id: str):
         ).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Poll not found")
+
+        # Auto-finalize options when suggestion deadline has passed but options not yet set
+        if (
+            row.get("suggestion_deadline")
+            and not row.get("options")
+            and not row.get("is_closed")
+            and datetime.now(timezone.utc) >= row["suggestion_deadline"]
+        ):
+            _finalize_suggestion_options(conn, poll_id, datetime.now(timezone.utc))
+            # Re-fetch to get updated options
+            row = conn.execute(
+                "SELECT * FROM polls WHERE id = %(poll_id)s",
+                {"poll_id": poll_id},
+            ).fetchone()
+
         poll_resp = _row_to_poll(row)
         # Include response count for open polls (used for min_responses threshold)
         if not row.get("is_closed", False):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -143,6 +143,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         max_participants=row.get("max_participants"),
         short_id=row.get("short_id"),
         suggestion_deadline=row["suggestion_deadline"].isoformat() if row.get("suggestion_deadline") else None,
+        suggestion_deadline_minutes=row.get("suggestion_deadline_minutes"),
         allow_pre_ranking=row.get("allow_pre_ranking", True),
         auto_close_after=row.get("auto_close_after"),
         details=row.get("details"),
@@ -358,7 +359,8 @@ def create_poll(req: CreatePollRequest):
             INSERT INTO polls (title, poll_type, options, response_deadline,
                                creator_secret, creator_name, follow_up_to,
                                fork_of, min_participants, max_participants,
-                               suggestion_deadline, allow_pre_ranking,
+                               suggestion_deadline, suggestion_deadline_minutes,
+                               allow_pre_ranking,
                                auto_close_after, details,
                                location_mode, location_value, resolved_location,
                                time_mode, time_value, resolved_time,
@@ -377,7 +379,8 @@ def create_poll(req: CreatePollRequest):
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
                     %(fork_of)s, %(min_participants)s, %(max_participants)s,
-                    %(suggestion_deadline)s, %(allow_pre_ranking)s,
+                    %(suggestion_deadline)s, %(suggestion_deadline_minutes)s,
+                    %(allow_pre_ranking)s,
                     %(auto_close_after)s, %(details)s,
                     %(location_mode)s, %(location_value)s, %(resolved_location)s,
                     %(time_mode)s, %(time_value)s, %(resolved_time)s,
@@ -406,7 +409,9 @@ def create_poll(req: CreatePollRequest):
                 "fork_of": req.fork_of,
                 "min_participants": req.min_participants,
                 "max_participants": req.max_participants,
-                "suggestion_deadline": req.suggestion_deadline,
+                # If suggestion_deadline_minutes is set, defer the deadline until first suggestion
+                "suggestion_deadline": None if req.suggestion_deadline_minutes else req.suggestion_deadline,
+                "suggestion_deadline_minutes": req.suggestion_deadline_minutes,
                 "allow_pre_ranking": req.allow_pre_ranking,
                 "auto_close_after": req.auto_close_after,
                 "details": req.details,
@@ -556,7 +561,7 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
     with get_db() as conn:
         # Verify poll exists and is open
         poll = conn.execute(
-            "SELECT id, is_closed, poll_type, suggestion_deadline, allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
+            "SELECT id, is_closed, poll_type, suggestion_deadline, suggestion_deadline_minutes, allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()
         if not poll:
@@ -564,10 +569,27 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
         if poll["is_closed"]:
             raise HTTPException(status_code=400, detail="Poll is closed")
 
-        has_suggestion_phase = poll.get("suggestion_deadline") is not None
+        # Deferred suggestion deadline: start timer on first suggestion
+        has_deferred_deadline = (
+            poll.get("suggestion_deadline_minutes")
+            and not poll.get("suggestion_deadline")
+            and req.suggestions
+        )
+        if has_deferred_deadline:
+            from datetime import timedelta
+            new_deadline = now + timedelta(minutes=poll["suggestion_deadline_minutes"])
+            conn.execute(
+                "UPDATE polls SET suggestion_deadline = %(deadline)s, updated_at = %(now)s WHERE id = %(poll_id)s",
+                {"deadline": new_deadline, "now": now, "poll_id": poll_id},
+            )
+            # Update local poll dict so downstream checks use the new deadline
+            poll = dict(poll)
+            poll["suggestion_deadline"] = new_deadline
+
+        has_suggestion_phase = poll.get("suggestion_deadline") is not None or poll.get("suggestion_deadline_minutes") is not None
 
         # Enforce suggestion phase timing
-        if has_suggestion_phase:
+        if has_suggestion_phase and poll.get("suggestion_deadline"):
             now_check = datetime.now(timezone.utc)
             cutoff = poll["suggestion_deadline"]
             in_suggestion_phase = now_check < cutoff
@@ -678,14 +700,14 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
 
         # Check poll is still open and get suggestion phase info
         poll = conn.execute(
-            "SELECT is_closed, poll_type, suggestion_deadline, allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
+            "SELECT is_closed, poll_type, suggestion_deadline, suggestion_deadline_minutes, allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()
         if poll and poll["is_closed"]:
             raise HTTPException(status_code=400, detail="Poll is closed")
 
-        has_suggestion_phase = poll.get("suggestion_deadline") is not None
-        if has_suggestion_phase:
+        has_suggestion_phase = poll.get("suggestion_deadline") is not None or poll.get("suggestion_deadline_minutes") is not None
+        if has_suggestion_phase and poll.get("suggestion_deadline"):
             now_check = datetime.now(timezone.utc)
             cutoff = poll["suggestion_deadline"]
             in_suggestion_phase = now_check < cutoff
@@ -1085,6 +1107,15 @@ def cutoff_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
     """End the suggestion phase immediately. Requires creator_secret."""
     now = datetime.now(timezone.utc)
     with get_db() as conn:
+        # Check if any suggestions exist before allowing cutoff
+        suggestion_count = conn.execute(
+            "SELECT COUNT(*) as cnt FROM votes WHERE poll_id = %(poll_id)s AND suggestions IS NOT NULL AND array_length(suggestions, 1) > 0",
+            {"poll_id": poll_id},
+        ).fetchone()["cnt"]
+        if suggestion_count == 0:
+            raise HTTPException(status_code=400, detail="Cannot cutoff suggestions before any have been submitted")
+
+        # Handle both active deadline and deferred deadline (suggestion_deadline_minutes without suggestion_deadline)
         row = conn.execute(
             """
             UPDATE polls
@@ -1092,8 +1123,10 @@ def cutoff_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
                 updated_at = %(now)s
             WHERE id = %(poll_id)s
               AND creator_secret = %(creator_secret)s
-              AND suggestion_deadline IS NOT NULL
-              AND suggestion_deadline > %(now)s
+              AND (
+                (suggestion_deadline IS NOT NULL AND suggestion_deadline > %(now)s)
+                OR (suggestion_deadline IS NULL AND suggestion_deadline_minutes IS NOT NULL)
+              )
             RETURNING *
             """,
             {

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -13,6 +13,7 @@ from models import (
     AccessiblePollsRequest,
     ClosePollRequest,
     CreatePollRequest,
+    CutoffSuggestionsRequest,
     EditVoteRequest,
     ParticipantResponse,
     PollResponse,
@@ -1061,6 +1062,36 @@ def reopen_poll(poll_id: str, req: ReopenPollRequest):
         ).fetchone()
     if not row:
         raise HTTPException(status_code=403, detail="Invalid creator secret or poll not found")
+    return _row_to_poll(row)
+
+
+@router.post("/{poll_id}/cutoff-suggestions", response_model=PollResponse)
+def cutoff_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
+    """End the suggestion phase immediately. Requires creator_secret."""
+    now = datetime.now(timezone.utc)
+    with get_db() as conn:
+        row = conn.execute(
+            """
+            UPDATE polls
+            SET suggestion_deadline = %(now)s,
+                updated_at = %(now)s
+            WHERE id = %(poll_id)s
+              AND creator_secret = %(creator_secret)s
+              AND suggestion_deadline IS NOT NULL
+              AND suggestion_deadline > %(now)s
+            RETURNING *
+            """,
+            {
+                "poll_id": poll_id,
+                "creator_secret": req.creator_secret,
+                "now": now,
+            },
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=403, detail="Invalid creator secret, poll not found, or suggestion phase already ended")
+
+        _finalize_suggestion_options(conn, poll_id, now)
+
     return _row_to_poll(row)
 
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +203,6 @@ def _create_sub_polls_for_field(
 ) -> None:
     """Create sub-polls for a location or time field on a participation poll."""
     import json
-    from datetime import timedelta
 
     if not mode or mode == "set":
         return
@@ -576,7 +575,6 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
             and req.suggestions
         )
         if has_deferred_deadline:
-            from datetime import timedelta
             new_deadline = now + timedelta(minutes=poll["suggestion_deadline_minutes"])
             conn.execute(
                 "UPDATE polls SET suggestion_deadline = %(deadline)s, updated_at = %(now)s WHERE id = %(poll_id)s",
@@ -1107,15 +1105,7 @@ def cutoff_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
     """End the suggestion phase immediately. Requires creator_secret."""
     now = datetime.now(timezone.utc)
     with get_db() as conn:
-        # Check if any suggestions exist before allowing cutoff
-        suggestion_count = conn.execute(
-            "SELECT COUNT(*) as cnt FROM votes WHERE poll_id = %(poll_id)s AND suggestions IS NOT NULL AND array_length(suggestions, 1) > 0",
-            {"poll_id": poll_id},
-        ).fetchone()["cnt"]
-        if suggestion_count == 0:
-            raise HTTPException(status_code=400, detail="Cannot cutoff suggestions before any have been submitted")
-
-        # Handle both active deadline and deferred deadline (suggestion_deadline_minutes without suggestion_deadline)
+        # Single query: update only if suggestions exist and deadline hasn't passed
         row = conn.execute(
             """
             UPDATE polls
@@ -1127,6 +1117,12 @@ def cutoff_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
                 (suggestion_deadline IS NOT NULL AND suggestion_deadline > %(now)s)
                 OR (suggestion_deadline IS NULL AND suggestion_deadline_minutes IS NOT NULL)
               )
+              AND EXISTS (
+                SELECT 1 FROM votes
+                WHERE poll_id = %(poll_id)s
+                  AND suggestions IS NOT NULL
+                  AND array_length(suggestions, 1) > 0
+              )
             RETURNING *
             """,
             {
@@ -1136,7 +1132,7 @@ def cutoff_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
             },
         ).fetchone()
         if not row:
-            raise HTTPException(status_code=403, detail="Invalid creator secret, poll not found, or suggestion phase already ended")
+            raise HTTPException(status_code=400, detail="No suggestions to cutoff, invalid creator secret, or suggestion phase already ended")
 
         _finalize_suggestion_options(conn, poll_id, now)
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -715,7 +715,7 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
             UPDATE votes
             SET yes_no_choice = %(yes_no_choice)s,
                 ranked_choices = %(ranked_choices)s,
-                suggestions = %(suggestions)s,
+                suggestions = COALESCE(%(suggestions)s, suggestions),
                 is_abstain = %(is_abstain)s,
                 voter_name = %(voter_name)s,
                 min_participants = %(min_participants)s,


### PR DESCRIPTION
## Summary
- **Deferred suggestion deadlines**: Timer starts when the first suggestion is submitted, not at poll creation. Prevents empty cutoffs.
- **"Cutoff Suggestions Now" button**: Creator can manually end suggestion phase (shown below respondents list, requires suggestions to exist)
- **Ranking flow after cutoff**: Fixed multiple issues where the ranking ballot wouldn't appear, votes couldn't be submitted, or preliminary results showed prematurely after suggestion cutoff
- **UI improvements**: Shrink drag handle width by 30%, hide ranking countdown during suggestion editing, show "no suggestions" message when suggestion phase ends empty
- **Auto-finalization**: `get_poll` endpoint auto-finalizes options when suggestion deadline passes naturally
- **Close Poll button**: Only visible when creator secret is detected (removed dev mode fallback)
- **Create poll UX**: Suggestion cutoff badge opens native picker directly (no redundant dropdown), custom option shows date/time fields, expiration badge shows actual date instead of "Custom"

## Test plan
- [ ] Create a suggestion poll → verify "Suggestions cutoff 2h after first suggestion" message
- [ ] Submit first suggestion → verify countdown timer starts
- [ ] As creator, verify "Cutoff Suggestions Now" button appears after suggestions exist
- [ ] Cutoff suggestions → verify ranking ballot appears with finalized options
- [ ] Submit ranking after cutoff → verify vote submits successfully
- [ ] Edit ranking after cutoff → verify edit works without "Suggestions cutoff has passed" error
- [ ] Let suggestion deadline expire naturally → reload page → verify options auto-finalize
- [ ] Verify Close Poll button only shows for creator
- [ ] Verify preliminary results hidden until ranking is submitted on suggestion polls

https://claude.ai/code/session_014ZuK7tMGov5iGMgewEvU7o