### PR TITLE
Fix yes/no poll symbol rendering as square

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -9,7 +9,7 @@ import FollowUpModal from "@/components/FollowUpModal";
 import { getBuiltInType } from "@/components/TypeFieldInput";
 
 const POLL_TYPE_SYMBOLS: Record<string, string> = {
-  yes_no: '☐',
+  yes_no: '👍',
   ranked_choice: '🗳️',
   participation: '🙋',
 };


### PR DESCRIPTION
## Summary
- Replace U+2610 (☐ BALLOT BOX) with 👍 emoji for yes/no polls in the poll list
- The Unicode ballot box character lacks font support on many devices, rendering as a broken square
- The 👍 emoji matches the icon already used in `TypeFieldInput.tsx` for the yes/no category

## Test plan
- [x] Verified on dev server: yes/no poll shows 👍 in the upper-left corner of poll cards
- [x] Screenshot confirms correct rendering

https://claude.ai/code/session_01DVwvpmSyZn7vbwNXg716K4