### PR TITLE
Reorder poll form, rename UI labels, hide participation mode

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -384,9 +384,7 @@ function CreatePollContent() {
     };
   };
 
-  // Removed: poll type preference now comes from URL query param
-
-  // Load form state from localStorage (excluding poll type which is loaded separately)
+  // Load form state from localStorage
   const loadFormState = () => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('pollFormState');
@@ -645,7 +643,6 @@ function CreatePollContent() {
       }
     }
   }, [followUpToParam, forkOfParam, duplicateOfParam, voteFromSuggestionParam]);
-
 
   // Load fork data if this is a fork
   useEffect(() => {

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -81,6 +81,7 @@ function CreatePollContent() {
   const forkOfParam = searchParams.get('fork');
   const duplicateOfParam = searchParams.get('duplicate');
   const voteFromSuggestionParam = searchParams.get('voteFromSuggestion');
+  const modeParam = searchParams.get('mode');
 
   // Track duplicate and fork relationships as part of form state
   const [followUpTo, setFollowUpTo] = useState<string | null>(null);
@@ -89,7 +90,16 @@ function CreatePollContent() {
   const [voteFromSuggestion, setVoteFromSuggestion] = useState<string | null>(null);
 
   const [title, setTitle] = useState("");
-  const [pollType, setPollType] = useState<'poll' | 'participation'>('poll');
+  const pollType = modeParam === 'participation' ? 'participation' : 'poll';
+  const setPollType = useCallback((type: 'poll' | 'participation') => {
+    const url = new URL(window.location.href);
+    if (type === 'participation') {
+      url.searchParams.set('mode', 'participation');
+    } else {
+      url.searchParams.delete('mode');
+    }
+    router.replace(url.pathname + url.search);
+  }, [router]);
   const [options, setOptions] = useState<string[]>(['']);
   const [minParticipants, setMinParticipants] = useState<number | null>(1);
   const [maxParticipants, setMaxParticipants] = useState<number | null>(null);
@@ -117,7 +127,7 @@ function CreatePollContent() {
   const [isAutoTitle, setIsAutoTitle] = useState(true);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const loadedTitleRef = useRef<string | null>(null);
-  const [hasLoadedPollType, setHasLoadedPollType] = useState(false);
+
   const [suggestionCutoff, setSuggestionCutoff] = useState("0.5x");
   const [customSuggestionDate, setCustomSuggestionDate] = useState('');
   const [customSuggestionTime, setCustomSuggestionTime] = useState('');
@@ -327,14 +337,7 @@ function CreatePollContent() {
     return `${m} month${m !== 1 ? 's' : ''}`;
   };
 
-  // Save poll type preference separately (persists across submissions)
-  const savePollTypePreference = useCallback((type: 'poll' | 'participation') => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('pollTypePreference', type);
-    }
-  }, []);
-
-  // Save form state to localStorage (excluding poll type which is saved separately)
+  // Save form state to localStorage
   const saveFormState = useCallback(() => {
     if (typeof window !== 'undefined') {
       const formState = {
@@ -381,19 +384,7 @@ function CreatePollContent() {
     };
   };
 
-  // Load poll type preference from localStorage
-  const loadPollTypePreference = () => {
-    if (typeof window !== 'undefined') {
-      const savedPollType = localStorage.getItem('pollTypePreference');
-      if (savedPollType && (savedPollType === 'poll' || savedPollType === 'participation')) {
-        setPollType(savedPollType as 'poll' | 'participation');
-      }
-      // Delay enabling transitions to avoid animation on initial load
-      setTimeout(() => {
-        setHasLoadedPollType(true);
-      }, 50);
-    }
-  };
+  // Removed: poll type preference now comes from URL query param
 
   // Load form state from localStorage (excluding poll type which is loaded separately)
   const loadFormState = () => {
@@ -624,11 +615,6 @@ function CreatePollContent() {
     if (voteFromSuggestionParam) setVoteFromSuggestion(voteFromSuggestionParam);
   }, [followUpToParam, forkOfParam, duplicateOfParam, voteFromSuggestionParam]);
 
-  // Load poll type preference first (runs once on mount)
-  useEffect(() => {
-    loadPollTypePreference();
-  }, []); // Empty deps - only run once on mount
-
   // Initialize client-side state
   useEffect(() => {
     setIsClient(true);
@@ -660,20 +646,6 @@ function CreatePollContent() {
     }
   }, [followUpToParam, forkOfParam, duplicateOfParam, voteFromSuggestionParam]);
 
-  // Save poll type preference and emit poll type changes to update the header
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      // Only save after initial load to avoid overwriting saved preference
-      if (hasLoadedPollType) {
-        savePollTypePreference(pollType);
-      }
-
-      // Emit event to update the header
-      window.dispatchEvent(new CustomEvent('pollTypeChange', {
-        detail: { pollType }
-      }));
-    }
-  }, [pollType, hasLoadedPollType, savePollTypePreference]);
 
   // Load fork data if this is a fork
   useEffect(() => {
@@ -1359,49 +1331,18 @@ function CreatePollContent() {
           e.stopPropagation();
           // Do nothing - all submission is handled by button onClick
         }} className="space-y-4">
-          <div className="flex justify-center">
-            <div className="relative w-36 bg-gray-100 dark:bg-gray-800 rounded-full p-0.5 -mb-2">
-              <div
-                className={`absolute top-0.5 bottom-0.5 rounded-full shadow-sm ${
-                  hasLoadedPollType ? 'transition-all duration-200 ease-in-out' : ''
-                } ${
-                  pollType === 'poll'
-                    ? 'bg-green-100 dark:bg-green-700/50'
-                    : 'bg-purple-100 dark:bg-purple-700/50'
-                }`}
-                style={{
-                  width: 'calc(50% - 3px)',
-                  left: pollType === 'poll' ? '2px' : 'calc(50% + 1px)'
-                }}
-              />
-              <div className="relative flex w-full">
-                <button
-                  type="button"
-                  onClick={() => setPollType('poll')}
-                  disabled={isLoading}
-                  className={`flex-1 py-1 text-xl rounded-md transition-colors duration-200 ${
-                    pollType === 'poll'
-                      ? 'text-gray-900 dark:text-white'
-                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
-                  } disabled:opacity-50 disabled:cursor-not-allowed`}
-                >
-                  🗳️
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setPollType('participation')}
-                  disabled={isLoading}
-                  className={`flex-1 py-1 text-xl rounded-md transition-colors duration-200 ${
-                    pollType === 'participation'
-                      ? 'text-gray-900 dark:text-white'
-                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
-                  } disabled:opacity-50 disabled:cursor-not-allowed`}
-                >
-                  🙋
-                </button>
-              </div>
+          {/* Participation mode: show link back to preferences form */}
+          {pollType === 'participation' && (
+            <div className="flex justify-center">
+              <button
+                type="button"
+                onClick={() => setPollType('poll')}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Switch to Preferences Poll
+              </button>
             </div>
-          </div>
+          )}
 
           {/* Category and For fields for suggestion and poll types */}
           {pollType !== 'participation' && (

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -471,7 +471,7 @@ function CreatePollContent() {
   const getValidationError = (): string | null => {
     // Check title first
     if (!title.trim()) {
-      return isAutoTitle ? "Please enter a category or title." : "Please enter a title.";
+      return isAutoTitle ? 'Please input "Category", "For", or "Options".' : "Please enter a title.";
     }
     
     if (title.length > 100) {

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1516,7 +1516,85 @@ function CreatePollContent() {
                 searchRadius={searchRadius}
                 label={<>Options <span className="font-normal">(leave blank to ask for suggestions)</span></>}
               />
+            </>
+          )}
 
+          {/* Preference/suggestion polls: voting cutoff, min responses, suggestion cutoff */}
+          {isPreferencePoll && (
+            <>
+              <div>
+                <label className="block text-sm font-medium cursor-pointer">
+                  <span>Voting Cutoff: </span>
+                  <span className="relative inline-flex">
+                    <span className="font-normal text-blue-600 dark:text-blue-400">
+                      {(() => {
+                        if (deadlineOption === 'none') return 'None';
+                        if (deadlineOption === 'custom') {
+                          if (customDate && customTime) {
+                            const dt = new Date(`${customDate}T${customTime}`);
+                            return dt.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+                          }
+                          return 'Custom';
+                        }
+                        return VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption)?.label || deadlineOption;
+                      })()}
+                    </span>
+                    <select
+                      value={deadlineOption}
+                      onChange={(e) => setDeadlineOption(e.target.value)}
+                      disabled={isLoading}
+                      className="absolute inset-0 opacity-0 cursor-pointer"
+                      aria-label="Voting cutoff duration"
+                    >
+                      <option value="none">None</option>
+                      {VOTING_CUTOFF_OPTIONS.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </span>
+                </label>
+                {deadlineOption === 'custom' && (
+                  <div className="mt-2 flex justify-between gap-2">
+                    <div className="w-auto">
+                      <label htmlFor="customDate" className="block text-xs text-gray-500 mb-1">Date</label>
+                      <input
+                        type="date"
+                        id="customDate"
+                        value={customDate}
+                        onChange={(e) => setCustomDate(e.target.value)}
+                        disabled={isLoading}
+                        min={isClient ? getTodayDate() : ''}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                        required
+                      />
+                    </div>
+                    <div className="w-auto">
+                      <label htmlFor="customTime" className="block text-xs text-gray-500 mb-1 text-right">Time</label>
+                      <input
+                        type="time"
+                        id="customTime"
+                        value={customTime}
+                        onChange={(e) => setCustomTime(e.target.value)}
+                        disabled={isLoading}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                        required
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+              <CompactMinResponsesField
+                value={minResponses}
+                setValue={(val) => {
+                  setMinResponses(val);
+                  saveUserMinResponses(val);
+                }}
+                showPreliminary={showPreliminaryResults}
+                setShowPreliminary={setShowPreliminaryResults}
+                disabled={isLoading}
+              />
               {/* Suggestions Cutoff - shown when no options provided (suggestion mode) */}
               {isSuggestionMode && (
                 <div>
@@ -1637,85 +1715,6 @@ function CreatePollContent() {
                   )}
                 </div>
               )}
-            </>
-          )}
-
-          {/* Preference/suggestion polls: voting cutoff, min responses */}
-          {isPreferencePoll && (
-            <>
-              <div>
-                <label className="block text-sm font-medium cursor-pointer">
-                  <span>Voting Cutoff: </span>
-                  <span className="relative inline-flex">
-                    <span className="font-normal text-blue-600 dark:text-blue-400">
-                      {(() => {
-                        if (deadlineOption === 'none') return 'None';
-                        if (deadlineOption === 'custom') {
-                          if (customDate && customTime) {
-                            const dt = new Date(`${customDate}T${customTime}`);
-                            return dt.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
-                          }
-                          return 'Custom';
-                        }
-                        return VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption)?.label || deadlineOption;
-                      })()}
-                    </span>
-                    <select
-                      value={deadlineOption}
-                      onChange={(e) => setDeadlineOption(e.target.value)}
-                      disabled={isLoading}
-                      className="absolute inset-0 opacity-0 cursor-pointer"
-                      aria-label="Voting cutoff duration"
-                    >
-                      <option value="none">None</option>
-                      {VOTING_CUTOFF_OPTIONS.map(opt => (
-                        <option key={opt.value} value={opt.value}>{opt.label}</option>
-                      ))}
-                    </select>
-                  </span>
-                </label>
-                {deadlineOption === 'custom' && (
-                  <div className="mt-2 flex justify-between gap-2">
-                    <div className="w-auto">
-                      <label htmlFor="customDate" className="block text-xs text-gray-500 mb-1">Date</label>
-                      <input
-                        type="date"
-                        id="customDate"
-                        value={customDate}
-                        onChange={(e) => setCustomDate(e.target.value)}
-                        disabled={isLoading}
-                        min={isClient ? getTodayDate() : ''}
-                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
-                        style={{ fontSize: '14px' }}
-                        required
-                      />
-                    </div>
-                    <div className="w-auto">
-                      <label htmlFor="customTime" className="block text-xs text-gray-500 mb-1 text-right">Time</label>
-                      <input
-                        type="time"
-                        id="customTime"
-                        value={customTime}
-                        onChange={(e) => setCustomTime(e.target.value)}
-                        disabled={isLoading}
-                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
-                        style={{ fontSize: '14px' }}
-                        required
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
-              <CompactMinResponsesField
-                value={minResponses}
-                setValue={(val) => {
-                  setMinResponses(val);
-                  saveUserMinResponses(val);
-                }}
-                showPreliminary={showPreliminaryResults}
-                setShowPreliminary={setShowPreliminaryResults}
-                disabled={isLoading}
-              />
             </>
           )}
 

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -129,7 +129,6 @@ export default function Template({ children }: AppTemplateProps) {
     };
   }, []);
 
-
   // Handle scroll direction detection for bottom bar.
   // Uses touch events as primary mechanism (reliable on iOS PWA + browser),
   // with scroll event listener as fallback for desktop/mouse-wheel.

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -603,7 +603,7 @@ export default function Template({ children }: AppTemplateProps) {
               isProfilePage
                 ? 'text-blue-600 dark:text-blue-400'
                 : 'text-gray-500 dark:text-gray-400'
-            }`}>Account</span>
+            }`}>Profile</span>
           </button>
         </div>
         </div>,

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -88,7 +88,6 @@ export default function Template({ children }: AppTemplateProps) {
   const [leftElement, setLeftElement] = useState<React.ReactNode>(getInitialLeftElement());
   const [rightElement, setRightElement] = useState<React.ReactNode>(<div className="w-6 h-6" />);
   const [pollPageTitle, setPollPageTitle] = useState('');
-  const [createPollType, setCreatePollType] = useState<'poll' | 'participation'>('poll');
 
   // Long-press detection for opening the debug modal (replaces simple tap)
   const { props: longPressProps } = useLongPress(() =>
@@ -102,7 +101,7 @@ export default function Template({ children }: AppTemplateProps) {
       setLeftElement(<div className="w-6 h-6" />); // spacer
       setRightElement(<div className="w-6 h-6" />); // spacer
     } else if (pathname === '/create-poll' || pathname === '/create-poll/') {
-      setPageTitle('Ask For…');
+      setPageTitle('Create Poll');
       setLeftElement(<div className="w-6 h-6" />); // spacer
       setRightElement(<div className="w-6 h-6" />); // spacer
     } else if (pathname.startsWith('/p/')) {
@@ -130,18 +129,6 @@ export default function Template({ children }: AppTemplateProps) {
     };
   }, []);
 
-  // Listen for poll type changes from create-poll page
-  useEffect(() => {
-    const handlePollTypeChange = (event: CustomEvent) => {
-      setCreatePollType(event.detail.pollType);
-    };
-
-    window.addEventListener('pollTypeChange', handlePollTypeChange as EventListener);
-
-    return () => {
-      window.removeEventListener('pollTypeChange', handlePollTypeChange as EventListener);
-    };
-  }, []);
 
   // Handle scroll direction detection for bottom bar.
   // Uses touch events as primary mechanism (reliable on iOS PWA + browser),
@@ -494,13 +481,7 @@ export default function Template({ children }: AppTemplateProps) {
                     className="text-2xl font-bold text-center whitespace-nowrap select-none"
                     {...longPressProps}
                   >
-                    Ask for{' '}
-                    <span
-                      className="text-blue-600 dark:text-blue-400"
-                      style={{ fontFamily: "'M PLUS 1 Code', monospace" }}
-                    >
-                      {createPollType === 'poll' ? 'Preferences' : 'Participation'}
-                    </span>
+                    Create Poll
                   </h1>
                 </div>
               )}

--- a/components/CommitInfo.tsx
+++ b/components/CommitInfo.tsx
@@ -90,7 +90,7 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
   const [commitData, setCommitData] = useState<CommitData | null>(null);
   const [relativeTime, setRelativeTime] = useState<string>('');
   const [showModal, setShowModal] = useState(false);
-  const [activeTab, setActiveTab] = useState<'build' | 'logs'>('build');
+  const [activeTab, setActiveTab] = useState<'build' | 'logs' | 'experimental'>('build');
   const [error, setError] = useState<string | null>(null);
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
   const [copyLabel, setCopyLabel] = useState('Copy All Logs');
@@ -259,6 +259,16 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
               >
                 Logs
               </button>
+              <button
+                className={`flex-1 py-1.5 text-center text-xs cursor-pointer border-b-2 transition-colors select-none ${
+                  activeTab === 'experimental'
+                    ? 'text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400'
+                    : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border-transparent'
+                }`}
+                onClick={() => setActiveTab('experimental')}
+              >
+                Experimental
+              </button>
             </div>
 
             {/* Build Info tab */}
@@ -328,6 +338,20 @@ export default function CommitInfo({ showTimeBadge = false }: { showTimeBadge?: 
                 >
                   {copyLabel}
                 </button>
+              </div>
+            )}
+
+            {/* Experimental tab */}
+            {activeTab === 'experimental' && (
+              <div className="space-y-3 overflow-y-auto">
+                <p className="text-xs text-gray-500 dark:text-gray-400">Hidden poll types and experimental features.</p>
+                <a
+                  href="/create-poll?mode=participation"
+                  className="block w-full px-3 py-2 text-sm text-center bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-700 rounded-md hover:bg-purple-200 dark:hover:bg-purple-800/50 transition-colors"
+                  onClick={() => setShowModal(false)}
+                >
+                  Create Participation Poll
+                </a>
               </div>
             )}
           </div>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -98,7 +98,7 @@ const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string 
 
   return (
     <>
-      {label && `${label} `}<span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{timeLeft}</span>
+      {label && `${label}: `}<span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{timeLeft}</span>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Move "Suggestions Cutoff" below "Min Responses" in the poll creation form
- Change validation message to reference specific form fields ("Category", "For", "Options")
- Rename bottom bar "Account" to "Profile"
- Replace header "Ask for Preferences/Participation" with static "Create Poll"
- Remove poll type toggle switch; hide participation mode behind debug modal's new "Experimental" tab
- Add colon after "Suggestions" and "Voting" countdown labels on the home page poll list

## Test plan
- [ ] Open /create-poll — verify header says "Create Poll", no toggle switch, form fields ordered: Options → Voting Cutoff → Min Responses → Suggestions Cutoff
- [ ] Submit empty form — verify validation says 'Please input "Category", "For", or "Options".'
- [ ] Check bottom bar shows "Profile" instead of "Account"
- [ ] Long-press header to open debug modal → click "Experimental" tab → click "Create Participation Poll" — verify participation form loads with "Switch to Preferences Poll" link
- [ ] View home page with active polls — verify "Suggestions:" and "Voting:" labels have colons

https://claude.ai/code/session_01GdWk5tw1aebvUxjeefnird