### PR TITLE
Add client-side log forwarding for dev sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,6 +595,48 @@ npm run debug:react poll-123 revisit   # Debug vote retrieval
 
 ---
 
+## Client Log Forwarding (Dev Sites Only)
+
+On dev/debug sites (`*.dev.whoeverwants.com`, `localhost`), the browser automatically forwards all `console.log/warn/error/info/debug` output plus unhandled errors/rejections to the server via `POST /api/client-logs`. Logs are stored in an in-memory ring buffer (last 2000 entries) on the API server.
+
+**This is NOT active on production** (whoeverwants.com).
+
+### When the user reports an issue
+
+**IMMEDIATELY check client logs** in addition to server-side logs. This is the fastest way to see what the browser was doing when the error occurred:
+
+```bash
+# Read recent client logs (most recent first)
+bash scripts/remote.sh "curl -s http://localhost:<api_port>/api/client-logs?limit=100" | python3 -m json.tool
+
+# Filter by level (error, warn, log, info, debug)
+bash scripts/remote.sh "curl -s 'http://localhost:<api_port>/api/client-logs?level=error&limit=50'" | python3 -m json.tool
+
+# Search for specific text in log messages
+bash scripts/remote.sh "curl -s 'http://localhost:<api_port>/api/client-logs?search=failed&limit=50'" | python3 -m json.tool
+
+# Clear logs (useful before reproducing an issue)
+bash scripts/remote.sh "curl -s -X DELETE http://localhost:<api_port>/api/client-logs"
+```
+
+Replace `<api_port>` with the dev server's API port (8001-8005).
+
+### Diagnostic checklist when user reports a bug
+
+1. **Client logs**: `curl http://localhost:<api_port>/api/client-logs?level=error&limit=50`
+2. **Server logs**: `docker compose logs --tail 100` or `tail -50 /root/dev-servers/<slug>/api.log`
+3. **Full client log dump**: `curl http://localhost:<api_port>/api/client-logs?limit=200` (includes info/debug for context)
+
+### How it works
+
+- `lib/clientLogForwarder.ts` patches `console.*` methods on dev sites only
+- Logs are batched every 2 seconds and sent via `navigator.sendBeacon` (survives page unloads)
+- Each entry includes: level, message, timestamp, page URL, user agent, session ID
+- Ring buffer auto-evicts entries beyond 2000 (no disk writes, no persistence across API restarts)
+- The forwarder is installed once in `app/template.tsx` on mount
+
+---
+
 ## Participation Poll Philosophy: Maximizing Inclusion
 
 ### Core Principle

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 import FloatingCopyLinkButton from '@/components/FloatingCopyLinkButton';
 import HeaderPortal from '@/components/HeaderPortal';
 import { useLongPress } from '@/lib/useLongPress';
+import { installClientLogForwarder } from '@/lib/clientLogForwarder';
 
 interface AppTemplateProps {
   children: React.ReactNode;
@@ -67,9 +68,10 @@ export default function Template({ children }: AppTemplateProps) {
     setIsIOSPWA(isIOSSPWAStandalone());
   }, []);
 
-  // Set mounted state for portal rendering
+  // Set mounted state for portal rendering + install client log forwarder on dev sites
   useEffect(() => {
     setIsMounted(true);
+    installClientLogForwarder();
   }, []);
   
   // Determine initial state based on pathname to avoid layout shift

--- a/lib/clientLogForwarder.ts
+++ b/lib/clientLogForwarder.ts
@@ -1,0 +1,137 @@
+/**
+ * Client-side log forwarder — intercepts console.{log,warn,error,info,debug}
+ * and sends them to the server for Claude to read when debugging issues.
+ *
+ * Only active on dev/debug sites (*.dev.whoeverwants.com, localhost).
+ * Does NOT activate on production (whoeverwants.com).
+ */
+
+const BATCH_INTERVAL_MS = 2000;
+const MAX_QUEUE_SIZE = 500;
+const MAX_MESSAGE_LENGTH = 4000;
+
+interface LogEntry {
+  level: string;
+  message: string;
+  timestamp: string;
+  url: string;
+  userAgent: string;
+}
+
+let queue: LogEntry[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let sessionId: string | null = null;
+let installed = false;
+
+function isDevSite(): boolean {
+  if (typeof window === 'undefined') return false;
+  const host = window.location.hostname;
+  return (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host.endsWith('.dev.whoeverwants.com')
+  );
+}
+
+function getSessionId(): string {
+  if (!sessionId) {
+    sessionId = Math.random().toString(36).slice(2) + Date.now().toString(36);
+  }
+  return sessionId;
+}
+
+function serialize(...args: unknown[]): string {
+  const parts = args.map(arg => {
+    if (arg === undefined) return 'undefined';
+    if (arg === null) return 'null';
+    if (arg instanceof Error) return `${arg.name}: ${arg.message}\n${arg.stack || ''}`;
+    if (typeof arg === 'object') {
+      try {
+        return JSON.stringify(arg, null, 2);
+      } catch {
+        return String(arg);
+      }
+    }
+    return String(arg);
+  });
+  const msg = parts.join(' ');
+  return msg.length > MAX_MESSAGE_LENGTH ? msg.slice(0, MAX_MESSAGE_LENGTH) + '…[truncated]' : msg;
+}
+
+function enqueue(level: string, ...args: unknown[]) {
+  if (queue.length >= MAX_QUEUE_SIZE) {
+    queue.shift(); // drop oldest
+  }
+  queue.push({
+    level,
+    message: serialize(...args),
+    timestamp: new Date().toISOString(),
+    url: window.location.href,
+    userAgent: navigator.userAgent,
+  });
+  scheduleFlush();
+}
+
+function scheduleFlush() {
+  if (flushTimer) return;
+  flushTimer = setTimeout(flush, BATCH_INTERVAL_MS);
+}
+
+function flush() {
+  flushTimer = null;
+  if (queue.length === 0) return;
+
+  const batch = queue.splice(0);
+  const payload = JSON.stringify({ logs: batch, sessionId: getSessionId() });
+
+  // Use sendBeacon for reliability (survives page unload), fall back to fetch
+  const url = '/api/client-logs';
+  const sent = navigator.sendBeacon?.(url, new Blob([payload], { type: 'application/json' }));
+  if (!sent) {
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+      keepalive: true,
+    }).catch(() => {
+      // silently discard — we don't want log forwarding to cause errors
+    });
+  }
+}
+
+/**
+ * Install console interceptors. Safe to call multiple times — only installs once.
+ * Call this from a useEffect in a client component (e.g., template.tsx).
+ */
+export function installClientLogForwarder() {
+  if (installed || typeof window === 'undefined') return;
+  if (!isDevSite()) return;
+
+  installed = true;
+
+  const levels = ['log', 'warn', 'error', 'info', 'debug'] as const;
+  for (const level of levels) {
+    const original = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      original(...args);
+      enqueue(level, ...args);
+    };
+  }
+
+  // Capture unhandled errors
+  window.addEventListener('error', (event) => {
+    enqueue('error', `[Unhandled Error] ${event.message} at ${event.filename}:${event.lineno}:${event.colno}`);
+  });
+
+  // Capture unhandled promise rejections
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason instanceof Error
+      ? `${event.reason.name}: ${event.reason.message}\n${event.reason.stack || ''}`
+      : String(event.reason);
+    enqueue('error', `[Unhandled Rejection] ${reason}`);
+  });
+
+  // Flush on page unload
+  window.addEventListener('beforeunload', flush);
+  window.addEventListener('pagehide', flush);
+}

--- a/lib/clientLogForwarder.ts
+++ b/lib/clientLogForwarder.ts
@@ -47,7 +47,7 @@ function serialize(...args: unknown[]): string {
     if (arg instanceof Error) return `${arg.name}: ${arg.message}\n${arg.stack || ''}`;
     if (typeof arg === 'object') {
       try {
-        return JSON.stringify(arg, null, 2);
+        return JSON.stringify(arg);
       } catch {
         return String(arg);
       }

--- a/next.config.ts
+++ b/next.config.ts
@@ -62,6 +62,14 @@ if (process.env.NEXT_OUTPUT === 'standalone') {
         source: '/api/search/:path*',
         destination: `${apiDest}/api/search/:path*`,
       },
+      {
+        source: '/api/client-logs',
+        destination: `${apiDest}/api/client-logs`,
+      },
+      {
+        source: '/api/client-logs/',
+        destination: `${apiDest}/api/client-logs`,
+      },
     ],
     afterFiles: [],
     fallback: [],

--- a/server/main.py
+++ b/server/main.py
@@ -7,6 +7,7 @@ import psycopg
 from middleware import RateLimitMiddleware
 from routers.polls import router as polls_router
 from routers.search import router as search_router
+from routers.client_logs import router as client_logs_router
 
 app = FastAPI(title="WhoeverWants API", redirect_slashes=False)
 
@@ -26,6 +27,7 @@ DATABASE_URL = os.environ.get("DATABASE_URL", "")
 
 app.include_router(polls_router)
 app.include_router(search_router)
+app.include_router(client_logs_router)
 
 
 @app.get("/health")

--- a/server/routers/client_logs.py
+++ b/server/routers/client_logs.py
@@ -1,0 +1,86 @@
+"""Client-side log collection endpoint (dev/debug only)."""
+
+import logging
+import os
+import time
+from collections import deque
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/client-logs", tags=["client-logs"])
+
+# In-memory ring buffer: last 2000 log entries, auto-evicts oldest
+_LOG_BUFFER: deque[dict] = deque(maxlen=2000)
+
+
+class ClientLogEntry(BaseModel):
+    level: str  # "log", "warn", "error", "info", "debug"
+    message: str
+    timestamp: str  # ISO string from the browser
+    url: Optional[str] = None
+    userAgent: Optional[str] = None
+
+
+class ClientLogBatch(BaseModel):
+    logs: list[ClientLogEntry]
+    sessionId: Optional[str] = None
+
+
+@router.post("")
+async def receive_client_logs(batch: ClientLogBatch, request: Request):
+    """Receive a batch of console logs from the browser client."""
+    client_ip = request.client.host if request.client else "unknown"
+    for entry in batch.logs:
+        _LOG_BUFFER.append({
+            "level": entry.level,
+            "message": entry.message,
+            "timestamp": entry.timestamp,
+            "url": entry.url or "",
+            "userAgent": entry.userAgent or "",
+            "sessionId": batch.sessionId or "",
+            "clientIp": client_ip,
+            "receivedAt": time.time(),
+        })
+    return {"status": "ok", "accepted": len(batch.logs)}
+
+
+@router.get("")
+async def get_client_logs(
+    limit: int = 200,
+    level: Optional[str] = None,
+    since: Optional[float] = None,
+    search: Optional[str] = None,
+):
+    """Retrieve recent client logs. Use query params to filter.
+
+    - limit: max entries to return (default 200)
+    - level: filter by level (e.g. "error", "warn")
+    - since: unix timestamp, only return logs received after this time
+    - search: substring search in message text
+    """
+    results = list(_LOG_BUFFER)
+
+    if level:
+        results = [r for r in results if r["level"] == level]
+    if since:
+        results = [r for r in results if r["receivedAt"] >= since]
+    if search:
+        search_lower = search.lower()
+        results = [r for r in results if search_lower in r["message"].lower()]
+
+    # Return most recent first, capped at limit
+    results = results[-limit:]
+    results.reverse()
+    return {"logs": results, "total": len(_LOG_BUFFER)}
+
+
+@router.delete("")
+async def clear_client_logs():
+    """Clear all stored client logs."""
+    count = len(_LOG_BUFFER)
+    _LOG_BUFFER.clear()
+    return {"status": "ok", "cleared": count}

--- a/server/routers/client_logs.py
+++ b/server/routers/client_logs.py
@@ -1,7 +1,6 @@
 """Client-side log collection endpoint (dev/debug only)."""
 
 import logging
-import os
 import time
 from collections import deque
 from typing import Optional
@@ -62,15 +61,13 @@ async def get_client_logs(
     - since: unix timestamp, only return logs received after this time
     - search: substring search in message text
     """
-    results = list(_LOG_BUFFER)
-
-    if level:
-        results = [r for r in results if r["level"] == level]
-    if since:
-        results = [r for r in results if r["receivedAt"] >= since]
-    if search:
-        search_lower = search.lower()
-        results = [r for r in results if search_lower in r["message"].lower()]
+    search_lower = search.lower() if search else None
+    results = [
+        r for r in _LOG_BUFFER
+        if (not level or r["level"] == level)
+        and (not since or r["receivedAt"] >= since)
+        and (not search_lower or search_lower in r["message"].lower())
+    ]
 
     # Return most recent first, capped at limit
     results = results[-limit:]


### PR DESCRIPTION
## Summary
- Browser console output (log/warn/error/info/debug) plus unhandled errors and promise rejections are automatically captured and forwarded to the FastAPI server on dev sites only (`*.dev.whoeverwants.com`, `localhost`)
- Logs stored in an in-memory ring buffer (2000 entries) accessible via `GET /api/client-logs` with filtering by level, time, and search text
- CLAUDE.md updated with diagnostic checklist: when user reports a bug, check client logs first before anything else

## How it works
- `lib/clientLogForwarder.ts` patches `console.*` methods on dev sites, batches every 2s via `sendBeacon`
- `server/routers/client_logs.py` provides POST (receive), GET (query), DELETE (clear) endpoints
- Not active on production — `isDevSite()` checks hostname

## Test plan
- [x] Verified API endpoints work (POST, GET with filters, DELETE)
- [x] Verified end-to-end: Playwright visit to dev site → logs appear in server buffer
- [x] Verified real iPhone browser session logs forwarded successfully
- [x] Confirmed production site (whoeverwants.com) is unaffected

https://claude.ai/code/session_013xUjTCw8cWZ3zRLTtFi14U