### PR TITLE
Add "For" field to preferences poll creation

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1809,7 +1809,7 @@ function CreatePollContent() {
               </>
             ) : (
               <span className="flex flex-col items-center">
-                <span className="text-lg font-bold bg-gradient-to-r from-red-400 via-yellow-400 to-green-400 dark:from-blue-400 dark:via-purple-400 dark:to-red-400 bg-clip-text text-transparent">Submit</span>
+                <span className="text-lg font-bold text-green-400 dark:text-green-700">Submit</span>
                 {isPreferencePoll && title && (
                   <span className="text-sm text-gray-200 dark:text-gray-600">&ldquo;{title}&rdquo;</span>
                 )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -151,7 +151,8 @@ function CreatePollContent() {
     const builtIn = getBuiltInType(category);
     const limit = 40;
     const catLabel = builtIn?.label || (category !== 'custom' ? category : 'one');
-    const forSuffix = forField.trim() ? ` for ${forField.trim()}` : '';
+    const trimmedFor = forField.trim();
+    const forSuffix = trimmedFor ? ` for ${trimmedFor}` : '';
 
     const joinWithOr = (items: string[]) => {
       if (items.length === 2) return `${items[0]} or ${items[1]}?`;
@@ -312,7 +313,7 @@ function CreatePollContent() {
       };
       localStorage.setItem('pollFormState', JSON.stringify(formState));
     }
-  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows, minResponses, showPreliminaryResults]);
+  }, [title, details, options, deadlineOption, customDate, customTime, creatorName, isAutoTitle, category, forField, minParticipants, maxParticipants, maxEnabled, durationMinValue, durationMaxValue, durationMinEnabled, durationMaxEnabled, dayTimeWindows, minResponses, showPreliminaryResults]);
 
   // Get default date/time values (client-side only to avoid hydration mismatch)
   const getDefaultDateTime = () => {

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -263,10 +263,11 @@ function CreatePollContent() {
     if (isPreferencePoll === prevIsPreferencePollRef.current) return;
     prevIsPreferencePollRef.current = isPreferencePoll;
     if (isPreferencePoll) {
-      // Switching to preference/suggestion poll: default to 4 weeks
+      // Switching to preference/suggestion poll: default to 4 weeks, force auto-title
       if (BASE_DEADLINE_OPTIONS.some(o => o.value === deadlineOption)) {
         setDeadlineOption('1week');
       }
+      setIsAutoTitle(true);
     } else {
       // Switching away: revert to inline default if it's a voting cutoff modal option
       if (VOTING_CUTOFF_OPTIONS.some(o => o.value === deadlineOption) && deadlineOption !== 'custom') {
@@ -1680,6 +1681,8 @@ function CreatePollContent() {
             </>
           )}
 
+          {/* Title field - hidden for preference polls (always auto-generated) */}
+          {!isPreferencePoll && (
           <div>
             {isAutoTitle ? (
               <button
@@ -1727,6 +1730,7 @@ function CreatePollContent() {
               </>
             )}
           </div>
+          )}
 
           {/* Optional details field */}
           <div>
@@ -1804,7 +1808,12 @@ function CreatePollContent() {
                 Creating Poll...
               </>
             ) : (
-              "Submit"
+              <span className="flex flex-col items-center">
+                <span>Submit</span>
+                {isPreferencePoll && title && (
+                  <span className="text-xs font-normal opacity-70">&ldquo;{title}&rdquo;</span>
+                )}
+              </span>
             )}
           </button>
         </form>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1809,9 +1809,9 @@ function CreatePollContent() {
               </>
             ) : (
               <span className="flex flex-col items-center">
-                <span>Submit</span>
+                <span className="bg-gradient-to-r from-red-500 via-yellow-400 via-green-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">Submit</span>
                 {isPreferencePoll && title && (
-                  <span className="text-xs font-normal opacity-70">&ldquo;{title}&rdquo;</span>
+                  <span className="text-sm text-foreground">&ldquo;{title}&rdquo;</span>
                 )}
               </span>
             )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1808,10 +1808,10 @@ function CreatePollContent() {
                 Creating Poll...
               </>
             ) : (
-              <span className="flex flex-col items-center">
-                <span className="text-lg font-bold text-green-400 dark:text-green-700">Submit</span>
+              <span className="flex flex-col items-center py-0.5">
+                <span className="text-lg font-bold text-green-400 dark:text-green-700 leading-tight">Submit</span>
                 {isPreferencePoll && title && (
-                  <span className="text-sm text-gray-200 dark:text-gray-600">&ldquo;{title}&rdquo;</span>
+                  <span className="text-sm text-gray-200 dark:text-gray-600 leading-tight">&ldquo;{title}&rdquo;</span>
                 )}
               </span>
             )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1809,7 +1809,7 @@ function CreatePollContent() {
               </>
             ) : (
               <span className="flex flex-col items-center">
-                <span className="bg-gradient-to-r from-rose-400 via-emerald-400 to-violet-400 dark:from-rose-600 dark:via-teal-600 dark:to-indigo-600 bg-clip-text text-transparent">Submit</span>
+                <span className="text-lg font-bold bg-gradient-to-r from-rose-400 via-emerald-400 to-violet-400 dark:from-rose-600 dark:via-teal-600 dark:to-indigo-600 bg-clip-text text-transparent">Submit</span>
                 {isPreferencePoll && title && (
                   <span className="text-sm text-gray-200 dark:text-gray-600">&ldquo;{title}&rdquo;</span>
                 )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1808,7 +1808,7 @@ function CreatePollContent() {
                 Creating Poll...
               </>
             ) : (
-              <span className="flex flex-col items-center py-0.5">
+              <span className="flex flex-col items-center pt-px pb-0.5">
                 <span className="text-lg font-bold text-green-400 dark:text-green-700 leading-tight">Submit</span>
                 {isPreferencePoll && title && (
                   <span className="text-sm text-gray-200 dark:text-gray-600 leading-tight">&ldquo;{title}&rdquo;</span>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -201,6 +201,8 @@ function CreatePollContent() {
         const prefix = category === 'location' ? 'Place'
           : builtIn?.label || (category !== 'custom' ? category : '');
         if (prefix) return appendFor(prefix + '?');
+        // No category but has "for" field → "Options for X?"
+        if (forSuffix) return `Options${forSuffix}?`;
         return '';
       }
       return appendFor(buildFromOptions(filled, 'Quick Vote'));

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1809,9 +1809,9 @@ function CreatePollContent() {
               </>
             ) : (
               <span className="flex flex-col items-center">
-                <span className="bg-gradient-to-r from-red-500 via-yellow-400 via-green-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">Submit</span>
+                <span className="bg-gradient-to-r from-rose-400 via-emerald-400 to-violet-400 dark:from-rose-600 dark:via-teal-600 dark:to-indigo-600 bg-clip-text text-transparent">Submit</span>
                 {isPreferencePoll && title && (
-                  <span className="text-sm text-foreground">&ldquo;{title}&rdquo;</span>
+                  <span className="text-sm text-gray-200 dark:text-gray-600">&ldquo;{title}&rdquo;</span>
                 )}
               </span>
             )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
 import type { OptionsMetadata } from "@/lib/types";
 import CompactNameField from "@/components/CompactNameField";
-import TypeFieldInput, { getBuiltInType, isLocationLikeCategory } from "@/components/TypeFieldInput";
+import TypeFieldInput, { getBuiltInType, isLocationLikeCategory, FOR_FIELD_PLACEHOLDERS } from "@/components/TypeFieldInput";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -120,6 +120,7 @@ function CreatePollContent() {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const detailsRef = useRef<HTMLTextAreaElement>(null);
   const [category, setCategory] = useState<string>('custom');
+  const [forField, setForField] = useState("");
   const [optionsMetadata, setOptionsMetadata] = useState<OptionsMetadata>({});
   // Location/time fields for participation polls
   const [locationMode, setLocationMode] = useState<'none' | 'set' | 'preferences' | 'suggestions'>('none');
@@ -150,6 +151,7 @@ function CreatePollContent() {
     const builtIn = getBuiltInType(category);
     const limit = 40;
     const catLabel = builtIn?.label || (category !== 'custom' ? category : 'one');
+    const forSuffix = forField.trim() ? ` for ${forField.trim()}` : '';
 
     const joinWithOr = (items: string[]) => {
       if (items.length === 2) return `${items[0]} or ${items[1]}?`;
@@ -181,6 +183,13 @@ function CreatePollContent() {
       return `Which ${catLabel}?`;
     };
 
+    const appendFor = (base: string) => {
+      if (!forSuffix || !base) return base;
+      // Insert " for X" before trailing "?" if present
+      if (base.endsWith('?')) return base.slice(0, -1) + forSuffix + '?';
+      return base + forSuffix;
+    };
+
     if (pollType === 'poll') {
       if (category === 'yes_no') {
         return '';
@@ -191,10 +200,10 @@ function CreatePollContent() {
         // Suggestion mode (no options) — use category name as title
         const prefix = category === 'location' ? 'Place'
           : builtIn?.label || (category !== 'custom' ? category : '');
-        if (prefix) return prefix + '?';
+        if (prefix) return appendFor(prefix + '?');
         return '';
       }
-      return buildFromOptions(filled, 'Quick Vote');
+      return appendFor(buildFromOptions(filled, 'Quick Vote'));
     }
 
     // participation
@@ -206,7 +215,7 @@ function CreatePollContent() {
       if (filled.length > 0) return buildFromOptions(filled, "Who's in?");
     }
     return "Who's in?";
-  }, [pollType, category, options, locationMode, locationValue, locationOptions]);
+  }, [pollType, category, options, forField, locationMode, locationValue, locationOptions]);
 
   // Focus details textarea when opening
   useEffect(() => {
@@ -286,6 +295,7 @@ function CreatePollContent() {
         creatorName,
         isAutoTitle,
         category,
+        forField,
         minParticipants,
         maxParticipants,
         maxEnabled,
@@ -350,6 +360,7 @@ function CreatePollContent() {
           setCustomTime(formState.customTime || '');
           setCreatorName(formState.creatorName || '');
           if (formState.category) setCategory(formState.category);
+          if (formState.forField) setForField(formState.forField);
 
           // Restore participation poll conditions
           if (formState.minParticipants !== undefined) setMinParticipants(formState.minParticipants);
@@ -1326,23 +1337,39 @@ function CreatePollContent() {
             </div>
           </div>
 
-          {/* Category selector for suggestion and poll types */}
+          {/* Category and For fields for suggestion and poll types */}
           {pollType !== 'participation' && (
-            <div>
-              <label htmlFor="category" className="block text-sm font-medium mb-1">
-                Category <span className="text-gray-400 font-normal">(optional)</span>
-              </label>
-              <TypeFieldInput
-                value={category}
-                onChange={(val) => {
-                  setCategory(val);
-                  if (val === 'yes_no') {
-                    setIsAutoTitle(false);
-                    setTitle('');
-                  }
-                }}
-                disabled={isLoading}
-              />
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="category" className="block text-sm font-medium mb-1">
+                  Category <span className="text-gray-400 font-normal">(optional)</span>
+                </label>
+                <TypeFieldInput
+                  value={category}
+                  onChange={(val) => {
+                    setCategory(val);
+                    if (val === 'yes_no') {
+                      setIsAutoTitle(false);
+                      setTitle('');
+                    }
+                  }}
+                  disabled={isLoading}
+                />
+              </div>
+              <div>
+                <label htmlFor="forField" className="block text-sm font-medium mb-1">
+                  For <span className="text-gray-400 font-normal">(optional)</span>
+                </label>
+                <input
+                  id="forField"
+                  type="text"
+                  value={forField}
+                  onChange={(e) => setForField(e.target.value)}
+                  disabled={isLoading}
+                  placeholder={FOR_FIELD_PLACEHOLDERS[category] || "Birthday, Team outing, etc."}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                />
+              </div>
             </div>
           )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1339,7 +1339,7 @@ function CreatePollContent() {
 
           {/* Category and For fields for suggestion and poll types */}
           {pollType !== 'participation' && (
-            <div className="grid grid-cols-2 gap-3">
+            <>
               <div>
                 <label htmlFor="category" className="block text-sm font-medium mb-1">
                   Category <span className="text-gray-400 font-normal">(optional)</span>
@@ -1370,7 +1370,7 @@ function CreatePollContent() {
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
-            </div>
+            </>
           )}
 
           {/* Reference location for location polls */}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1809,7 +1809,7 @@ function CreatePollContent() {
               </>
             ) : (
               <span className="flex flex-col items-center">
-                <span className="text-lg font-bold bg-gradient-to-r from-rose-400 via-emerald-400 to-violet-400 dark:from-rose-600 dark:via-teal-600 dark:to-indigo-600 bg-clip-text text-transparent">Submit</span>
+                <span className="text-lg font-bold bg-gradient-to-r from-red-400 via-yellow-400 to-green-400 dark:from-blue-400 dark:via-purple-400 dark:to-red-400 bg-clip-text text-transparent">Submit</span>
                 {isPreferencePoll && title && (
                   <span className="text-sm text-gray-200 dark:text-gray-600">&ldquo;{title}&rdquo;</span>
                 )}

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -16,6 +16,14 @@ const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "video_game", label: "Video Game", icon: "🎮" },
 ];
 
+/** Placeholder examples for the "For" field, keyed by category value. */
+export const FOR_FIELD_PLACEHOLDERS: Record<string, string> = {
+  restaurant: "Dinner, Lunch, etc.",
+  location: "Vacation, Day trip, etc.",
+  movie: "Movie night, Date night, etc.",
+  video_game: "Game night, Tournament, etc.",
+};
+
 export function getBuiltInType(value: string): BuiltInType | undefined {
   return BUILT_IN_TYPES.find((t) => t.value === value);
 }


### PR DESCRIPTION
## Summary
- Adds a new "For (optional)" text field below the Category field on the preferences poll creation form
- Auto-generates titles incorporating the "For" value (e.g., "Restaurant for Dinner?", "Chili's or Burger King for Lunch?")
- Dynamic placeholder text per category (Restaurant: "Dinner, Lunch, etc.", Movie: "Movie night, Date night, etc.")
- Hides the title field entirely for preference polls — title is always auto-generated
- Shows the auto-generated title in quotes under a green "Submit" text on the submit button
- Handles all input combinations: category-only, for-only ("Options for X?"), options-only, or any mix

## Test plan
- [ ] Create a preference poll with category + for field → verify title like "Restaurant for Dinner?"
- [ ] Create a preference poll with options + for field → verify title like "Chili's or Burger King for Lunch?"
- [ ] Create a preference poll with only for field → verify title "Options for Dinner?"
- [ ] Verify placeholder text changes when switching categories
- [ ] Verify title field is hidden for preference polls, visible for Yes/No and Participation
- [ ] Verify submit button shows green "Submit" with quoted title underneath
- [ ] Verify form state persists in localStorage (navigate away and back)
- [ ] Check both light and dark themes for button text colors

https://claude.ai/code/session_01CsXwMCogSvqgz8zqmT89E9