### PR TITLE
Enforce suggestion cutoff before voting cutoff

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -52,13 +52,26 @@ const BASE_DEADLINE_OPTIONS = [
   { value: "custom", label: "Custom", minutes: 0 },
 ];
 
-const SUGGESTION_CUTOFF_OPTIONS = [
-  ...BASE_DEADLINE_OPTIONS.filter(o => o.value !== 'custom'),
+// Fractional suggestion cutoff options (relative to voting deadline)
+const FRACTIONAL_CUTOFF_OPTIONS = [
+  { value: "0.25x", fraction: 0.25 },
+  { value: "0.5x", fraction: 0.5 },
+  { value: "0.75x", fraction: 0.75 },
+];
+
+// Absolute duration options for suggestion cutoff (used as fallback or alongside fractional)
+const ABSOLUTE_CUTOFF_OPTIONS = [
+  { value: "5min", label: "5 min", minutes: 5 },
+  { value: "10min", label: "10 min", minutes: 10 },
+  { value: "15min", label: "15 min", minutes: 15 },
+  { value: "30min", label: "30 min", minutes: 30 },
+  { value: "1hr", label: "1 hr", minutes: 60 },
+  { value: "2hr", label: "2 hr", minutes: 120 },
+  { value: "4hr", label: "4 hr", minutes: 240 },
   { value: "8hr", label: "8 hr", minutes: 480 },
   { value: "1day", label: "1 day", minutes: 1440 },
   { value: "3day", label: "3 days", minutes: 4320 },
   { value: "1week", label: "1 week", minutes: 10080 },
-  { value: "custom", label: "Custom", minutes: 0 },
 ];
 
 const DEV_DEADLINE_OPTIONS = [
@@ -111,7 +124,7 @@ function CreatePollContent() {
   const titleInputRef = useRef<HTMLInputElement>(null);
   const loadedTitleRef = useRef<string | null>(null);
   const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
-  const [suggestionCutoff, setSuggestionCutoff] = useState("2hr");
+  const [suggestionCutoff, setSuggestionCutoff] = useState("0.5x");
   const [customSuggestionDate, setCustomSuggestionDate] = useState('');
   const [customSuggestionTime, setCustomSuggestionTime] = useState('');
   const [allowPreRanking, setAllowPreRanking] = useState(true);
@@ -278,6 +291,55 @@ function CreatePollContent() {
       }
     }
   }, [isPreferencePoll, deadlineOption]);
+
+  // Resolve voting deadline to minutes (null if no deadline or custom date/time)
+  const getVotingDeadlineMinutes = useCallback((): number | null => {
+    if (deadlineOption === 'none') return null;
+    if (deadlineOption === 'custom') {
+      if (!customDate || !customTime) return null;
+      const dt = new Date(`${customDate}T${customTime}`);
+      const diffMs = dt.getTime() - Date.now();
+      return diffMs > 0 ? diffMs / 60000 : null;
+    }
+    const opt = VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption)
+      || BASE_DEADLINE_OPTIONS.find(o => o.value === deadlineOption);
+    return opt?.minutes ?? null;
+  }, [deadlineOption, customDate, customTime]);
+
+  // Resolve suggestion cutoff to minutes based on current selection
+  const getSuggestionCutoffMinutes = useCallback((): number | null => {
+    const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+    if (frac) {
+      const votingMin = getVotingDeadlineMinutes();
+      if (votingMin == null) return null;
+      return votingMin * frac.fraction;
+    }
+    const abs = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+    if (abs) return abs.minutes;
+    // 'custom' — computed from customSuggestionDate/Time at submit time
+    return null;
+  }, [suggestionCutoff, getVotingDeadlineMinutes]);
+
+  // Format minutes as a human-readable label
+  const formatMinutesLabel = (minutes: number): string => {
+    if (minutes < 1) return `${Math.round(minutes * 60)} sec`;
+    if (minutes < 60) return `${Math.round(minutes)} min`;
+    const hours = minutes / 60;
+    if (hours < 24) {
+      const h = Math.floor(hours);
+      const m = Math.round((hours - h) * 60);
+      return m > 0 ? `${h} hr ${m} min` : `${h} hr`;
+    }
+    const days = hours / 24;
+    if (days < 7) {
+      const d = Math.floor(days);
+      const h = Math.round((days - d) * 24);
+      return h > 0 ? `${d} day${d !== 1 ? 's' : ''} ${h} hr` : `${d} day${d !== 1 ? 's' : ''}`;
+    }
+    const weeks = Math.floor(days / 7);
+    const rd = Math.round(days - weeks * 7);
+    return rd > 0 ? `${weeks} week${weeks !== 1 ? 's' : ''} ${rd} day${rd !== 1 ? 's' : ''}` : `${weeks} week${weeks !== 1 ? 's' : ''}`;
+  };
 
   // Save poll type preference separately (persists across submissions)
   const savePollTypePreference = useCallback((type: 'poll' | 'participation') => {
@@ -506,6 +568,34 @@ function CreatePollContent() {
           if (tooShort) {
             return `Each time window must be at least ${formatDurationLabel(minDurMinutes)} long (the minimum duration).`;
           }
+        }
+      }
+    }
+
+    // Suggestion cutoff validation
+    if (isSuggestionMode) {
+      if (suggestionCutoff === 'custom') {
+        if (!customSuggestionDate || !customSuggestionTime) {
+          return "Please select both a suggestion cutoff date and time.";
+        }
+        const sugDt = new Date(`${customSuggestionDate}T${customSuggestionTime}`);
+        if (sugDt <= new Date()) {
+          return "Suggestion cutoff must be in the future.";
+        }
+        // Check suggestion cutoff is before voting cutoff
+        const votingDeadline = calculateDeadline();
+        if (votingDeadline) {
+          const votingDt = new Date(votingDeadline);
+          if (sugDt >= votingDt) {
+            return "Suggestion cutoff must be before the voting cutoff.";
+          }
+        }
+      } else {
+        // For fractional/absolute: check computed minutes vs voting deadline
+        const cutoffMin = getSuggestionCutoffMinutes();
+        const votingMin = getVotingDeadlineMinutes();
+        if (cutoffMin != null && votingMin != null && cutoffMin >= votingMin) {
+          return "Suggestion cutoff must be before the voting cutoff.";
         }
       }
     }
@@ -1147,9 +1237,9 @@ function CreatePollContent() {
           const cutoffDate = new Date(`${customSuggestionDate}T${customSuggestionTime}`);
           pollData.suggestion_deadline = cutoffDate.toISOString();
         } else {
-          // Preset: deferred until first suggestion
-          const cutoffMinutes = SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.minutes || 120;
-          pollData.suggestion_deadline_minutes = cutoffMinutes;
+          // Fractional or absolute: compute minutes and defer until first suggestion
+          const cutoffMinutes = getSuggestionCutoffMinutes();
+          pollData.suggestion_deadline_minutes = cutoffMinutes != null ? Math.round(cutoffMinutes) : 120;
         }
         pollData.allow_pre_ranking = allowPreRanking;
       }
@@ -1463,9 +1553,16 @@ function CreatePollContent() {
                       <span>Suggestions Cutoff: </span>
                       <span className="relative inline-flex">
                         <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-                          {suggestionCutoff === 'custom'
-                            ? 'Custom'
-                            : SUGGESTION_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.label || suggestionCutoff}
+                          {(() => {
+                            if (suggestionCutoff === 'custom') return 'Custom';
+                            const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+                            if (frac) {
+                              const votingMin = getVotingDeadlineMinutes();
+                              if (votingMin != null) return formatMinutesLabel(votingMin * frac.fraction);
+                              return `${frac.fraction}x`;
+                            }
+                            return ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.label || suggestionCutoff;
+                          })()}
                         </span>
                         <select
                           value={suggestionCutoff}
@@ -1474,9 +1571,26 @@ function CreatePollContent() {
                           className="absolute inset-0 opacity-0 cursor-pointer"
                           aria-label="Suggestions cutoff duration"
                         >
-                          {SUGGESTION_CUTOFF_OPTIONS.map(opt => (
-                            <option key={opt.value} value={opt.value}>{opt.label}</option>
-                          ))}
+                          {/* Fractional options (only when voting deadline is set) */}
+                          {getVotingDeadlineMinutes() != null && (
+                            <optgroup label="Relative to Voting Cutoff">
+                              {FRACTIONAL_CUTOFF_OPTIONS.map(opt => {
+                                const votingMin = getVotingDeadlineMinutes()!;
+                                const mins = votingMin * opt.fraction;
+                                return (
+                                  <option key={opt.value} value={opt.value}>
+                                    {formatMinutesLabel(mins)} ({opt.fraction}x Voting Cutoff)
+                                  </option>
+                                );
+                              })}
+                            </optgroup>
+                          )}
+                          <optgroup label="Fixed Duration">
+                            {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
+                              <option key={opt.value} value={opt.value}>{opt.label}</option>
+                            ))}
+                          </optgroup>
+                          <option value="custom">Custom</option>
                         </select>
                       </span>
                     </label>
@@ -1493,6 +1607,26 @@ function CreatePollContent() {
                       </span>
                     </label>
                   </div>
+                  {/* Suggestion cutoff warnings */}
+                  {isClient && (() => {
+                    const warnings: string[] = [];
+                    const cutoffMin = getSuggestionCutoffMinutes();
+                    if (cutoffMin != null && cutoffMin < 5) {
+                      warnings.push("Suggestions cutoff is less than 5 minutes from now.");
+                    }
+                    const votingMin = getVotingDeadlineMinutes();
+                    if (cutoffMin != null && votingMin != null && (votingMin - cutoffMin) < 5) {
+                      warnings.push("Suggestions cutoff is less than 5 minutes before voting cutoff.");
+                    }
+                    if (warnings.length === 0) return null;
+                    return (
+                      <div className="mt-1.5">
+                        {warnings.map((w, i) => (
+                          <p key={i} className="text-xs text-amber-600 dark:text-amber-400">{w}</p>
+                        ))}
+                      </div>
+                    );
+                  })()}
                   {/* Custom date/time fields */}
                   {suggestionCutoff === 'custom' && (
                     <div className="mt-2 flex justify-between gap-2">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -320,24 +320,19 @@ function CreatePollContent() {
   }, [suggestionCutoff, getVotingDeadlineMinutes]);
 
   // Format minutes as a human-readable label
+  // Format minutes as a single-unit label. Uses the largest unit where the value is >= 2,
+  // except minutes which is always used below 2 hours.
   const formatMinutesLabel = (minutes: number): string => {
     if (minutes < 1) return `${Math.round(minutes * 60)} sec`;
-    if (minutes < 60) return `${Math.round(minutes)} min`;
     const hours = minutes / 60;
-    if (hours < 24) {
-      const h = Math.floor(hours);
-      const m = Math.round((hours - h) * 60);
-      return m > 0 ? `${h} hr ${m} min` : `${h} hr`;
-    }
+    if (hours < 2) return `${Math.round(minutes)} min`;
     const days = hours / 24;
-    if (days < 7) {
-      const d = Math.floor(days);
-      const h = Math.round((days - d) * 24);
-      return h > 0 ? `${d} day${d !== 1 ? 's' : ''} ${h} hr` : `${d} day${d !== 1 ? 's' : ''}`;
-    }
-    const weeks = Math.floor(days / 7);
-    const rd = Math.round(days - weeks * 7);
-    return rd > 0 ? `${weeks} week${weeks !== 1 ? 's' : ''} ${rd} day${rd !== 1 ? 's' : ''}` : `${weeks} week${weeks !== 1 ? 's' : ''}`;
+    if (days < 2) return `${Math.round(hours)} hr`;
+    const weeks = days / 7;
+    if (weeks < 2) return `${Math.round(days)} day${Math.round(days) !== 1 ? 's' : ''}`;
+    const months = days / 30;
+    if (months < 2) return `${Math.round(weeks)} week${Math.round(weeks) !== 1 ? 's' : ''}`;
+    return `${Math.round(months)} month${Math.round(months) !== 1 ? 's' : ''}`;
   };
 
   // Save poll type preference separately (persists across submissions)
@@ -1653,24 +1648,14 @@ function CreatePollContent() {
             </>
           )}
 
-          {/* Preference/suggestion polls: min responses, preliminary results, voting cutoff */}
+          {/* Preference/suggestion polls: voting cutoff, min responses */}
           {isPreferencePoll && (
             <>
-              <CompactMinResponsesField
-                value={minResponses}
-                setValue={(val) => {
-                  setMinResponses(val);
-                  saveUserMinResponses(val);
-                }}
-                showPreliminary={showPreliminaryResults}
-                setShowPreliminary={setShowPreliminaryResults}
-                disabled={isLoading}
-              />
               <div>
                 <label className="block text-sm font-medium cursor-pointer">
                   <span>Voting Cutoff: </span>
                   <span className="relative inline-flex">
-                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                    <span className="font-normal text-blue-600 dark:text-blue-400">
                       {(() => {
                         if (deadlineOption === 'none') return 'None';
                         if (deadlineOption === 'custom') {
@@ -1729,6 +1714,16 @@ function CreatePollContent() {
                   </div>
                 )}
               </div>
+              <CompactMinResponsesField
+                value={minResponses}
+                setValue={(val) => {
+                  setMinResponses(val);
+                  saveUserMinResponses(val);
+                }}
+                showPreliminary={showPreliminaryResults}
+                setShowPreliminary={setShowPreliminaryResults}
+                disabled={isLoading}
+              />
             </>
           )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1579,7 +1579,7 @@ function CreatePollContent() {
                                 const mins = votingMin * opt.fraction;
                                 return (
                                   <option key={opt.value} value={opt.value}>
-                                    {formatMinutesLabel(mins)} ({opt.fraction}x Voting Cutoff)
+                                    {opt.fraction}x ({formatMinutesLabel(mins)})
                                   </option>
                                 );
                               })}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -17,7 +17,7 @@ import { getUserName, saveUserName, getUserMinResponses, saveUserMinResponses } 
 import { debugLog } from "@/lib/debugLogger";
 import OptionsInput from "@/components/OptionsInput";
 import CompactMinResponsesField from "@/components/CompactMinResponsesField";
-import VotingCutoffConditionsModal, { VOTING_CUTOFF_OPTIONS } from "@/components/VotingCutoffConditionsModal";
+import { VOTING_CUTOFF_OPTIONS } from "@/components/VotingCutoffConditionsModal";
 import MinMaxCounter from "@/components/MinMaxCounter";
 import ParticipationConditions, { DayTimeWindow } from "@/components/ParticipationConditions";
 import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
@@ -128,7 +128,6 @@ function CreatePollContent() {
   const [customSuggestionDate, setCustomSuggestionDate] = useState('');
   const [customSuggestionTime, setCustomSuggestionTime] = useState('');
   const [allowPreRanking, setAllowPreRanking] = useState(true);
-  const [autoCloseAfter, setAutoCloseAfter] = useState<number | null>(null);
   const [details, setDetails] = useState("");
   const [detailsOpen, setDetailsOpen] = useState(false);
   const detailsRef = useRef<HTMLTextAreaElement>(null);
@@ -154,7 +153,7 @@ function CreatePollContent() {
   // Minimum responses / preliminary results / voting cutoff modal
   const [minResponses, setMinResponses] = useState<number>(1);
   const [showPreliminaryResults, setShowPreliminaryResults] = useState(true);
-  const [showVotingCutoffModal, setShowVotingCutoffModal] = useState(false);
+
 
   const hasNoOptions = options.filter(o => o.trim()).length === 0;
   const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && hasNoOptions;
@@ -765,11 +764,6 @@ function CreatePollContent() {
           if (forkData.creator_name) {
             setCreatorName(forkData.creator_name);
           }
-          if (forkData.auto_close_after != null) {
-            setAutoCloseAfter(forkData.auto_close_after);
-          } else if (forkData.total_votes) {
-            setAutoCloseAfter(forkData.total_votes);
-          }
           if (forkData.category) {
             setCategory(forkData.category);
           }
@@ -853,11 +847,6 @@ function CreatePollContent() {
           }
           if (duplicateData.creator_name) {
             setCreatorName(duplicateData.creator_name);
-          }
-          if (duplicateData.auto_close_after != null) {
-            setAutoCloseAfter(duplicateData.auto_close_after);
-          } else if (duplicateData.total_votes) {
-            setAutoCloseAfter(duplicateData.total_votes);
           }
           if (duplicateData.category) {
             setCategory(duplicateData.category);
@@ -1299,10 +1288,6 @@ function CreatePollContent() {
         addFieldData('location', locationMode, locationValue, locationOptions, locationSuggestionsDeadline, locationPreferencesDeadline);
       }
 
-      // Add auto-close after N respondents
-      if (autoCloseAfter !== null && autoCloseAfter > 0) {
-        pollData.auto_close_after = autoCloseAfter;
-      }
 
       // Add min_responses and show_preliminary_results for preference polls
       if (dbPollType === 'ranked_choice') {
@@ -1668,7 +1653,7 @@ function CreatePollContent() {
             </>
           )}
 
-          {/* Preference/suggestion polls: min responses, preliminary results, voting cutoff modal */}
+          {/* Preference/suggestion polls: min responses, preliminary results, voting cutoff */}
           {isPreferencePoll && (
             <>
               <CompactMinResponsesField
@@ -1681,98 +1666,90 @@ function CreatePollContent() {
                 setShowPreliminary={setShowPreliminaryResults}
                 disabled={isLoading}
               />
-              <button
-                type="button"
-                onClick={() => setShowVotingCutoffModal(true)}
-                disabled={isLoading}
-                className="block text-sm font-medium text-left"
-              >
-                <span className="inline-flex items-center gap-1.5 flex-wrap">
-                  <span className="whitespace-nowrap">Voting Cutoff:</span>
-                  {(() => {
-                    let timeLabel: string | null = null;
-                    if (deadlineOption !== 'none') {
-                      if (deadlineOption === 'custom' && customDate && customTime) {
-                        const dt = new Date(`${customDate}T${customTime}`);
-                        timeLabel = dt.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
-                      } else {
-                        timeLabel = VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption)?.label ||
-                          deadlineOptions.find(o => o.value === deadlineOption)?.label ||
-                          deadlineOption;
-                      }
-                    }
-                    const voteLabel = autoCloseAfter ? `${autoCloseAfter} votes` : null;
-                    if (!timeLabel && !voteLabel) return (
-                      <span className="font-normal text-blue-600 dark:text-blue-400">none</span>
-                    );
-                    return (
-                      <>
-                        {timeLabel && (
-                          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-                            {timeLabel}
-                          </span>
-                        )}
-                        {timeLabel && voteLabel && (
-                          <span className="text-xs text-gray-400 dark:text-gray-500 font-normal">or</span>
-                        )}
-                        {voteLabel && (
-                          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-                            {voteLabel}
-                          </span>
-                        )}
-                      </>
-                    );
-                  })()}
-                </span>
-              </button>
+              <div>
+                <label className="block text-sm font-medium cursor-pointer">
+                  <span>Voting Cutoff: </span>
+                  <span className="relative inline-flex">
+                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                      {(() => {
+                        if (deadlineOption === 'none') return 'None';
+                        if (deadlineOption === 'custom') {
+                          if (customDate && customTime) {
+                            const dt = new Date(`${customDate}T${customTime}`);
+                            return dt.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+                          }
+                          return 'Custom';
+                        }
+                        return VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption)?.label || deadlineOption;
+                      })()}
+                    </span>
+                    <select
+                      value={deadlineOption}
+                      onChange={(e) => setDeadlineOption(e.target.value)}
+                      disabled={isLoading}
+                      className="absolute inset-0 opacity-0 cursor-pointer"
+                      aria-label="Voting cutoff duration"
+                    >
+                      <option value="none">None</option>
+                      {VOTING_CUTOFF_OPTIONS.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </span>
+                </label>
+                {deadlineOption === 'custom' && (
+                  <div className="mt-2 flex justify-between gap-2">
+                    <div className="w-auto">
+                      <label htmlFor="customDate" className="block text-xs text-gray-500 mb-1">Date</label>
+                      <input
+                        type="date"
+                        id="customDate"
+                        value={customDate}
+                        onChange={(e) => setCustomDate(e.target.value)}
+                        disabled={isLoading}
+                        min={isClient ? getTodayDate() : ''}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                        required
+                      />
+                    </div>
+                    <div className="w-auto">
+                      <label htmlFor="customTime" className="block text-xs text-gray-500 mb-1 text-right">Time</label>
+                      <input
+                        type="time"
+                        id="customTime"
+                        value={customTime}
+                        onChange={(e) => setCustomTime(e.target.value)}
+                        disabled={isLoading}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                        required
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
             </>
           )}
 
-          {/* Auto-close + Response Deadline (for yes_no and participation polls) */}
+          {/* Response Deadline (for yes_no and participation polls) */}
           {!isPreferencePoll && (
             <>
               <div>
                 <label className="block text-sm font-medium mb-1">Close After</label>
-                <div className="flex items-center gap-2 min-w-0">
-                  <input
-                    type="number"
-                    min="1"
-                    value={autoCloseAfter ?? ''}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      setAutoCloseAfter(val === '' ? null : Math.max(1, parseInt(val, 10) || 1));
-                    }}
-                    disabled={isLoading}
-                    placeholder="—"
-                    className="w-16 shrink-0 px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm text-center"
-                  />
-                  <span className="text-sm text-gray-600 dark:text-gray-400 shrink-0">votes or</span>
-                  <select
-                    id="deadline"
-                    value={deadlineOption}
-                    onChange={(e) => setDeadlineOption(e.target.value)}
-                    disabled={isLoading}
-                    className="min-w-0 flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm truncate"
-                  >
-                    {deadlineOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {isClient ? getTimeLabel(option.value) : option.label}
-                      </option>
-                    ))}
-                  </select>
-                  {autoCloseAfter !== null && (
-                    <button
-                      type="button"
-                      onClick={() => setAutoCloseAfter(null)}
-                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0"
-                      title="Disable auto-close"
-                    >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                      </svg>
-                    </button>
-                  )}
-                </div>
+                <select
+                  id="deadline"
+                  value={deadlineOption}
+                  onChange={(e) => setDeadlineOption(e.target.value)}
+                  disabled={isLoading}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                >
+                  {deadlineOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {isClient ? getTimeLabel(option.value) : option.label}
+                    </option>
+                  ))}
+                </select>
               </div>
 
               {deadlineOption === "custom" && (
@@ -1993,20 +1970,6 @@ function CreatePollContent() {
         cancelText="Cancel"
       />
 
-      <VotingCutoffConditionsModal
-        isOpen={showVotingCutoffModal}
-        onClose={() => setShowVotingCutoffModal(false)}
-        deadlineOption={deadlineOption}
-        setDeadlineOption={setDeadlineOption}
-        customDate={customDate}
-        setCustomDate={setCustomDate}
-        customTime={customTime}
-        setCustomTime={setCustomTime}
-        autoCloseAfter={autoCloseAfter}
-        setAutoCloseAfter={setAutoCloseAfter}
-        isClient={isClient}
-        disabled={isLoading}
-      />
 
     </div>
   );

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1537,7 +1537,7 @@ function CreatePollContent() {
                     <label className="block text-sm font-medium cursor-pointer">
                       <span>Suggestions Cutoff: </span>
                       <span className="relative inline-flex">
-                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+                        <span className="font-normal text-blue-600 dark:text-blue-400">
                           {(() => {
                             if (suggestionCutoff === 'custom') return 'Custom';
                             const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -59,15 +59,9 @@ const FRACTIONAL_CUTOFF_OPTIONS = [
   { value: "0.75x", fraction: 0.75 },
 ];
 
-// Absolute duration options for suggestion cutoff (used as fallback or alongside fractional)
+// Absolute duration options for suggestion cutoff (base options + longer durations)
 const ABSOLUTE_CUTOFF_OPTIONS = [
-  { value: "5min", label: "5 min", minutes: 5 },
-  { value: "10min", label: "10 min", minutes: 10 },
-  { value: "15min", label: "15 min", minutes: 15 },
-  { value: "30min", label: "30 min", minutes: 30 },
-  { value: "1hr", label: "1 hr", minutes: 60 },
-  { value: "2hr", label: "2 hr", minutes: 120 },
-  { value: "4hr", label: "4 hr", minutes: 240 },
+  ...BASE_DEADLINE_OPTIONS.filter(o => o.value !== 'custom'),
   { value: "8hr", label: "8 hr", minutes: 480 },
   { value: "1day", label: "1 day", minutes: 1440 },
   { value: "3day", label: "3 days", minutes: 4320 },
@@ -150,10 +144,8 @@ function CreatePollContent() {
   const [refLongitude, setRefLongitude] = useState<number | undefined>(undefined);
   const [refLocationLabel, setRefLocationLabel] = useState("");
   const [searchRadius, setSearchRadius] = useState(25);
-  // Minimum responses / preliminary results / voting cutoff modal
   const [minResponses, setMinResponses] = useState<number>(1);
   const [showPreliminaryResults, setShowPreliminaryResults] = useState(true);
-
 
   const hasNoOptions = options.filter(o => o.trim()).length === 0;
   const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && hasNoOptions;
@@ -319,20 +311,20 @@ function CreatePollContent() {
     return null;
   }, [suggestionCutoff, getVotingDeadlineMinutes]);
 
-  // Format minutes as a human-readable label
-  // Format minutes as a single-unit label. Uses the largest unit where the value is >= 2,
+  // Single-unit label using truncation: uses the largest unit where the value is >= 2,
   // except minutes which is always used below 2 hours.
   const formatMinutesLabel = (minutes: number): string => {
-    if (minutes < 1) return `${Math.round(minutes * 60)} sec`;
+    if (minutes < 1) return `${Math.floor(minutes * 60)} sec`;
     const hours = minutes / 60;
-    if (hours < 2) return `${Math.round(minutes)} min`;
+    if (hours < 2) return `${Math.floor(minutes)} min`;
     const days = hours / 24;
-    if (days < 2) return `${Math.round(hours)} hr`;
+    if (days < 2) return `${Math.floor(hours)} hr`;
     const weeks = days / 7;
-    if (weeks < 2) return `${Math.round(days)} day${Math.round(days) !== 1 ? 's' : ''}`;
+    if (weeks < 2) { const d = Math.floor(days); return `${d} day${d !== 1 ? 's' : ''}`; }
     const months = days / 30;
-    if (months < 2) return `${Math.round(weeks)} week${Math.round(weeks) !== 1 ? 's' : ''}`;
-    return `${Math.round(months)} month${Math.round(months) !== 1 ? 's' : ''}`;
+    if (months < 2) { const w = Math.floor(weeks); return `${w} week${w !== 1 ? 's' : ''}`; }
+    const m = Math.floor(months);
+    return `${m} month${m !== 1 ? 's' : ''}`;
   };
 
   // Save poll type preference separately (persists across submissions)
@@ -1964,8 +1956,6 @@ function CreatePollContent() {
         confirmText="Create"
         cancelText="Cancel"
       />
-
-
     </div>
   );
 }

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -348,6 +348,29 @@ def create_poll(req: CreatePollRequest):
     if req.time_mode == "preferences" and (not req.time_options or len(req.time_options) < 2):
         raise HTTPException(status_code=400, detail="At least 2 time options are required for 'preferences' mode")
 
+    # Validate deadlines are in the future and suggestion cutoff < voting cutoff
+    if req.response_deadline:
+        response_dt = datetime.fromisoformat(req.response_deadline.replace("Z", "+00:00"))
+        if response_dt <= now:
+            raise HTTPException(status_code=400, detail="Voting deadline must be in the future")
+
+    if req.suggestion_deadline:
+        suggestion_dt = datetime.fromisoformat(req.suggestion_deadline.replace("Z", "+00:00"))
+        if suggestion_dt <= now:
+            raise HTTPException(status_code=400, detail="Suggestion deadline must be in the future")
+        if req.response_deadline:
+            response_dt = datetime.fromisoformat(req.response_deadline.replace("Z", "+00:00"))
+            if suggestion_dt >= response_dt:
+                raise HTTPException(status_code=400, detail="Suggestion deadline must be before the voting deadline")
+
+    if req.suggestion_deadline_minutes and req.response_deadline:
+        # For deferred deadlines, the max possible suggestion deadline is now + minutes.
+        # Validate that this doesn't exceed the voting deadline.
+        response_dt = datetime.fromisoformat(req.response_deadline.replace("Z", "+00:00"))
+        max_suggestion_dt = now + timedelta(minutes=req.suggestion_deadline_minutes)
+        if max_suggestion_dt >= response_dt:
+            raise HTTPException(status_code=400, detail="Suggestion deadline must be before the voting deadline")
+
     with get_db() as conn:
         # Determine resolved values for 'set' mode
         resolved_location = req.location_value if req.location_mode == "set" else None
@@ -560,7 +583,7 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
     with get_db() as conn:
         # Verify poll exists and is open
         poll = conn.execute(
-            "SELECT id, is_closed, poll_type, suggestion_deadline, suggestion_deadline_minutes, allow_pre_ranking FROM polls WHERE id = %(poll_id)s",
+            "SELECT id, is_closed, poll_type, suggestion_deadline, suggestion_deadline_minutes, allow_pre_ranking, response_deadline FROM polls WHERE id = %(poll_id)s",
             {"poll_id": poll_id},
         ).fetchone()
         if not poll:
@@ -576,6 +599,13 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
         )
         if has_deferred_deadline:
             new_deadline = now + timedelta(minutes=poll["suggestion_deadline_minutes"])
+            # Cap at response_deadline to ensure suggestions close before voting
+            if poll.get("response_deadline"):
+                response_dt = poll["response_deadline"]
+                if not response_dt.tzinfo:
+                    response_dt = response_dt.replace(tzinfo=timezone.utc)
+                if new_deadline >= response_dt:
+                    new_deadline = response_dt - timedelta(minutes=1)
             conn.execute(
                 "UPDATE polls SET suggestion_deadline = %(deadline)s, updated_at = %(now)s WHERE id = %(poll_id)s",
                 {"deadline": new_deadline, "now": now, "poll_id": poll_id},

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -349,24 +349,21 @@ def create_poll(req: CreatePollRequest):
         raise HTTPException(status_code=400, detail="At least 2 time options are required for 'preferences' mode")
 
     # Validate deadlines are in the future and suggestion cutoff < voting cutoff
-    if req.response_deadline:
-        response_dt = datetime.fromisoformat(req.response_deadline.replace("Z", "+00:00"))
-        if response_dt <= now:
-            raise HTTPException(status_code=400, detail="Voting deadline must be in the future")
+    response_dt = (
+        datetime.fromisoformat(req.response_deadline.replace("Z", "+00:00"))
+        if req.response_deadline else None
+    )
+    if response_dt and response_dt <= now:
+        raise HTTPException(status_code=400, detail="Voting deadline must be in the future")
 
     if req.suggestion_deadline:
         suggestion_dt = datetime.fromisoformat(req.suggestion_deadline.replace("Z", "+00:00"))
         if suggestion_dt <= now:
             raise HTTPException(status_code=400, detail="Suggestion deadline must be in the future")
-        if req.response_deadline:
-            response_dt = datetime.fromisoformat(req.response_deadline.replace("Z", "+00:00"))
-            if suggestion_dt >= response_dt:
-                raise HTTPException(status_code=400, detail="Suggestion deadline must be before the voting deadline")
+        if response_dt and suggestion_dt >= response_dt:
+            raise HTTPException(status_code=400, detail="Suggestion deadline must be before the voting deadline")
 
-    if req.suggestion_deadline_minutes and req.response_deadline:
-        # For deferred deadlines, the max possible suggestion deadline is now + minutes.
-        # Validate that this doesn't exceed the voting deadline.
-        response_dt = datetime.fromisoformat(req.response_deadline.replace("Z", "+00:00"))
+    if req.suggestion_deadline_minutes and response_dt:
         max_suggestion_dt = now + timedelta(minutes=req.suggestion_deadline_minutes)
         if max_suggestion_dt >= response_dt:
             raise HTTPException(status_code=400, detail="Suggestion deadline must be before the voting deadline")


### PR DESCRIPTION
## Summary
- Suggestion cutoff now defaults to a fraction of the voting cutoff (0.25x, 0.5x default, 0.75x), with absolute durations and custom date/time as fallbacks
- Fractional labels auto-recalculate when voting deadline changes; picker shows "0.5x (5 min)", form shows just "5 min"
- Duration labels use single-unit truncation (e.g. "3 weeks" not "3 weeks 6 days")
- Replace voting cutoff modal with compact inline picker matching other form fields
- Remove auto-close-after-N-responses feature from poll creation
- Client-side validation: suggestion cutoff must be before voting cutoff, with warnings for tight windows (<5 min)
- Server-side validation: both deadlines must be in the future, suggestion deadline must precede voting deadline
- Deferred suggestion deadlines are capped at response_deadline during activation

## Test plan
- [ ] Create a suggestion poll with default 0.5x cutoff — verify suggestion deadline is half the voting deadline
- [ ] Change voting cutoff and verify suggestion cutoff label updates
- [ ] Select an absolute duration for suggestion cutoff — verify it works independently
- [ ] Select custom date/time for suggestion cutoff before voting cutoff — verify it submits
- [ ] Try custom suggestion cutoff after voting cutoff — verify validation error
- [ ] Verify warnings appear when suggestion cutoff is <5 min from now or <5 min before voting cutoff
- [ ] Submit a suggestion to a poll with deferred deadline near voting deadline — verify it caps correctly