### PR TITLE
Add submit button to modal header with animated title

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback, Suspense } from "react";
+import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
@@ -581,6 +582,23 @@ export function CreatePollContent() {
   const isFormValid = (): boolean => {
     return getValidationError() === null;
   };
+
+  // Compute the header center text: title in quotes if valid, else validation error
+  const validationError = getValidationError();
+  const headerText = validationError
+    ? validationError
+    : (title ? `\u201C${title}\u201D` : 'Create Poll');
+  const headerIsError = !!validationError;
+
+  // Portal targets in the modal header (rendered by template.tsx)
+  const [submitPortal, setSubmitPortal] = useState<HTMLElement | null>(null);
+  const [titlePortal, setTitlePortal] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    const submitEl = document.getElementById('create-poll-submit-portal');
+    const titleEl = document.getElementById('create-poll-title-portal');
+    if (submitEl) setSubmitPortal(submitEl);
+    if (titleEl) setTitlePortal(titleEl);
+  }, []);
 
   // Get today's date in YYYY-MM-DD format (client-side only to avoid hydration mismatch)
   const getTodayDate = () => {
@@ -1357,8 +1375,38 @@ export function CreatePollContent() {
     </div>
   );
 
+  const submitDisabled = isLoading || isSubmitted || !isFormValid() || (!!forkOf && !hasFormChanged);
+
   return (
     <div className="poll-content">
+      {/* Portal: Submit button in modal header (upper right) */}
+      {submitPortal && createPortal(
+        <button
+          type="button"
+          onClick={handleSubmitClick}
+          disabled={submitDisabled}
+          className="h-[43px] px-4 flex items-center justify-center rounded-full bg-blue-500 text-white font-semibold text-[15px] cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {isSubmitted || isLoading ? (
+            <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+          ) : 'Done'}
+        </button>,
+        submitPortal
+      )}
+
+      {/* Portal: Title/validation in modal header (center) */}
+      {titlePortal && createPortal(
+        <p className={`text-[15px] font-semibold text-center truncate ${
+          headerIsError ? 'text-red-500 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'
+        }`}>
+          {headerText}
+        </p>,
+        titlePortal
+      )}
+
       {error && (
         <div className="mb-4 p-2 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md">
           {error}
@@ -1825,44 +1873,6 @@ export function CreatePollContent() {
           </div>
 
           <CompactNameField name={creatorName} setName={setCreatorName} disabled={isLoading} />
-          
-          {!isFormValid() && !isLoading && (
-            <div className="text-center text-red-600 dark:text-red-400 text-sm mb-3">
-              {getValidationError()}
-            </div>
-          )}
-          
-          <button
-            type="button"
-            onClick={handleSubmitClick}
-            disabled={isLoading || isSubmitted || !isFormValid() || (!!forkOf && !hasFormChanged)}
-            className="w-full py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] active:scale-95 font-medium text-base transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
-          >
-            {isSubmitted ? (
-              <>
-                <svg className="animate-spin -ml-1 mr-3 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                Redirecting...
-              </>
-            ) : isLoading ? (
-              <>
-                <svg className="animate-spin -ml-1 mr-3 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                Creating Poll...
-              </>
-            ) : (
-              <span className="flex flex-col items-center pt-px pb-0.5">
-                <span className="text-lg font-bold text-green-400 dark:text-green-700 leading-tight">Submit</span>
-                {isPreferencePoll && title && (
-                  <span className="text-sm text-gray-200 dark:text-gray-600 leading-tight">&ldquo;{title}&rdquo;</span>
-                )}
-              </span>
-            )}
-          </button>
         </form>
 
         {/* Show only one header, prioritizing in order: fork > duplicate > followUpTo */}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1381,7 +1381,7 @@ export function CreatePollContent() {
 
       {/* Portal: Animated title below header */}
       {titlePortal && createPortal(
-        <AnimatedTitle title={title} />,
+        <AnimatedTitle title={title} initialDelay={300} />,
         titlePortal
       )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1882,7 +1882,7 @@ export function CreatePollContent() {
         )}
 
         {!followUpTo && !forkOf && !duplicateOf && (
-          <p className="text-sm text-gray-500 dark:text-gray-400 text-center mt-1">
+          <p className="text-sm text-gray-500 dark:text-gray-400 text-center mt-4">
             Private until you share the link
           </p>
         )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -590,14 +590,11 @@ export function CreatePollContent() {
     : (title ? `\u201C${title}\u201D` : 'Create Poll');
   const headerIsError = !!validationError;
 
-  // Portal targets in the modal header (rendered by template.tsx)
+  // Portal target in the modal header (rendered by template.tsx)
   const [submitPortal, setSubmitPortal] = useState<HTMLElement | null>(null);
-  const [titlePortal, setTitlePortal] = useState<HTMLElement | null>(null);
   useEffect(() => {
     const submitEl = document.getElementById('create-poll-submit-portal');
-    const titleEl = document.getElementById('create-poll-title-portal');
     if (submitEl) setSubmitPortal(submitEl);
-    if (titleEl) setTitlePortal(titleEl);
   }, []);
 
   // Get today's date in YYYY-MM-DD format (client-side only to avoid hydration mismatch)
@@ -1397,16 +1394,6 @@ export function CreatePollContent() {
         submitPortal
       )}
 
-      {/* Portal: Generated title or validation message below header */}
-      {titlePortal && createPortal(
-        <p className={`text-sm text-center truncate ${
-          headerIsError ? 'text-red-500 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'
-        }`}>
-          {headerText}
-        </p>,
-        titlePortal
-      )}
-
       {error && (
         <div className="mb-4 p-2 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md">
           {error}
@@ -1897,8 +1884,17 @@ export function CreatePollContent() {
           </div>
         ) : null}
 
+        {/* Generated title or validation message */}
+        <p className={`text-center mt-3 ${
+          headerIsError
+            ? 'text-sm text-red-500 dark:text-red-400'
+            : 'text-lg text-gray-500 dark:text-gray-400'
+        }`}>
+          {headerText}
+        </p>
+
         {!followUpTo && !forkOf && !duplicateOf && (
-          <p className="text-sm text-gray-500 dark:text-gray-400 text-center mt-3">
+          <p className="text-sm text-gray-500 dark:text-gray-400 text-center mt-1">
             Private until you share the link
           </p>
         )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -10,7 +10,6 @@ import CompactNameField from "@/components/CompactNameField";
 import TypeFieldInput, { getBuiltInType, isLocationLikeCategory, FOR_FIELD_PLACEHOLDERS } from "@/components/TypeFieldInput";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
-import ConfirmationModal from "@/components/ConfirmationModal";
 import FollowUpHeader from "@/components/FollowUpHeader";
 import ForkHeader from "@/components/ForkHeader";
 import { triggerDiscoveryIfNeeded } from "@/lib/pollDiscovery";
@@ -121,7 +120,6 @@ export function CreatePollContent() {
   const optionRefs = useRef<(HTMLInputElement | null)[]>([]);
   const [shouldFocusNewOption, setShouldFocusNewOption] = useState(false);
   const isSubmittingRef = useRef(false);
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [creatorName, setCreatorName] = useState<string>("");
   const [originalPollData, setOriginalPollData] = useState<any>(null);
   const [hasFormChanged, setHasFormChanged] = useState(false);
@@ -1046,25 +1044,17 @@ export function CreatePollContent() {
     return ` (${displayParts.join(', ')})`;
   };
 
-  const handleSubmitClick = (e: React.FormEvent | React.MouseEvent) => {
+  const handleSubmitClick = async (e: React.FormEvent | React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    
-    // Check for validation errors before showing modal
+
+    // Check for validation errors
     const validationError = getValidationError();
     if (validationError) {
       setError(validationError);
       return;
     }
-    
-    // Show confirmation modal
-    setShowConfirmModal(true);
-  };
 
-  const handleConfirmSubmit = async () => {
-    // Hide modal
-    setShowConfirmModal(false);
-    
     // Prevent duplicate submissions - check ref first for immediate blocking
     if (isSubmittingRef.current) {
       return;
@@ -1389,7 +1379,7 @@ export function CreatePollContent() {
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
             </svg>
-          ) : 'Done'}
+          ) : 'Submit'}
         </button>,
         submitPortal
       )}
@@ -1899,15 +1889,6 @@ export function CreatePollContent() {
           </p>
         )}
       
-      <ConfirmationModal
-        isOpen={showConfirmModal}
-        onConfirm={handleConfirmSubmit}
-        onCancel={() => setShowConfirmModal(false)}
-        title="Create Poll"
-        message={`Are you sure you want to create "${title}"?`}
-        confirmText="Create"
-        cancelText="Cancel"
-      />
     </div>
   );
 }

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback, Suspense } from "react";
 import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
+import AnimatedTitle from "@/components/AnimatedTitle";
 import Link from "next/link";
 import { apiCreatePoll, apiFindDuplicatePoll } from "@/lib/api";
 import type { OptionsMetadata } from "@/lib/types";
@@ -1378,11 +1379,9 @@ export function CreatePollContent() {
         submitPortal
       )}
 
-      {/* Portal: Generated title below header */}
-      {titlePortal && title && createPortal(
-        <p className="text-blue-600 dark:text-blue-400 font-bold text-center text-lg truncate pb-1">
-          {title}
-        </p>,
+      {/* Portal: Animated title below header */}
+      {titlePortal && createPortal(
+        <AnimatedTitle title={title} />,
         titlePortal
       )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -581,18 +581,12 @@ export function CreatePollContent() {
     return getValidationError() === null;
   };
 
-  // Compute the header center text: title in quotes if valid, else validation error
-  const validationError = getValidationError();
-  const headerText = validationError
-    ? validationError
-    : (title ? `\u201C${title}\u201D` : 'Create Poll');
-  const headerIsError = !!validationError;
-
-  // Portal target in the modal header (rendered by template.tsx)
+  // Portal targets in the modal header (rendered by template.tsx)
   const [submitPortal, setSubmitPortal] = useState<HTMLElement | null>(null);
+  const [titlePortal, setTitlePortal] = useState<HTMLElement | null>(null);
   useEffect(() => {
-    const submitEl = document.getElementById('create-poll-submit-portal');
-    if (submitEl) setSubmitPortal(submitEl);
+    setSubmitPortal(document.getElementById('create-poll-submit-portal'));
+    setTitlePortal(document.getElementById('create-poll-title-portal'));
   }, []);
 
   // Get today's date in YYYY-MM-DD format (client-side only to avoid hydration mismatch)
@@ -1384,6 +1378,14 @@ export function CreatePollContent() {
         submitPortal
       )}
 
+      {/* Portal: Generated title below header */}
+      {titlePortal && title && createPortal(
+        <p className="text-blue-600 dark:text-blue-400 font-bold text-center text-lg truncate pb-1">
+          {title}
+        </p>,
+        titlePortal
+      )}
+
       {error && (
         <div className="mb-4 p-2 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md">
           {error}
@@ -1874,14 +1876,11 @@ export function CreatePollContent() {
           </div>
         ) : null}
 
-        {/* Generated title or validation message */}
-        <p className={`text-center mt-3 ${
-          headerIsError
-            ? 'text-sm text-red-500 dark:text-red-400'
-            : 'text-lg text-gray-500 dark:text-gray-400'
-        }`}>
-          {headerText}
-        </p>
+        {getValidationError() && (
+          <p className="text-sm text-red-500 dark:text-red-400 text-center mt-3">
+            {getValidationError()}
+          </p>
+        )}
 
         {!followUpTo && !forkOf && !duplicateOf && (
           <p className="text-sm text-gray-500 dark:text-gray-400 text-center mt-1">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1357,11 +1357,11 @@ export function CreatePollContent() {
     </div>
   );
 
-  const submitDisabled = isLoading || isSubmitted || !isFormValid() || (!!forkOf && !hasFormChanged);
+  const validationError = getValidationError();
+  const submitDisabled = isLoading || isSubmitted || !!validationError || (!!forkOf && !hasFormChanged);
 
   return (
     <div className="poll-content">
-      {/* Portal: Submit button in modal header (upper right) */}
       {submitPortal && createPortal(
         <button
           type="button"
@@ -1379,7 +1379,6 @@ export function CreatePollContent() {
         submitPortal
       )}
 
-      {/* Portal: Animated title below header */}
       {titlePortal && createPortal(
         <AnimatedTitle title={title} initialDelay={300} />,
         titlePortal
@@ -1875,9 +1874,9 @@ export function CreatePollContent() {
           </div>
         ) : null}
 
-        {getValidationError() && (
+        {validationError && (
           <p className="text-sm text-red-500 dark:text-red-400 text-center mt-3">
-            {getValidationError()}
+            {validationError}
           </p>
         )}
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1397,10 +1397,10 @@ export function CreatePollContent() {
         submitPortal
       )}
 
-      {/* Portal: Title/validation in modal header (center) */}
+      {/* Portal: Generated title or validation message below header */}
       {titlePortal && createPortal(
-        <p className={`text-[15px] font-semibold text-center truncate ${
-          headerIsError ? 'text-red-500 dark:text-red-400' : 'text-gray-900 dark:text-gray-100'
+        <p className={`text-sm text-center truncate ${
+          headerIsError ? 'text-red-500 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'
         }`}>
           {headerText}
         </p>,

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -759,8 +759,6 @@ function TemplateInner({ children }: AppTemplateProps) {
               <h2 className="text-[17px] font-semibold">New Poll</h2>
               <div id="create-poll-submit-portal" className="flex-shrink-0" />
             </div>
-            {/* Generated title / validation line */}
-            <div id="create-poll-title-portal" className="flex-shrink-0 px-4 pb-2" />
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">
               <div className="max-w-4xl mx-auto px-4 pt-2 pb-8">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -759,6 +759,8 @@ function TemplateInner({ children }: AppTemplateProps) {
               <h2 className="absolute inset-0 flex items-center justify-center text-[17px] font-semibold pointer-events-none">New Poll</h2>
               <div id="create-poll-submit-portal" className="flex-shrink-0 z-10" />
             </div>
+            {/* Generated title line */}
+            <div id="create-poll-title-portal" className="flex-shrink-0 px-4" />
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">
               <div className="max-w-4xl mx-auto px-4 pt-2 pb-8">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -756,9 +756,11 @@ function TemplateInner({ children }: AppTemplateProps) {
                   <path stroke="currentColor" strokeLinecap="round" strokeWidth={0.75} d="M6 6l12 12M18 6L6 18" />
                 </svg>
               </button>
-              <div id="create-poll-title-portal" className="flex-1 mx-3 min-w-0" />
+              <h2 className="text-[17px] font-semibold">New Poll</h2>
               <div id="create-poll-submit-portal" className="flex-shrink-0" />
             </div>
+            {/* Generated title / validation line */}
+            <div id="create-poll-title-portal" className="flex-shrink-0 px-4 pb-2" />
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">
               <div className="max-w-4xl mx-auto px-4 pt-2 pb-8">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -756,8 +756,8 @@ function TemplateInner({ children }: AppTemplateProps) {
                   <path stroke="currentColor" strokeLinecap="round" strokeWidth={0.75} d="M6 6l12 12M18 6L6 18" />
                 </svg>
               </button>
-              <h2 className="text-[17px] font-semibold">Create Poll</h2>
-              <div className="w-[43px]" />
+              <div id="create-poll-title-portal" className="flex-1 mx-3 min-w-0" />
+              <div id="create-poll-submit-portal" className="flex-shrink-0" />
             </div>
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -746,18 +746,18 @@ function TemplateInner({ children }: AppTemplateProps) {
               <div className="w-9 h-1 rounded-full bg-gray-300 dark:bg-gray-600" />
             </div>
             {/* Header */}
-            <div className="flex-shrink-0 flex items-center justify-between px-4 pb-2">
+            <div className="flex-shrink-0 relative flex items-center justify-between px-4 pb-2">
               <button
                 onClick={handleCloseCreateModal}
-                className="w-[43px] h-[43px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer"
+                className="w-[43px] h-[43px] flex items-center justify-center rounded-full bg-gray-200/80 dark:bg-gray-700/80 cursor-pointer z-10"
                 aria-label="Close"
               >
                 <svg className="w-[34px] h-[34px] text-black dark:text-white" fill="none" viewBox="0 0 24 24">
                   <path stroke="currentColor" strokeLinecap="round" strokeWidth={0.75} d="M6 6l12 12M18 6L6 18" />
                 </svg>
               </button>
-              <h2 className="text-[17px] font-semibold">New Poll</h2>
-              <div id="create-poll-submit-portal" className="flex-shrink-0" />
+              <h2 className="absolute inset-0 flex items-center justify-center text-[17px] font-semibold pointer-events-none">New Poll</h2>
+              <div id="create-poll-submit-portal" className="flex-shrink-0 z-10" />
             </div>
             {/* Scrollable content */}
             <div ref={modalScrollRef} className="flex-1 overflow-auto overscroll-contain">

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+// Total animation time in ms (matches main page typing animation)
+const TOTAL_ANIMATION_MS = 630;
+// Minimum font size in px before truncating
+const MIN_FONT_PX = 13;
+// Maximum font size in px
+const MAX_FONT_PX = 20;
+
+/**
+ * Find the longest common prefix and suffix between two strings.
+ * Returns { prefix, oldMiddle, newMiddle, suffix }.
+ * The "middle" is the part that differs.
+ */
+function diffStrings(oldStr: string, newStr: string) {
+  let prefixLen = 0;
+  const minLen = Math.min(oldStr.length, newStr.length);
+  while (prefixLen < minLen && oldStr[prefixLen] === newStr[prefixLen]) {
+    prefixLen++;
+  }
+
+  let suffixLen = 0;
+  while (
+    suffixLen < minLen - prefixLen &&
+    oldStr[oldStr.length - 1 - suffixLen] === newStr[newStr.length - 1 - suffixLen]
+  ) {
+    suffixLen++;
+  }
+
+  return {
+    prefix: newStr.slice(0, prefixLen),
+    oldMiddle: oldStr.slice(prefixLen, oldStr.length - suffixLen),
+    newMiddle: newStr.slice(prefixLen, newStr.length - suffixLen),
+    suffix: newStr.slice(newStr.length - suffixLen),
+  };
+}
+
+interface AnimatedTitleProps {
+  title: string;
+}
+
+export default function AnimatedTitle({ title }: AnimatedTitleProps) {
+  const [displayedText, setDisplayedText] = useState(title);
+  const prevTitleRef = useRef(title);
+  const animatingRef = useRef(false);
+  const cancelRef = useRef<() => void>(() => {});
+  const containerRef = useRef<HTMLDivElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [fontSizePx, setFontSizePx] = useState(MAX_FONT_PX);
+
+  // Auto-shrink font to fit container width
+  const fitFont = useCallback(() => {
+    const container = containerRef.current;
+    const textEl = textRef.current;
+    if (!container || !textEl) return;
+
+    // Temporarily set max size to measure
+    textEl.style.fontSize = `${MAX_FONT_PX}px`;
+    const containerWidth = container.clientWidth;
+
+    if (textEl.scrollWidth <= containerWidth) {
+      setFontSizePx(MAX_FONT_PX);
+      return;
+    }
+
+    // Binary search for the right font size
+    let lo = MIN_FONT_PX;
+    let hi = MAX_FONT_PX;
+    while (hi - lo > 0.5) {
+      const mid = (lo + hi) / 2;
+      textEl.style.fontSize = `${mid}px`;
+      if (textEl.scrollWidth > containerWidth) {
+        hi = mid;
+      } else {
+        lo = mid;
+      }
+    }
+    setFontSizePx(lo);
+    textEl.style.fontSize = `${lo}px`;
+  }, []);
+
+  // Fit font whenever displayedText changes
+  useEffect(() => {
+    fitFont();
+  }, [displayedText, fitFont]);
+
+  // Fit font on resize
+  useEffect(() => {
+    const observer = new ResizeObserver(fitFont);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [fitFont]);
+
+  // Animate when title changes
+  useEffect(() => {
+    const oldTitle = prevTitleRef.current;
+    prevTitleRef.current = title;
+
+    if (oldTitle === title) return;
+
+    // Cancel any in-progress animation
+    cancelRef.current();
+
+    // If transitioning to/from empty, just set immediately
+    if (!oldTitle || !title) {
+      setDisplayedText(title);
+      animatingRef.current = false;
+      return;
+    }
+
+    const { prefix, oldMiddle, newMiddle, suffix } = diffStrings(oldTitle, title);
+    const deleteCount = oldMiddle.length;
+    const typeCount = newMiddle.length;
+    const totalSteps = deleteCount + typeCount;
+
+    if (totalSteps === 0) {
+      setDisplayedText(title);
+      return;
+    }
+
+    const charDelay = Math.max(15, TOTAL_ANIMATION_MS / totalSteps);
+    animatingRef.current = true;
+    let step = 0;
+    let cancelled = false;
+
+    cancelRef.current = () => {
+      cancelled = true;
+    };
+
+    const tick = () => {
+      if (cancelled) {
+        // Jump to final state
+        setDisplayedText(title);
+        animatingRef.current = false;
+        return;
+      }
+
+      if (step < deleteCount) {
+        // Deleting phase: remove chars from end of oldMiddle
+        const remaining = oldMiddle.slice(0, oldMiddle.length - step - 1);
+        setDisplayedText(prefix + remaining + suffix);
+      } else {
+        // Typing phase: add chars from start of newMiddle
+        const typed = newMiddle.slice(0, step - deleteCount + 1);
+        setDisplayedText(prefix + typed + suffix);
+      }
+
+      step++;
+      if (step < totalSteps) {
+        setTimeout(tick, charDelay);
+      } else {
+        animatingRef.current = false;
+      }
+    };
+
+    tick();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [title]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="text-center overflow-hidden whitespace-nowrap"
+      style={{ minHeight: `${MAX_FONT_PX + 8}px` }}
+    >
+      {displayedText && (
+        <span
+          ref={textRef}
+          className="text-blue-600 dark:text-blue-400 font-bold inline-block"
+          style={{
+            fontSize: `${fontSizePx}px`,
+            fontFamily: "'M PLUS 1 Code', monospace",
+          }}
+        >
+          {displayedText}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -120,9 +120,10 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
     textEl.style.fontSize = `${lo}px`;
   }, []);
 
-  // Fit font whenever displayedText changes
+  // Fit font only when animation reaches final state (avoid layout thrashing
+  // from binary-search reflows on every intermediate animation step)
   useEffect(() => {
-    fitFont();
+    if (displayedRef.current === targetRef.current) fitFont();
   }, [displayedText, fitFont]);
 
   // Fit font on resize
@@ -207,7 +208,6 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
 
     if (delay > 0) {
       const timer = setTimeout(tick, delay);
-      const prevCancel = cancelRef.current;
       cancelRef.current = () => { cancelled = true; clearTimeout(timer); };
     } else {
       tick();

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -38,31 +38,26 @@ function diffStrings(oldStr: string, newStr: string) {
 }
 
 /**
- * Check if a character at a given step should be animated instantly (0 delay).
- * Spaces are instant. When typing " for X", the " for " prefix is instant
- * so the first visible character appears right away.
+ * Check if a character should skip its animation delay.
+ * Spaces and " for " scaffolding are always instant.
  */
-function shouldSkipDelay(
+function isScaffoldChar(
   char: string,
   phase: "delete" | "type",
   middle: string,
   charIndex: number,
 ): boolean {
-  // Spaces are always instant
   if (char === " ") return true;
 
-  // When typing, if the new middle starts with " for ", skip those chars
-  // so the user-typed character (after " for ") appears instantly
+  // When typing, " for " prefix is scaffold
   if (phase === "type" && middle.startsWith(" for ")) {
     if (charIndex < " for ".length) return true;
   }
 
-  // When deleting, if the old middle ends with " for " + content,
-  // skip the " for " portion
+  // When deleting, " for " within the old middle is scaffold
   if (phase === "delete") {
     const forIdx = middle.indexOf(" for ");
     if (forIdx >= 0) {
-      // charIndex counts from the right during deletion
       const posFromLeft = middle.length - 1 - charIndex;
       if (posFromLeft >= forIdx && posFromLeft < forIdx + " for ".length) return true;
     }
@@ -146,25 +141,24 @@ export default function AnimatedTitle({ title }: AnimatedTitleProps) {
     const deleteCount = oldMiddle.length;
     const typeCount = newMiddle.length;
 
-    // Build step list with delay info. Each step is { frame, instant }.
-    // Instant steps (spaces, " for " prefix) get 0 delay.
+    // Build step list. Scaffold chars (spaces, " for ") are always instant.
+    // The first non-scaffold char is also instant (no delay before the first
+    // visible change). Only the 2nd+ visible chars get animation delays.
     const steps: { phase: "delete" | "type"; index: number; instant: boolean }[] = [];
+    let firstVisibleSeen = false;
     for (let i = 0; i < deleteCount; i++) {
-      const charIndex = i; // counts from right during deletion
-      const char = oldMiddle[oldMiddle.length - 1 - charIndex];
-      steps.push({
-        phase: "delete",
-        index: i,
-        instant: shouldSkipDelay(char, "delete", oldMiddle, charIndex),
-      });
+      const char = oldMiddle[oldMiddle.length - 1 - i];
+      const scaffold = isScaffoldChar(char, "delete", oldMiddle, i);
+      const instant = scaffold || !firstVisibleSeen;
+      if (!scaffold) firstVisibleSeen = true;
+      steps.push({ phase: "delete", index: i, instant });
     }
     for (let i = 0; i < typeCount; i++) {
       const char = newMiddle[i];
-      steps.push({
-        phase: "type",
-        index: i,
-        instant: shouldSkipDelay(char, "type", newMiddle, i),
-      });
+      const scaffold = isScaffoldChar(char, "type", newMiddle, i);
+      const instant = scaffold || !firstVisibleSeen;
+      if (!scaffold) firstVisibleSeen = true;
+      steps.push({ phase: "type", index: i, instant });
     }
 
     const animatedSteps = steps.filter((s) => !s.instant).length;

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -73,13 +73,21 @@ interface AnimatedTitleProps {
 }
 
 export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitleProps) {
-  const [displayedText, setDisplayedText] = useState("");
-  const prevTitleRef = useRef("");
+  const [displayedText, _setDisplayedText] = useState("");
+  const displayedRef = useRef("");
+  const setDisplayedText = useCallback((text: string) => {
+    displayedRef.current = text;
+    _setDisplayedText(text);
+  }, []);
+  const targetRef = useRef(title);
   const initialDelayDone = useRef(initialDelay === 0);
   const cancelRef = useRef<() => void>(() => {});
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [fontSizePx, setFontSizePx] = useState(MAX_FONT_PX);
+
+  // Always keep targetRef in sync
+  targetRef.current = title;
 
   // Auto-shrink font to fit container width
   const fitFont = useCallback(() => {
@@ -124,33 +132,20 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
     return () => observer.disconnect();
   }, [fitFont]);
 
-  // Animate when title changes
-  useEffect(() => {
-    const oldTitle = prevTitleRef.current;
-    prevTitleRef.current = title;
-
-    if (oldTitle === title) return;
-
-    // Cancel any in-progress animation
+  // Core animation runner — extracted so it can be called from the effect
+  // and from the safety-net check.
+  const runAnimation = useCallback((from: string, to: string, delay: number) => {
     cancelRef.current();
 
-    // If transitioning to empty, just clear immediately
-    if (!title) {
-      setDisplayedText(title);
+    if (!to) {
+      setDisplayedText("");
       return;
     }
 
-    // On first animation, wait for modal to finish sliding up
-    const delay = initialDelayDone.current ? 0 : initialDelay;
-    initialDelayDone.current = true;
-
-    const { prefix, oldMiddle, newMiddle, suffix } = diffStrings(oldTitle, title);
+    const { prefix, oldMiddle, newMiddle, suffix } = diffStrings(from, to);
     const deleteCount = oldMiddle.length;
     const typeCount = newMiddle.length;
 
-    // Build step list. Scaffold chars (spaces, " for ") are always instant.
-    // The first non-scaffold char is also instant (no delay before the first
-    // visible change). Only the 2nd+ visible chars get animation delays.
     const steps: { phase: "delete" | "type"; index: number; instant: boolean }[] = [];
     let firstVisibleSeen = false;
     for (let i = 0; i < deleteCount; i++) {
@@ -170,7 +165,7 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
 
     const animatedSteps = steps.filter((s) => !s.instant).length;
     if (animatedSteps === 0) {
-      setDisplayedText(title);
+      setDisplayedText(to);
       return;
     }
 
@@ -178,9 +173,7 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
     let stepIdx = 0;
     let cancelled = false;
 
-    cancelRef.current = () => {
-      cancelled = true;
-    };
+    cancelRef.current = () => { cancelled = true; };
 
     const applyStep = (s: (typeof steps)[number]) => {
       if (s.phase === "delete") {
@@ -194,15 +187,14 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
 
     const tick = () => {
       if (cancelled) {
-        setDisplayedText(title);
+        // Jump to whatever the *current* target is (not stale closure)
+        setDisplayedText(targetRef.current);
         return;
       }
 
-      // Apply current step and all consecutive instant steps
       applyStep(steps[stepIdx]);
       stepIdx++;
 
-      // Fast-forward through any instant steps
       while (stepIdx < steps.length && steps[stepIdx].instant) {
         applyStep(steps[stepIdx]);
         stepIdx++;
@@ -214,13 +206,38 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
     };
 
     if (delay > 0) {
-      const delayTimer = setTimeout(tick, delay);
-      return () => { cancelled = true; clearTimeout(delayTimer); };
+      const timer = setTimeout(tick, delay);
+      const prevCancel = cancelRef.current;
+      cancelRef.current = () => { cancelled = true; clearTimeout(timer); };
     } else {
       tick();
-      return () => { cancelled = true; };
     }
-  }, [title, initialDelay]);
+  }, [setDisplayedText]);
+
+  // Trigger animation when title changes
+  useEffect(() => {
+    if (displayedRef.current === title) return;
+
+    const delay = initialDelayDone.current ? 0 : initialDelay;
+    initialDelayDone.current = true;
+
+    runAnimation(displayedRef.current, title, delay);
+
+    return () => { cancelRef.current(); };
+  }, [title, initialDelay, runAnimation]);
+
+  // Safety net: if after initialDelay + buffer, displayed doesn't match title
+  // (e.g. React strict mode cancelled the first run), retry.
+  useEffect(() => {
+    if (!initialDelay) return;
+    const timer = setTimeout(() => {
+      if (displayedRef.current !== targetRef.current && targetRef.current) {
+        initialDelayDone.current = true;
+        runAnimation(displayedRef.current, targetRef.current, 0);
+      }
+    }, initialDelay + 50);
+    return () => clearTimeout(timer);
+  }, [initialDelay, runAnimation]);
 
   return (
     <div

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -71,8 +71,8 @@ interface AnimatedTitleProps {
 }
 
 export default function AnimatedTitle({ title }: AnimatedTitleProps) {
-  const [displayedText, setDisplayedText] = useState(title);
-  const prevTitleRef = useRef(title);
+  const [displayedText, setDisplayedText] = useState("");
+  const prevTitleRef = useRef("");
   const cancelRef = useRef<() => void>(() => {});
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -68,11 +68,14 @@ function isScaffoldChar(
 
 interface AnimatedTitleProps {
   title: string;
+  /** Delay in ms before the first animation starts (e.g. wait for modal slide-up) */
+  initialDelay?: number;
 }
 
-export default function AnimatedTitle({ title }: AnimatedTitleProps) {
+export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitleProps) {
   const [displayedText, setDisplayedText] = useState("");
   const prevTitleRef = useRef("");
+  const initialDelayDone = useRef(initialDelay === 0);
   const cancelRef = useRef<() => void>(() => {});
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
@@ -136,6 +139,10 @@ export default function AnimatedTitle({ title }: AnimatedTitleProps) {
       setDisplayedText(title);
       return;
     }
+
+    // On first animation, wait for modal to finish sliding up
+    const delay = initialDelayDone.current ? 0 : initialDelay;
+    initialDelayDone.current = true;
 
     const { prefix, oldMiddle, newMiddle, suffix } = diffStrings(oldTitle, title);
     const deleteCount = oldMiddle.length;
@@ -206,12 +213,14 @@ export default function AnimatedTitle({ title }: AnimatedTitleProps) {
       }
     };
 
-    tick();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [title]);
+    if (delay > 0) {
+      const delayTimer = setTimeout(tick, delay);
+      return () => { cancelled = true; clearTimeout(delayTimer); };
+    } else {
+      tick();
+      return () => { cancelled = true; };
+    }
+  }, [title, initialDelay]);
 
   return (
     <div

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -131,8 +131,8 @@ export default function AnimatedTitle({ title }: AnimatedTitleProps) {
     // Cancel any in-progress animation
     cancelRef.current();
 
-    // If transitioning to/from empty, just set immediately
-    if (!oldTitle || !title) {
+    // If transitioning to empty, just clear immediately
+    if (!title) {
       setDisplayedText(title);
       return;
     }

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -37,6 +37,40 @@ function diffStrings(oldStr: string, newStr: string) {
   };
 }
 
+/**
+ * Check if a character at a given step should be animated instantly (0 delay).
+ * Spaces are instant. When typing " for X", the " for " prefix is instant
+ * so the first visible character appears right away.
+ */
+function shouldSkipDelay(
+  char: string,
+  phase: "delete" | "type",
+  middle: string,
+  charIndex: number,
+): boolean {
+  // Spaces are always instant
+  if (char === " ") return true;
+
+  // When typing, if the new middle starts with " for ", skip those chars
+  // so the user-typed character (after " for ") appears instantly
+  if (phase === "type" && middle.startsWith(" for ")) {
+    if (charIndex < " for ".length) return true;
+  }
+
+  // When deleting, if the old middle ends with " for " + content,
+  // skip the " for " portion
+  if (phase === "delete") {
+    const forIdx = middle.indexOf(" for ");
+    if (forIdx >= 0) {
+      // charIndex counts from the right during deletion
+      const posFromLeft = middle.length - 1 - charIndex;
+      if (posFromLeft >= forIdx && posFromLeft < forIdx + " for ".length) return true;
+    }
+  }
+
+  return false;
+}
+
 interface AnimatedTitleProps {
   title: string;
 }
@@ -44,7 +78,6 @@ interface AnimatedTitleProps {
 export default function AnimatedTitle({ title }: AnimatedTitleProps) {
   const [displayedText, setDisplayedText] = useState(title);
   const prevTitleRef = useRef(title);
-  const animatingRef = useRef(false);
   const cancelRef = useRef<() => void>(() => {});
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
@@ -106,52 +139,76 @@ export default function AnimatedTitle({ title }: AnimatedTitleProps) {
     // If transitioning to/from empty, just set immediately
     if (!oldTitle || !title) {
       setDisplayedText(title);
-      animatingRef.current = false;
       return;
     }
 
     const { prefix, oldMiddle, newMiddle, suffix } = diffStrings(oldTitle, title);
     const deleteCount = oldMiddle.length;
     const typeCount = newMiddle.length;
-    const totalSteps = deleteCount + typeCount;
 
-    if (totalSteps === 0) {
+    // Build step list with delay info. Each step is { frame, instant }.
+    // Instant steps (spaces, " for " prefix) get 0 delay.
+    const steps: { phase: "delete" | "type"; index: number; instant: boolean }[] = [];
+    for (let i = 0; i < deleteCount; i++) {
+      const charIndex = i; // counts from right during deletion
+      const char = oldMiddle[oldMiddle.length - 1 - charIndex];
+      steps.push({
+        phase: "delete",
+        index: i,
+        instant: shouldSkipDelay(char, "delete", oldMiddle, charIndex),
+      });
+    }
+    for (let i = 0; i < typeCount; i++) {
+      const char = newMiddle[i];
+      steps.push({
+        phase: "type",
+        index: i,
+        instant: shouldSkipDelay(char, "type", newMiddle, i),
+      });
+    }
+
+    const animatedSteps = steps.filter((s) => !s.instant).length;
+    if (animatedSteps === 0) {
       setDisplayedText(title);
       return;
     }
 
-    const charDelay = Math.max(15, TOTAL_ANIMATION_MS / totalSteps);
-    animatingRef.current = true;
-    let step = 0;
+    const charDelay = Math.max(15, TOTAL_ANIMATION_MS / animatedSteps);
+    let stepIdx = 0;
     let cancelled = false;
 
     cancelRef.current = () => {
       cancelled = true;
     };
 
+    const applyStep = (s: (typeof steps)[number]) => {
+      if (s.phase === "delete") {
+        const remaining = oldMiddle.slice(0, oldMiddle.length - s.index - 1);
+        setDisplayedText(prefix + remaining + suffix);
+      } else {
+        const typed = newMiddle.slice(0, s.index + 1);
+        setDisplayedText(prefix + typed + suffix);
+      }
+    };
+
     const tick = () => {
       if (cancelled) {
-        // Jump to final state
         setDisplayedText(title);
-        animatingRef.current = false;
         return;
       }
 
-      if (step < deleteCount) {
-        // Deleting phase: remove chars from end of oldMiddle
-        const remaining = oldMiddle.slice(0, oldMiddle.length - step - 1);
-        setDisplayedText(prefix + remaining + suffix);
-      } else {
-        // Typing phase: add chars from start of newMiddle
-        const typed = newMiddle.slice(0, step - deleteCount + 1);
-        setDisplayedText(prefix + typed + suffix);
+      // Apply current step and all consecutive instant steps
+      applyStep(steps[stepIdx]);
+      stepIdx++;
+
+      // Fast-forward through any instant steps
+      while (stepIdx < steps.length && steps[stepIdx].instant) {
+        applyStep(steps[stepIdx]);
+        stepIdx++;
       }
 
-      step++;
-      if (step < totalSteps) {
+      if (stepIdx < steps.length) {
         setTimeout(tick, charDelay);
-      } else {
-        animatingRef.current = false;
       }
     };
 

--- a/components/AnimatedTitle.tsx
+++ b/components/AnimatedTitle.tsx
@@ -226,8 +226,8 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
     return () => { cancelRef.current(); };
   }, [title, initialDelay, runAnimation]);
 
-  // Safety net: if after initialDelay + buffer, displayed doesn't match title
-  // (e.g. React strict mode cancelled the first run), retry.
+  // Safety net: if after the initial animation should have completed but
+  // displayed doesn't match title (e.g. React strict mode cancelled the run), retry.
   useEffect(() => {
     if (!initialDelay) return;
     const timer = setTimeout(() => {
@@ -235,7 +235,7 @@ export default function AnimatedTitle({ title, initialDelay = 0 }: AnimatedTitle
         initialDelayDone.current = true;
         runAnimation(displayedRef.current, targetRef.current, 0);
       }
-    }, initialDelay + 50);
+    }, initialDelay + TOTAL_ANIMATION_MS + 100);
     return () => clearTimeout(timer);
   }, [initialDelay, runAnimation]);
 

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -11,7 +11,7 @@ export interface BuiltInType {
 const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "yes_no", label: "Yes / No", icon: "👍" },
   { value: "restaurant", label: "Restaurant", icon: "🍽️" },
-  { value: "location", label: "Location", icon: "📍" },
+  { value: "location", label: "Place", icon: "📍" },
   { value: "movie", label: "Movie", icon: "🎬" },
   { value: "video_game", label: "Video Game", icon: "🎮" },
 ];


### PR DESCRIPTION
## Summary
- Move submit button from bottom of create-poll form to upper-right of modal header (blue rounded pill, matching iOS style)
- Remove confirmation modal — submit button acts directly
- Add animated title below header that types character-by-character using diff-based animation (only changed section animates)
- Auto-shrink font to fit container width via binary search
- Animation skips delays for spaces and " for " scaffolding; first visible character is always instant
- Center "New Poll" title with absolute positioning (independent of button widths)
- Rename Location category to Place
- Show validation error at bottom above privacy note

## Test plan
- [ ] Open create poll modal — title animates in after slide-up completes
- [ ] Select a category (e.g. Restaurant) — title animates "Restaurant?"
- [ ] Type in For field — " for X" appears instantly then subsequent chars animate
- [ ] Add options — title updates with diff-based animation (only changed portion)
- [ ] Submit button disabled when form invalid, enabled when valid
- [ ] Submit button shows spinner during submission
- [ ] Long titles auto-shrink font to fit
- [ ] Reopen modal with saved form state — title animates correctly

https://claude.ai/code/session_01Cz3WXMt6NLtXXEDq185arm