### PR TITLE
Update yes/no poll form: simplify fields and use Voting Cutoff

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1307,6 +1307,56 @@ export function CreatePollContent() {
     }
   };
 
+  const titleField = (
+    <div>
+      {isAutoTitle ? (
+        <button
+          type="button"
+          onClick={() => {
+            setIsAutoTitle(false);
+            setTitle('');
+            setTimeout(() => titleInputRef.current?.focus(), 0);
+          }}
+          className="block text-sm font-medium text-left"
+        >
+          Title: <span className="text-blue-600 dark:text-blue-400 font-normal">{title || <span className="italic">auto</span>}</span>
+        </button>
+      ) : (
+        <>
+          <div className="flex items-center justify-between mb-1">
+            <label htmlFor="title" className="text-sm font-medium">
+              Title
+            </label>
+            {category !== 'yes_no' && (
+              <button
+                type="button"
+                onClick={() => setIsAutoTitle(true)}
+                className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Generate
+              </button>
+            )}
+          </div>
+          <input
+            type="text"
+            id="title"
+            ref={titleInputRef}
+            value={title}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              setIsAutoTitle(false);
+            }}
+            disabled={isLoading}
+            maxLength={100}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+            placeholder="Enter your title..."
+            required
+          />
+        </>
+      )}
+    </div>
+  );
+
   return (
     <div className="poll-content">
       {error && (
@@ -1451,29 +1501,8 @@ export function CreatePollContent() {
             </>
           )}
 
-          {/* Title field for yes/no polls - shown above voting cutoff */}
-          {category === 'yes_no' && (
-          <div>
-            <label htmlFor="title" className="text-sm font-medium">
-              Title
-            </label>
-            <input
-              type="text"
-              id="title"
-              ref={titleInputRef}
-              value={title}
-              onChange={(e) => {
-                setTitle(e.target.value);
-                setIsAutoTitle(false);
-              }}
-              disabled={isLoading}
-              maxLength={100}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              placeholder="Enter your title..."
-              required
-            />
-          </div>
-          )}
+          {/* Title for yes/no polls - rendered above voting cutoff */}
+          {category === 'yes_no' && titleField}
 
           {/* Voting cutoff (yes/no and preference polls), min responses, suggestion cutoff */}
           {pollType === 'poll' && (
@@ -1747,56 +1776,8 @@ export function CreatePollContent() {
             </>
           )}
 
-          {/* Title field - hidden for preference polls (auto-generated) and yes/no (rendered above) */}
-          {!isPreferencePoll && category !== 'yes_no' && (
-          <div>
-            {isAutoTitle ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setIsAutoTitle(false);
-                  setTitle('');
-                  setTimeout(() => titleInputRef.current?.focus(), 0);
-                }}
-                className="block text-sm font-medium text-left"
-              >
-                Title: <span className="text-blue-600 dark:text-blue-400 font-normal">{title || <span className="italic">auto</span>}</span>
-              </button>
-            ) : (
-              <>
-                <div className="flex items-center justify-between mb-1">
-                  <label htmlFor="title" className="text-sm font-medium">
-                    Title
-                  </label>
-                  {category !== 'yes_no' && (
-                    <button
-                      type="button"
-                      onClick={() => setIsAutoTitle(true)}
-                      className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    >
-                      Generate
-                    </button>
-                  )}
-                </div>
-                <input
-                  type="text"
-                  id="title"
-                  ref={titleInputRef}
-                  value={title}
-                  onChange={(e) => {
-                    setTitle(e.target.value);
-                    setIsAutoTitle(false);
-                  }}
-                  disabled={isLoading}
-                  maxLength={100}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                  placeholder="Enter your title..."
-                  required
-                />
-              </>
-            )}
-          </div>
-          )}
+          {/* Title for participation polls - rendered below close after */}
+          {!isPreferencePoll && category !== 'yes_no' && titleField}
 
           {/* Optional details field */}
           <div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1451,6 +1451,30 @@ export function CreatePollContent() {
             </>
           )}
 
+          {/* Title field for yes/no polls - shown above voting cutoff */}
+          {category === 'yes_no' && (
+          <div>
+            <label htmlFor="title" className="text-sm font-medium">
+              Title
+            </label>
+            <input
+              type="text"
+              id="title"
+              ref={titleInputRef}
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                setIsAutoTitle(false);
+              }}
+              disabled={isLoading}
+              maxLength={100}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              placeholder="Enter your title..."
+              required
+            />
+          </div>
+          )}
+
           {/* Voting cutoff (yes/no and preference polls), min responses, suggestion cutoff */}
           {pollType === 'poll' && (
             <>
@@ -1723,8 +1747,8 @@ export function CreatePollContent() {
             </>
           )}
 
-          {/* Title field - hidden for preference polls (always auto-generated) */}
-          {!isPreferencePoll && (
+          {/* Title field - hidden for preference polls (auto-generated) and yes/no (rendered above) */}
+          {!isPreferencePoll && category !== 'yes_no' && (
           <div>
             {isAutoTitle ? (
               <button

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1352,6 +1352,7 @@ export function CreatePollContent() {
                   disabled={isLoading}
                 />
               </div>
+              {category !== 'yes_no' && (
               <div>
                 <label htmlFor="forField" className="block text-sm font-medium mb-1">
                   For <span className="text-gray-400 font-normal">(optional)</span>
@@ -1366,6 +1367,7 @@ export function CreatePollContent() {
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
+              )}
             </>
           )}
 
@@ -1449,8 +1451,8 @@ export function CreatePollContent() {
             </>
           )}
 
-          {/* Preference/suggestion polls: voting cutoff, min responses, suggestion cutoff */}
-          {isPreferencePoll && (
+          {/* Voting cutoff (yes/no and preference polls), min responses, suggestion cutoff */}
+          {pollType === 'poll' && (
             <>
               <div>
                 <label className="block text-sm font-medium cursor-pointer">
@@ -1519,6 +1521,7 @@ export function CreatePollContent() {
                   </div>
                 )}
               </div>
+              {isPreferencePoll && (
               <CompactMinResponsesField
                 value={minResponses}
                 setValue={(val) => {
@@ -1529,6 +1532,7 @@ export function CreatePollContent() {
                 setShowPreliminary={setShowPreliminaryResults}
                 disabled={isLoading}
               />
+              )}
               {/* Suggestions Cutoff - shown when no options provided (suggestion mode) */}
               {isSuggestionMode && (
                 <div>
@@ -1656,8 +1660,8 @@ export function CreatePollContent() {
             </>
           )}
 
-          {/* Response Deadline (for yes_no and participation polls) */}
-          {!isPreferencePoll && (
+          {/* Response Deadline (for participation polls) */}
+          {pollType === 'participation' && (
             <>
               <div>
                 <label className="block text-sm font-medium mb-1">Close After</label>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -668,7 +668,7 @@ function TemplateInner({ children }: AppTemplateProps) {
         <div className="pwa-safe-top relative">
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode. */}
-          <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top"></div>
+          <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top" suppressHydrationWarning></div>
           {/* Spacer div for header elements that are now rendered in portal */}
           {(isPollPage || isProfilePage || pathname === '/') && (
             <div className="relative">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -667,8 +667,10 @@ function TemplateInner({ children }: AppTemplateProps) {
         }}>
         <div className="pwa-safe-top relative">
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
-               Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode. */}
-          <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top" suppressHydrationWarning></div>
+               Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode.
+               Only rendered after mount to avoid hydration mismatch — CommitInfo (in layout)
+               injects portal content here client-side. */}
+          {isMounted && <div id="commit-badge-portal" className="absolute left-0 right-0 z-10 pwa-badge-top"></div>}
           {/* Spacer div for header elements that are now rendered in portal */}
           {(isPollPage || isProfilePage || pathname === '/') && (
             <div className="relative">


### PR DESCRIPTION
## Summary
- Hide the "For" field for yes/no polls (not relevant for simple yes/no questions)
- Replace "Close After" dropdown with the inline "Voting Cutoff" field (same style as preference/suggestion polls) for yes/no polls
- Move Title field above Voting Cutoff for yes/no polls
- Fix pre-existing hydration mismatch caused by CommitInfo portal rendering into `commit-badge-portal`
- Extract shared `titleField` variable to eliminate duplicate Title JSX between yes/no and participation positions

## Test plan
- [ ] Open create poll form, select "Yes / No" category — verify no "For" field, Title above Voting Cutoff
- [ ] Verify Voting Cutoff shows inline style with time options (None, 5min–1month, Custom)
- [ ] Switch between categories — verify fields update correctly
- [ ] Create a yes/no poll — verify it works end-to-end
- [ ] Check no hydration errors in browser console on page load