### PR TITLE
Require long press on page header to open debug modal

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -87,6 +87,27 @@ export default function Template({ children }: AppTemplateProps) {
   const [pollPageTitle, setPollPageTitle] = useState('');
   const [createPollType, setCreatePollType] = useState<'poll' | 'participation'>('poll');
 
+  // Long-press detection for opening the debug modal (replaces simple tap)
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelLongPress = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+  const longPressProps = {
+    onPointerDown: () => {
+      longPressTimerRef.current = setTimeout(() => {
+        window.dispatchEvent(new Event('openCommitInfo'));
+        longPressTimerRef.current = null;
+      }, 500);
+    },
+    onPointerUp: cancelLongPress,
+    onPointerLeave: cancelLongPress,
+    onPointerCancel: cancelLongPress,
+    onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+  };
+
   // Determine page-specific header content based on pathname
   useEffect(() => {
     if (pathname === '/') {
@@ -432,8 +453,8 @@ export default function Template({ children }: AppTemplateProps) {
             {pageTitle && (
               <div className="absolute left-1/2 top-1/2" style={{transform: 'translate(-50%, -50%) translateY(0.125em) translateX(-0.5rem)'}}>
                 <h1
-                  className="text-xl font-bold text-center break-words select-none whitespace-nowrap cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                  onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
+                  className="text-xl font-bold text-center break-words select-none whitespace-nowrap"
+                  {...longPressProps}
                 >
                   {pageTitle}
                 </h1>
@@ -471,8 +492,8 @@ export default function Template({ children }: AppTemplateProps) {
               {isPollPage && pollPageTitle && (
                 <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
                   <h1
-                    className="text-2xl font-bold text-center break-words cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
+                    className="text-2xl font-bold text-center break-words select-none"
+                    {...longPressProps}
                   >
                     {pollPageTitle}
                   </h1>
@@ -483,8 +504,8 @@ export default function Template({ children }: AppTemplateProps) {
               {isCreatePollPage && (
                 <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
                   <h1
-                    className="text-2xl font-bold text-center whitespace-nowrap cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
+                    className="text-2xl font-bold text-center whitespace-nowrap select-none"
+                    {...longPressProps}
                   >
                     Ask for{' '}
                     <span
@@ -501,8 +522,8 @@ export default function Template({ children }: AppTemplateProps) {
               {isProfilePage && (
                 <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
                   <h1
-                    className="text-2xl font-bold text-center break-words cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                    onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
+                    className="text-2xl font-bold text-center break-words select-none"
+                    {...longPressProps}
                   >
                     Profile
                   </h1>
@@ -524,8 +545,8 @@ export default function Template({ children }: AppTemplateProps) {
                   </Link>
                   <div className="text-center">
                     <h1
-                      className="text-2xl font-bold mb-1 cursor-pointer hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                      onClick={() => window.dispatchEvent(new Event('openCommitInfo'))}
+                      className="text-2xl font-bold mb-1 select-none"
+                      {...longPressProps}
                     >Whoever Wants</h1>
                     <div className="h-7 flex items-center justify-center mb-1" id="home-phrase-content">
                       {/* Blue phrase will be injected here */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { createPortal } from 'react-dom';
 import FloatingCopyLinkButton from '@/components/FloatingCopyLinkButton';
 import HeaderPortal from '@/components/HeaderPortal';
+import { useLongPress } from '@/lib/useLongPress';
 
 interface AppTemplateProps {
   children: React.ReactNode;
@@ -88,25 +89,9 @@ export default function Template({ children }: AppTemplateProps) {
   const [createPollType, setCreatePollType] = useState<'poll' | 'participation'>('poll');
 
   // Long-press detection for opening the debug modal (replaces simple tap)
-  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cancelLongPress = () => {
-    if (longPressTimerRef.current) {
-      clearTimeout(longPressTimerRef.current);
-      longPressTimerRef.current = null;
-    }
-  };
-  const longPressProps = {
-    onPointerDown: () => {
-      longPressTimerRef.current = setTimeout(() => {
-        window.dispatchEvent(new Event('openCommitInfo'));
-        longPressTimerRef.current = null;
-      }, 500);
-    },
-    onPointerUp: cancelLongPress,
-    onPointerLeave: cancelLongPress,
-    onPointerCancel: cancelLongPress,
-    onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
-  };
+  const { props: longPressProps } = useLongPress(() =>
+    window.dispatchEvent(new Event('openCommitInfo'))
+  );
 
   // Determine page-specific header content based on pathname
   useEffect(() => {

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { useLongPress } from '@/lib/useLongPress';
 import { createPortal } from 'react-dom';
 
 interface CommitData {
@@ -99,25 +100,7 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
   const branchName = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF || '';
   const [commitHash, setCommitHash] = useState(vercelHash);
   const [badgeTarget, setBadgeTarget] = useState<HTMLElement | null>(null);
-  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cancelLongPress = () => {
-    if (longPressTimerRef.current) {
-      clearTimeout(longPressTimerRef.current);
-      longPressTimerRef.current = null;
-    }
-  };
-  const badgeLongPressProps = {
-    onPointerDown: () => {
-      longPressTimerRef.current = setTimeout(() => {
-        setShowModal(true);
-        longPressTimerRef.current = null;
-      }, 500);
-    },
-    onPointerUp: cancelLongPress,
-    onPointerLeave: cancelLongPress,
-    onPointerCancel: cancelLongPress,
-    onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
-  };
+  const { props: badgeLongPressProps } = useLongPress(() => setShowModal(true));
 
   // Find the portal target for the time badge (inside scroll container so it scrolls with content)
   useEffect(() => {

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -99,6 +99,25 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
   const branchName = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF || '';
   const [commitHash, setCommitHash] = useState(vercelHash);
   const [badgeTarget, setBadgeTarget] = useState<HTMLElement | null>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelLongPress = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+  const badgeLongPressProps = {
+    onPointerDown: () => {
+      longPressTimerRef.current = setTimeout(() => {
+        setShowModal(true);
+        longPressTimerRef.current = null;
+      }, 500);
+    },
+    onPointerUp: cancelLongPress,
+    onPointerLeave: cancelLongPress,
+    onPointerCancel: cancelLongPress,
+    onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+  };
 
   // Find the portal target for the time badge (inside scroll container so it scrolls with content)
   useEffect(() => {
@@ -218,8 +237,8 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
       {/* Time badge - only shown in dev mode, portaled into scroll container so it scrolls with content */}
       {showTimeBadge && badgeTarget && createPortal(
         <div
-          className="flex justify-center cursor-pointer select-none"
-          onClick={() => setShowModal(true)}
+          className="flex justify-center select-none"
+          {...badgeLongPressProps}
         >
           <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
             {relativeTime || error || '...'}

--- a/components/FollowUpHeader.tsx
+++ b/components/FollowUpHeader.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { apiGetPollById } from "@/lib/api";
 import ConfirmationModal from "@/components/ConfirmationModal";
+import { useLongPress } from "@/lib/useLongPress";
 
 interface FollowUpHeaderProps {
   followUpToPollId: string;
@@ -17,8 +18,9 @@ export default function FollowUpHeader({ followUpToPollId, onRemove }: FollowUpH
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
-  const [isPressed, setIsPressed] = useState(false);
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const { props: longPressProps, isPressed } = useLongPress(
+    onRemove ? () => setShowRemoveModal(true) : null
+  );
 
   useEffect(() => {
     async function fetchOriginalPoll() {
@@ -41,24 +43,6 @@ export default function FollowUpHeader({ followUpToPollId, onRemove }: FollowUpH
 
     fetchOriginalPoll();
   }, [followUpToPollId]);
-
-  const handleLongPressStart = () => {
-    setIsPressed(true);
-    if (onRemove) {
-      longPressTimer.current = setTimeout(() => {
-        setShowRemoveModal(true);
-        setIsPressed(false);
-      }, 500); // 500ms long press
-    }
-  };
-
-  const handleLongPressEnd = () => {
-    setIsPressed(false);
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-  };
 
   const handleRemoveConfirm = () => {
     setShowRemoveModal(false);
@@ -110,11 +94,7 @@ export default function FollowUpHeader({ followUpToPollId, onRemove }: FollowUpH
     <>
       <div
         className={`my-3 p-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg text-center select-none transition-all ${isPressed ? 'scale-95 !bg-blue-100 dark:!bg-blue-900/40 !border-blue-400 dark:!border-blue-600 shadow-md' : ''}`}
-        onMouseDown={handleLongPressStart}
-        onMouseUp={handleLongPressEnd}
-        onMouseLeave={handleLongPressEnd}
-        onTouchStart={handleLongPressStart}
-        onTouchEnd={handleLongPressEnd}
+        {...longPressProps}
       >
         <div className="text-sm text-blue-900 dark:text-blue-100 mb-1 flex items-center justify-center flex-wrap gap-x-1">
           <span>Follow up to</span>

--- a/components/ForkHeader.tsx
+++ b/components/ForkHeader.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { apiGetPollById } from "@/lib/api";
 import ConfirmationModal from "@/components/ConfirmationModal";
+import { useLongPress } from "@/lib/useLongPress";
 
 interface ForkHeaderProps {
   forkOfPollId: string;
@@ -17,8 +18,9 @@ export default function ForkHeader({ forkOfPollId, onRemove }: ForkHeaderProps) 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
-  const [isPressed, setIsPressed] = useState(false);
-  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const { props: longPressProps, isPressed } = useLongPress(
+    onRemove ? () => setShowRemoveModal(true) : null
+  );
 
   useEffect(() => {
     async function fetchOriginalPoll() {
@@ -41,24 +43,6 @@ export default function ForkHeader({ forkOfPollId, onRemove }: ForkHeaderProps) 
 
     fetchOriginalPoll();
   }, [forkOfPollId]);
-
-  const handleLongPressStart = () => {
-    setIsPressed(true);
-    if (onRemove) {
-      longPressTimer.current = setTimeout(() => {
-        setShowRemoveModal(true);
-        setIsPressed(false);
-      }, 500); // 500ms long press
-    }
-  };
-
-  const handleLongPressEnd = () => {
-    setIsPressed(false);
-    if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-  };
 
   const handleRemoveConfirm = () => {
     setShowRemoveModal(false);
@@ -110,11 +94,7 @@ export default function ForkHeader({ forkOfPollId, onRemove }: ForkHeaderProps) 
     <>
       <div
         className={`my-3 p-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-center select-none transition-all ${isPressed ? 'scale-95 !bg-green-100 dark:!bg-green-900/40 !border-green-400 dark:!border-green-600 shadow-md' : ''}`}
-        onMouseDown={handleLongPressStart}
-        onMouseUp={handleLongPressEnd}
-        onMouseLeave={handleLongPressEnd}
-        onTouchStart={handleLongPressStart}
-        onTouchEnd={handleLongPressEnd}
+        {...longPressProps}
       >
         <div className="text-sm text-green-900 dark:text-green-100 mb-1 flex items-center justify-center flex-wrap gap-x-1">
           <span>Fork of</span>

--- a/lib/useLongPress.ts
+++ b/lib/useLongPress.ts
@@ -1,0 +1,64 @@
+import { useRef, useState } from 'react';
+
+interface LongPressOptions {
+  /** Duration in ms before the long-press fires. Default: 500. */
+  delay?: number;
+}
+
+interface LongPressResult {
+  /** Spread these props onto the target element. */
+  props: {
+    onPointerDown: () => void;
+    onPointerUp: () => void;
+    onPointerLeave: () => void;
+    onPointerCancel: () => void;
+    onContextMenu: (e: React.MouseEvent) => void;
+  };
+  /** True while the pointer is held down (before the timer fires). */
+  isPressed: boolean;
+}
+
+/**
+ * Detects a long-press gesture on any element.
+ *
+ * Usage:
+ *   const { props, isPressed } = useLongPress(() => doSomething());
+ *   return <div {...props} />;
+ *
+ * The callback is only called if the pointer is held for `delay` ms without
+ * moving off the element. Context-menu (right-click / long-tap on iOS) is
+ * suppressed to prevent the browser menu from competing with the gesture.
+ */
+export function useLongPress(
+  callback: (() => void) | null | undefined,
+  { delay = 500 }: LongPressOptions = {}
+): LongPressResult {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isPressed, setIsPressed] = useState(false);
+
+  const cancel = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setIsPressed(false);
+  };
+
+  const props = {
+    onPointerDown: () => {
+      if (!callback) return;
+      setIsPressed(true);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        setIsPressed(false);
+        callback();
+      }, delay);
+    },
+    onPointerUp: cancel,
+    onPointerLeave: cancel,
+    onPointerCancel: cancel,
+    onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+  };
+
+  return { props, isPressed };
+}


### PR DESCRIPTION
## Summary
- Replace simple tap/click with a 500ms long-press gesture on all page header titles and the commit time badge to open the debug modal
- Extract a shared `useLongPress` hook (`lib/useLongPress.ts`) to deduplicate the pattern
- Refactor `ForkHeader` and `FollowUpHeader` to use the new hook, removing ~36 lines of hand-rolled timer/event code
- Remove visual click hints (cursor-pointer, hover color) from headers since this is a hidden developer feature

## Test plan
- [ ] Long-press any page header title for ~500ms — debug modal opens
- [ ] Quick tap on header does nothing (no modal)
- [ ] Moving pointer off the header during press cancels the gesture
- [ ] Fork/follow-up headers still show press feedback and removal modal on long press
- [ ] Right-click / long-tap context menu is suppressed on headers

https://claude.ai/code/session_019tagg7BuYf7ZEmADToyzLi