### PR TITLE
Move create poll to bottom bar + iOS-style modal sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -974,6 +974,17 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Don't append category keywords (e.g., " restaurant") to Nominatim queries.** OSM tags fast food chains as `fast_food`, not `restaurant`, so the suffix causes Nominatim to miss them entirely. Instead, search with the raw query and post-filter results by `_FOOD_TYPES` (the `type` field in Nominatim's JSON response). The `_FOOD_TYPES` frozenset in `search.py` defines which OSM amenity types count as food/drink.
 - **Favicon cache is name-based and in-memory** (`_restaurant_favicon_cache` in `search.py`). Bounded to 500 entries with LRU eviction. Persists for the API process lifetime. Populated from OSM `website`, `contact:website`, and `brand:website` extratags.
 
+### Create Poll Modal (Query-Param Sheet)
+
+- **The create-poll form is a modal overlay**, not a separate route. It's triggered by the `?create` query parameter on any page. The underlying page stays mounted behind the backdrop.
+- **`CreatePollContent` is exported** from `app/create-poll/page.tsx` and lazy-loaded via `React.lazy` in `template.tsx`. The `/create-poll` route redirects to `/?create`.
+- **All buttons that open the create form** (FollowUp, Fork, Duplicate, VoteOnIt, bottom bar "+") append `?create=1` plus any action params to the current page URL via `router.push`. They do NOT navigate to `/create-poll`.
+- **Close removes `?create`** (and related params) from the URL via `router.replace`, keeping the user on their current page.
+- **Drag-to-dismiss** uses native touch listeners with refs for 60fps. Velocity-based dismissal (>500px/s flick) and 33% position threshold. Uses `requestAnimationFrame` coalescing. Force reflow (`offsetHeight`) is required between setting `transition` and the target `transform` after `transition: none` during drag.
+- **Body scroll lock on iOS** requires `position: fixed` on `<body>` — `overflow: hidden` alone doesn't prevent native pull-to-refresh in Safari/WebKit. Scroll position is saved/restored on mount/unmount.
+- **`navigateCloseModal` uses a ref** (`navigateCloseModalRef`) instead of a `useCallback` with `searchParams` in its deps. This prevents touch listeners from being re-attached on every query param change.
+- **ConfirmationModal z-index must be above z-60** (the create-poll modal). Currently at `z-[70]`. Any new modal that needs to appear over the create form must exceed z-60.
+
 ### Adding New Poll Categories
 
 - **Built-in categories** are defined in `TypeFieldInput.tsx: BUILT_IN_TYPES`. Add new entries there.

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1898,16 +1898,23 @@ export function CreatePollContent() {
 }
 
 // Redirect /create-poll to /?create so the modal opens over the home page.
-export default function CreatePollRedirect() {
+function CreatePollRedirectInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   useEffect(() => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('create', '1');
-    // Remove any standalone /create-poll path — redirect to home with modal open
     router.replace(`/?${params.toString()}`);
   }, [router, searchParams]);
 
   return null;
+}
+
+export default function CreatePollRedirect() {
+  return (
+    <Suspense fallback={null}>
+      <CreatePollRedirectInner />
+    </Suspense>
+  );
 }

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1898,23 +1898,12 @@ export function CreatePollContent() {
 }
 
 // Redirect /create-poll to /?create so the modal opens over the home page.
-function CreatePollRedirectInner() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
+export default function CreatePollRedirect() {
   useEffect(() => {
-    const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(window.location.search);
     params.set('create', '1');
-    router.replace(`/?${params.toString()}`);
-  }, [router, searchParams]);
+    window.location.replace(`/?${params.toString()}`);
+  }, []);
 
   return null;
-}
-
-export default function CreatePollRedirect() {
-  return (
-    <Suspense fallback={null}>
-      <CreatePollRedirectInner />
-    </Suspense>
-  );
 }

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -73,7 +73,7 @@ const DEV_DEADLINE_OPTIONS = [
   ...BASE_DEADLINE_OPTIONS,
 ];
 
-function CreatePollContent() {
+export function CreatePollContent() {
   const { prefetch } = useAppPrefetch();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -1897,17 +1897,17 @@ function CreatePollContent() {
   );
 }
 
-export default function CreatePoll() {
-  return (
-    <Suspense fallback={
-      <div className="flex justify-center items-center h-screen">
-        <svg className="animate-spin h-8 w-8 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-        </svg>
-      </div>
-    }>
-      <CreatePollContent />
-    </Suspense>
-  );
+// Redirect /create-poll to /?create so the modal opens over the home page.
+export default function CreatePollRedirect() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('create', '1');
+    // Remove any standalone /create-poll path — redirect to home with modal open
+    router.replace(`/?${params.toString()}`);
+  }, [router, searchParams]);
+
+  return null;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -114,6 +114,32 @@ body {
   animation: fade-in 0.2s ease-out;
 }
 
+@keyframes slide-down {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.animate-slide-down {
+  animation: slide-down 0.3s ease-in forwards;
+}
+
+.animate-fade-out {
+  animation: fade-out 0.3s ease-in forwards;
+}
+
 /* Poll content specific styling for narrow content */
 .poll-content {
   max-width: 28rem; /* 448px - narrower for poll pages */

--- a/app/p/[shortId]/page.tsx
+++ b/app/p/[shortId]/page.tsx
@@ -20,7 +20,6 @@ function PollContent() {
   // Prefetch critical pages
   useEffect(() => {
     router.prefetch('/');
-    router.prefetch('/create-poll');
   }, [router]);
 
   useEffect(() => {

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -377,7 +377,6 @@ export default function Template({ children }: AppTemplateProps) {
   }, [isIOSPWA]);
 
   const isPollPage = pathname.startsWith('/p/');
-  const isCreatePollPage = pathname === '/create-poll' || pathname === '/create-poll/';
   const isCreateModalOpen = searchParams.has('create');
   const isProfilePage = pathname === '/profile' || pathname === '/profile/';
   const [modalClosing, setModalClosing] = useState(false);
@@ -397,27 +396,28 @@ export default function Template({ children }: AppTemplateProps) {
     lastMoveTime: 0,
     lastMoveY: 0,
   });
+  const closeTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const navigateCloseModal = useCallback(() => {
-    // Remove ?create (and any create-poll params) from the URL, keeping the current page.
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('create');
-    params.delete('followUpTo');
-    params.delete('fork');
-    params.delete('duplicate');
-    params.delete('voteFromSuggestion');
-    params.delete('mode');
-    const qs = params.toString();
-    router.replace(qs ? `${pathname}?${qs}` : pathname);
+  // Stable ref for close navigation — avoids searchParams in deps, preventing listener churn.
+  const navigateCloseModalRef = useRef(() => {});
+  useEffect(() => {
+    navigateCloseModalRef.current = () => {
+      const params = new URLSearchParams(searchParams.toString());
+      ['create', 'followUpTo', 'fork', 'duplicate', 'voteFromSuggestion', 'mode']
+        .forEach(p => params.delete(p));
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    };
   }, [router, pathname, searchParams]);
 
   const handleCloseCreateModal = useCallback(() => {
     if (dragState.current.isClosing) return;
+    dragState.current.isClosing = true;
     setModalClosing(true);
-    setTimeout(() => {
-      navigateCloseModal();
+    closeTimerRef.current = setTimeout(() => {
+      navigateCloseModalRef.current();
     }, 300);
-  }, [navigateCloseModal]);
+  }, []);
 
   // Drag-to-dismiss touch handling for the create poll modal sheet.
   useEffect(() => {
@@ -518,8 +518,8 @@ export default function Template({ children }: AppTemplateProps) {
           backdropRef.current.offsetHeight;
           backdropRef.current.style.opacity = '0';
         }
-        setTimeout(() => {
-          navigateCloseModal();
+        closeTimerRef.current = setTimeout(() => {
+          navigateCloseModalRef.current();
         }, 300);
       } else {
         // Under halfway — spring back
@@ -550,7 +550,7 @@ export default function Template({ children }: AppTemplateProps) {
       sheet.removeEventListener('touchmove', onTouchMove);
       sheet.removeEventListener('touchend', onTouchEnd);
     };
-  }, [isCreateModalOpen, isMounted, navigateCloseModal]);
+  }, [isCreateModalOpen, isMounted]);
 
   // Lock body scroll when create-poll modal is open to prevent browser pull-to-refresh.
   // On iOS, overflow:hidden alone doesn't prevent native PTR — position:fixed is required.
@@ -568,6 +568,8 @@ export default function Template({ children }: AppTemplateProps) {
     document.body.style.right = '0';
     document.body.style.overflow = 'hidden';
     return () => {
+      // Cancel any pending close animation timeout to prevent stale navigation.
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
       html.style.overscrollBehavior = '';
       document.body.style.position = '';
       document.body.style.top = '';
@@ -616,7 +618,7 @@ export default function Template({ children }: AppTemplateProps) {
       )}
 
       {/* Fixed Header - skip for poll, create poll, profile, and home pages */}
-      {!isPollPage && !isCreatePollPage && !isProfilePage && pathname !== '/' && (
+      {!isPollPage && !isProfilePage && pathname !== '/' && (
         <div className="flex-shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700" 
              style={{ paddingTop: 'env(safe-area-inset-top)' }}>
           <div className="relative flex items-start justify-between pt-2 pb-2 pl-2 pr-2.5">
@@ -704,7 +706,7 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -38,6 +38,14 @@ const PTR_CIRCUMFERENCE = 2 * Math.PI * 10; // SVG arc circumference (radius=10)
 const PTR_INDICATOR_SIZE = 40; // approx height of circle + padding
 
 export default function Template({ children }: AppTemplateProps) {
+  return (
+    <Suspense fallback={<div className="h-screen-safe flex flex-col" />}>
+      <TemplateInner>{children}</TemplateInner>
+    </Suspense>
+  );
+}
+
+function TemplateInner({ children }: AppTemplateProps) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createPortal } from 'react-dom';
@@ -374,6 +374,20 @@ export default function Template({ children }: AppTemplateProps) {
   const isPollPage = pathname.startsWith('/p/');
   const isCreatePollPage = pathname === '/create-poll' || pathname === '/create-poll/';
   const isProfilePage = pathname === '/profile' || pathname === '/profile/';
+  const [modalClosing, setModalClosing] = useState(false);
+
+  const handleCloseCreateModal = useCallback(() => {
+    setModalClosing(true);
+    setTimeout(() => {
+      setModalClosing(false);
+      const navCount = parseInt(sessionStorage.getItem(NAV_COUNT_KEY) || '0', 10);
+      if (navCount > 1) {
+        router.back();
+      } else {
+        router.push('/');
+      }
+    }, 300);
+  }, [router]);
 
   return (
     <>
@@ -457,9 +471,9 @@ export default function Template({ children }: AppTemplateProps) {
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode. */}
           <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top"></div>
           {/* Spacer div for header elements that are now rendered in portal */}
-          {(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') && (
+          {(isPollPage || isProfilePage || pathname === '/') && (
             <div className="relative">
-              
+
               {/* Poll page title */}
               {isPollPage && pollPageTitle && (
                 <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
@@ -468,18 +482,6 @@ export default function Template({ children }: AppTemplateProps) {
                     {...longPressProps}
                   >
                     {pollPageTitle}
-                  </h1>
-                </div>
-              )}
-
-              {/* Create poll page title */}
-              {isCreatePollPage && (
-                <div className="max-w-4xl mx-auto px-16 pt-4 pb-1">
-                  <h1
-                    className="text-2xl font-bold text-center whitespace-nowrap select-none"
-                    {...longPressProps}
-                  >
-                    Create Poll
                   </h1>
                 </div>
               )}
@@ -513,11 +515,57 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
-            {children}
-          </div>
+          {!isCreatePollPage && (
+            <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
+              {children}
+            </div>
+          )}
         </div>
       </div>
+
+      {/* Create poll modal - iOS-style sheet rendered via portal */}
+      {isCreatePollPage && isMounted && createPortal(
+        <div className="fixed inset-0 z-[60]">
+          {/* Backdrop */}
+          <div
+            className={`absolute inset-0 bg-black/40 ${modalClosing ? 'animate-fade-out' : 'animate-fade-in'}`}
+            onClick={handleCloseCreateModal}
+          />
+          {/* Modal sheet */}
+          <div
+            className={`absolute bottom-0 left-0 right-0 rounded-t-[20px] bg-white dark:bg-gray-900 flex flex-col shadow-2xl ${
+              modalClosing ? 'animate-slide-down' : 'animate-slide-up'
+            }`}
+            style={{ top: '4%' }}
+            onClick={e => e.stopPropagation()}
+          >
+            {/* Drag handle */}
+            <div className="flex-shrink-0 flex justify-center pt-2.5 pb-1">
+              <div className="w-9 h-1 rounded-full bg-gray-300 dark:bg-gray-600" />
+            </div>
+            {/* Header */}
+            <div className="flex-shrink-0 flex items-center justify-between px-4 pb-2">
+              <button
+                onClick={handleCloseCreateModal}
+                className="text-blue-500 text-[17px] w-[60px] text-left cursor-pointer"
+              >
+                Cancel
+              </button>
+              <h2 className="text-[17px] font-semibold">Create Poll</h2>
+              <div className="w-[60px]" />
+            </div>
+            {/* Separator */}
+            <div className="border-b border-gray-200 dark:border-gray-700" />
+            {/* Scrollable content */}
+            <div className="flex-1 overflow-auto overscroll-contain">
+              <div className="max-w-4xl mx-auto px-4 pt-2 pb-8">
+                {children}
+              </div>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
 
       {/* Scroll-aware bottom bar - rendered via portal outside scaled container */}
       {isMounted && createPortal(
@@ -601,7 +649,7 @@ export default function Template({ children }: AppTemplateProps) {
         {/* Back/home button in upper left — PWA standalone mode only.
              In regular browser tabs, the browser's own back button handles navigation.
              Shows back arrow if user has navigated within the app, home icon otherwise. */}
-        {isStandalone && (isPollPage || isCreatePollPage || isProfilePage) && (
+        {isStandalone && (isPollPage || isProfilePage) && (
           <div className="fixed left-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
             {hasAppHistory ? (
               <button

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -524,6 +524,13 @@ export default function Template({ children }: AppTemplateProps) {
     };
   }, [isCreatePollPage, isMounted, navigateCloseModal]);
 
+  // Lock body scroll when create-poll modal is open to prevent browser pull-to-refresh.
+  useEffect(() => {
+    if (!isCreatePollPage) return;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }, [isCreatePollPage]);
+
   return (
     <>
       {/* Pull-to-refresh indicator — rendered via portal to escape scaling container.

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -485,7 +485,7 @@ export default function Template({ children }: AppTemplateProps) {
       if (scrollEl) scrollEl.style.overflowY = '';
 
       const modalHeight = modalSheetRef.current?.offsetHeight || window.innerHeight;
-      const threshold = modalHeight * 0.5;
+      const threshold = modalHeight * 0.33;
 
       // Compute downward velocity (px/ms) from the last touchmove to touchend.
       const endY = e.changedTouches[0].clientY;

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -533,10 +533,10 @@ export default function Template({ children }: AppTemplateProps) {
           />
           {/* Modal sheet */}
           <div
-            className={`absolute bottom-0 left-0 right-0 rounded-t-[20px] bg-white dark:bg-gray-900 flex flex-col shadow-2xl ${
+            className={`absolute bottom-0 left-0 right-0 rounded-t-[32px] bg-white dark:bg-gray-900 flex flex-col shadow-2xl ${
               modalClosing ? 'animate-slide-down' : 'animate-slide-up'
             }`}
-            style={{ top: '4%' }}
+            style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}
             onClick={e => e.stopPropagation()}
           >
             {/* Drag handle */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -547,15 +547,16 @@ export default function Template({ children }: AppTemplateProps) {
             <div className="flex-shrink-0 flex items-center justify-between px-4 pb-2">
               <button
                 onClick={handleCloseCreateModal}
-                className="text-blue-500 text-[17px] w-[60px] text-left cursor-pointer"
+                className="w-[30px] h-[30px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
+                aria-label="Close"
               >
-                Cancel
+                <svg className="w-[15px] h-[15px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
+                  <path stroke="currentColor" strokeLinecap="round" strokeWidth={3} d="M6 6l12 12M18 6L6 18" />
+                </svg>
               </button>
               <h2 className="text-[17px] font-semibold">Create Poll</h2>
-              <div className="w-[60px]" />
+              <div className="w-[30px]" />
             </div>
-            {/* Separator */}
-            <div className="border-b border-gray-200 dark:border-gray-700" />
             {/* Scrollable content */}
             <div className="flex-1 overflow-auto overscroll-contain">
               <div className="max-w-4xl mx-auto px-4 pt-2 pb-8">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -473,14 +473,18 @@ export default function Template({ children }: AppTemplateProps) {
       const threshold = modalHeight * 0.5;
 
       if (state.currentTranslate > threshold) {
-        // Past halfway — close
+        // Past halfway — close. Must force reflow between setting transition
+        // and target value, otherwise browser skips the animation (transition
+        // was 'none' during drag).
         state.isClosing = true;
         if (modalSheetRef.current) {
           modalSheetRef.current.style.transition = 'transform 0.3s ease-in';
+          modalSheetRef.current.offsetHeight; // force reflow
           modalSheetRef.current.style.transform = 'translateY(100%)';
         }
         if (backdropRef.current) {
           backdropRef.current.style.transition = 'opacity 0.3s ease-in';
+          backdropRef.current.offsetHeight;
           backdropRef.current.style.opacity = '0';
         }
         setTimeout(() => {
@@ -499,10 +503,12 @@ export default function Template({ children }: AppTemplateProps) {
         // Under halfway — spring back
         if (modalSheetRef.current) {
           modalSheetRef.current.style.transition = 'transform 0.3s ease-out';
+          modalSheetRef.current.offsetHeight;
           modalSheetRef.current.style.transform = '';
         }
         if (backdropRef.current) {
           backdropRef.current.style.transition = 'opacity 0.3s ease-out';
+          backdropRef.current.offsetHeight;
           backdropRef.current.style.opacity = '';
         }
         setTimeout(() => {

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -499,16 +499,6 @@ export default function Template({ children }: AppTemplateProps) {
               {/* Home page title */}
               {pathname === '/' && (
                 <div className="relative max-w-4xl mx-auto px-2 pt-4 pb-1">
-                  {/* Create poll button - top right, scrolls with content */}
-                  <Link
-                    href="/create-poll"
-                    className="absolute right-2 top-4 w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-                    aria-label="Create new poll"
-                  >
-                    <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
-                  </Link>
                   <div className="text-center">
                     <h1
                       className="text-2xl font-bold mb-1 select-none"
@@ -563,6 +553,23 @@ export default function Template({ children }: AppTemplateProps) {
                 : 'text-gray-500 dark:text-gray-400'
             }`}>Home</span>
           </button>
+
+          {/* Create poll button */}
+          <Link
+            href="/create-poll"
+            className="flex flex-col items-center gap-0.5 min-w-[64px]"
+            aria-label="Create new poll"
+          >
+            <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
+              isCreatePollPage
+                ? 'bg-blue-600 dark:bg-blue-500'
+                : 'bg-blue-500 dark:bg-blue-600'
+            } shadow-md`}>
+              <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+            </div>
+          </Link>
 
           {/* Profile button */}
           <button

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -376,18 +376,153 @@ export default function Template({ children }: AppTemplateProps) {
   const isProfilePage = pathname === '/profile' || pathname === '/profile/';
   const [modalClosing, setModalClosing] = useState(false);
 
+  // Refs for modal drag-to-dismiss — uses direct DOM manipulation for 60fps.
+  const modalSheetRef = useRef<HTMLDivElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const modalScrollRef = useRef<HTMLDivElement>(null);
+  const dragState = useRef({
+    startY: 0,
+    currentTranslate: 0,
+    isDragging: false,
+    startedInHeader: false,
+    isClosing: false,
+    rAFPending: false,
+  });
+
+  const navigateCloseModal = useCallback(() => {
+    const navCount = parseInt(sessionStorage.getItem(NAV_COUNT_KEY) || '0', 10);
+    if (navCount > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  }, [router]);
+
   const handleCloseCreateModal = useCallback(() => {
+    if (dragState.current.isClosing) return;
     setModalClosing(true);
     setTimeout(() => {
       setModalClosing(false);
-      const navCount = parseInt(sessionStorage.getItem(NAV_COUNT_KEY) || '0', 10);
-      if (navCount > 1) {
-        router.back();
-      } else {
-        router.push('/');
-      }
+      navigateCloseModal();
     }, 300);
-  }, [router]);
+  }, [navigateCloseModal]);
+
+  // Drag-to-dismiss touch handling for the create poll modal sheet.
+  useEffect(() => {
+    if (!isCreatePollPage || !isMounted) return;
+    const sheet = modalSheetRef.current;
+    if (!sheet) return;
+
+    const state = dragState.current;
+
+    const updateDOM = () => {
+      state.rAFPending = false;
+      const t = state.currentTranslate;
+      if (modalSheetRef.current) {
+        modalSheetRef.current.style.transform = `translateY(${t}px)`;
+      }
+      if (backdropRef.current) {
+        const h = modalSheetRef.current?.offsetHeight || window.innerHeight;
+        const progress = Math.min(t / (h * 0.5), 1);
+        backdropRef.current.style.opacity = String(1 - progress * 0.7);
+      }
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (state.isClosing) return;
+      state.startY = e.touches[0].clientY;
+      state.isDragging = false;
+      state.currentTranslate = 0;
+      const scrollEl = modalScrollRef.current;
+      if (scrollEl) {
+        const rect = scrollEl.getBoundingClientRect();
+        state.startedInHeader = e.touches[0].clientY < rect.top;
+      }
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (state.isClosing) return;
+      const touchY = e.touches[0].clientY;
+      const deltaY = touchY - state.startY;
+
+      if (!state.isDragging) {
+        const scrollEl = modalScrollRef.current;
+        const scrollAtTop = !scrollEl || scrollEl.scrollTop <= 0;
+        if (!(state.startedInHeader || (scrollAtTop && deltaY > 5))) return;
+        state.isDragging = true;
+        if (scrollEl) scrollEl.style.overflowY = 'hidden';
+        if (modalSheetRef.current) modalSheetRef.current.style.transition = 'none';
+        if (backdropRef.current) backdropRef.current.style.transition = 'none';
+      }
+
+      state.currentTranslate = Math.max(0, deltaY);
+      if (!state.rAFPending) {
+        state.rAFPending = true;
+        requestAnimationFrame(updateDOM);
+      }
+    };
+
+    const onTouchEnd = () => {
+      if (!state.isDragging || state.isClosing) return;
+      state.isDragging = false;
+
+      const scrollEl = modalScrollRef.current;
+      if (scrollEl) scrollEl.style.overflowY = '';
+
+      const modalHeight = modalSheetRef.current?.offsetHeight || window.innerHeight;
+      const threshold = modalHeight * 0.5;
+
+      if (state.currentTranslate > threshold) {
+        // Past halfway — close
+        state.isClosing = true;
+        if (modalSheetRef.current) {
+          modalSheetRef.current.style.transition = 'transform 0.3s ease-in';
+          modalSheetRef.current.style.transform = 'translateY(100%)';
+        }
+        if (backdropRef.current) {
+          backdropRef.current.style.transition = 'opacity 0.3s ease-in';
+          backdropRef.current.style.opacity = '0';
+        }
+        setTimeout(() => {
+          state.isClosing = false;
+          if (modalSheetRef.current) {
+            modalSheetRef.current.style.transform = '';
+            modalSheetRef.current.style.transition = '';
+          }
+          if (backdropRef.current) {
+            backdropRef.current.style.opacity = '';
+            backdropRef.current.style.transition = '';
+          }
+          navigateCloseModal();
+        }, 300);
+      } else {
+        // Under halfway — spring back
+        if (modalSheetRef.current) {
+          modalSheetRef.current.style.transition = 'transform 0.3s ease-out';
+          modalSheetRef.current.style.transform = '';
+        }
+        if (backdropRef.current) {
+          backdropRef.current.style.transition = 'opacity 0.3s ease-out';
+          backdropRef.current.style.opacity = '';
+        }
+        setTimeout(() => {
+          if (modalSheetRef.current) modalSheetRef.current.style.transition = '';
+          if (backdropRef.current) backdropRef.current.style.transition = '';
+        }, 300);
+      }
+      state.currentTranslate = 0;
+    };
+
+    sheet.addEventListener('touchstart', onTouchStart, { passive: true });
+    sheet.addEventListener('touchmove', onTouchMove, { passive: true });
+    sheet.addEventListener('touchend', onTouchEnd, { passive: true });
+
+    return () => {
+      sheet.removeEventListener('touchstart', onTouchStart);
+      sheet.removeEventListener('touchmove', onTouchMove);
+      sheet.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [isCreatePollPage, isMounted, navigateCloseModal]);
 
   return (
     <>
@@ -528,11 +663,13 @@ export default function Template({ children }: AppTemplateProps) {
         <div className="fixed inset-0 z-[60]">
           {/* Backdrop */}
           <div
+            ref={backdropRef}
             className={`absolute inset-0 bg-black/40 ${modalClosing ? 'animate-fade-out' : 'animate-fade-in'}`}
             onClick={handleCloseCreateModal}
           />
           {/* Modal sheet */}
           <div
+            ref={modalSheetRef}
             className={`absolute bottom-0 left-0 right-0 rounded-t-[32px] bg-white dark:bg-gray-900 flex flex-col shadow-2xl ${
               modalClosing ? 'animate-slide-down' : 'animate-slide-up'
             }`}
@@ -547,18 +684,18 @@ export default function Template({ children }: AppTemplateProps) {
             <div className="flex-shrink-0 flex items-center justify-between px-4 pb-2">
               <button
                 onClick={handleCloseCreateModal}
-                className="w-[30px] h-[30px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
+                className="w-[48px] h-[48px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
                 aria-label="Close"
               >
-                <svg className="w-[15px] h-[15px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
+                <svg className="w-[27px] h-[27px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
                   <path stroke="currentColor" strokeLinecap="round" strokeWidth={3} d="M6 6l12 12M18 6L6 18" />
                 </svg>
               </button>
               <h2 className="text-[17px] font-semibold">Create Poll</h2>
-              <div className="w-[30px]" />
+              <div className="w-[48px]" />
             </div>
             {/* Scrollable content */}
-            <div className="flex-1 overflow-auto overscroll-contain">
+            <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">
               <div className="max-w-4xl mx-auto px-4 pt-2 pb-8">
                 {children}
               </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -415,7 +415,6 @@ export default function Template({ children }: AppTemplateProps) {
     if (dragState.current.isClosing) return;
     setModalClosing(true);
     setTimeout(() => {
-      setModalClosing(false);
       navigateCloseModal();
     }, 300);
   }, [navigateCloseModal]);
@@ -520,15 +519,6 @@ export default function Template({ children }: AppTemplateProps) {
           backdropRef.current.style.opacity = '0';
         }
         setTimeout(() => {
-          state.isClosing = false;
-          if (modalSheetRef.current) {
-            modalSheetRef.current.style.transform = '';
-            modalSheetRef.current.style.transition = '';
-          }
-          if (backdropRef.current) {
-            backdropRef.current.style.opacity = '';
-            backdropRef.current.style.transition = '';
-          }
           navigateCloseModal();
         }, 300);
       } else {
@@ -566,6 +556,9 @@ export default function Template({ children }: AppTemplateProps) {
   // On iOS, overflow:hidden alone doesn't prevent native PTR — position:fixed is required.
   useEffect(() => {
     if (!isCreateModalOpen) return;
+    // Reset stale close state from previous dismiss
+    setModalClosing(false);
+    dragState.current.isClosing = false;
     const scrollY = window.scrollY;
     const html = document.documentElement;
     html.style.overscrollBehavior = 'none';

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -387,6 +387,9 @@ export default function Template({ children }: AppTemplateProps) {
     startedInHeader: false,
     isClosing: false,
     rAFPending: false,
+    rAFId: 0,
+    lastMoveTime: 0,
+    lastMoveY: 0,
   });
 
   const navigateCloseModal = useCallback(() => {
@@ -433,6 +436,8 @@ export default function Template({ children }: AppTemplateProps) {
       state.startY = e.touches[0].clientY;
       state.isDragging = false;
       state.currentTranslate = 0;
+      state.lastMoveTime = Date.now();
+      state.lastMoveY = e.touches[0].clientY;
       const scrollEl = modalScrollRef.current;
       if (scrollEl) {
         const rect = scrollEl.getBoundingClientRect();
@@ -455,16 +460,26 @@ export default function Template({ children }: AppTemplateProps) {
         if (backdropRef.current) backdropRef.current.style.transition = 'none';
       }
 
+      // Track velocity from the last few touchmove events
+      state.lastMoveTime = Date.now();
+      state.lastMoveY = touchY;
+
       state.currentTranslate = Math.max(0, deltaY);
       if (!state.rAFPending) {
         state.rAFPending = true;
-        requestAnimationFrame(updateDOM);
+        state.rAFId = requestAnimationFrame(updateDOM);
       }
     };
 
-    const onTouchEnd = () => {
+    const onTouchEnd = (e: TouchEvent) => {
       if (!state.isDragging || state.isClosing) return;
       state.isDragging = false;
+
+      // Cancel any pending rAF so it doesn't overwrite the animation.
+      if (state.rAFPending) {
+        cancelAnimationFrame(state.rAFId);
+        state.rAFPending = false;
+      }
 
       const scrollEl = modalScrollRef.current;
       if (scrollEl) scrollEl.style.overflowY = '';
@@ -472,7 +487,14 @@ export default function Template({ children }: AppTemplateProps) {
       const modalHeight = modalSheetRef.current?.offsetHeight || window.innerHeight;
       const threshold = modalHeight * 0.5;
 
-      if (state.currentTranslate > threshold) {
+      // Compute downward velocity (px/ms) from the last touchmove to touchend.
+      const endY = e.changedTouches[0].clientY;
+      const dt = Date.now() - state.lastMoveTime;
+      const velocity = dt > 0 ? (endY - state.lastMoveY) / dt : 0;
+      // Dismiss if past halfway OR flicked downward fast (>0.5 px/ms ≈ 500px/s).
+      const shouldClose = state.currentTranslate > threshold || (velocity > 0.5 && state.currentTranslate > 30);
+
+      if (shouldClose) {
         // Past halfway — close. Must force reflow between setting transition
         // and target value, otherwise browser skips the animation (transition
         // was 'none' during drag).

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -687,8 +687,8 @@ export default function Template({ children }: AppTemplateProps) {
                 className="w-[48px] h-[48px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
                 aria-label="Close"
               >
-                <svg className="w-[27px] h-[27px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
-                  <path stroke="currentColor" strokeLinecap="round" strokeWidth={3} d="M6 6l12 12M18 6L6 18" />
+                <svg className="w-[40px] h-[40px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
+                  <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M6 6l12 12M18 6L6 18" />
                 </svg>
               </button>
               <h2 className="text-[17px] font-semibold">Create Poll</h2>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -673,7 +673,7 @@ export default function Template({ children }: AppTemplateProps) {
             className={`absolute bottom-0 left-0 right-0 rounded-t-[32px] bg-white dark:bg-gray-900 flex flex-col shadow-2xl ${
               modalClosing ? 'animate-slide-down' : 'animate-slide-up'
             }`}
-            style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}
+            style={{ top: 'calc(env(safe-area-inset-top, 0px) + 15px)', overscrollBehavior: 'none' }}
             onClick={e => e.stopPropagation()}
           >
             {/* Drag handle */}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -735,15 +735,15 @@ export default function Template({ children }: AppTemplateProps) {
             <div className="flex-shrink-0 flex items-center justify-between px-4 pb-2">
               <button
                 onClick={handleCloseCreateModal}
-                className="w-[48px] h-[48px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
+                className="w-[41px] h-[41px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
                 aria-label="Close"
               >
-                <svg className="w-[40px] h-[40px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
-                  <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M6 6l12 12M18 6L6 18" />
+                <svg className="w-[34px] h-[34px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
+                  <path stroke="currentColor" strokeLinecap="round" strokeWidth={0.75} d="M6 6l12 12M18 6L6 18" />
                 </svg>
               </button>
               <h2 className="text-[17px] font-semibold">Create Poll</h2>
-              <div className="w-[48px]" />
+              <div className="w-[41px]" />
             </div>
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -525,10 +525,26 @@ export default function Template({ children }: AppTemplateProps) {
   }, [isCreatePollPage, isMounted, navigateCloseModal]);
 
   // Lock body scroll when create-poll modal is open to prevent browser pull-to-refresh.
+  // On iOS, overflow:hidden alone doesn't prevent native PTR — position:fixed is required.
   useEffect(() => {
     if (!isCreatePollPage) return;
+    const scrollY = window.scrollY;
+    const html = document.documentElement;
+    html.style.overscrollBehavior = 'none';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.left = '0';
+    document.body.style.right = '0';
     document.body.style.overflow = 'hidden';
-    return () => { document.body.style.overflow = ''; };
+    return () => {
+      html.style.overscrollBehavior = '';
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      document.body.style.overflow = '';
+      window.scrollTo(0, scrollY);
+    };
   }, [isCreatePollPage]);
 
   return (

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
+import React, { useEffect, useState, useRef, useCallback, Suspense } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { createPortal } from 'react-dom';
 import FloatingCopyLinkButton from '@/components/FloatingCopyLinkButton';
 import HeaderPortal from '@/components/HeaderPortal';
 import { useLongPress } from '@/lib/useLongPress';
 import { installClientLogForwarder } from '@/lib/clientLogForwarder';
+
+const LazyCreatePollContent = React.lazy(() =>
+  import('@/app/create-poll/page').then(m => ({ default: m.CreatePollContent }))
+);
 
 interface AppTemplateProps {
   children: React.ReactNode;
@@ -36,6 +40,7 @@ const PTR_INDICATOR_SIZE = 40; // approx height of circle + padding
 export default function Template({ children }: AppTemplateProps) {
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isStandalone, setIsStandalone] = useState(false);
   const [hasAppHistory, setHasAppHistory] = useState(false);
   const [showBottomBar, setShowBottomBar] = useState(true);
@@ -373,6 +378,7 @@ export default function Template({ children }: AppTemplateProps) {
 
   const isPollPage = pathname.startsWith('/p/');
   const isCreatePollPage = pathname === '/create-poll' || pathname === '/create-poll/';
+  const isCreateModalOpen = searchParams.has('create');
   const isProfilePage = pathname === '/profile' || pathname === '/profile/';
   const [modalClosing, setModalClosing] = useState(false);
 
@@ -393,13 +399,17 @@ export default function Template({ children }: AppTemplateProps) {
   });
 
   const navigateCloseModal = useCallback(() => {
-    const navCount = parseInt(sessionStorage.getItem(NAV_COUNT_KEY) || '0', 10);
-    if (navCount > 1) {
-      router.back();
-    } else {
-      router.push('/');
-    }
-  }, [router]);
+    // Remove ?create (and any create-poll params) from the URL, keeping the current page.
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('create');
+    params.delete('followUpTo');
+    params.delete('fork');
+    params.delete('duplicate');
+    params.delete('voteFromSuggestion');
+    params.delete('mode');
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname);
+  }, [router, pathname, searchParams]);
 
   const handleCloseCreateModal = useCallback(() => {
     if (dragState.current.isClosing) return;
@@ -412,7 +422,7 @@ export default function Template({ children }: AppTemplateProps) {
 
   // Drag-to-dismiss touch handling for the create poll modal sheet.
   useEffect(() => {
-    if (!isCreatePollPage || !isMounted) return;
+    if (!isCreateModalOpen || !isMounted) return;
     const sheet = modalSheetRef.current;
     if (!sheet) return;
 
@@ -550,12 +560,12 @@ export default function Template({ children }: AppTemplateProps) {
       sheet.removeEventListener('touchmove', onTouchMove);
       sheet.removeEventListener('touchend', onTouchEnd);
     };
-  }, [isCreatePollPage, isMounted, navigateCloseModal]);
+  }, [isCreateModalOpen, isMounted, navigateCloseModal]);
 
   // Lock body scroll when create-poll modal is open to prevent browser pull-to-refresh.
   // On iOS, overflow:hidden alone doesn't prevent native PTR — position:fixed is required.
   useEffect(() => {
-    if (!isCreatePollPage) return;
+    if (!isCreateModalOpen) return;
     const scrollY = window.scrollY;
     const html = document.documentElement;
     html.style.overscrollBehavior = 'none';
@@ -573,7 +583,7 @@ export default function Template({ children }: AppTemplateProps) {
       document.body.style.overflow = '';
       window.scrollTo(0, scrollY);
     };
-  }, [isCreatePollPage]);
+  }, [isCreateModalOpen]);
 
   return (
     <>
@@ -701,16 +711,15 @@ export default function Template({ children }: AppTemplateProps) {
             </div>
           )}
           
-          {!isCreatePollPage && (
-            <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
-              {children}
-            </div>
-          )}
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isCreatePollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
+            {children}
+          </div>
         </div>
       </div>
 
-      {/* Create poll modal - iOS-style sheet rendered via portal */}
-      {isCreatePollPage && isMounted && createPortal(
+      {/* Create poll modal - iOS-style sheet rendered via portal.
+           Triggered by ?create query param so the underlying page stays mounted. */}
+      {isCreateModalOpen && isMounted && createPortal(
         <div className="fixed inset-0 z-[60]">
           {/* Backdrop */}
           <div
@@ -748,7 +757,16 @@ export default function Template({ children }: AppTemplateProps) {
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">
               <div className="max-w-4xl mx-auto px-4 pt-2 pb-8">
-                {children}
+                <Suspense fallback={
+                  <div className="flex justify-center items-center py-20">
+                    <svg className="animate-spin h-8 w-8 text-gray-400" viewBox="0 0 24 24" fill="none">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                  </div>
+                }>
+                  <LazyCreatePollContent />
+                </Suspense>
               </div>
             </div>
           </div>
@@ -792,13 +810,17 @@ export default function Template({ children }: AppTemplateProps) {
           </button>
 
           {/* Create poll button */}
-          <Link
-            href="/create-poll"
-            className="flex flex-col items-center gap-0.5 min-w-[64px]"
+          <button
+            onClick={() => {
+              const params = new URLSearchParams(searchParams.toString());
+              params.set('create', '1');
+              router.push(`${pathname}?${params.toString()}`);
+            }}
+            className="flex flex-col items-center gap-0.5 min-w-[64px] cursor-pointer"
             aria-label="Create new poll"
           >
             <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
-              isCreatePollPage
+              isCreateModalOpen
                 ? 'bg-blue-600 dark:bg-blue-500'
                 : 'bg-blue-500 dark:bg-blue-600'
             } shadow-md`}>
@@ -806,7 +828,7 @@ export default function Template({ children }: AppTemplateProps) {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
               </svg>
             </div>
-          </Link>
+          </button>
 
           {/* Profile button */}
           <button

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -735,15 +735,15 @@ export default function Template({ children }: AppTemplateProps) {
             <div className="flex-shrink-0 flex items-center justify-between px-4 pb-2">
               <button
                 onClick={handleCloseCreateModal}
-                className="w-[41px] h-[41px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
+                className="w-[43px] h-[43px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
                 aria-label="Close"
               >
-                <svg className="w-[34px] h-[34px] text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24">
+                <svg className="w-[34px] h-[34px] text-black dark:text-white" fill="none" viewBox="0 0 24 24">
                   <path stroke="currentColor" strokeLinecap="round" strokeWidth={0.75} d="M6 6l12 12M18 6L6 18" />
                 </svg>
               </button>
               <h2 className="text-[17px] font-semibold">Create Poll</h2>
-              <div className="w-[41px]" />
+              <div className="w-[43px]" />
             </div>
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -48,7 +48,7 @@ export default function ConfirmationModal({
 
   return (
     <ModalPortal>
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
         {/* Backdrop */}
         <div
           className="absolute inset-0 bg-black/50 dark:bg-black/70"

--- a/components/DuplicateButton.tsx
+++ b/components/DuplicateButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { Poll } from "@/lib/types";
 import { buildPollSnapshot } from "@/lib/pollCreator";
 import { debugLog } from "@/lib/debugLogger";
@@ -11,6 +11,7 @@ interface DuplicateButtonProps {
 
 export default function DuplicateButton({ poll }: DuplicateButtonProps) {
   const router = useRouter();
+  const pathname = usePathname();
 
   const handleDuplicate = () => {
     const duplicateData = buildPollSnapshot(poll);
@@ -23,8 +24,8 @@ export default function DuplicateButton({ poll }: DuplicateButtonProps) {
     
     debugLog.logObject('Stored duplicate data', { storageKey, data: localStorage.getItem(storageKey) }, 'DuplicateButton');
     
-    // Navigate to create-poll with duplicate parameter
-    const navigateUrl = `/create-poll?duplicate=${poll.id}`;
+    // Open create modal with duplicate parameter
+    const navigateUrl = `${pathname}?create=1&duplicate=${poll.id}`;
     debugLog.info(`Navigating to: ${navigateUrl}`, 'DuplicateButton');
     router.push(navigateUrl);
   };

--- a/components/FollowUpButton.tsx
+++ b/components/FollowUpButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 
 interface FollowUpButtonProps {
   pollId: string;
@@ -10,10 +10,11 @@ interface FollowUpButtonProps {
 
 export default function FollowUpButton({ pollId, isPollClosed, className = "" }: FollowUpButtonProps) {
   const router = useRouter();
+  const pathname = usePathname();
 
   return (
     <button
-      onClick={() => router.push(`/create-poll?followUpTo=${pollId}`)}
+      onClick={() => router.push(`${pathname}?create=1&followUpTo=${pollId}`)}
       className={`inline-flex items-center gap-2 px-4 py-2.5 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 active:bg-gray-300 dark:active:bg-gray-600 active:scale-95 text-gray-900 dark:text-white font-medium text-sm rounded-lg transition-all duration-200 border border-gray-200 dark:border-gray-700 ${className}`}
     >
       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import ModalPortal from "@/components/ModalPortal";
 import { Poll } from "@/lib/types";
 import { buildPollSnapshot } from "@/lib/pollCreator";
@@ -14,6 +14,7 @@ interface FollowUpModalProps {
 
 export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: FollowUpModalProps) {
   const router = useRouter();
+  const pathname = usePathname();
 
   if (!isOpen) return null;
 
@@ -36,7 +37,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
           <div className="flex gap-3 mb-4">
             <button
               onClick={() => {
-                router.push(`/create-poll?followUpTo=${poll.id}`);
+                router.push(`${pathname}?create=1&followUpTo=${poll.id}`);
                 onClose();
               }}
               className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-green-600 hover:bg-green-700 active:bg-green-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
@@ -50,7 +51,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
             <button
               onClick={() => {
                 localStorage.setItem(`duplicate-data-${poll.id}`, JSON.stringify(pollSnapshot));
-                router.push(`/create-poll?duplicate=${poll.id}`);
+                router.push(`${pathname}?create=1&duplicate=${poll.id}`);
                 onClose();
               }}
               className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
@@ -65,7 +66,7 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
             <button
               onClick={() => {
                 localStorage.setItem(`fork-data-${poll.id}`, JSON.stringify(pollSnapshot));
-                router.push(`/create-poll?fork=${poll.id}`);
+                router.push(`${pathname}?create=1&fork=${poll.id}`);
                 onClose();
               }}
               className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-purple-600 hover:bg-purple-700 active:bg-purple-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"

--- a/components/ForkButton.tsx
+++ b/components/ForkButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { Poll } from "@/lib/types";
 import { buildPollSnapshot } from "@/lib/pollCreator";
 import { debugLog } from "@/lib/debugLogger";
@@ -12,6 +12,7 @@ interface ForkButtonProps {
 
 export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
   const router = useRouter();
+  const pathname = usePathname();
 
   const handleFork = () => {
     const forkData = buildPollSnapshot(poll);
@@ -23,8 +24,8 @@ export default function ForkButton({ poll, className = "" }: ForkButtonProps) {
     
     debugLog.logObject('Stored fork data', { storageKey, data: localStorage.getItem(storageKey) }, 'ForkButton');
     
-    // Navigate to create-poll with fork parameter
-    const navigateUrl = `/create-poll?fork=${poll.id}`;
+    // Open create modal with fork parameter
+    const navigateUrl = `${pathname}?create=1&fork=${poll.id}`;
     debugLog.info(`Navigating to: ${navigateUrl}`, 'ForkButton');
     router.push(navigateUrl);
   };

--- a/components/VoteOnItModal.tsx
+++ b/components/VoteOnItModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import ModalPortal from "@/components/ModalPortal";
 import { apiCreatePoll } from "@/lib/api";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
@@ -27,6 +27,7 @@ const DEADLINE_OPTIONS = [
 
 export default function VoteOnItModal({ isOpen, pollId, pollTitle, suggestions, onClose }: VoteOnItModalProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const [deadlineOption, setDeadlineOption] = useState("10min");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -80,7 +81,7 @@ export default function VoteOnItModal({ isOpen, pollId, pollTitle, suggestions, 
       followUpTo: pollId,
     };
     localStorage.setItem(`vote-from-suggestion-${pollId}`, JSON.stringify(voteData));
-    router.push(`/create-poll?voteFromSuggestion=${pollId}`);
+    router.push(`${pathname}?create=1&voteFromSuggestion=${pollId}`);
     onClose();
   };
 

--- a/lib/prefetch.ts
+++ b/lib/prefetch.ts
@@ -80,7 +80,7 @@ export function useAppPrefetch() {
   
   // Prefetch critical app routes
   useEffect(() => {
-    const criticalRoutes = ['/', '/create-poll'];
+    const criticalRoutes = ['/'];
     prefetchBatch(criticalRoutes, { priority: "high" });
   }, [prefetchBatch]);
   


### PR DESCRIPTION
## Summary
- Move the create poll button from the home page title area to the center of the bottom navigation bar as a prominent blue "+" circle
- Convert the create-poll form from a separate route to a query-param (`?create`) triggered iOS-style modal sheet that slides up over the current page
- Add drag-to-dismiss with velocity detection, body scroll lock for iOS pull-to-refresh prevention, and smooth animations
- All existing flows (follow-up, fork, duplicate, vote-from-suggestion) updated to use `?create` param overlay

## Test plan
- [ ] Tap "+" button on home page — modal slides up instantly with no loading delay
- [ ] Home page content visible behind dark backdrop
- [ ] Drag modal down past 33% — dismisses with animation
- [ ] Drag modal down less than 33% — springs back
- [ ] Fast flick down — dismisses via velocity detection
- [ ] Tap X button — modal slides down and closes
- [ ] Tap backdrop — modal closes
- [ ] Fill form and submit — confirmation modal appears above the sheet
- [ ] iOS browser: no pull-to-refresh when dragging down on modal
- [ ] Direct URL `/?create=1` opens the modal
- [ ] `/create-poll` redirects to `/?create=1`
- [ ] Follow-up/fork/duplicate buttons on poll pages open modal as overlay

https://claude.ai/code/session_013WN7PfmYtSWFPtWCGaScu2