### PR TITLE
Fix poll modal scroll inside autocomplete dropdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -985,6 +985,7 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Body scroll lock on iOS** requires `position: fixed` on `<body>` — `overflow: hidden` alone doesn't prevent native pull-to-refresh in Safari/WebKit. Scroll position is saved/restored on mount/unmount.
 - **`navigateCloseModal` uses a ref** (`navigateCloseModalRef`) instead of a `useCallback` with `searchParams` in its deps. This prevents touch listeners from being re-attached on every query param change.
 - **ConfirmationModal z-index must be above z-60** (the create-poll modal). Currently at `z-[70]`. Any new modal that needs to appear over the create form must exceed z-60.
+- **Scrollable children inside the modal must stop touch propagation.** The drag-to-dismiss handler on the modal sheet intercepts all touch events. Any scrollable child (like AutocompleteInput's dropdown `<ul>`) must call `e.stopPropagation()` on native `touchstart`/`touchmove` events so they don't bubble to the modal's drag handler. Use native `addEventListener` (not React's `onTouchStart`) to ensure listeners fire before the modal's bubble-phase handler. The template also has a general `startedInScrollableChild` check (walks DOM for `overflow-y: auto/scroll` ancestors) as a fallback, but explicit `stopPropagation` is more reliable.
 
 ### Adding New Poll Categories
 

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -398,6 +398,7 @@ function TemplateInner({ children }: AppTemplateProps) {
     currentTranslate: 0,
     isDragging: false,
     startedInHeader: false,
+    startedInScrollableChild: false,
     isClosing: false,
     rAFPending: false,
     rAFId: 0,
@@ -460,6 +461,22 @@ function TemplateInner({ children }: AppTemplateProps) {
         const rect = scrollEl.getBoundingClientRect();
         state.startedInHeader = e.touches[0].clientY < rect.top;
       }
+      // Check if touch started inside a scrollable child (e.g. autocomplete dropdown).
+      // If so, don't engage drag-to-dismiss — let the child scroll naturally.
+      state.startedInScrollableChild = false;
+      if (scrollEl) {
+        let el = e.target as HTMLElement | null;
+        while (el && el !== scrollEl) {
+          if (el.scrollHeight > el.clientHeight) {
+            const overflowY = window.getComputedStyle(el).overflowY;
+            if (overflowY === 'auto' || overflowY === 'scroll') {
+              state.startedInScrollableChild = true;
+              break;
+            }
+          }
+          el = el.parentElement;
+        }
+      }
     };
 
     const onTouchMove = (e: TouchEvent) => {
@@ -470,7 +487,7 @@ function TemplateInner({ children }: AppTemplateProps) {
       if (!state.isDragging) {
         const scrollEl = modalScrollRef.current;
         const scrollAtTop = !scrollEl || scrollEl.scrollTop <= 0;
-        if (!(state.startedInHeader || (scrollAtTop && deltaY > 5))) return;
+        if (!(state.startedInHeader || (!state.startedInScrollableChild && scrollAtTop && deltaY > 5))) return;
         state.isDragging = true;
         if (scrollEl) scrollEl.style.overflowY = 'hidden';
         if (modalSheetRef.current) modalSheetRef.current.style.transition = 'none';

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -463,16 +463,16 @@ function TemplateInner({ children }: AppTemplateProps) {
       }
       // Check if touch started inside a scrollable child (e.g. autocomplete dropdown).
       // If so, don't engage drag-to-dismiss — let the child scroll naturally.
+      // Only check for overflow-y style, not scrollHeight vs clientHeight — the height
+      // check has edge cases near the max-height boundary that cause false negatives.
       state.startedInScrollableChild = false;
       if (scrollEl) {
         let el = e.target as HTMLElement | null;
         while (el && el !== scrollEl) {
-          if (el.scrollHeight > el.clientHeight) {
-            const overflowY = window.getComputedStyle(el).overflowY;
-            if (overflowY === 'auto' || overflowY === 'scroll') {
-              state.startedInScrollableChild = true;
-              break;
-            }
+          const overflowY = window.getComputedStyle(el).overflowY;
+          if (overflowY === 'auto' || overflowY === 'scroll') {
+            state.startedInScrollableChild = true;
+            break;
           }
           el = el.parentElement;
         }

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -40,6 +40,7 @@ export default function AutocompleteInput({
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const localInputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
 
   const lastSuccessfulQueryRef = useRef("");
   const lastResultsRef = useRef<SearchResult[]>([]);
@@ -137,6 +138,20 @@ export default function AutocompleteInput({
     };
   }, []);
 
+  // Stop touch events on the dropdown from bubbling to the modal's
+  // drag-to-dismiss handler, so scrolling inside the dropdown works.
+  useEffect(() => {
+    const el = dropdownRef.current;
+    if (!el) return;
+    const stop = (e: TouchEvent) => e.stopPropagation();
+    el.addEventListener('touchstart', stop, { passive: true });
+    el.addEventListener('touchmove', stop, { passive: true });
+    return () => {
+      el.removeEventListener('touchstart', stop);
+      el.removeEventListener('touchmove', stop);
+    };
+  }, [showSuggestions, suggestions.length]);
+
   return (
     <div ref={containerRef} className="relative">
       <input
@@ -155,7 +170,7 @@ export default function AutocompleteInput({
         placeholder={placeholder}
       />
       {showSuggestions && suggestions.length > 0 && (
-        <ul className="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+        <ul ref={dropdownRef} className="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto">
           {suggestions.map((result, index) => (
             <li
               key={index}


### PR DESCRIPTION
## Summary
- Fix scrolling inside autocomplete search results in the create-poll modal sheet. Previously, trying to scroll the dropdown (especially on a second touch to scroll back up) would trigger the modal's drag-to-dismiss gesture instead.
- Two-layer fix: (1) native `stopPropagation` on dropdown touch events prevents them from reaching the modal handler, (2) general `startedInScrollableChild` detection in the modal for any future scrollable children.

## Test plan
- [ ] Open create poll form, pick Restaurant category, search for something
- [ ] Scroll down in the autocomplete results dropdown
- [ ] Lift finger, then scroll back up with a new touch — should scroll results, not dismiss modal
- [ ] Verify modal can still be dismissed by dragging the handle or pulling down on the form content

https://claude.ai/code/session_01D4bizmbCZoHVPmwAM5GqFM