### PR TITLE
Show clock times next to cutoff duration options

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -22,7 +22,7 @@ import MinMaxCounter from "@/components/MinMaxCounter";
 import ParticipationConditions, { DayTimeWindow } from "@/components/ParticipationConditions";
 import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
 import ReferenceLocationInput from "@/components/ReferenceLocationInput";
-import { windowDurationMinutes, formatDurationLabel } from "@/lib/timeUtils";
+import { windowDurationMinutes, formatDurationLabel, formatDeadlineLabel } from "@/lib/timeUtils";
 export const dynamic = 'force-dynamic';
 
 // Matches the rendered height of a single-line <input> with py-2 padding.
@@ -986,29 +986,13 @@ function CreatePollContent() {
   const getTimeLabel = (option: string) => {
     const selected = deadlineOptions.find(opt => opt.value === option);
     if (!selected || option === "custom") return selected?.label || "";
-    
-    // Only calculate time on client to avoid hydration mismatch
-    if (typeof window === 'undefined') {
-      return selected.label; // Server-side: just return the label
+    // 10-second dev option: include seconds in the time
+    if (option === "10sec" && typeof window !== 'undefined') {
+      const deadline = new Date(Date.now() + selected.minutes * 60 * 1000);
+      const timeString = deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+      return `${selected.label} (${timeString})`;
     }
-    
-    const now = new Date();
-    const deadline = new Date(now.getTime() + selected.minutes * 60 * 1000);
-    
-    // For 10-second option, show seconds
-    const timeString = option === "10sec" 
-      ? deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' })
-      : deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-    
-    return `${selected.label} (${timeString})`;
-  };
-
-  // Format a duration in minutes as "label (HH:MM)" showing the absolute clock time
-  const formatTimeAt = (minutes: number, label: string): string => {
-    if (typeof window === 'undefined') return label;
-    const deadline = new Date(Date.now() + minutes * 60 * 1000);
-    const timeString = deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-    return `${label} (${timeString})`;
+    return formatDeadlineLabel(selected.minutes, selected.label);
   };
 
   // Calculate and format time until custom deadline
@@ -1484,7 +1468,7 @@ function CreatePollContent() {
                         }
                         const opt = VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption);
                         if (!opt) return deadlineOption;
-                        return isClient && opt.minutes > 0 ? formatTimeAt(opt.minutes, opt.label) : opt.label;
+                        return formatDeadlineLabel(opt.minutes, opt.label);
                       })()}
                     </span>
                     <select
@@ -1497,7 +1481,7 @@ function CreatePollContent() {
                       <option value="none">None</option>
                       {VOTING_CUTOFF_OPTIONS.map(opt => (
                         <option key={opt.value} value={opt.value}>
-                          {isClient && opt.minutes > 0 ? formatTimeAt(opt.minutes, opt.label) : opt.label}
+                          {formatDeadlineLabel(opt.minutes, opt.label)}
                         </option>
                       ))}
                     </select>
@@ -1563,7 +1547,7 @@ function CreatePollContent() {
                             }
                             const absOpt = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
                             if (!absOpt) return suggestionCutoff;
-                            return isClient ? formatTimeAt(absOpt.minutes, absOpt.label) : absOpt.label;
+                            return formatDeadlineLabel(absOpt.minutes, absOpt.label);
                           })()}
                         </span>
                         <select
@@ -1590,7 +1574,7 @@ function CreatePollContent() {
                           <optgroup label="Fixed Duration">
                             {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
                               <option key={opt.value} value={opt.value}>
-                                {isClient ? formatTimeAt(opt.minutes, opt.label) : opt.label}
+                                {formatDeadlineLabel(opt.minutes, opt.label)}
                               </option>
                             ))}
                           </optgroup>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1003,6 +1003,14 @@ function CreatePollContent() {
     return `${selected.label} (${timeString})`;
   };
 
+  // Format a duration in minutes as "label (HH:MM)" showing the absolute clock time
+  const formatTimeAt = (minutes: number, label: string): string => {
+    if (typeof window === 'undefined') return label;
+    const deadline = new Date(Date.now() + minutes * 60 * 1000);
+    const timeString = deadline.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `${label} (${timeString})`;
+  };
+
   // Calculate and format time until custom deadline
   const getCustomDeadlineDisplay = () => {
     if (!customDate || !customTime) return "";
@@ -1474,7 +1482,9 @@ function CreatePollContent() {
                           }
                           return 'Custom';
                         }
-                        return VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption)?.label || deadlineOption;
+                        const opt = VOTING_CUTOFF_OPTIONS.find(o => o.value === deadlineOption);
+                        if (!opt) return deadlineOption;
+                        return isClient && opt.minutes > 0 ? formatTimeAt(opt.minutes, opt.label) : opt.label;
                       })()}
                     </span>
                     <select
@@ -1486,7 +1496,9 @@ function CreatePollContent() {
                     >
                       <option value="none">None</option>
                       {VOTING_CUTOFF_OPTIONS.map(opt => (
-                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        <option key={opt.value} value={opt.value}>
+                          {isClient && opt.minutes > 0 ? formatTimeAt(opt.minutes, opt.label) : opt.label}
+                        </option>
                       ))}
                     </select>
                   </span>
@@ -1549,7 +1561,9 @@ function CreatePollContent() {
                               if (votingMin != null) return formatMinutesLabel(votingMin * frac.fraction);
                               return `${frac.fraction}x`;
                             }
-                            return ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff)?.label || suggestionCutoff;
+                            const absOpt = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+                            if (!absOpt) return suggestionCutoff;
+                            return isClient ? formatTimeAt(absOpt.minutes, absOpt.label) : absOpt.label;
                           })()}
                         </span>
                         <select
@@ -1575,7 +1589,9 @@ function CreatePollContent() {
                           )}
                           <optgroup label="Fixed Duration">
                             {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
-                              <option key={opt.value} value={opt.value}>{opt.label}</option>
+                              <option key={opt.value} value={opt.value}>
+                                {isClient ? formatTimeAt(opt.minutes, opt.label) : opt.label}
+                              </option>
                             ))}
                           </optgroup>
                           <option value="custom">Custom</option>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -997,8 +997,8 @@ function CreatePollContent() {
     
     // For 10-second option, show seconds
     const timeString = option === "10sec" 
-      ? deadline.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-      : deadline.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      ? deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' })
+      : deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
     
     return `${selected.label} (${timeString})`;
   };
@@ -1007,7 +1007,7 @@ function CreatePollContent() {
   const formatTimeAt = (minutes: number, label: string): string => {
     if (typeof window === 'undefined') return label;
     const deadline = new Date(Date.now() + minutes * 60 * 1000);
-    const timeString = deadline.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const timeString = deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
     return `${label} (${timeString})`;
   };
 

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -446,13 +446,13 @@ export default function Template({ children }: AppTemplateProps) {
       {/* Scrollable Content Area - consistent across all pages */}
       <div
         ref={scrollContainerRef}
-        className="flex-1 overflow-auto safari-scroll-container"
+        className="flex-1 overflow-auto safari-scroll-container mb-14"
         style={{
           paddingTop: '0',
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
         }}>
-        <div className="pwa-safe-top relative min-h-full" style={{ paddingBottom: '4rem' }}>
+        <div className="pwa-safe-top relative">
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode. */}
           <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top"></div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -452,7 +452,7 @@ export default function Template({ children }: AppTemplateProps) {
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
         }}>
-        <div className="pwa-safe-top relative" style={{ paddingBottom: '4rem' }}>
+        <div className="pwa-safe-top relative min-h-full" style={{ paddingBottom: '4rem' }}>
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode. */}
           <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top"></div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -451,9 +451,8 @@ export default function Template({ children }: AppTemplateProps) {
           paddingTop: '0',
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
-          paddingBottom: '4rem',
         }}>
-        <div className="pwa-safe-top relative">
+        <div className="pwa-safe-top relative" style={{ paddingBottom: '4rem' }}>
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode. */}
           <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top"></div>

--- a/components/VotingCutoffConditionsModal.tsx
+++ b/components/VotingCutoffConditionsModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import ModalPortal from '@/components/ModalPortal';
+import { formatDeadlineLabel } from '@/lib/timeUtils';
 
 // Deadline options starting small and scaling up to 1 month
 const VOTING_CUTOFF_OPTIONS = [
@@ -69,12 +70,8 @@ export default function VotingCutoffConditionsModal({
     if (optionValue === 'custom') return 'Custom';
     const opt = VOTING_CUTOFF_OPTIONS.find(o => o.value === optionValue);
     if (!opt) return optionValue;
-    if (!isClient) return opt.label;
-    const now = new Date();
-    const deadline = new Date(now.getTime() + opt.minutes * 60 * 1000);
-    const timeStr = deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-    return `${opt.label} (${timeStr})`;
-  }, [isClient]);
+    return formatDeadlineLabel(opt.minutes, opt.label);
+  }, []);
 
   if (!isOpen) return null;
 

--- a/components/VotingCutoffConditionsModal.tsx
+++ b/components/VotingCutoffConditionsModal.tsx
@@ -72,7 +72,8 @@ export default function VotingCutoffConditionsModal({
     if (!isClient) return opt.label;
     const now = new Date();
     const deadline = new Date(now.getTime() + opt.minutes * 60 * 1000);
-    return `${opt.label} (${deadline.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })})`;
+    const timeStr = deadline.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `${opt.label} (${timeStr})`;
   }, [isClient]);
 
   if (!isOpen) return null;

--- a/components/VotingCutoffConditionsModal.tsx
+++ b/components/VotingCutoffConditionsModal.tsx
@@ -72,7 +72,7 @@ export default function VotingCutoffConditionsModal({
     if (!isClient) return opt.label;
     const now = new Date();
     const deadline = new Date(now.getTime() + opt.minutes * 60 * 1000);
-    const timeStr = deadline.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const timeStr = deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
     return `${opt.label} (${timeStr})`;
   }, [isClient]);
 

--- a/lib/timeUtils.ts
+++ b/lib/timeUtils.ts
@@ -25,3 +25,12 @@ export function formatDurationLabel(minutes: number): string {
   if (hours > 0) return `${hours}h`;
   return `${mins}m`;
 }
+
+/** Format "label (clock time)" showing the absolute time `minutes` from now.
+ *  Returns just the label on the server or when minutes <= 0. */
+export function formatDeadlineLabel(minutes: number, label: string): string {
+  if (typeof window === 'undefined' || minutes <= 0) return label;
+  const deadline = new Date(Date.now() + minutes * 60 * 1000);
+  const timeString = deadline.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  return `${label} (${timeString})`;
+}


### PR DESCRIPTION
## Summary
- Add absolute clock times in parentheses next to duration options in the Voting Cutoff and Suggestions Cutoff dropdowns (e.g. "10 min (4:13 PM)")
- Exclude relative suggestion cutoff options (0.25x, 0.5x, 0.75x) — those stay as resolved durations
- Extract shared `formatDeadlineLabel()` utility to `lib/timeUtils.ts`, consolidating three duplicate implementations
- Fix scroll overflow on short pages by using margin on the scroll container instead of internal padding

## Test plan
- [ ] Open create poll form — Voting Cutoff should show "10 min (time)" with no leading zero on the hour
- [ ] Open the Voting Cutoff dropdown — all duration options show clock times
- [ ] Suggestions Cutoff display label shows clock time for absolute durations, resolved duration for fractional options
- [ ] Open Suggestions Cutoff dropdown — "Fixed Duration" options show clock times, "Relative to Voting Cutoff" options do not
- [ ] Verify no hydration errors in browser console

https://claude.ai/code/session_01DiDLQe65Her4Hv8Nz5tUjG