### PR TITLE
Redesign poll list: category icons, cutoff labels, sorting

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -104,10 +104,10 @@ const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string 
 };
 
 function formatDurationShort(minutes: number): string {
-  if (minutes < 60) return `${minutes}m`;
+  if (minutes < 60) return `${minutes}m 0s`;
   const h = Math.floor(minutes / 60);
   const m = minutes % 60;
-  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  return m > 0 ? `${h}h ${m}m 0s` : `${h}h 0m 0s`;
 }
 
 function isInSuggestionPhase(poll: Poll): boolean {

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -591,10 +591,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                                     hour12: true
                                   });
                                 } else {
-                                  const mm = String(deadline.getMonth() + 1).padStart(2, '0');
-                                  const dd = String(deadline.getDate()).padStart(2, '0');
-                                  const yy = String(deadline.getFullYear()).slice(-2);
-                                  return `${mm}/${dd}/${yy}`;
+                                  return deadline.toLocaleDateString("en-US", {
+                                    month: "numeric",
+                                    day: "numeric",
+                                    year: "2-digit"
+                                  });
                                 }
                               })()}</>
                             </ClientOnly>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -443,13 +443,13 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                             {(() => {
                               const inSuggestions = isInSuggestionPhase(poll);
                               if (inSuggestions && poll.suggestion_deadline) {
-                                return <SimpleCountdown deadline={poll.suggestion_deadline} label="Suggestions Cutoff in" />;
+                                return <SimpleCountdown deadline={poll.suggestion_deadline} label="Suggestions" />;
                               }
                               if (inSuggestions && poll.suggestion_deadline_minutes) {
                                 return <span className="font-semibold text-blue-600 dark:text-blue-400">Taking Suggestions</span>;
                               }
                               if (poll.response_deadline) {
-                                return <SimpleCountdown deadline={poll.response_deadline} label="Voting Cutoff in" />;
+                                return <SimpleCountdown deadline={poll.response_deadline} label="Voting" />;
                               }
                               return null;
                             })()}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -51,7 +51,7 @@ function relativeTime(dateStr: string): string {
 }
 
 // Simple countdown component
-const SimpleCountdown = ({ deadline }: { deadline: string }) => {
+const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
   const [isClient, setIsClient] = useState(false);
 
@@ -61,7 +61,7 @@ const SimpleCountdown = ({ deadline }: { deadline: string }) => {
 
   useEffect(() => {
     if (!isClient) return;
-    
+
     const updateCountdown = () => {
       const now = new Date().getTime();
       const deadlineTime = new Date(deadline).getTime();
@@ -98,11 +98,26 @@ const SimpleCountdown = ({ deadline }: { deadline: string }) => {
 
   return (
     <>
-      <span className="font-mono font-semibold text-green-600 dark:text-green-400">{timeLeft}</span>
-      {timeLeft !== "Expired" && " left"}
+      {label}{label && " "}<span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{timeLeft}</span>
     </>
   );
 };
+
+function formatDurationShort(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function isInSuggestionPhase(poll: Poll): boolean {
+  if (poll.poll_type !== 'ranked_choice') return false;
+  // Timer started and deadline in the future
+  if (poll.suggestion_deadline && new Date(poll.suggestion_deadline) > new Date()) return true;
+  // Timer not started yet (waiting for first suggestion)
+  if (!poll.suggestion_deadline && poll.suggestion_deadline_minutes) return true;
+  return false;
+}
 
 function getOptionDisplayName(optionKey: string, poll: Poll): string {
   const meta = poll.options_metadata?.[optionKey];
@@ -430,13 +445,23 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       )}
                       <div className="flex items-center justify-between">
                         <span className="text-sm">{getCategoryIcon(poll)}</span>
-                        {poll.response_deadline && (
-                          <span className="text-xs text-gray-500 dark:text-gray-400">
-                            <ClientOnly fallback={<>Loading...</>}>
-                              <SimpleCountdown deadline={poll.response_deadline} />
-                            </ClientOnly>
-                          </span>
-                        )}
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          <ClientOnly fallback={<>Loading...</>}>
+                            {(() => {
+                              const inSuggestions = isInSuggestionPhase(poll);
+                              if (inSuggestions && poll.suggestion_deadline) {
+                                return <SimpleCountdown deadline={poll.suggestion_deadline} label="Suggestions Cutoff in" />;
+                              }
+                              if (inSuggestions && poll.suggestion_deadline_minutes) {
+                                return <>Suggestions Cutoff in <span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{formatDurationShort(poll.suggestion_deadline_minutes)}</span></>;
+                              }
+                              if (poll.response_deadline) {
+                                return <SimpleCountdown deadline={poll.response_deadline} label="Voting Cutoff in" />;
+                              }
+                              return null;
+                            })()}
+                          </ClientOnly>
+                        </span>
                       </div>
                       <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                         {poll.title}

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -21,13 +21,14 @@ function getPollSymbol(pollType: string, isClosed: boolean): string {
   return POLL_TYPE_SYMBOLS[pollType] || '☰';
 }
 
-function getCategoryDisplay(poll: Poll): { label: string; icon: string } | null {
+function getCategoryIcon(poll: Poll): string {
   const category = poll.category;
-  if (!category || category === 'custom') return null;
-  const builtIn = getBuiltInType(category);
-  if (builtIn) return { label: builtIn.label, icon: builtIn.icon };
-  // Custom category string — capitalize first letter
-  return { label: category.charAt(0).toUpperCase() + category.slice(1), icon: '' };
+  if (category && category !== 'custom') {
+    const builtIn = getBuiltInType(category);
+    if (builtIn?.icon) return builtIn.icon;
+  }
+  // Custom or no category — use poll type symbol
+  return getPollSymbol(poll.poll_type, poll.is_closed ?? false);
 }
 
 function relativeTime(dateStr: string): string {
@@ -335,8 +336,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               const prevPoll = index > 0 ? openPolls[index - 1] : null;
               const isPrevVoted = prevPoll ? (votedPollIds.has(prevPoll.id) || abstainedPollIds.has(prevPoll.id)) : false;
               const isFirstVoted = hasVotedOrAbstained && !isPrevVoted;
-              const categoryDisplay = getCategoryDisplay(poll);
-
               const handleTouchStart = (e: React.TouchEvent) => {
                 isLongPress.current = false;
                 isScrolling.current = false;
@@ -430,19 +429,12 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         </div>
                       )}
                       <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm">{getPollSymbol(poll.poll_type, false)}</span>
-                          {poll.response_deadline && (
-                            <span className="text-xs text-gray-500 dark:text-gray-400">
-                              <ClientOnly fallback={<>Loading...</>}>
-                                <SimpleCountdown deadline={poll.response_deadline} />
-                              </ClientOnly>
-                            </span>
-                          )}
-                        </div>
-                        {categoryDisplay && (
-                          <span className="text-xs text-gray-400 dark:text-gray-500">
-                            {categoryDisplay.label} {categoryDisplay.icon}
+                        <span className="text-sm">{getCategoryIcon(poll)}</span>
+                        {poll.response_deadline && (
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                            <ClientOnly fallback={<>Loading...</>}>
+                              <SimpleCountdown deadline={poll.response_deadline} />
+                            </ClientOnly>
                           </span>
                         )}
                       </div>
@@ -478,7 +470,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
           </div>
           <div>
               {closedPolls.map((poll, index) => {
-                const categoryDisplay = getCategoryDisplay(poll);
                 const handleTouchStart = (e: React.TouchEvent) => {
                   isLongPress.current = false;
                   isScrolling.current = false;
@@ -566,37 +557,30 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                         </div>
                       )}
                       <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm">{getPollSymbol(poll.poll_type, true)}</span>
-                          {poll.response_deadline && (
-                            <span className="text-xs text-gray-500 dark:text-gray-400">
-                              <ClientOnly fallback={<>Closed</>}>
-                                <>Closed {(() => {
-                                  const deadline = new Date(poll.response_deadline);
-                                  const now = new Date();
-                                  const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+                        <span className="text-sm">{getCategoryIcon(poll)}</span>
+                        {poll.response_deadline && (
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                            <ClientOnly fallback={<>Closed</>}>
+                              <>Closed {(() => {
+                                const deadline = new Date(poll.response_deadline);
+                                const now = new Date();
+                                const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
 
-                                  if (hoursAgo <= 24) {
-                                    return deadline.toLocaleTimeString("en-US", {
-                                      hour: "numeric",
-                                      minute: "2-digit",
-                                      hour12: true
-                                    });
-                                  } else {
-                                    return deadline.toLocaleDateString("en-US", {
-                                      month: "numeric",
-                                      day: "numeric",
-                                      year: "2-digit"
-                                    });
-                                  }
-                                })()}</>
-                              </ClientOnly>
-                            </span>
-                          )}
-                        </div>
-                        {categoryDisplay && (
-                          <span className="text-xs text-gray-400 dark:text-gray-500">
-                            {categoryDisplay.label} {categoryDisplay.icon}
+                                if (hoursAgo <= 24) {
+                                  return deadline.toLocaleTimeString("en-US", {
+                                    hour: "numeric",
+                                    minute: "2-digit",
+                                    hour12: true
+                                  });
+                                } else {
+                                  return deadline.toLocaleDateString("en-US", {
+                                    month: "numeric",
+                                    day: "numeric",
+                                    year: "2-digit"
+                                  });
+                                }
+                              })()}</>
+                            </ClientOnly>
                           </span>
                         )}
                       </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -576,22 +576,24 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       )}
                       <div className="flex items-center justify-between">
                         <span className="text-sm">{getCategoryIcon(poll)}</span>
-                        {poll.response_deadline && (
+                        {(poll.response_deadline || poll.updated_at) && (
                           <span className="text-xs text-gray-500 dark:text-gray-400">
                             <ClientOnly fallback={<>Closed</>}>
                               <>Closed {(() => {
-                                const deadline = new Date(poll.response_deadline);
+                                const closedAt = poll.close_reason === 'manual'
+                                  ? new Date(poll.updated_at)
+                                  : new Date(poll.response_deadline || poll.updated_at);
                                 const now = new Date();
-                                const hoursAgo = (now.getTime() - deadline.getTime()) / (1000 * 60 * 60);
+                                const hoursAgo = (now.getTime() - closedAt.getTime()) / (1000 * 60 * 60);
 
                                 if (hoursAgo <= 24) {
-                                  return deadline.toLocaleTimeString("en-US", {
+                                  return closedAt.toLocaleTimeString("en-US", {
                                     hour: "numeric",
                                     minute: "2-digit",
                                     hour12: true
                                   });
                                 } else {
-                                  return deadline.toLocaleDateString("en-US", {
+                                  return closedAt.toLocaleDateString("en-US", {
                                     month: "numeric",
                                     day: "numeric",
                                     year: "2-digit"

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -103,13 +103,6 @@ const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string 
   );
 };
 
-function formatDurationShort(minutes: number): string {
-  if (minutes < 60) return `${minutes}m 0s`;
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  return m > 0 ? `${h}h ${m}m 0s` : `${h}h 0m 0s`;
-}
-
 function isInSuggestionPhase(poll: Poll): boolean {
   if (poll.poll_type !== 'ranked_choice') return false;
   // Timer started and deadline in the future
@@ -445,7 +438,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       )}
                       <div className="flex items-center justify-between">
                         <span className="text-sm">{getCategoryIcon(poll)}</span>
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
                           <ClientOnly fallback={<>Loading...</>}>
                             {(() => {
                               const inSuggestions = isInSuggestionPhase(poll);
@@ -453,7 +446,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                                 return <SimpleCountdown deadline={poll.suggestion_deadline} label="Suggestions Cutoff in" />;
                               }
                               if (inSuggestions && poll.suggestion_deadline_minutes) {
-                                return <>Suggestions Cutoff in <span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{formatDurationShort(poll.suggestion_deadline_minutes)}</span></>;
+                                return <span className="font-semibold text-blue-600 dark:text-blue-400">Taking Suggestions</span>;
                               }
                               if (poll.response_deadline) {
                                 return <SimpleCountdown deadline={poll.response_deadline} label="Voting Cutoff in" />;

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -124,7 +124,7 @@ const BADGE_COLORS = {
 
 function getResultBadge(poll: Poll, results: PollResults | null | undefined, userVoteId?: string | null, userVoted?: boolean, userName?: string | null): ResultBadge {
   if (!results) {
-    return { text: 'No results', emoji: '—', color: 'gray' };
+    return { text: 'No results', emoji: '🔇', color: 'gray' };
   }
 
   if (results.total_votes === 0) {
@@ -136,13 +136,13 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined, use
       if (results.winner === 'yes') return { text: 'Yes', emoji: '👑', color: 'green' };
       if (results.winner === 'no') return { text: 'No', emoji: '👑', color: 'red' };
       if (results.winner === 'tie') return { text: 'Tie', emoji: '🤝', color: 'yellow' };
-      return { text: 'No winner', emoji: '—', color: 'gray' };
+      return { text: 'No winner', emoji: '🤷', color: 'gray' };
     }
     case 'ranked_choice': {
       if (results.winner) {
         return { text: getOptionDisplayName(results.winner, poll), emoji: '👑', color: 'green' };
       }
-      return { text: 'No winner', emoji: '—', color: 'gray' };
+      return { text: 'No winner', emoji: '🤷', color: 'gray' };
     }
     case 'participation': {
       const participatingCount = results.yes_count || 0;
@@ -167,7 +167,7 @@ function getResultBadge(poll: Poll, results: PollResults | null | undefined, use
       return { text: 'Not happening', emoji: '✗', color: 'red' };
     }
     default:
-      return { text: 'Closed', emoji: '—', color: 'gray' };
+      return { text: 'Closed', emoji: '🔒', color: 'gray' };
   }
 }
 

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -266,44 +266,40 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       return new Date(poll.response_deadline) <= now || poll.is_closed;
     });
     
+    // Get the effective cutoff for an open poll: suggestion deadline if in
+    // suggestion phase, otherwise the voting deadline.
+    const getEffectiveCutoff = (poll: Poll): number => {
+      if (isInSuggestionPhase(poll)) {
+        if (poll.suggestion_deadline) return new Date(poll.suggestion_deadline).getTime();
+        // Timer not started — sort after polls with active countdowns
+        return Infinity;
+      }
+      return new Date(poll.response_deadline || poll.created_at).getTime();
+    };
+
     // Sort open polls by voted status (unvoted first, then voted/abstained)
-    // Within each group, sort by expiring soonest first
+    // Within each group, sort by soonest cutoff first
     const sortByVoted = (pollList: Poll[]) => {
       const unvoted = pollList.filter(p => !votedPollIds.has(p.id) && !abstainedPollIds.has(p.id));
       const voted = pollList.filter(p => votedPollIds.has(p.id) || abstainedPollIds.has(p.id));
-      
-      // Sort each group by expiring soonest (ascending deadline)
-      const sortByDeadline = (polls: Poll[]) => {
-        return polls.sort((a, b) => {
-          const deadlineA = new Date(a.response_deadline || a.created_at).getTime();
-          const deadlineB = new Date(b.response_deadline || b.created_at).getTime();
-          return deadlineA - deadlineB; // Ascending order - soonest first
-        });
+
+      const sortByCutoff = (polls: Poll[]) => {
+        return polls.sort((a, b) => getEffectiveCutoff(a) - getEffectiveCutoff(b));
       };
-      
-      return [...sortByDeadline(unvoted), ...sortByDeadline(voted)];
+
+      return [...sortByCutoff(unvoted), ...sortByCutoff(voted)];
     };
-    
-    // Sort closed polls by most recently closed (newest closed first)
+
+    // Sort closed polls by most recently closed first
     const sortClosedByTime = (pollList: Poll[]) => {
       return pollList.sort((a, b) => {
-        // First determine when each poll was closed
         const getClosingTime = (poll: Poll) => {
-          if (poll.is_closed) {
-            // If manually closed, we'll use response_deadline as proxy for closing time
-            // In the future, we could add a closed_at timestamp field
-            return new Date(poll.response_deadline || poll.created_at).getTime();
-          } else {
-            // If closed by deadline expiry, use response_deadline
-            return new Date(poll.response_deadline || poll.created_at).getTime();
+          if (poll.close_reason === 'manual') {
+            return new Date(poll.updated_at).getTime();
           }
+          return new Date(poll.response_deadline || poll.created_at).getTime();
         };
-        
-        const timeA = getClosingTime(a);
-        const timeB = getClosingTime(b);
-        
-        // Sort by most recently closed first (descending order)
-        return timeB - timeA;
+        return getClosingTime(b) - getClosingTime(a);
       });
     };
     

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -336,7 +336,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {/* Open Polls Section */}
       {openPolls.length > 0 && (
         <div>
-          <div className="border-t border-gray-200 dark:border-gray-700 mx-1.5">
+          <div>
             {openPolls.map((poll, index) => {
               const isVoted = votedPollIds.has(poll.id);
               const isAbstained = abstainedPollIds.has(poll.id);
@@ -413,11 +413,11 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               return (
                 <React.Fragment key={poll.id}>
                   {isFirstVoted && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-y border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
                       Already Voted
                     </div>
                   )}
-                  <div key={poll.id} className="border-b border-gray-200 dark:border-gray-700 mx-1.5">
+                  <div key={poll.id} className={`border-b ${index === 0 && !isFirstVoted ? 'border-t' : ''} border-gray-200 dark:border-gray-700 mx-1.5`}>
                     <div
                       onClick={() => {
                         setNavigatingPollId(poll.id);
@@ -483,7 +483,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {/* Closed Polls Section */}
       {closedPolls.length > 0 && (
         <div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
+          <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-y border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
             Closed
           </div>
           <div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -79,9 +79,9 @@ const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string 
 
       let timeString = "";
       if (days > 0) {
-        timeString = `${days}d ${hours}h`;
+        timeString = `${days}d ${hours}h ${minutes}m ${seconds}s`;
       } else if (hours > 0) {
-        timeString = `${hours}h ${minutes}m`;
+        timeString = `${hours}h ${minutes}m ${seconds}s`;
       } else if (minutes > 0) {
         timeString = `${minutes}m ${seconds}s`;
       } else {

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -343,7 +343,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {/* Open Polls Section */}
       {openPolls.length > 0 && (
         <div>
-          <div>
+          <div className="border-t border-gray-200 dark:border-gray-700 mx-1.5">
             {openPolls.map((poll, index) => {
               const isVoted = votedPollIds.has(poll.id);
               const isAbstained = abstainedPollIds.has(poll.id);

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -591,11 +591,10 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                                     hour12: true
                                   });
                                 } else {
-                                  return deadline.toLocaleDateString("en-US", {
-                                    month: "numeric",
-                                    day: "numeric",
-                                    year: "2-digit"
-                                  });
+                                  const mm = String(deadline.getMonth() + 1).padStart(2, '0');
+                                  const dd = String(deadline.getDate()).padStart(2, '0');
+                                  const yy = String(deadline.getFullYear()).slice(-2);
+                                  return `${mm}/${dd}/${yy}`;
                                 }
                               })()}</>
                             </ClientOnly>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -98,16 +98,14 @@ const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string 
 
   return (
     <>
-      {label}{label && " "}<span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{timeLeft}</span>
+      {label && `${label} `}<span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{timeLeft}</span>
     </>
   );
 };
 
 function isInSuggestionPhase(poll: Poll): boolean {
   if (poll.poll_type !== 'ranked_choice') return false;
-  // Timer started and deadline in the future
   if (poll.suggestion_deadline && new Date(poll.suggestion_deadline) > new Date()) return true;
-  // Timer not started yet (waiting for first suggestion)
   if (!poll.suggestion_deadline && poll.suggestion_deadline_minutes) return true;
   return false;
 }
@@ -266,8 +264,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       return new Date(poll.response_deadline) <= now || poll.is_closed;
     });
     
-    // Get the effective cutoff for an open poll: suggestion deadline if in
-    // suggestion phase, otherwise the voting deadline.
     const getEffectiveCutoff = (poll: Poll): number => {
       if (isInSuggestionPhase(poll)) {
         if (poll.suggestion_deadline) return new Date(poll.suggestion_deadline).getTime();
@@ -277,8 +273,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       return new Date(poll.response_deadline || poll.created_at).getTime();
     };
 
-    // Sort open polls by voted status (unvoted first, then voted/abstained)
-    // Within each group, sort by soonest cutoff first
     const sortByVoted = (pollList: Poll[]) => {
       const unvoted = pollList.filter(p => !votedPollIds.has(p.id) && !abstainedPollIds.has(p.id));
       const voted = pollList.filter(p => votedPollIds.has(p.id) || abstainedPollIds.has(p.id));
@@ -290,7 +284,6 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       return [...sortByCutoff(unvoted), ...sortByCutoff(voted)];
     };
 
-    // Sort closed polls by most recently closed first
     const sortClosedByTime = (pollList: Poll[]) => {
       return pollList.sort((a, b) => {
         const getClosingTime = (poll: Poll) => {


### PR DESCRIPTION
## Summary
- Move category icon (🍽️, 📍, 🎬, 🎮) to upper-left of each poll; fall back to poll type symbol (🗳️, ☐, 🙋) for custom categories
- Move time info to upper-right: "Suggestions [countdown]" / "Taking Suggestions" / "Voting [countdown]" for open polls; "Closed [time/date]" for closed
- Replace dash result symbols with emojis (🔇 no results, 🤷 no winner, 🔒 closed)
- Show seconds precision in all countdowns
- Fix closed poll time display: use `updated_at` for manually closed polls instead of `response_deadline`
- Sort open polls by effective cutoff (suggestion deadline if active, voting deadline otherwise)
- Sort closed polls by actual close time (fixes manual close sorting)
- Fix inconsistent border widths on section headers
- Add top border above first poll item

## Test plan
- [ ] Open polls show category icon top-left, cutoff countdown top-right
- [ ] Suggestion polls show "Suggestions [time]" or "Taking Suggestions"
- [ ] Non-suggestion open polls show "Voting [time]"
- [ ] Closed polls show correct close time (manual vs deadline)
- [ ] Closed polls >24h ago show date format (m/d/yy)
- [ ] Section header borders are consistent width
- [ ] Sorting: open polls by soonest cutoff, closed by most recent close

https://claude.ai/code/session_014wyUWEUfsathqQk8pMh5aC