### PR TITLE
Make commit age and create poll button scroll with page

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -487,6 +487,8 @@ export default function Template({ children }: AppTemplateProps) {
           paddingBottom: '4rem',
         }}>
         <div style={isStandalone ? { paddingTop: 'env(safe-area-inset-top, 0px)' } : undefined}>
+          {/* Portal target for commit age badge (rendered by CommitInfo component) */}
+          <div id="commit-badge-portal"></div>
           {/* Spacer div for header elements that are now rendered in portal */}
           {(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') && (
             <div className="relative">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -495,7 +495,7 @@ export default function Template({ children }: AppTemplateProps) {
               
               {/* Poll page title */}
               {isPollPage && pollPageTitle && (
-                <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
+                <div className="max-w-4xl mx-auto px-16 pt-2 pb-1">
                   <h1
                     className="text-2xl font-bold text-center break-words cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
@@ -507,7 +507,7 @@ export default function Template({ children }: AppTemplateProps) {
 
               {/* Create poll page title */}
               {isCreatePollPage && (
-                <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
+                <div className="max-w-4xl mx-auto px-16 pt-2 pb-1">
                   <h1
                     className="text-2xl font-bold text-center whitespace-nowrap cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
@@ -525,7 +525,7 @@ export default function Template({ children }: AppTemplateProps) {
 
               {/* Profile page title */}
               {isProfilePage && (
-                <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
+                <div className="max-w-4xl mx-auto px-16 pt-2 pb-1">
                   <h1
                     className="text-2xl font-bold text-center break-words cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
@@ -537,11 +537,11 @@ export default function Template({ children }: AppTemplateProps) {
               
               {/* Home page title */}
               {pathname === '/' && (
-                <div className="relative max-w-4xl mx-auto px-2 pt-4 pb-1">
+                <div className="relative max-w-4xl mx-auto px-2 pt-2 pb-1">
                   {/* Create poll button - top right, scrolls with content */}
                   <Link
                     href="/create-poll"
-                    className="absolute right-2 top-4 w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+                    className="absolute right-2 top-2 w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                     aria-label="Create new poll"
                   >
                     <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -495,7 +495,7 @@ export default function Template({ children }: AppTemplateProps) {
               
               {/* Poll page title */}
               {isPollPage && pollPageTitle && (
-                <div className="max-w-4xl mx-auto px-16 pt-2 pb-1">
+                <div className="max-w-4xl mx-auto px-16 pt-1 pb-1">
                   <h1
                     className="text-2xl font-bold text-center break-words cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
@@ -507,7 +507,7 @@ export default function Template({ children }: AppTemplateProps) {
 
               {/* Create poll page title */}
               {isCreatePollPage && (
-                <div className="max-w-4xl mx-auto px-16 pt-2 pb-1">
+                <div className="max-w-4xl mx-auto px-16 pt-1 pb-1">
                   <h1
                     className="text-2xl font-bold text-center whitespace-nowrap cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
@@ -525,7 +525,7 @@ export default function Template({ children }: AppTemplateProps) {
 
               {/* Profile page title */}
               {isProfilePage && (
-                <div className="max-w-4xl mx-auto px-16 pt-2 pb-1">
+                <div className="max-w-4xl mx-auto px-16 pt-1 pb-1">
                   <h1
                     className="text-2xl font-bold text-center break-words cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                     onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
@@ -537,11 +537,11 @@ export default function Template({ children }: AppTemplateProps) {
               
               {/* Home page title */}
               {pathname === '/' && (
-                <div className="relative max-w-4xl mx-auto px-2 pt-2 pb-1">
+                <div className="relative max-w-4xl mx-auto px-2 pt-1 pb-1">
                   {/* Create poll button - top right, scrolls with content */}
                   <Link
                     href="/create-poll"
-                    className="absolute right-2 top-2 w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+                    className="absolute right-2 top-1 w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                     aria-label="Create new poll"
                   >
                     <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -537,7 +537,17 @@ export default function Template({ children }: AppTemplateProps) {
               
               {/* Home page title */}
               {pathname === '/' && (
-                <div className="max-w-4xl mx-auto px-2 pt-4 pb-1">
+                <div className="relative max-w-4xl mx-auto px-2 pt-4 pb-1">
+                  {/* Create poll button - top right, scrolls with content */}
+                  <Link
+                    href="/create-poll"
+                    className="absolute right-2 top-4 w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+                    aria-label="Create new poll"
+                  >
+                    <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  </Link>
                   <div className="text-center">
                     <h1
                       className="text-2xl font-bold mb-1 cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
@@ -661,20 +671,6 @@ export default function Template({ children }: AppTemplateProps) {
           </div>
         )}
         
-        {/* New poll button in upper right for home page */}
-        {pathname === '/' && (
-          <div className="fixed right-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
-            <Link
-              href="/create-poll"
-              className="w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-              aria-label="Create new poll"
-            >
-              <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </Link>
-          </div>
-        )}
       </HeaderPortal>
     </>
   );

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
 interface CommitData {
   sha: string;
@@ -97,6 +98,20 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
   const vercelHash = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA || '';
   const branchName = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF || '';
   const [commitHash, setCommitHash] = useState(vercelHash);
+  const [badgeTarget, setBadgeTarget] = useState<HTMLElement | null>(null);
+
+  // Find the portal target for the time badge (rendered inside scroll container by template.tsx)
+  useEffect(() => {
+    if (!showTimeBadge) return;
+    const findTarget = () => {
+      const el = document.getElementById('commit-badge-portal');
+      if (el) setBadgeTarget(el);
+    };
+    findTarget();
+    // Template may not be mounted yet on first layout render
+    const timer = setTimeout(findTarget, 100);
+    return () => clearTimeout(timer);
+  }, [showTimeBadge]);
 
   // In dev mode, fetch the current git SHA from the server on mount and on visibility change
   useEffect(() => {
@@ -200,17 +215,17 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
 
   return (
     <>
-      {/* Time badge - only shown in dev mode, positioned top center with no top margin */}
-      {showTimeBadge && (
+      {/* Time badge - only shown in dev mode, portaled into scroll container so it scrolls with content */}
+      {showTimeBadge && badgeTarget && createPortal(
         <div
-          className="fixed left-1/2 -translate-x-1/2 z-[9999] cursor-pointer select-none"
-          style={{ top: 'calc(env(safe-area-inset-top, 0px) + 2px)' }}
+          className="flex justify-center cursor-pointer select-none pt-1"
           onClick={() => setShowModal(true)}
         >
           <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
             {relativeTime || error || '...'}
           </span>
-        </div>
+        </div>,
+        badgeTarget
       )}
 
       {/* Modal */}

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -218,7 +218,7 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
       {/* Time badge - only shown in dev mode, portaled into scroll container so it scrolls with content */}
       {showTimeBadge && badgeTarget && createPortal(
         <div
-          className="flex justify-center cursor-pointer select-none pt-1"
+          className="flex justify-center cursor-pointer select-none"
           onClick={() => setShowModal(true)}
         >
           <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -100,16 +100,16 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
   const [commitHash, setCommitHash] = useState(vercelHash);
   const [badgeTarget, setBadgeTarget] = useState<HTMLElement | null>(null);
 
-  // Find the portal target for the time badge (rendered inside scroll container by template.tsx)
+  // Find the portal target for the time badge (inside scroll container so it scrolls with content)
   useEffect(() => {
     if (!showTimeBadge) return;
-    const findTarget = () => {
+    const el = document.getElementById('commit-badge-portal');
+    if (el) { setBadgeTarget(el); return; }
+    // Fallback: template may not be mounted yet on first layout render
+    const timer = setTimeout(() => {
       const el = document.getElementById('commit-badge-portal');
       if (el) setBadgeTarget(el);
-    };
-    findTarget();
-    // Template may not be mounted yet on first layout render
-    const timer = setTimeout(findTarget, 100);
+    }, 100);
     return () => clearTimeout(timer);
   }, [showTimeBadge]);
 


### PR DESCRIPTION
## Summary
- Changed the commit age badge from `position: fixed` to a portal rendered inside the scroll container, so it scrolls away with page content
- Moved the create poll button from the fixed HeaderPortal into the home page title section (absolute positioned within scroll content)
- Tightened top padding on all page title sections (`pt-4` → `pt-1`) to keep headers close to the top

## Test plan
- [ ] Home page: commit age badge and create poll button visible at top, scroll away when scrolling down
- [ ] Create poll page: title sits near top, scrolls with content
- [ ] Poll page: title sits near top, scrolls with content
- [ ] Profile page: title sits near top, scrolls with content
- [ ] PWA standalone mode: safe area inset still respected, elements not behind notch

https://claude.ai/code/session_017a9b7yW1yzFyZku36eSG7v