### PR TITLE
Skip acronymize in title shortening; show option icons in poll list

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -30,13 +30,6 @@ export const dynamic = 'force-dynamic';
 // Used for the Details textarea initial height and auto-grow reset.
 const SINGLE_LINE_INPUT_HEIGHT = 42;
 
-// Acronymize multi-word options: "Call of Duty" → "CoD", "Halo" stays "Halo"
-function acronymize(text: string) {
-  const words = text.split(/\s+/);
-  if (words.length <= 1) return text;
-  return words.map(w => w[0].toUpperCase()).join('');
-}
-
 // Strip parenthesized suffixes and colon suffixes from option text for titles
 function shortenOption(text: string) { return text.split(/[:(]/)[0].trim(); }
 // For locations, take just the name (first comma segment) then apply shortenOption
@@ -193,8 +186,6 @@ export function CreatePollContent() {
       if (filled.length === 1) return filled[0];
       const full = buildTitle(filled);
       if (full.allFit) return full.text;
-      const abbrev = buildTitle(filled.map(acronymize));
-      if (abbrev.allFit) return abbrev.text;
       return `Which ${catLabel}?`;
     };
 

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -57,6 +57,7 @@ function OptionIcons({ poll }: { poll: Poll }) {
           alt=""
           className="inline-block h-[1em] w-[1em] object-cover rounded-sm align-middle ml-0.5"
           loading="lazy"
+          onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
         />
       ))}
       <span className="text-gray-400 dark:text-gray-500 align-middle text-[0.65em] ml-px select-none">…</span>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -35,16 +35,18 @@ function getCategoryIcon(poll: Poll): string {
 function getOptionIconUrls(poll: Poll): string[] {
   const meta = poll.options_metadata;
   if (!meta) return [];
-  // Use poll.options order if available, otherwise metadata key order
   const keys = poll.options?.filter(o => meta[o]?.imageUrl) ??
     Object.keys(meta).filter(k => meta[k]?.imageUrl);
   return keys.map(k => meta[k].imageUrl!);
 }
 
+// Re-check overflow after lazy images load/fail
+const IMAGE_SETTLE_MS = 1500;
+
 /** Poll title h3 with inline option icons and overflow-based ellipsis. */
-function PollTitle({ title, poll, className }: { title: string; poll: Poll; className: string }) {
+function PollTitle({ poll, className }: { poll: Poll; className: string }) {
   const ref = useRef<HTMLHeadingElement>(null);
-  const icons = getOptionIconUrls(poll);
+  const icons = useMemo(() => getOptionIconUrls(poll), [poll]);
   const [overflows, setOverflows] = useState(false);
 
   useEffect(() => {
@@ -52,20 +54,20 @@ function PollTitle({ title, poll, className }: { title: string; poll: Poll; clas
     if (!el || icons.length === 0) { setOverflows(false); return; }
     const check = () => setOverflows(el.scrollHeight > el.clientHeight + 1);
     check();
-    const t = setTimeout(check, 1500);
+    const t = setTimeout(check, IMAGE_SETTLE_MS);
     return () => clearTimeout(t);
-  }, [icons, title]);
+  }, [icons, poll.title]);
 
   return (
     <div className="relative">
       <h3 ref={ref} className={className}>
-        {title}
+        {poll.title}
         {icons.length > 0 && (
           <>
             {' '}
-            {icons.map((url, i) => (
+            {icons.map((url) => (
               <img
-                key={i}
+                key={url}
                 src={url}
                 alt=""
                 className="inline-block h-[1em] w-[1em] object-cover rounded-sm align-middle ml-0.5"
@@ -497,7 +499,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </ClientOnly>
                         </span>
                       </div>
-                      <PollTitle title={poll.title} poll={poll} className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white" />
+                      <PollTitle poll={poll} className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white" />
                       <div className="flex items-center justify-between">
                         <div className="text-xs text-gray-400 dark:text-gray-500">
                           <ClientOnly fallback={null}>
@@ -643,7 +645,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </span>
                         )}
                       </div>
-                      <PollTitle title={poll.title} poll={poll} className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1" />
+                      <PollTitle poll={poll} className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1" />
                       <div className="flex items-center justify-between">
                         <div className="text-xs text-gray-400 dark:text-gray-500">
                           <ClientOnly fallback={null}>

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -43,9 +43,11 @@ function getOptionIconUrls(poll: Poll): string[] {
 
 /** Inline option icons rendered after the poll title text.
  *  Shows icons from options_metadata that have an imageUrl (skips placeholders).
- *  Parent's line-clamp clips overflow naturally. */
+ *  Parent's line-clamp clips overflow naturally.
+ *  Ellipsis only appears once at least one icon loads successfully. */
 function OptionIcons({ poll }: { poll: Poll }) {
   const icons = getOptionIconUrls(poll);
+  const ellipsisRef = useRef<HTMLSpanElement>(null);
   if (icons.length === 0) return null;
   return (
     <>
@@ -57,10 +59,11 @@ function OptionIcons({ poll }: { poll: Poll }) {
           alt=""
           className="inline-block h-[1em] w-[1em] object-cover rounded-sm align-middle ml-0.5"
           loading="lazy"
+          onLoad={() => { if (ellipsisRef.current) ellipsisRef.current.style.display = ''; }}
           onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
         />
       ))}
-      <span className="text-gray-400 dark:text-gray-500 align-middle text-[0.65em] ml-px select-none">…</span>
+      <span ref={ellipsisRef} className="text-gray-400 dark:text-gray-500 align-middle text-[0.65em] ml-px select-none" style={{ display: 'none' }}>…</span>
     </>
   );
 }

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -31,6 +31,39 @@ function getCategoryIcon(poll: Poll): string {
   return getPollSymbol(poll.poll_type, poll.is_closed ?? false);
 }
 
+/** Extract image URLs from poll options metadata (skip entries without images). */
+function getOptionIconUrls(poll: Poll): string[] {
+  const meta = poll.options_metadata;
+  if (!meta) return [];
+  // Use poll.options order if available, otherwise metadata key order
+  const keys = poll.options?.filter(o => meta[o]?.imageUrl) ??
+    Object.keys(meta).filter(k => meta[k]?.imageUrl);
+  return keys.map(k => meta[k].imageUrl!);
+}
+
+/** Inline option icons rendered after the poll title text.
+ *  Shows icons from options_metadata that have an imageUrl (skips placeholders).
+ *  Parent's line-clamp clips overflow naturally. */
+function OptionIcons({ poll }: { poll: Poll }) {
+  const icons = getOptionIconUrls(poll);
+  if (icons.length === 0) return null;
+  return (
+    <>
+      {' '}
+      {icons.map((url, i) => (
+        <img
+          key={i}
+          src={url}
+          alt=""
+          className="inline-block h-[1em] w-[1em] object-cover rounded-sm align-middle ml-0.5"
+          loading="lazy"
+        />
+      ))}
+      <span className="text-gray-400 dark:text-gray-500 align-middle text-[0.65em] ml-px select-none">…</span>
+    </>
+  );
+}
+
 function relativeTime(dateStr: string): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();
@@ -447,6 +480,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       </div>
                       <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
                         {poll.title}
+                        <OptionIcons poll={poll} />
                       </h3>
                       <div className="flex items-center justify-between">
                         <div className="text-xs text-gray-400 dark:text-gray-500">
@@ -595,6 +629,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                       </div>
                       <h3 className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1">
                         {poll.title}
+                        <OptionIcons poll={poll} />
                       </h3>
                       <div className="flex items-center justify-between">
                         <div className="text-xs text-gray-400 dark:text-gray-500">

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -41,30 +41,45 @@ function getOptionIconUrls(poll: Poll): string[] {
   return keys.map(k => meta[k].imageUrl!);
 }
 
-/** Inline option icons rendered after the poll title text.
- *  Shows icons from options_metadata that have an imageUrl (skips placeholders).
- *  Parent's line-clamp clips overflow naturally.
- *  Ellipsis only appears once at least one icon loads successfully. */
-function OptionIcons({ poll }: { poll: Poll }) {
+/** Poll title h3 with inline option icons and overflow-based ellipsis. */
+function PollTitle({ title, poll, className }: { title: string; poll: Poll; className: string }) {
+  const ref = useRef<HTMLHeadingElement>(null);
   const icons = getOptionIconUrls(poll);
-  const ellipsisRef = useRef<HTMLSpanElement>(null);
-  if (icons.length === 0) return null;
+  const [overflows, setOverflows] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || icons.length === 0) { setOverflows(false); return; }
+    const check = () => setOverflows(el.scrollHeight > el.clientHeight + 1);
+    check();
+    const t = setTimeout(check, 1500);
+    return () => clearTimeout(t);
+  }, [icons, title]);
+
   return (
-    <>
-      {' '}
-      {icons.map((url, i) => (
-        <img
-          key={i}
-          src={url}
-          alt=""
-          className="inline-block h-[1em] w-[1em] object-cover rounded-sm align-middle ml-0.5"
-          loading="lazy"
-          onLoad={() => { if (ellipsisRef.current) ellipsisRef.current.style.display = ''; }}
-          onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-        />
-      ))}
-      <span ref={ellipsisRef} className="text-gray-400 dark:text-gray-500 align-middle text-[0.65em] ml-px select-none" style={{ display: 'none' }}>…</span>
-    </>
+    <div className="relative">
+      <h3 ref={ref} className={className}>
+        {title}
+        {icons.length > 0 && (
+          <>
+            {' '}
+            {icons.map((url, i) => (
+              <img
+                key={i}
+                src={url}
+                alt=""
+                className="inline-block h-[1em] w-[1em] object-cover rounded-sm align-middle ml-0.5"
+                loading="lazy"
+                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+              />
+            ))}
+          </>
+        )}
+      </h3>
+      {overflows && (
+        <span className="absolute bottom-0 right-0 text-gray-400 dark:text-gray-500 text-[0.85em] leading-[1.4] pointer-events-none select-none">…</span>
+      )}
+    </div>
   );
 }
 
@@ -482,10 +497,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </ClientOnly>
                         </span>
                       </div>
-                      <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
-                        {poll.title}
-                        <OptionIcons poll={poll} />
-                      </h3>
+                      <PollTitle title={poll.title} poll={poll} className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white" />
                       <div className="flex items-center justify-between">
                         <div className="text-xs text-gray-400 dark:text-gray-500">
                           <ClientOnly fallback={null}>
@@ -631,10 +643,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                           </span>
                         )}
                       </div>
-                      <h3 className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1">
-                        {poll.title}
-                        <OptionIcons poll={poll} />
-                      </h3>
+                      <PollTitle title={poll.title} poll={poll} className="font-medium text-lg leading-[1.2] line-clamp-2 text-gray-900 dark:text-white mt-1 mb-1" />
                       <div className="flex items-center justify-between">
                         <div className="text-xs text-gray-400 dark:text-gray-500">
                           <ClientOnly fallback={null}>


### PR DESCRIPTION
## Summary
- Title generation now falls back directly to "Which [category]?" when options don't fit the 40-char limit, instead of trying acronymized versions (e.g. "CoD or H?") as an intermediate step
- Poll list items display inline option icons (from `options_metadata`) after the title text, filling remaining horizontal space on the line. Only entries with real `imageUrl` are shown (placeholder icons like 🍽️ are skipped)
- Ellipsis (…) appears at the bottom-right only when icons overflow the line-clamp-2 bounds, detected via `scrollHeight > clientHeight`
- Broken images are hidden via `onError` handler

## Test plan
- [ ] Create a movie/restaurant poll with options that have metadata images — verify icons appear inline after the title in the poll list
- [ ] Create a poll without metadata — verify no icons or ellipsis appear
- [ ] Create a poll with many options — verify ellipsis appears when icons overflow 2 lines
- [ ] Verify broken image URLs are hidden gracefully
- [ ] Verify title generation falls back to "Which [category]?" instead of acronymizing

https://claude.ai/code/session_01R4xfCcMwWGU2YtmGqtEXFy