### PR TITLE
Fix bottom bar scroll-to-hide and edge-to-edge PWA layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -893,8 +893,14 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 ### iOS PWA Safe Area Positioning
 
 - **`position: fixed; top: 0` goes behind the notch** in iOS PWA with `viewport-fit: cover` and `black-translucent` status bar. All fixed header elements must use `calc(env(safe-area-inset-top, 0px) + offset)`.
-- **The `<html>` element has `padding: env(safe-area-inset-top) ...`** in globals.css, which pushes `<body>` content below the safe area. Elements inside the `ResponsiveScaling` container have their `position: fixed` coordinates relative to the container (because `transform` creates a new containing block), so `top: 0` inside the scaling container is *not* the screen top — it's already below the safe area.
+- **In PWA standalone mode, `html` padding-top/bottom is zeroed out** (globals.css `@media (display-mode: standalone)`). Safe-area-inset-top is applied as scrollable content padding instead (template.tsx inner wrapper div), so content starts below the notch at rest but scrolls behind it. Fixed elements (back button, copy link, time badge) use `calc(env(safe-area-inset-top) + offset)` and are unaffected.
 - **To position at the true screen edge**, render via a portal to `document.body` (outside the scaling container). From there, `fixed top: 0` = the safe area boundary (notch bottom), not the physical screen top.
+
+### iOS PWA Full-Screen Layout
+
+- **Viewport height units (`100vh`, `100dvh`, `-webkit-fill-available`) all stop at the safe-area boundary** on iOS PWA even with `viewport-fit: cover`. They exclude the home indicator area (~34px). Use `position: fixed; inset: 0` on `.h-screen-safe` in standalone mode to reliably span the full physical screen.
+- **Don't use `scrollContainer.scrollTop || window.scrollY`** to get scroll position — when `scrollTop` is 0 (at the very top), the `||` falls through to `window.scrollY` which may be nonzero. Use a deterministic source: check `scrollHeight > clientHeight` to decide whether the container or window is scrollable, then read from that source.
+- **Bottom bar scroll-to-hide needs touch events on iOS PWA**, not just scroll event listeners. In PWA standalone mode, the scroll container's `scroll` events may not fire reliably (pull-to-refresh sets `overscrollBehavior: none`, `passive: false` touchmove). Use `touchstart`/`touchend` to record and compare `scrollTop`, with scroll events as a desktop fallback.
 
 ### Back Button Navigation Strategy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -898,7 +898,7 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 
 ### iOS PWA Full-Screen Layout
 
-- **Viewport height units (`100vh`, `100dvh`, `-webkit-fill-available`) all stop at the safe-area boundary** on iOS PWA even with `viewport-fit: cover`. They exclude the home indicator area (~34px). Use `position: fixed; inset: 0` on `.h-screen-safe` in standalone mode to reliably span the full physical screen.
+- **Viewport height units (`100vh`, `100dvh`, `-webkit-fill-available`) all stop at the safe-area boundary** on iOS PWA even with `viewport-fit: cover`. They exclude the home indicator area (~34px). `position: fixed; inset: 0` can't be used because `.responsive-scaling-container` has `transform: scale(1)` on mobile which creates a containing block, trapping fixed children. `height: 100%` chain also fails because the parent collapses. Accept the ~34px bottom gap — it's the iOS home indicator safe area.
 - **Don't use `scrollContainer.scrollTop || window.scrollY`** to get scroll position — when `scrollTop` is 0 (at the very top), the `||` falls through to `window.scrollY` which may be nonzero. Use a deterministic source: check `scrollHeight > clientHeight` to decide whether the container or window is scrollable, then read from that source.
 - **Bottom bar scroll-to-hide needs touch events on iOS PWA**, not just scroll event listeners. In PWA standalone mode, the scroll container's `scroll` events may not fire reliably (pull-to-refresh sets `overscrollBehavior: none`, `passive: false` touchmove). Use `touchstart`/`touchend` to record and compare `scrollTop`, with scroll events as a desktop fallback.
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -176,6 +176,16 @@ body {
 
 /* PWA-specific fixes for iOS */
 @media (display-mode: standalone) {
+  /* Remove html safe-area top/bottom padding so content extends edge-to-edge.
+     The scroll container adds safe-area-inset-top as internal content padding
+     instead, so it scrolls with the content — items become visible (but
+     non-interactable) behind the notch/status bar as they scroll past. */
+  html {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    min-height: 100% !important;
+  }
+
   /* Only apply non-conflicting PWA styles */
   body {
     margin: 0 !important;
@@ -193,19 +203,5 @@ body {
   /* Ensure content area doesn't interfere */
   .safari-scroll-container {
     margin-bottom: 0 !important;
-  }
-}
-
-/* In PWA standalone mode on iOS, remove html safe-area padding so content
-   extends edge-to-edge. The scroll container adds the safe area as internal
-   content padding instead, so it scrolls with the content — items become
-   visible (but non-interactable) behind the notch/status bar as they scroll past. */
-@media (display-mode: standalone) {
-  @supports (-webkit-touch-callout: none) and (not (hover: hover)) {
-    html {
-      padding-top: 0 !important;
-      padding-bottom: 0 !important;
-      min-height: 100% !important;
-    }
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -183,7 +183,11 @@ body {
   html {
     padding-top: 0 !important;
     padding-bottom: 0 !important;
-    min-height: 100% !important;
+    /* Extend html background into the home indicator zone. The original
+       padding-bottom filled this area, but we removed padding to avoid
+       pushing body up. min-height extends the element (and its background)
+       past the viewport bottom into the safe area. */
+    min-height: calc(100% + env(safe-area-inset-bottom, 0px)) !important;
   }
 
   body {

--- a/app/globals.css
+++ b/app/globals.css
@@ -190,19 +190,8 @@ body {
     min-height: -webkit-fill-available !important;
   }
   
-  /* Bottom bar positioning without overriding safe area padding */
-  .fixed.bottom-0 {
-    bottom: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    margin: 0 !important;
-    transform: none !important;
-    position: fixed !important;
-  }
-  
   /* Ensure content area doesn't interfere */
   .safari-scroll-container {
-    padding-bottom: 1rem !important;
     margin-bottom: 0 !important;
   }
   

--- a/app/globals.css
+++ b/app/globals.css
@@ -183,26 +183,26 @@ body {
   html {
     padding-top: 0 !important;
     padding-bottom: 0 !important;
+    height: 100% !important;
     min-height: 100% !important;
   }
 
-  /* Only apply non-conflicting PWA styles */
   body {
     margin: 0 !important;
     overflow-x: hidden !important;
+    height: 100% !important;
   }
 
-  /* Pin to physical screen edges. Viewport height units (100vh, 100dvh,
-     -webkit-fill-available) all stop at the safe-area boundary on iOS even
-     with viewport-fit:cover. position:fixed + inset:0 reliably spans the
-     full physical screen including behind the notch and home indicator. */
+  /* Cascade height:100% through the parent chain so .h-screen-safe fills the
+     full screen. Can't use position:fixed because .responsive-scaling-container
+     has transform:scale(1) which creates a containing block, trapping fixed
+     children inside a 0-height collapsed parent. */
+  .responsive-scaling-container {
+    height: 100% !important;
+  }
+
   .h-screen-safe {
-    position: fixed !important;
-    top: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    bottom: 0 !important;
-    height: auto !important;
+    height: 100% !important;
     min-height: 0 !important;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -181,7 +181,7 @@ body {
     margin: 0 !important;
     overflow-x: hidden !important;
   }
-  
+
   /* Force viewport to use full screen */
   .h-screen-safe {
     height: 100vh !important;
@@ -189,10 +189,23 @@ body {
     min-height: 100vh !important;
     min-height: -webkit-fill-available !important;
   }
-  
+
   /* Ensure content area doesn't interfere */
   .safari-scroll-container {
     margin-bottom: 0 !important;
   }
-  
+}
+
+/* In PWA standalone mode on iOS, remove html safe-area padding so content
+   extends edge-to-edge. The scroll container adds the safe area as internal
+   content padding instead, so it scrolls with the content — items become
+   visible (but non-interactable) behind the notch/status bar as they scroll past. */
+@media (display-mode: standalone) {
+  @supports (-webkit-touch-callout: none) and (not (hover: hover)) {
+    html {
+      padding-top: 0 !important;
+      padding-bottom: 0 !important;
+      min-height: 100% !important;
+    }
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -182,12 +182,9 @@ body {
      non-interactable) behind the notch/status bar as they scroll past. */
   html {
     padding-top: 0 !important;
-    padding-bottom: 0 !important;
-    /* Extend html background into the home indicator zone. The original
-       padding-bottom filled this area, but we removed padding to avoid
-       pushing body up. min-height extends the element (and its background)
-       past the viewport bottom into the safe area. */
-    min-height: calc(100% + env(safe-area-inset-bottom, 0px)) !important;
+    /* Keep padding-bottom from iOS CSS — it fills the home indicator zone
+       with the background color. Only top padding is removed so content
+       can scroll behind the notch. */
   }
 
   body {

--- a/app/globals.css
+++ b/app/globals.css
@@ -183,27 +183,24 @@ body {
   html {
     padding-top: 0 !important;
     padding-bottom: 0 !important;
-    height: 100% !important;
     min-height: 100% !important;
   }
 
   body {
     margin: 0 !important;
     overflow-x: hidden !important;
-    height: 100% !important;
   }
 
-  /* Cascade height:100% through the parent chain so .h-screen-safe fills the
-     full screen. Can't use position:fixed because .responsive-scaling-container
-     has transform:scale(1) which creates a containing block, trapping fixed
-     children inside a 0-height collapsed parent. */
-  .responsive-scaling-container {
-    height: 100% !important;
-  }
-
+  /* Keep original viewport height — don't change this. height:100% breaks
+     because the parent chain collapses, and position:fixed breaks because
+     .responsive-scaling-container has transform:scale(1) which traps fixed
+     children. The bottom gap below the home indicator is an iOS safe area
+     that can't be filled with viewport units. */
   .h-screen-safe {
-    height: 100% !important;
-    min-height: 0 !important;
+    height: 100vh !important;
+    height: -webkit-fill-available !important;
+    min-height: 100vh !important;
+    min-height: -webkit-fill-available !important;
   }
 
   /* Ensure content area doesn't interfere */

--- a/app/globals.css
+++ b/app/globals.css
@@ -192,12 +192,18 @@ body {
     overflow-x: hidden !important;
   }
 
-  /* Use full physical screen height, not -webkit-fill-available which excludes
-     the home indicator area. With viewport-fit:cover, 100vh includes the area
-     behind the notch and home indicator — exactly what we want for edge-to-edge. */
+  /* Pin to physical screen edges. Viewport height units (100vh, 100dvh,
+     -webkit-fill-available) all stop at the safe-area boundary on iOS even
+     with viewport-fit:cover. position:fixed + inset:0 reliably spans the
+     full physical screen including behind the notch and home indicator. */
   .h-screen-safe {
-    height: 100vh !important;
-    min-height: 100vh !important;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    height: auto !important;
+    min-height: 0 !important;
   }
 
   /* Ensure content area doesn't interfere */

--- a/app/globals.css
+++ b/app/globals.css
@@ -192,12 +192,12 @@ body {
     overflow-x: hidden !important;
   }
 
-  /* Force viewport to use full screen */
+  /* Use full physical screen height, not -webkit-fill-available which excludes
+     the home indicator area. With viewport-fit:cover, 100vh includes the area
+     behind the notch and home indicator — exactly what we want for edge-to-edge. */
   .h-screen-safe {
     height: 100vh !important;
-    height: -webkit-fill-available !important;
     min-height: 100vh !important;
-    min-height: -webkit-fill-available !important;
   }
 
   /* Ensure content area doesn't interfere */

--- a/app/globals.css
+++ b/app/globals.css
@@ -189,19 +189,15 @@ body {
 
   body {
     margin: 0 !important;
-    overflow-x: hidden !important;
+    overflow: hidden !important;
   }
 
-  /* Keep original viewport height — don't change this. height:100% breaks
-     because the parent chain collapses, and position:fixed breaks because
-     .responsive-scaling-container has transform:scale(1) which traps fixed
-     children. The bottom gap below the home indicator is an iOS safe area
-     that can't be filled with viewport units. */
+  /* Extend content container into the home indicator zone so content is
+     visible when the bottom bar hides. 100vh stops at the safe-area boundary,
+     so add safe-area-inset-bottom to reach the physical screen bottom. */
   .h-screen-safe {
-    height: 100vh !important;
-    height: -webkit-fill-available !important;
-    min-height: 100vh !important;
-    min-height: -webkit-fill-available !important;
+    height: calc(100vh + env(safe-area-inset-bottom, 0px)) !important;
+    min-height: calc(100vh + env(safe-area-inset-bottom, 0px)) !important;
   }
 
   /* Ensure content area doesn't interfere */

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -484,7 +484,7 @@ export default function Template({ children }: AppTemplateProps) {
           paddingTop: '0',
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
-          paddingBottom: 'calc(4rem + env(safe-area-inset-bottom, 0px))',
+          paddingBottom: '4rem',
         }}>
         <div style={isStandalone ? { paddingTop: 'env(safe-area-inset-top, 0px)' } : undefined}>
           {/* Spacer div for header elements that are now rendered in portal */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -136,14 +136,15 @@ export default function Template({ children }: AppTemplateProps) {
   }, []);
 
   // Handle scroll direction detection for bottom bar.
-  // Listens on both the inner scroll container AND the window, because on iOS Safari
-  // the body can be scrollable (html safe-area padding + body overflow:auto) and
-  // scroll events may fire on the window instead of the inner container.
+  // Uses touch events as primary mechanism (reliable on iOS PWA + browser),
+  // with scroll event listener as fallback for desktop/mouse-wheel.
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
     let rAFId: number | null = null;
-    let scrollContainer: HTMLElement | null = null;
 
     // Track current visibility to avoid no-op setState calls during scroll
     let isVisible = true;
@@ -154,27 +155,37 @@ export default function Template({ children }: AppTemplateProps) {
       }
     };
 
-    // Which scroll source is active — avoid mixing them
-    let activeSource: 'container' | 'window' | null = null;
+    // --- Touch-based direction detection (primary, works in iOS PWA) ---
+    let touchStartScrollTop = 0;
 
-    const getScrollY = (source: 'container' | 'window'): { scrollY: number; maxScrollY: number } => {
-      if (source === 'container' && scrollContainer) {
-        return {
-          scrollY: scrollContainer.scrollTop,
-          maxScrollY: scrollContainer.scrollHeight - scrollContainer.clientHeight,
-        };
-      }
-      return {
-        scrollY: window.scrollY,
-        maxScrollY: document.documentElement.scrollHeight - window.innerHeight,
-      };
+    const handleTouchStart = () => {
+      touchStartScrollTop = scrollContainer.scrollTop || window.scrollY;
     };
 
+    const handleTouchEnd = () => {
+      const currentScrollTop = scrollContainer.scrollTop || window.scrollY;
+      const delta = currentScrollTop - touchStartScrollTop;
+
+      // Near the top — always show
+      if (currentScrollTop < SCROLL_TOP_SAFE_ZONE) {
+        setVisible(true);
+        return;
+      }
+
+      // Need a meaningful scroll to trigger (avoids taps)
+      if (Math.abs(delta) >= scrollThreshold.current) {
+        setVisible(delta < 0); // scrolled up → show, scrolled down → hide
+      }
+    };
+
+    scrollContainer.addEventListener('touchstart', handleTouchStart, { passive: true });
+    scrollContainer.addEventListener('touchend', handleTouchEnd, { passive: true });
+
+    // --- Scroll event fallback (desktop mouse wheel, and browser scroll) ---
     const processScroll = () => {
       rAFId = null;
-      if (!activeSource) return;
-
-      const { scrollY: currentScrollY, maxScrollY } = getScrollY(activeSource);
+      const currentScrollY = scrollContainer.scrollTop || window.scrollY;
+      const maxScrollY = scrollContainer.scrollHeight - scrollContainer.clientHeight;
 
       if (currentScrollY <= 0) {
         setVisible(true);
@@ -182,20 +193,16 @@ export default function Template({ children }: AppTemplateProps) {
         return;
       }
 
-      // Keep bottom bar visible near the top so a tiny scroll can't hide it
-      // on pages with little content where the user can't scroll up to recover.
       if (currentScrollY < SCROLL_TOP_SAFE_ZONE) {
         setVisible(true);
         lastScrollY.current = currentScrollY;
         return;
       }
 
-      // iOS rubber band past the bottom — ignore and clamp lastScrollY
+      // iOS rubber band past the bottom — ignore
       if (currentScrollY > maxScrollY) {
         isInBounceRef.current = true;
-        if (bounceTimeoutRef.current) {
-          clearTimeout(bounceTimeoutRef.current);
-        }
+        if (bounceTimeoutRef.current) clearTimeout(bounceTimeoutRef.current);
         bounceTimeoutRef.current = setTimeout(() => {
           isInBounceRef.current = false;
           bounceTimeoutRef.current = null;
@@ -204,14 +211,12 @@ export default function Template({ children }: AppTemplateProps) {
         return;
       }
 
-      // Scroll position is unreliable during bounce cooldown
       if (isInBounceRef.current) {
         lastScrollY.current = currentScrollY;
         return;
       }
 
       const scrollDifference = Math.abs(currentScrollY - lastScrollY.current);
-
       if (scrollDifference >= scrollThreshold.current) {
         setVisible(currentScrollY < lastScrollY.current);
       }
@@ -219,59 +224,22 @@ export default function Template({ children }: AppTemplateProps) {
       lastScrollY.current = currentScrollY;
     };
 
-    const scheduleProcess = () => {
+    const handleScroll = () => {
       if (rAFId === null) {
         rAFId = requestAnimationFrame(processScroll);
       }
     };
 
-    const handleContainerScroll = () => {
-      activeSource = 'container';
-      scheduleProcess();
-    };
-
-    const handleWindowScroll = () => {
-      // Only use window scroll if the container isn't the one scrolling
-      if (!scrollContainer || scrollContainer.scrollTop === 0) {
-        activeSource = 'window';
-        scheduleProcess();
-      }
-    };
-
-    // Attach container listener — retry briefly if ref not ready
-    const attachContainer = () => {
-      scrollContainer = scrollContainerRef.current;
-      if (scrollContainer) {
-        scrollContainer.addEventListener('scroll', handleContainerScroll, { passive: true });
-        return true;
-      }
-      return false;
-    };
-
-    // Always listen on window as fallback for iOS body-scroll
-    window.addEventListener('scroll', handleWindowScroll, { passive: true });
-
-    // Try immediately, then retry after a short delay
-    if (!attachContainer()) {
-      const retryId = setTimeout(attachContainer, 150);
-      // Store for cleanup
-      var retryTimeout: ReturnType<typeof setTimeout> | null = retryId;
-    }
+    scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('scroll', handleScroll, { passive: true });
 
     return () => {
-      if (typeof retryTimeout !== 'undefined' && retryTimeout !== null) {
-        clearTimeout(retryTimeout);
-      }
-      if (rAFId !== null) {
-        cancelAnimationFrame(rAFId);
-      }
-      if (scrollContainer) {
-        scrollContainer.removeEventListener('scroll', handleContainerScroll);
-      }
-      window.removeEventListener('scroll', handleWindowScroll);
-      if (bounceTimeoutRef.current) {
-        clearTimeout(bounceTimeoutRef.current);
-      }
+      scrollContainer.removeEventListener('touchstart', handleTouchStart);
+      scrollContainer.removeEventListener('touchend', handleTouchEnd);
+      scrollContainer.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('scroll', handleScroll);
+      if (rAFId !== null) cancelAnimationFrame(rAFId);
+      if (bounceTimeoutRef.current) clearTimeout(bounceTimeoutRef.current);
     };
   }, []);
 

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -135,7 +135,10 @@ export default function Template({ children }: AppTemplateProps) {
     };
   }, []);
 
-  // Handle scroll direction detection for bottom bar
+  // Handle scroll direction detection for bottom bar.
+  // Listens on both the inner scroll container AND the window, because on iOS Safari
+  // the body can be scrollable (html safe-area padding + body overflow:auto) and
+  // scroll events may fire on the window instead of the inner container.
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
@@ -151,12 +154,27 @@ export default function Template({ children }: AppTemplateProps) {
       }
     };
 
+    // Which scroll source is active — avoid mixing them
+    let activeSource: 'container' | 'window' | null = null;
+
+    const getScrollY = (source: 'container' | 'window'): { scrollY: number; maxScrollY: number } => {
+      if (source === 'container' && scrollContainer) {
+        return {
+          scrollY: scrollContainer.scrollTop,
+          maxScrollY: scrollContainer.scrollHeight - scrollContainer.clientHeight,
+        };
+      }
+      return {
+        scrollY: window.scrollY,
+        maxScrollY: document.documentElement.scrollHeight - window.innerHeight,
+      };
+    };
+
     const processScroll = () => {
       rAFId = null;
-      if (!scrollContainer) return;
+      if (!activeSource) return;
 
-      const currentScrollY = scrollContainer.scrollTop;
-      const maxScrollY = scrollContainer.scrollHeight - scrollContainer.clientHeight;
+      const { scrollY: currentScrollY, maxScrollY } = getScrollY(activeSource);
 
       if (currentScrollY <= 0) {
         setVisible(true);
@@ -201,27 +219,56 @@ export default function Template({ children }: AppTemplateProps) {
       lastScrollY.current = currentScrollY;
     };
 
-    const handleScroll = () => {
+    const scheduleProcess = () => {
       if (rAFId === null) {
         rAFId = requestAnimationFrame(processScroll);
       }
     };
 
-    const timeoutId = setTimeout(() => {
+    const handleContainerScroll = () => {
+      activeSource = 'container';
+      scheduleProcess();
+    };
+
+    const handleWindowScroll = () => {
+      // Only use window scroll if the container isn't the one scrolling
+      if (!scrollContainer || scrollContainer.scrollTop === 0) {
+        activeSource = 'window';
+        scheduleProcess();
+      }
+    };
+
+    // Attach container listener — retry briefly if ref not ready
+    const attachContainer = () => {
       scrollContainer = scrollContainerRef.current;
       if (scrollContainer) {
-        scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
+        scrollContainer.addEventListener('scroll', handleContainerScroll, { passive: true });
+        return true;
       }
-    }, 100);
+      return false;
+    };
+
+    // Always listen on window as fallback for iOS body-scroll
+    window.addEventListener('scroll', handleWindowScroll, { passive: true });
+
+    // Try immediately, then retry after a short delay
+    if (!attachContainer()) {
+      const retryId = setTimeout(attachContainer, 150);
+      // Store for cleanup
+      var retryTimeout: ReturnType<typeof setTimeout> | null = retryId;
+    }
 
     return () => {
-      clearTimeout(timeoutId);
+      if (typeof retryTimeout !== 'undefined' && retryTimeout !== null) {
+        clearTimeout(retryTimeout);
+      }
       if (rAFId !== null) {
         cancelAnimationFrame(rAFId);
       }
       if (scrollContainer) {
-        scrollContainer.removeEventListener('scroll', handleScroll);
+        scrollContainer.removeEventListener('scroll', handleContainerScroll);
       }
+      window.removeEventListener('scroll', handleWindowScroll);
       if (bounceTimeoutRef.current) {
         clearTimeout(bounceTimeoutRef.current);
       }
@@ -474,7 +521,7 @@ export default function Template({ children }: AppTemplateProps) {
           paddingTop: '0',
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
-          paddingBottom: '1rem',
+          paddingBottom: 'calc(4rem + env(safe-area-inset-bottom, 0px))',
         }}>
         <div>
           {/* Spacer div for header elements that are now rendered in portal */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -491,7 +491,7 @@ export default function Template({ children }: AppTemplateProps) {
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
           paddingBottom: 'calc(4rem + env(safe-area-inset-bottom, 0px))',
         }}>
-        <div>
+        <div style={isStandalone ? { paddingTop: 'env(safe-area-inset-top, 0px)' } : undefined}>
           {/* Spacer div for header elements that are now rendered in portal */}
           {(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') && (
             <div className="relative">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -563,7 +563,12 @@ export default function Template({ children }: AppTemplateProps) {
             showBottomBar ? '' : 'pointer-events-none'
           }`}
           style={{
-            paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+            // In standalone PWA, fixed bottom:0 stops at the viewport edge, not the
+            // physical screen bottom. Push the bar down into the home indicator zone
+            // with a negative bottom offset, and double the padding to keep buttons
+            // above the unsafe area.
+            bottom: isStandalone ? 'calc(-1 * env(safe-area-inset-bottom, 0px))' : '0',
+            paddingBottom: isStandalone ? 'calc(2 * env(safe-area-inset-bottom, 0px))' : 'env(safe-area-inset-bottom, 0px)',
             transform: showBottomBar ? 'translateY(0)' : 'translateY(100%)',
             transition: 'transform 200ms ease-out',
             willChange: 'transform',

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -155,24 +155,25 @@ export default function Template({ children }: AppTemplateProps) {
       }
     };
 
+    // Prefer container scrollTop; fall back to window only if container isn't scrollable
+    const getScrollTop = () =>
+      scrollContainer.scrollHeight > scrollContainer.clientHeight
+        ? scrollContainer.scrollTop
+        : window.scrollY;
+
+    const isNearTop = (pos: number) => pos < SCROLL_TOP_SAFE_ZONE;
+
     // --- Touch-based direction detection (primary, works in iOS PWA) ---
     let touchStartScrollTop = 0;
 
     const handleTouchStart = () => {
-      touchStartScrollTop = scrollContainer.scrollTop || window.scrollY;
+      touchStartScrollTop = getScrollTop();
     };
 
     const handleTouchEnd = () => {
-      const currentScrollTop = scrollContainer.scrollTop || window.scrollY;
-      const delta = currentScrollTop - touchStartScrollTop;
-
-      // Near the top — always show
-      if (currentScrollTop < SCROLL_TOP_SAFE_ZONE) {
-        setVisible(true);
-        return;
-      }
-
-      // Need a meaningful scroll to trigger (avoids taps)
+      const pos = getScrollTop();
+      if (isNearTop(pos)) { setVisible(true); return; }
+      const delta = pos - touchStartScrollTop;
       if (Math.abs(delta) >= scrollThreshold.current) {
         setVisible(delta < 0); // scrolled up → show, scrolled down → hide
       }
@@ -184,16 +185,10 @@ export default function Template({ children }: AppTemplateProps) {
     // --- Scroll event fallback (desktop mouse wheel, and browser scroll) ---
     const processScroll = () => {
       rAFId = null;
-      const currentScrollY = scrollContainer.scrollTop || window.scrollY;
+      const currentScrollY = getScrollTop();
       const maxScrollY = scrollContainer.scrollHeight - scrollContainer.clientHeight;
 
-      if (currentScrollY <= 0) {
-        setVisible(true);
-        lastScrollY.current = currentScrollY;
-        return;
-      }
-
-      if (currentScrollY < SCROLL_TOP_SAFE_ZONE) {
+      if (isNearTop(currentScrollY)) {
         setVisible(true);
         lastScrollY.current = currentScrollY;
         return;


### PR DESCRIPTION
## Summary
- Fix bottom bar hiding page content by increasing scroll container bottom padding from 1rem to 4rem
- Fix bottom bar not collapsing on scroll by adding touch-based direction detection (touchstart/touchend) as primary mechanism — scroll events alone don't fire reliably in iOS PWA standalone mode
- Remove CSS rule that forced `transform: none !important` on `.fixed.bottom-0`, which prevented the translateY hide animation in PWA mode
- Make PWA layout edge-to-edge: zero out html top padding, extend `.h-screen-safe` height into home indicator zone via `calc(100vh + env(safe-area-inset-bottom))`, push bottom bar into safe area with negative bottom offset, and add safe-area-inset-top as scrollable content padding so items scroll behind the notch

## Test plan
- [x] Browser: bottom bar hides on scroll down, shows on scroll up
- [x] Browser: all content visible above bottom bar (no clipping)
- [x] PWA: bottom bar hides on scroll down, shows on scroll up
- [x] PWA: content extends edge-to-edge (behind notch at top, to screen bottom)
- [x] PWA: content starts below notch when scrolled to top
- [x] PWA: no gap at bottom of screen
- [ ] PWA: pull-to-refresh still works
- [ ] Desktop: scroll-to-hide works with mouse wheel

https://claude.ai/code/session_01SyY7AV7Zh7gnpbLh5eRAh5