### PR TITLE
Switch dev servers to per-branch keying with standalone builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ You do NOT need SSH — all server management goes through `scripts/remote.sh`.
 - **After pushing, wait for the dev server to be ready.** Build takes ~2-3 min. Poll with `bash scripts/remote.sh "curl -s -o /dev/null -w '%{http_code}' http://localhost:<port>"` until it returns 200.
 - URL is derived from branch name: `<branch-slug>.dev.whoeverwants.com`
   - Example: `claude/fix-voting-bug` → `https://fix-voting-bug.dev.whoeverwants.com`
+- **Backward-compatible redirects**: Old email-based URLs (e.g., `sam-at-samcarey-com.dev.whoeverwants.com`) auto-redirect to the branch-based URL via 302. Redirects are created automatically from commit author emails on each push.
 - Dev servers are fully isolated — each has its own API and database
 - **Post-build cleanup**: `node_modules` and `.next/cache` are deleted after build to save disk (~500MB per server)
 - **Idle suspension**: Servers idle >30 min auto-suspend (0 RAM). Resumed on next push.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,17 +75,18 @@ The droplet is hardened with:
 
 ### Development Workflow
 
-**Full-Stack Dev Servers** (auto-deployed per-user on push):
+**Full-Stack Dev Servers** (auto-deployed per-branch on push):
 1. **Write code** in this environment (Claude Code sandbox)
 2. **Commit and push** to GitHub
-3. GitHub webhook creates/updates your full-stack dev server on the droplet
-4. Your dev site URL (based on `GIT_AUTHOR_EMAIL`) stays the same across all branches
+3. GitHub webhook creates/updates a dev server for the branch on the droplet
+4. Dev site URL is derived from the branch name (e.g., `claude/my-feature` → `my-feature.dev.whoeverwants.com`)
 
 Each dev server gets its own:
-- **Next.js frontend** on port 3001-3005
-- **FastAPI backend** on port 8001-8005 (runs via `uv run uvicorn`, 1 worker)
-- **PostgreSQL database** (separate DB in the shared PostgreSQL container, e.g., `dev_sam_at_samcarey_com`)
+- **Next.js standalone build** on port 3001-3099 (~50MB RAM vs ~300MB for `next dev`)
+- **FastAPI backend** on port 8001-8099 (runs via `uv run uvicorn`, 1 worker)
+- **PostgreSQL database** (separate DB in the shared PostgreSQL container, e.g., `dev_my_feature`)
 - **All migrations from the branch** auto-applied on creation and update
+- **Idle suspension**: Servers idle for 30+ min are auto-suspended (processes stopped, build retained). Resumed on next push or manual `resume` command.
 
 **Production Frontend** (Vercel):
 - Vercel auto-deploys on push to `main` → `whoeverwants.com`
@@ -98,17 +99,18 @@ Each dev server gets its own:
 
 You do NOT need SSH — all server management goes through `scripts/remote.sh`.
 
-**Per-User Dev Servers** (automatic on push):
-- Every push to GitHub auto-updates your dev server via webhook (restarts both frontend and API)
-- Frontend uses `next dev` with `PYTHON_API_URL` pointing to the local API
+**Per-Branch Dev Servers** (automatic on push):
+- Every push to GitHub auto-creates/updates a dev server for that branch via webhook
+- Frontend uses a **standalone build** (`npm run build` with `output: 'standalone'`), not `next dev`
 - API runs via `uv run uvicorn` with `DATABASE_URL` pointing to the dev database
 - Migrations from the branch are auto-applied to the dev database on each update
-- **After pushing, wait for the dev server to be ready.** The server takes ~30-60 seconds. Poll with `bash scripts/remote.sh "curl -s -o /dev/null -w '%{http_code}' http://localhost:<port>"` until it returns 200.
-- URL is based on your `GIT_AUTHOR_EMAIL`: `<email-slug>.dev.whoeverwants.com`
-  - Example: `sam@example.com` → `https://sam-at-example-com.dev.whoeverwants.com`
-- URL stays the same regardless of branch — bookmark it
-- Claude/bot emails (`*@anthropic.com`) are ignored
+- **After pushing, wait for the dev server to be ready.** Build takes ~2-3 min. Poll with `bash scripts/remote.sh "curl -s -o /dev/null -w '%{http_code}' http://localhost:<port>"` until it returns 200.
+- URL is derived from branch name: `<branch-slug>.dev.whoeverwants.com`
+  - Example: `claude/fix-voting-bug` → `https://fix-voting-bug.dev.whoeverwants.com`
 - Dev servers are fully isolated — each has its own API and database
+- **Post-build cleanup**: `node_modules` and `.next/cache` are deleted after build to save disk (~500MB per server)
+- **Idle suspension**: Servers idle >30 min auto-suspend (0 RAM). Resumed on next push.
+- **Capacity**: Up to 20 concurrent dev servers (up from 3) on the 1GB RAM droplet
 - Auto-cleaned after 7 days of inactivity
 
 ```bash
@@ -116,10 +118,17 @@ You do NOT need SSH — all server management goes through `scripts/remote.sh`.
 bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh list"
 
 # Manually trigger a dev server update
-bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh upsert user@example.com claude/my-branch" /root 600
+bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh upsert claude/my-branch" /root 600
 
 # Destroy a dev server (also drops its database)
-bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh destroy user-at-example-com"
+bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh destroy my-branch-slug"
+
+# Suspend/resume a dev server
+bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh suspend my-branch-slug"
+bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh resume my-branch-slug"
+
+# Suspend all idle servers (>30 min since last update)
+bash scripts/remote.sh "bash /root/whoeverwants/scripts/dev-server-manager.sh suspend-idle 30"
 
 # Check dev API health
 bash scripts/remote.sh "curl -s http://localhost:<api_port>/health"
@@ -960,8 +969,11 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 
 ### Dev Server Pitfalls
 
-- **`npm run dev` spawns a process chain** (`npm` -> `next` -> `node`). Killing the parent PID doesn't reliably kill child processes holding the TCP port. After PID-based kill, always `fuser -k <port>/tcp` to clean up orphaned children — otherwise the next start gets `EADDRINUSE`.
-- **Dev server shows stale commit info** when the restart fails silently. The old process keeps serving pages. Always check `dev-server-manager.sh list` for `[STOPPED]` status after a push if the commit info doesn't update.
+- **Dev servers use standalone builds**, not `next dev`. There's no hot reload — each push triggers a full `npm run build`. The standalone server (`node .next/standalone/server.js`) uses ~50MB RAM vs ~300MB for `next dev`.
+- **`node_modules` is deleted after build** to save disk. If a build fails partway, the next upsert re-installs deps from scratch.
+- **Standalone server is a single `node` process** (not a process chain like `npm run dev`). PID management is simpler and more reliable.
+- **Dev server shows stale commit info** when the build/restart fails silently. Always check `dev-server-manager.sh list` for `DOWN` or `SUSPENDED` status after a push if the commit info doesn't update.
+- **Suspended servers use 0 RAM** but keep the build on disk (~200MB). Resume is instant (just restarts processes). A full upsert re-clones, rebuilds, and reinstalls.
 
 ### Nominatim / Location Search
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ You do NOT need SSH — all server management goes through `scripts/remote.sh`.
 - URL is derived from branch name: `<branch-slug>.dev.whoeverwants.com`
   - Example: `claude/fix-voting-bug` → `https://fix-voting-bug.dev.whoeverwants.com`
 - **Backward-compatible redirects**: Old email-based URLs (e.g., `sam-at-samcarey-com.dev.whoeverwants.com`) auto-redirect to the branch-based URL via 302. Redirects are created automatically from commit author emails on each push.
+  - The URL stays in the browser (reverse proxy, not redirect) — you can bookmark and refresh the email-based URL to always see whatever branch you last pushed.
 - Dev servers are fully isolated — each has its own API and database
 - **Post-build cleanup**: `node_modules` and `.next/cache` are deleted after build to save disk (~500MB per server)
 - **Idle suspension**: Servers idle >30 min auto-suspend (0 RAM). Resumed on next push.

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -580,7 +580,21 @@ function TemplateInner({ children }: AppTemplateProps) {
   // Lock body scroll when create-poll modal is open to prevent browser pull-to-refresh.
   // On iOS, overflow:hidden alone doesn't prevent native PTR — position:fixed is required.
   useEffect(() => {
-    if (!isCreateModalOpen) return;
+    if (!isCreateModalOpen) {
+      // Safety net: if the modal is closed but body still has scroll-lock styles
+      // (e.g. from a navigation race or error), clean them up proactively.
+      if (document.body.style.position === 'fixed') {
+        const scrollY = Math.abs(parseInt(document.body.style.top || '0', 10));
+        document.documentElement.style.overscrollBehavior = '';
+        document.body.style.position = '';
+        document.body.style.top = '';
+        document.body.style.left = '';
+        document.body.style.right = '';
+        document.body.style.overflow = '';
+        window.scrollTo(0, scrollY);
+      }
+      return;
+    }
     // Reset stale close state from previous dismiss
     setModalClosing(false);
     dragState.current.isClosing = false;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,11 @@ import type { NextConfig } from "next";
 import { branchToSlug } from "./lib/slug";
 
 // Determine the backend API origin for rewrites.
+// On Vercel (production frontend), use external API URLs.
+// On dev server standalone builds, PYTHON_API_URL is set at build time.
 function getApiRewriteDestination(): string {
   const branch = process.env.VERCEL_GIT_COMMIT_REF || process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF;
-  if (process.env.VERCEL || process.env.NODE_ENV === 'production') {
+  if (process.env.VERCEL) {
     if (branch && branch !== 'main' && branch !== 'master') {
       return `https://${branchToSlug(branch)}.api.whoeverwants.com`;
     }

--- a/next.config.ts
+++ b/next.config.ts
@@ -36,100 +36,96 @@ const nextConfig: NextConfig = {
 };
 
 if (process.env.NEXT_OUTPUT === 'standalone') {
-  // Docker production build: standalone output for minimal image size
   nextConfig.output = 'standalone';
-} else {
-  const apiDest = getApiRewriteDestination();
-
-  // Proxy /api/polls to the backend API (same-origin for Safari ITP compatibility)
-  nextConfig.rewrites = async () => ({
-    beforeFiles: [
-      // API rewrites must be in beforeFiles so they take priority over
-      // the trailingSlash redirect (which otherwise 308s API POST requests)
-      {
-        source: '/api/polls',
-        destination: `${apiDest}/api/polls`,
-      },
-      {
-        source: '/api/polls/',
-        destination: `${apiDest}/api/polls`,
-      },
-      {
-        source: '/api/polls/:path*',
-        destination: `${apiDest}/api/polls/:path*`,
-      },
-      {
-        source: '/api/search/:path*',
-        destination: `${apiDest}/api/search/:path*`,
-      },
-      {
-        source: '/api/client-logs',
-        destination: `${apiDest}/api/client-logs`,
-      },
-      {
-        source: '/api/client-logs/',
-        destination: `${apiDest}/api/client-logs`,
-      },
-    ],
-    afterFiles: [],
-    fallback: [],
-  });
-
-  // Headers for tunnel compatibility and environment-specific caching
-  // (not supported with static export)
-  nextConfig.headers = async () => {
-    const isDev = process.env.NODE_ENV === 'development';
-
-    return [
-      {
-        source: '/(.*)',
-        headers: [
-          {
-            key: 'X-Forwarded-Proto',
-            value: 'https'
-          },
-          {
-            key: 'Access-Control-Allow-Origin',
-            value: '*'
-          },
-          // Cache control for pages
-          {
-            key: 'Cache-Control',
-            value: isDev
-              ? 'no-cache, no-store, must-revalidate, max-age=0'
-              : 'public, max-age=3600, stale-while-revalidate=3600'
-          },
-        ],
-      },
-      {
-        source: '/_next/static/(.*)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: isDev
-              ? 'no-cache, no-store, must-revalidate, max-age=0'
-              : 'public, max-age=31536000, immutable',
-          },
-          {
-            key: 'Access-Control-Allow-Origin',
-            value: '*'
-          },
-        ],
-      },
-      // API routes caching
-      {
-        source: '/api/(.*)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: isDev
-              ? 'no-cache, no-store, must-revalidate, max-age=0'
-              : 'public, max-age=3600, stale-while-revalidate=3600'
-          },
-        ],
-      },
-    ];
-  };
 }
+
+const apiDest = getApiRewriteDestination();
+
+// Proxy /api/polls to the backend API (same-origin for Safari ITP compatibility)
+// Always configured so standalone dev server builds bake in rewrites at build time.
+nextConfig.rewrites = async () => ({
+  beforeFiles: [
+    // API rewrites must be in beforeFiles so they take priority over
+    // the trailingSlash redirect (which otherwise 308s API POST requests)
+    {
+      source: '/api/polls',
+      destination: `${apiDest}/api/polls`,
+    },
+    {
+      source: '/api/polls/',
+      destination: `${apiDest}/api/polls`,
+    },
+    {
+      source: '/api/polls/:path*',
+      destination: `${apiDest}/api/polls/:path*`,
+    },
+    {
+      source: '/api/search/:path*',
+      destination: `${apiDest}/api/search/:path*`,
+    },
+    {
+      source: '/api/client-logs',
+      destination: `${apiDest}/api/client-logs`,
+    },
+    {
+      source: '/api/client-logs/',
+      destination: `${apiDest}/api/client-logs`,
+    },
+  ],
+  afterFiles: [],
+  fallback: [],
+});
+
+nextConfig.headers = async () => {
+  const isDev = process.env.NODE_ENV === 'development';
+
+  return [
+    {
+      source: '/(.*)',
+      headers: [
+        {
+          key: 'X-Forwarded-Proto',
+          value: 'https'
+        },
+        {
+          key: 'Access-Control-Allow-Origin',
+          value: '*'
+        },
+        {
+          key: 'Cache-Control',
+          value: isDev
+            ? 'no-cache, no-store, must-revalidate, max-age=0'
+            : 'public, max-age=3600, stale-while-revalidate=3600'
+        },
+      ],
+    },
+    {
+      source: '/_next/static/(.*)',
+      headers: [
+        {
+          key: 'Cache-Control',
+          value: isDev
+            ? 'no-cache, no-store, must-revalidate, max-age=0'
+            : 'public, max-age=31536000, immutable',
+        },
+        {
+          key: 'Access-Control-Allow-Origin',
+          value: '*'
+        },
+      ],
+    },
+    {
+      source: '/api/(.*)',
+      headers: [
+        {
+          key: 'Cache-Control',
+          value: isDev
+            ? 'no-cache, no-store, must-revalidate, max-age=0'
+            : 'public, max-age=3600, stale-while-revalidate=3600'
+        },
+      ],
+    },
+  ];
+};
 
 export default nextConfig;

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
-# Per-user FULL-STACK dev server manager for the WhoeverWants droplet.
-# Each developer (identified by git author email) gets their own:
-#   - Next.js frontend on a unique port (3001-3005)
-#   - FastAPI backend on a unique port (8001-8005)
+# Per-BRANCH full-stack dev server manager for the WhoeverWants droplet.
+# Each branch gets its own:
+#   - Next.js standalone build on a unique port (3001-3099)
+#   - FastAPI backend on a unique port (8001-8099)
 #   - PostgreSQL database (shared instance, separate DB per dev server)
-#   - All migrations from their branch auto-applied
+#   - All migrations from the branch auto-applied
 #
 # Usage (run on droplet):
-#   dev-server-manager.sh upsert <email> <branch>
+#   dev-server-manager.sh upsert <branch>
 #   dev-server-manager.sh list
-#   dev-server-manager.sh destroy <email-slug>
+#   dev-server-manager.sh destroy <slug>
 #   dev-server-manager.sh destroy-all
 #   dev-server-manager.sh cleanup [days]
+#   dev-server-manager.sh suspend <slug>      # Stop processes, keep build
+#   dev-server-manager.sh resume <slug>       # Restart stopped processes
 #
-# Email-to-slug mapping:
-#   sam@example.com -> sam-at-example-com
-#   user.name@company.co.uk -> user-name-at-company-co-uk
+# Branch-to-slug mapping (matches lib/slug.ts branchToSlug):
+#   claude/fix-voting-bug-abc123 -> fix-voting-bug-abc123
+#   feature/my-thing -> feature-my-thing
 
 set -euo pipefail
 
@@ -23,10 +25,10 @@ DEV_DIR="/root/dev-servers"
 CADDY_DEV_DIR="/etc/caddy/dev-servers"
 REPO_URL="https://github.com/samcarey/whoeverwants.git"
 FRONTEND_PORT_START=3001
-FRONTEND_PORT_MAX=3005
+FRONTEND_PORT_MAX=3099
 API_PORT_START=8001
-API_PORT_MAX=8005
-MAX_DEV_SERVERS=3
+API_PORT_MAX=8099
+MAX_DEV_SERVERS=20
 LOCK_DIR="/tmp/dev-server-locks"
 LOG_FILE="/var/log/dev-server-manager.log"
 
@@ -40,51 +42,31 @@ DB_PORT="5432"
 # Path to uv (installed via astral.sh)
 UV_BIN="/root/.local/bin/uv"
 
-# Claude/bot email patterns to ignore
-IGNORE_EMAIL_PATTERNS=(
-  "noreply@anthropic.com"
-  "claude@anthropic.com"
-  "noreply@github.com"
-  "actions@github.com"
-)
-
 log() {
   local msg="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
   echo "$msg" >&2
   echo "$msg" >> "$LOG_FILE" 2>/dev/null || true
 }
 
-# Convert email to URL-safe slug
-# sam@example.com -> sam-at-example-com
-email_to_slug() {
-  local email="$1"
-  echo "$email" | tr '[:upper:]' '[:lower:]' \
-    | sed 's/@/-at-/g' \
+# Convert branch name to URL-safe slug (matches lib/slug.ts branchToSlug)
+# claude/fix-voting-bug-abc123 -> fix-voting-bug-abc123
+# feature/my-thing -> feature-my-thing
+branch_to_slug() {
+  local branch="$1"
+  echo "$branch" \
+    | sed 's|^claude/||' \
+    | tr '[:upper:]' '[:lower:]' \
     | sed 's/[^a-z0-9-]/-/g' \
     | sed 's/--*/-/g' \
-    | sed 's/^-//; s/-$//'
+    | sed 's/^-//; s/-$//' \
+    | cut -c1-50
 }
 
 # Convert slug to database name (replace hyphens with underscores)
-# sam-at-example-com -> dev_sam_at_example_com
+# fix-voting-bug -> dev_fix_voting_bug
 slug_to_dbname() {
   local slug="$1"
   echo "dev_${slug//-/_}"
-}
-
-# Check if email should be ignored (Claude, bots, etc.)
-is_ignored_email() {
-  local email="$1"
-  for pattern in "${IGNORE_EMAIL_PATTERNS[@]}"; do
-    if [ "$email" = "$pattern" ]; then
-      return 0
-    fi
-  done
-  # Also ignore any *@anthropic.com
-  if echo "$email" | grep -qi '@anthropic\.com$'; then
-    return 0
-  fi
-  return 1
 }
 
 # Find an available port in a range
@@ -199,7 +181,42 @@ stop_api() {
   fi
 }
 
-# Start the Next.js dev server
+# Build the Next.js standalone output (run once, before start_nextjs)
+build_nextjs() {
+  local slug="$1"
+  local api_port="$2"
+  local dir="${DEV_DIR}/${slug}"
+
+  cd "$dir"
+
+  local git_sha git_branch
+  git_sha=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
+  git_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+  log "Building Next.js standalone for $slug (API on port $api_port)..."
+
+  # PYTHON_API_URL is baked into the build for rewrite destinations.
+  # NEXT_OUTPUT=standalone triggers output: 'standalone' in next.config.ts.
+  PYTHON_API_URL="http://localhost:${api_port}" \
+  NEXT_OUTPUT=standalone \
+  NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA="$git_sha" \
+  NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF="$git_branch" \
+    npm run build >> "${dir}/nextjs-build.log" 2>&1
+
+  if [ ! -f "${dir}/.next/standalone/server.js" ]; then
+    log "ERROR: Standalone build failed for $slug. Last 30 lines of build log:"
+    tail -30 "${dir}/nextjs-build.log" >&2 2>/dev/null || true
+    return 1
+  fi
+
+  # Copy static assets into standalone output (Next.js doesn't do this automatically)
+  cp -r "${dir}/public" "${dir}/.next/standalone/public" 2>/dev/null || true
+  cp -r "${dir}/.next/static" "${dir}/.next/standalone/.next/static" 2>/dev/null || true
+
+  log "Next.js standalone build complete for $slug"
+}
+
+# Start the Next.js standalone server (must call build_nextjs first)
 # NOTE: Only the PID is written to stdout (for capture). All log messages go to stderr.
 start_nextjs() {
   local slug="$1"
@@ -209,33 +226,28 @@ start_nextjs() {
 
   cd "$dir"
 
-  log "Starting Next.js dev server for $slug on port $frontend_port (API on $api_port)..."
+  if [ ! -f "${dir}/.next/standalone/server.js" ]; then
+    log "ERROR: No standalone build found for $slug. Run build_nextjs first."
+    return 1
+  fi
 
-  local git_sha git_branch
-  git_sha=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
-  git_branch=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  log "Starting Next.js standalone server for $slug on port $frontend_port..."
 
-  # PYTHON_API_URL tells next.config.ts where to proxy /api/polls requests.
-  # Do NOT set NEXT_PUBLIC_API_URL — it leaks into the client bundle and
-  # the browser can't reach localhost on the server. Client uses relative
-  # /api/polls path, proxied by Next.js rewrites via PYTHON_API_URL.
-  PYTHON_API_URL="http://localhost:${api_port}" \
-  NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA="$git_sha" \
-  NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF="$git_branch" \
   HOSTNAME=0.0.0.0 \
-    npm run dev -- -p "$frontend_port" \
+  PORT="$frontend_port" \
+    node "${dir}/.next/standalone/server.js" \
     >> "${dir}/nextjs.log" 2>&1 200>&- &
   local new_pid=$!
   echo "$new_pid" > "${dir}/.nextjs.pid"
 
-  sleep 5
+  sleep 3
   if ! kill -0 "$new_pid" 2>/dev/null; then
-    log "ERROR: Next.js dev server failed to start for $slug. Last 20 lines of log:"
+    log "ERROR: Next.js standalone server failed to start for $slug. Last 20 lines of log:"
     tail -20 "${dir}/nextjs.log" 2>/dev/null || true
     return 1
   fi
 
-  log "Next.js dev server started for $slug (PID $new_pid, port $frontend_port)"
+  log "Next.js standalone server started for $slug (PID $new_pid, port $frontend_port)"
   echo "$new_pid"
 }
 
@@ -426,13 +438,18 @@ evict_excess_servers() {
 # --- Commands ---
 
 cmd_upsert() {
-  local email="${1:?Usage: dev-server-manager.sh upsert <email> <branch>}"
-  local branch="${2:?Usage: dev-server-manager.sh upsert <email> <branch>}"
+  local branch="${1:?Usage: dev-server-manager.sh upsert <branch>}"
   local slug
-  slug=$(email_to_slug "$email")
+  slug=$(branch_to_slug "$branch")
 
-  if is_ignored_email "$email"; then
-    log "Ignoring email: $email"
+  if [ -z "$slug" ]; then
+    log "ERROR: branch '$branch' produced empty slug"
+    return 1
+  fi
+
+  # Don't create dev servers for main/master
+  if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    log "Skipping dev server for $branch"
     return 0
   fi
 
@@ -444,7 +461,7 @@ cmd_upsert() {
 
   evict_excess_servers "$slug"
 
-  # Lock to prevent concurrent updates for same user
+  # Lock to prevent concurrent updates for same branch
   mkdir -p "$LOCK_DIR"
   local lockfile="${LOCK_DIR}/${slug}.lock"
   exec 200>"$lockfile"
@@ -453,7 +470,7 @@ cmd_upsert() {
     return 0
   fi
 
-  log "=== Upsert dev server: $email (slug: $slug, branch: $branch) ==="
+  log "=== Upsert dev server: branch=$branch (slug: $slug) ==="
 
   local dir="${DEV_DIR}/${slug}"
   local db_name
@@ -543,20 +560,29 @@ cmd_upsert() {
   stop_api "$slug"
   stop_nextjs "$slug"
 
-  # --- Install JS deps if needed ---
-  if [ "$needs_npm_install" = true ]; then
+  # --- Install JS deps (needed for build) ---
+  if [ "$needs_npm_install" = true ] || [ ! -d "${dir}/node_modules" ]; then
     log "--- Installing JS dependencies ---"
     npm ci --prefer-offline 2>&1 | tail -5
-    if [ "$is_new" = true ]; then
-      rm -rf .next
-    fi
   fi
+
+  # --- Build Next.js standalone ---
+  log "--- Building Next.js standalone ---"
+  build_nextjs "$slug" "$api_port"
+
+  # --- Post-build cleanup: delete node_modules and build cache to free disk ---
+  log "--- Post-build cleanup ---"
+  rm -rf "${dir}/node_modules"
+  rm -rf "${dir}/.next/cache"
+  local disk_saved
+  disk_saved=$(du -sh "${dir}" 2>/dev/null | cut -f1)
+  log "  Dev server disk usage after cleanup: $disk_saved"
 
   # --- Start API server ---
   local api_pid
   api_pid=$(start_api "$slug" "$api_port" "$db_name")
 
-  # --- Start Next.js frontend ---
+  # --- Start Next.js standalone server ---
   local frontend_pid
   frontend_pid=$(start_nextjs "$slug" "$frontend_port" "$api_port")
 
@@ -566,7 +592,6 @@ cmd_upsert() {
   cat > "${dir}/.dev-meta.json" <<EOF
 {
   "slug": "${slug}",
-  "email": "${email}",
   "branch": "${branch}",
   "port": ${frontend_port},
   "api_port": ${api_port},
@@ -591,7 +616,6 @@ EOF
   log ""
   log "=== Dev server ready ==="
   log "  URL:       https://${slug}.dev.whoeverwants.com"
-  log "  Email:     $email"
   log "  Branch:    $branch"
   log "  Commit:    ${commit_sha:0:8}"
   log "  Frontend:  port $frontend_port (PID $frontend_pid)"
@@ -600,8 +624,8 @@ EOF
 }
 
 cmd_list() {
-  printf "%-35s %-30s %-30s %-5s %-5s %-20s %s\n" "SLUG" "EMAIL" "BRANCH" "FE" "API" "UPDATED" "STATUS"
-  printf "%-35s %-30s %-30s %-5s %-5s %-20s %s\n" "----" "-----" "------" "--" "---" "-------" "------"
+  printf "%-35s %-40s %-5s %-5s %-20s %s\n" "SLUG" "BRANCH" "FE" "API" "UPDATED" "STATUS"
+  printf "%-35s %-40s %-5s %-5s %-20s %s\n" "----" "------" "--" "---" "-------" "------"
 
   if [ ! -d "$DEV_DIR" ]; then
     echo "(no dev servers)"
@@ -612,27 +636,32 @@ cmd_list() {
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
     found=1
-    local slug branch email port api_port updated pid api_pid fe_status api_status
+    local slug branch port api_port updated pid api_pid suspended fe_status api_status
     slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
-    email=$(python3 -c "import json; print(json.load(open('$meta'))['email'])")
     branch=$(python3 -c "import json; print(json.load(open('$meta'))['branch'])")
     port=$(python3 -c "import json; print(json.load(open('$meta'))['port'])")
     api_port=$(python3 -c "import json; print(json.load(open('$meta')).get('api_port', 'N/A'))")
     updated=$(python3 -c "import json; print(json.load(open('$meta'))['updated_at'][:19])")
     pid=$(python3 -c "import json; print(json.load(open('$meta')).get('pid', 'N/A'))")
     api_pid=$(python3 -c "import json; print(json.load(open('$meta')).get('api_pid', 'N/A'))")
+    suspended=$(python3 -c "import json; print(json.load(open('$meta')).get('suspended', False))" 2>/dev/null || echo "False")
 
-    fe_status="DOWN"
-    if [ "$pid" != "N/A" ] && kill -0 "$pid" 2>/dev/null; then
-      fe_status="UP"
-    fi
-    api_status="DOWN"
-    if [ "$api_pid" != "N/A" ] && kill -0 "$api_pid" 2>/dev/null; then
-      api_status="UP"
+    if [ "$suspended" = "True" ]; then
+      fe_status="SUSPENDED"
+      api_status="SUSPENDED"
+    else
+      fe_status="DOWN"
+      if [ "$pid" != "N/A" ] && [ "$pid" != "0" ] && kill -0 "$pid" 2>/dev/null; then
+        fe_status="UP"
+      fi
+      api_status="DOWN"
+      if [ "$api_pid" != "N/A" ] && [ "$api_pid" != "0" ] && kill -0 "$api_pid" 2>/dev/null; then
+        api_status="UP"
+      fi
     fi
 
-    printf "%-35s %-30s %-30s %-5s %-5s %-20s FE:%s API:%s\n" \
-      "$slug" "$email" "$branch" "$port" "$api_port" "$updated" "$fe_status" "$api_status"
+    printf "%-35s %-40s %-5s %-5s %-20s FE:%s API:%s\n" \
+      "$slug" "$branch" "$port" "$api_port" "$updated" "$fe_status" "$api_status"
   done
 
   if [ "$found" -eq 0 ]; then
@@ -757,9 +786,13 @@ with open('$meta', 'r+') as f:
       fi
     fi
 
-    # Revive frontend if not running
+    # Revive frontend if not running (standalone build must exist)
     if ! kill -0 "$pid" 2>/dev/null; then
-      if [ -d "$dir/node_modules" ] && [ -n "$api_port" ]; then
+      local suspended
+      suspended=$(python3 -c "import json; print(json.load(open('$meta')).get('suspended', False))" 2>/dev/null || echo "False")
+      if [ "$suspended" = "True" ]; then
+        log "Dev server '$slug' is suspended, skipping revive"
+      elif [ -f "${dir}/.next/standalone/server.js" ] && [ -n "$api_port" ]; then
         log "Frontend for '$slug' is not running, restarting on port $port..."
         local new_pid
         new_pid=$(start_nextjs "$slug" "$port" "$api_port")
@@ -774,34 +807,165 @@ with open('$meta', 'r+') as f:
 "
         log "Revived frontend for '$slug' with PID $new_pid"
       else
-        log "Missing node_modules or api_port for '$slug', skipping (needs full upsert)"
+        log "Missing standalone build or api_port for '$slug', skipping (needs full upsert)"
       fi
+    fi
+  done
+}
+
+# Suspend a dev server (stop processes, keep build on disk for fast resume)
+cmd_suspend() {
+  local slug="${1:?Usage: dev-server-manager.sh suspend <slug>}"
+
+  if [ ! -f "${DEV_DIR}/${slug}/.dev-meta.json" ]; then
+    log "ERROR: No dev server found with slug '$slug'"
+    return 1
+  fi
+
+  log "=== Suspending dev server: $slug ==="
+  stop_api "$slug"
+  stop_nextjs "$slug"
+
+  # Mark as suspended in metadata
+  python3 -c "
+import json
+meta_path = '${DEV_DIR}/${slug}/.dev-meta.json'
+with open(meta_path, 'r+') as f:
+    d = json.load(f)
+    d['suspended'] = True
+    d['pid'] = 0
+    d['api_pid'] = 0
+    f.seek(0)
+    json.dump(d, f, indent=2)
+    f.truncate()
+"
+  log "=== Dev server '$slug' suspended (processes stopped, build retained) ==="
+}
+
+# Resume a suspended dev server (restart processes from existing build)
+cmd_resume() {
+  local slug="${1:?Usage: dev-server-manager.sh resume <slug>}"
+  local meta="${DEV_DIR}/${slug}/.dev-meta.json"
+
+  if [ ! -f "$meta" ]; then
+    log "ERROR: No dev server found with slug '$slug'"
+    return 1
+  fi
+
+  local port api_port db_name
+  port=$(python3 -c "import json; print(json.load(open('$meta'))['port'])")
+  api_port=$(python3 -c "import json; print(json.load(open('$meta')).get('api_port', ''))")
+  db_name=$(python3 -c "import json; print(json.load(open('$meta')).get('db_name', ''))")
+
+  if [ ! -f "${DEV_DIR}/${slug}/.next/standalone/server.js" ]; then
+    log "ERROR: No standalone build found for '$slug'. Run upsert instead."
+    return 1
+  fi
+
+  log "=== Resuming dev server: $slug ==="
+
+  # Start API
+  local api_pid=0
+  if [ -n "$api_port" ] && [ -n "$db_name" ]; then
+    api_pid=$(start_api "$slug" "$api_port" "$db_name")
+  fi
+
+  # Start frontend
+  local frontend_pid
+  frontend_pid=$(start_nextjs "$slug" "$port" "$api_port")
+
+  # Update metadata
+  python3 -c "
+import json
+with open('$meta', 'r+') as f:
+    d = json.load(f)
+    d['suspended'] = False
+    d['pid'] = $frontend_pid
+    d['api_pid'] = $api_pid
+    f.seek(0)
+    json.dump(d, f, indent=2)
+    f.truncate()
+"
+  log "=== Dev server '$slug' resumed (FE PID $frontend_pid, API PID $api_pid) ==="
+}
+
+# Suspend dev servers idle for more than N minutes (default: 30)
+cmd_suspend_idle() {
+  local max_idle_minutes="${1:-30}"
+  local now
+  now=$(date +%s)
+
+  if [ ! -d "$DEV_DIR" ]; then
+    return
+  fi
+
+  for meta in "${DEV_DIR}"/*/.dev-meta.json; do
+    [ ! -f "$meta" ] && continue
+    local slug updated updated_epoch idle_minutes pid api_pid suspended
+    slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
+    updated=$(python3 -c "import json; print(json.load(open('$meta'))['updated_at'])")
+    pid=$(python3 -c "import json; print(json.load(open('$meta')).get('pid', '0'))")
+    api_pid=$(python3 -c "import json; print(json.load(open('$meta')).get('api_pid', '0'))")
+    suspended=$(python3 -c "import json; print(json.load(open('$meta')).get('suspended', False))" 2>/dev/null || echo "False")
+
+    # Skip already suspended servers
+    if [ "$suspended" = "True" ]; then
+      continue
+    fi
+
+    # Skip servers with no running processes
+    local fe_running=false api_running=false
+    if [ "$pid" != "0" ] && kill -0 "$pid" 2>/dev/null; then
+      fe_running=true
+    fi
+    if [ "$api_pid" != "0" ] && kill -0 "$api_pid" 2>/dev/null; then
+      api_running=true
+    fi
+    if [ "$fe_running" = false ] && [ "$api_running" = false ]; then
+      continue
+    fi
+
+    updated_epoch=$(date -d "$updated" +%s 2>/dev/null || echo 0)
+    if [ "$updated_epoch" -eq 0 ]; then
+      continue
+    fi
+
+    idle_minutes=$(( (now - updated_epoch) / 60 ))
+    if [ "$idle_minutes" -ge "$max_idle_minutes" ]; then
+      log "Dev server '$slug' idle for ${idle_minutes} min (max: ${max_idle_minutes}). Suspending..."
+      cmd_suspend "$slug"
     fi
   done
 }
 
 # --- Main ---
 case "${1:-help}" in
-  upsert)      cmd_upsert "${2:-}" "${3:-}" ;;
-  list)        cmd_list ;;
-  destroy)     cmd_destroy "${2:-}" ;;
-  destroy-all) cmd_destroy_all ;;
-  cleanup)     cmd_cleanup_old "${2:-7}" ;;
-  revive)      cmd_revive ;;
+  upsert)       cmd_upsert "${2:-}" ;;
+  list)         cmd_list ;;
+  destroy)      cmd_destroy "${2:-}" ;;
+  destroy-all)  cmd_destroy_all ;;
+  cleanup)      cmd_cleanup_old "${2:-7}" ;;
+  revive)       cmd_revive ;;
+  suspend)      cmd_suspend "${2:-}" ;;
+  resume)       cmd_resume "${2:-}" ;;
+  suspend-idle) cmd_suspend_idle "${2:-30}" ;;
   *)
     echo "Usage: dev-server-manager.sh <command> [args]"
     echo ""
     echo "Commands:"
-    echo "  upsert <email> <branch>   Create or update a full-stack dev server"
-    echo "  list                      List all active dev servers"
-    echo "  destroy <email-slug>      Destroy a specific dev server (including database)"
-    echo "  destroy-all               Destroy all dev servers"
-    echo "  cleanup [days]            Destroy dev servers not updated in N days (default: 7)"
-    echo "  revive                    Restart any stopped dev servers"
+    echo "  upsert <branch>          Create or update a dev server for a branch"
+    echo "  list                     List all dev servers"
+    echo "  destroy <slug>           Destroy a dev server (including database)"
+    echo "  destroy-all              Destroy all dev servers"
+    echo "  cleanup [days]           Destroy dev servers not updated in N days (default: 7)"
+    echo "  revive                   Restart any stopped (non-suspended) dev servers"
+    echo "  suspend <slug>           Stop processes but keep build on disk"
+    echo "  resume <slug>            Restart a suspended dev server"
+    echo "  suspend-idle [minutes]   Suspend servers idle for N minutes (default: 30)"
     echo ""
     echo "Each dev server gets:"
-    echo "  - Next.js frontend (port 3001-3005)"
-    echo "  - FastAPI backend (port 8001-8005)"
+    echo "  - Next.js standalone build (port 3001-3099)"
+    echo "  - FastAPI backend (port 8001-8099)"
     echo "  - PostgreSQL database (shared instance, separate DB)"
     echo "  - Migrations auto-applied from branch"
     exit 1

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -94,12 +94,25 @@ find_available_port_in_range() {
   return 1
 }
 
+# Read one or more fields from a .dev-meta.json file in a single python3 call.
+# Usage: read_meta <meta_file> <field1> [field2] ...
+# Prints one value per line (empty string for missing fields).
+read_meta() {
+  local meta="$1"; shift
+  python3 -c "
+import json, sys
+d = json.load(open('$meta'))
+for f in sys.argv[1:]:
+    print(d.get(f, ''))
+" "$@" 2>/dev/null
+}
+
 # Get port from existing dev server metadata
 get_dev_port() {
   local slug="$1"
   local meta="${DEV_DIR}/${slug}/.dev-meta.json"
   if [ -f "$meta" ]; then
-    python3 -c "import json; print(json.load(open('$meta'))['port'])" 2>/dev/null || echo ""
+    read_meta "$meta" port
   fi
 }
 
@@ -108,7 +121,7 @@ get_api_port() {
   local slug="$1"
   local meta="${DEV_DIR}/${slug}/.dev-meta.json"
   if [ -f "$meta" ]; then
-    python3 -c "import json; print(json.load(open('$meta')).get('api_port', ''))" 2>/dev/null || echo ""
+    read_meta "$meta" api_port
   fi
 }
 
@@ -373,7 +386,12 @@ ensure_caddy_import() {
   fi
 }
 
-configure_caddy() {
+reload_caddy() {
+  caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl restart caddy
+}
+
+# Write a Caddy reverse proxy config for a slug → port. Does NOT reload Caddy.
+write_caddy_proxy() {
   local slug="$1"
   local port="$2"
 
@@ -384,34 +402,34 @@ ${slug}.dev.whoeverwants.com {
 	reverse_proxy 127.0.0.1:${port}
 }
 EOF
+}
 
-  caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl restart caddy
+configure_caddy() {
+  local slug="$1"
+  local port="$2"
+  write_caddy_proxy "$slug" "$port"
+  reload_caddy
   log "Caddy configured for ${slug}.dev.whoeverwants.com -> port $port"
 }
 
 remove_caddy() {
   local slug="$1"
   rm -f "${CADDY_DEV_DIR}/${slug}.caddy"
-  caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl restart caddy
+  reload_caddy
   log "Caddy config removed for $slug"
 }
 
-# Configure a Caddy reverse proxy from an email-based slug to a branch-based server.
-# The email URL stays in the browser — it proxies to the branch server's port.
-# e.g., sam-at-samcarey-com.dev.whoeverwants.com proxies to 127.0.0.1:<branch-server-port>
+# Set up a Caddy reverse proxy from an email-slug to a branch server's port.
+# The email URL stays in the browser — proxies to the same port as the branch server.
 configure_caddy_redirect() {
   local email_slug="$1"
   local branch_slug="$2"
 
-  ensure_caddy_import
-
-  # Don't overwrite an actual dev server config with a proxy
+  # Don't overwrite an actual dev server config
   if [ -f "${DEV_DIR}/${email_slug}/.dev-meta.json" ]; then
-    log "Skipping proxy for $email_slug — active dev server exists with that slug"
     return
   fi
 
-  # Look up the branch server's frontend port
   local port
   port=$(get_dev_port "$branch_slug")
   if [ -z "$port" ]; then
@@ -419,20 +437,14 @@ configure_caddy_redirect() {
     return
   fi
 
+  # Skip if already pointing to the right port
   local proxy_file="${CADDY_DEV_DIR}/${email_slug}.caddy"
-
-  # Check if proxy already points to the right port
   if [ -f "$proxy_file" ] && grep -q "127.0.0.1:${port}" "$proxy_file" 2>/dev/null; then
-    return  # Already correct, skip reload
+    return
   fi
 
-  cat > "$proxy_file" <<EOF
-${email_slug}.dev.whoeverwants.com {
-	reverse_proxy 127.0.0.1:${port}
-}
-EOF
-
-  caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl restart caddy
+  write_caddy_proxy "$email_slug" "$port"
+  reload_caddy
   log "Caddy proxy: ${email_slug}.dev.whoeverwants.com -> 127.0.0.1:${port} (branch: ${branch_slug})"
 }
 
@@ -449,8 +461,7 @@ evict_excess_servers() {
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
     local slug updated
-    slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
-    updated=$(python3 -c "import json; print(json.load(open('$meta'))['updated_at'])")
+    { read -r slug; read -r updated; } < <(read_meta "$meta" slug updated_at)
     servers+=("${updated}|${slug}")
   done
 
@@ -688,14 +699,21 @@ cmd_list() {
     [ ! -f "$meta" ] && continue
     found=1
     local slug branch port api_port updated pid api_pid suspended fe_status api_status
-    slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
-    branch=$(python3 -c "import json; print(json.load(open('$meta'))['branch'])")
-    port=$(python3 -c "import json; print(json.load(open('$meta'))['port'])")
-    api_port=$(python3 -c "import json; print(json.load(open('$meta')).get('api_port', 'N/A'))")
-    updated=$(python3 -c "import json; print(json.load(open('$meta'))['updated_at'][:19])")
-    pid=$(python3 -c "import json; print(json.load(open('$meta')).get('pid', 'N/A'))")
-    api_pid=$(python3 -c "import json; print(json.load(open('$meta')).get('api_pid', 'N/A'))")
-    suspended=$(python3 -c "import json; print(json.load(open('$meta')).get('suspended', False))" 2>/dev/null || echo "False")
+    {
+      read -r slug; read -r branch; read -r port; read -r api_port
+      read -r updated; read -r pid; read -r api_pid; read -r suspended
+    } < <(python3 -c "
+import json
+d = json.load(open('$meta'))
+print(d.get('slug',''))
+print(d.get('branch',''))
+print(d.get('port',''))
+print(d.get('api_port','N/A'))
+print(d.get('updated_at','')[:19])
+print(d.get('pid','N/A'))
+print(d.get('api_pid','N/A'))
+print(d.get('suspended', False))
+" 2>/dev/null)
 
     if [ "$suspended" = "True" ]; then
       fe_status="SUSPENDED"
@@ -764,7 +782,7 @@ cmd_destroy_all() {
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
     local slug
-    slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
+    read -r slug < <(read_meta "$meta" slug)
     cmd_destroy "$slug"
   done
 
@@ -783,8 +801,7 @@ cmd_cleanup_old() {
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
     local slug updated created_epoch age_days
-    slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
-    updated=$(python3 -c "import json; print(json.load(open('$meta'))['updated_at'])")
+    { read -r slug; read -r updated; } < <(read_meta "$meta" slug updated_at)
     created_epoch=$(date -d "$updated" +%s 2>/dev/null || echo 0)
 
     if [ "$created_epoch" -eq 0 ]; then
@@ -809,12 +826,12 @@ cmd_revive() {
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
     local slug port api_port db_name pid api_pid
-    slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
-    port=$(python3 -c "import json; print(json.load(open('$meta'))['port'])")
-    api_port=$(python3 -c "import json; print(json.load(open('$meta')).get('api_port', ''))")
-    db_name=$(python3 -c "import json; print(json.load(open('$meta')).get('db_name', ''))")
-    pid=$(python3 -c "import json; print(json.load(open('$meta')).get('pid', '0'))")
-    api_pid=$(python3 -c "import json; print(json.load(open('$meta')).get('api_pid', '0'))")
+    {
+      read -r slug; read -r port; read -r api_port; read -r db_name
+      read -r pid; read -r api_pid
+    } < <(read_meta "$meta" slug port api_port db_name pid api_pid)
+    [ -z "$pid" ] && pid=0
+    [ -z "$api_pid" ] && api_pid=0
 
     local dir="${DEV_DIR}/${slug}"
 
@@ -840,7 +857,8 @@ with open('$meta', 'r+') as f:
     # Revive frontend if not running (standalone build must exist)
     if ! kill -0 "$pid" 2>/dev/null; then
       local suspended
-      suspended=$(python3 -c "import json; print(json.load(open('$meta')).get('suspended', False))" 2>/dev/null || echo "False")
+      read -r suspended < <(read_meta "$meta" suspended)
+      [ -z "$suspended" ] && suspended="False"
       if [ "$suspended" = "True" ]; then
         log "Dev server '$slug' is suspended, skipping revive"
       elif [ -f "${dir}/.next/standalone/server.js" ] && [ -n "$api_port" ]; then
@@ -904,9 +922,7 @@ cmd_resume() {
   fi
 
   local port api_port db_name
-  port=$(python3 -c "import json; print(json.load(open('$meta'))['port'])")
-  api_port=$(python3 -c "import json; print(json.load(open('$meta')).get('api_port', ''))")
-  db_name=$(python3 -c "import json; print(json.load(open('$meta')).get('db_name', ''))")
+  { read -r port; read -r api_port; read -r db_name; } < <(read_meta "$meta" port api_port db_name)
 
   if [ ! -f "${DEV_DIR}/${slug}/.next/standalone/server.js" ]; then
     log "ERROR: No standalone build found for '$slug'. Run upsert instead."
@@ -953,11 +969,13 @@ cmd_suspend_idle() {
   for meta in "${DEV_DIR}"/*/.dev-meta.json; do
     [ ! -f "$meta" ] && continue
     local slug updated updated_epoch idle_minutes pid api_pid suspended
-    slug=$(python3 -c "import json; print(json.load(open('$meta'))['slug'])")
-    updated=$(python3 -c "import json; print(json.load(open('$meta'))['updated_at'])")
-    pid=$(python3 -c "import json; print(json.load(open('$meta')).get('pid', '0'))")
-    api_pid=$(python3 -c "import json; print(json.load(open('$meta')).get('api_pid', '0'))")
-    suspended=$(python3 -c "import json; print(json.load(open('$meta')).get('suspended', False))" 2>/dev/null || echo "False")
+    {
+      read -r slug; read -r updated; read -r pid; read -r api_pid; read -r suspended
+    } < <(read_meta "$meta" slug updated_at pid api_pid suspended)
+
+    # Default empty fields
+    [ -z "$pid" ] && pid=0
+    [ -z "$api_pid" ] && api_pid=0
 
     # Skip already suspended servers
     if [ "$suspended" = "True" ]; then

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -62,6 +62,17 @@ branch_to_slug() {
     | cut -c1-50
 }
 
+# Convert email to URL-safe slug (for backward-compatible redirects)
+# sam@example.com -> sam-at-example-com
+email_to_slug() {
+  local email="$1"
+  echo "$email" | tr '[:upper:]' '[:lower:]' \
+    | sed 's/@/-at-/g' \
+    | sed 's/[^a-z0-9-]/-/g' \
+    | sed 's/--*/-/g' \
+    | sed 's/^-//; s/-$//'
+}
+
 # Convert slug to database name (replace hyphens with underscores)
 # fix-voting-bug -> dev_fix_voting_bug
 slug_to_dbname() {
@@ -383,6 +394,39 @@ remove_caddy() {
   rm -f "${CADDY_DEV_DIR}/${slug}.caddy"
   caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl restart caddy
   log "Caddy config removed for $slug"
+}
+
+# Configure a Caddy redirect from an email-based slug to a branch-based slug.
+# This provides backward compatibility for old email-based dev server URLs.
+# e.g., sam-at-samcarey-com.dev.whoeverwants.com -> fix-voting-bug.dev.whoeverwants.com
+configure_caddy_redirect() {
+  local email_slug="$1"
+  local branch_slug="$2"
+
+  ensure_caddy_import
+
+  # Don't overwrite an actual dev server config with a redirect
+  if [ -f "${DEV_DIR}/${email_slug}/.dev-meta.json" ]; then
+    log "Skipping redirect for $email_slug — active dev server exists with that slug"
+    return
+  fi
+
+  local redirect_file="${CADDY_DEV_DIR}/${email_slug}.caddy"
+  local target_url="https://${branch_slug}.dev.whoeverwants.com"
+
+  # Check if redirect already points to the right place
+  if [ -f "$redirect_file" ] && grep -q "$target_url" "$redirect_file" 2>/dev/null; then
+    return  # Already correct, skip reload
+  fi
+
+  cat > "$redirect_file" <<EOF
+${email_slug}.dev.whoeverwants.com {
+	redir ${target_url}{uri} temporary
+}
+EOF
+
+  caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl restart caddy
+  log "Caddy redirect: ${email_slug}.dev.whoeverwants.com -> ${target_url}"
 }
 
 # --- Eviction ---
@@ -938,6 +982,27 @@ cmd_suspend_idle() {
   done
 }
 
+# Set up a redirect from an email-based URL to a branch-based URL
+cmd_redirect() {
+  local email="${1:?Usage: dev-server-manager.sh redirect <email> <branch>}"
+  local branch="${2:?Usage: dev-server-manager.sh redirect <email> <branch>}"
+  local email_slug branch_slug
+  email_slug=$(email_to_slug "$email")
+  branch_slug=$(branch_to_slug "$branch")
+
+  if [ -z "$email_slug" ] || [ -z "$branch_slug" ]; then
+    log "ERROR: empty slug from email='$email' or branch='$branch'"
+    return 1
+  fi
+
+  # Don't redirect if the email slug is the same as the branch slug
+  if [ "$email_slug" = "$branch_slug" ]; then
+    return 0
+  fi
+
+  configure_caddy_redirect "$email_slug" "$branch_slug"
+}
+
 # --- Main ---
 case "${1:-help}" in
   upsert)       cmd_upsert "${2:-}" ;;
@@ -949,6 +1014,7 @@ case "${1:-help}" in
   suspend)      cmd_suspend "${2:-}" ;;
   resume)       cmd_resume "${2:-}" ;;
   suspend-idle) cmd_suspend_idle "${2:-30}" ;;
+  redirect)     cmd_redirect "${2:-}" "${3:-}" ;;
   *)
     echo "Usage: dev-server-manager.sh <command> [args]"
     echo ""
@@ -962,6 +1028,7 @@ case "${1:-help}" in
     echo "  suspend <slug>           Stop processes but keep build on disk"
     echo "  resume <slug>            Restart a suspended dev server"
     echo "  suspend-idle [minutes]   Suspend servers idle for N minutes (default: 30)"
+    echo "  redirect <email> <branch> Set up email-slug redirect to branch-slug"
     echo ""
     echo "Each dev server gets:"
     echo "  - Next.js standalone build (port 3001-3099)"

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -396,37 +396,44 @@ remove_caddy() {
   log "Caddy config removed for $slug"
 }
 
-# Configure a Caddy redirect from an email-based slug to a branch-based slug.
-# This provides backward compatibility for old email-based dev server URLs.
-# e.g., sam-at-samcarey-com.dev.whoeverwants.com -> fix-voting-bug.dev.whoeverwants.com
+# Configure a Caddy reverse proxy from an email-based slug to a branch-based server.
+# The email URL stays in the browser — it proxies to the branch server's port.
+# e.g., sam-at-samcarey-com.dev.whoeverwants.com proxies to 127.0.0.1:<branch-server-port>
 configure_caddy_redirect() {
   local email_slug="$1"
   local branch_slug="$2"
 
   ensure_caddy_import
 
-  # Don't overwrite an actual dev server config with a redirect
+  # Don't overwrite an actual dev server config with a proxy
   if [ -f "${DEV_DIR}/${email_slug}/.dev-meta.json" ]; then
-    log "Skipping redirect for $email_slug — active dev server exists with that slug"
+    log "Skipping proxy for $email_slug — active dev server exists with that slug"
     return
   fi
 
-  local redirect_file="${CADDY_DEV_DIR}/${email_slug}.caddy"
-  local target_url="https://${branch_slug}.dev.whoeverwants.com"
+  # Look up the branch server's frontend port
+  local port
+  port=$(get_dev_port "$branch_slug")
+  if [ -z "$port" ]; then
+    log "WARNING: No port found for branch slug '$branch_slug', skipping proxy for $email_slug"
+    return
+  fi
 
-  # Check if redirect already points to the right place
-  if [ -f "$redirect_file" ] && grep -q "$target_url" "$redirect_file" 2>/dev/null; then
+  local proxy_file="${CADDY_DEV_DIR}/${email_slug}.caddy"
+
+  # Check if proxy already points to the right port
+  if [ -f "$proxy_file" ] && grep -q "127.0.0.1:${port}" "$proxy_file" 2>/dev/null; then
     return  # Already correct, skip reload
   fi
 
-  cat > "$redirect_file" <<EOF
+  cat > "$proxy_file" <<EOF
 ${email_slug}.dev.whoeverwants.com {
-	redir ${target_url}{uri} temporary
+	reverse_proxy 127.0.0.1:${port}
 }
 EOF
 
   caddy reload --config /etc/caddy/Caddyfile 2>/dev/null || systemctl restart caddy
-  log "Caddy redirect: ${email_slug}.dev.whoeverwants.com -> ${target_url}"
+  log "Caddy proxy: ${email_slug}.dev.whoeverwants.com -> 127.0.0.1:${port} (branch: ${branch_slug})"
 }
 
 # --- Eviction ---

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -61,6 +61,34 @@ def verify_signature(payload: bytes, signature: str) -> bool:
     return hmac.compare_digest(f"sha256={expected}", signature)
 
 
+# Email patterns to ignore for redirect mapping
+IGNORE_EMAIL_PATTERNS = [
+    "@anthropic.com",
+    "noreply@github.com",
+    "actions@github.com",
+]
+
+
+def is_ignored_email(email: str) -> bool:
+    """Check if an email should be ignored for redirect mapping."""
+    email_lower = email.lower()
+    return any(pattern in email_lower for pattern in IGNORE_EMAIL_PATTERNS)
+
+
+def extract_author_emails(payload: dict) -> set[str]:
+    """Extract unique non-bot author emails from a push event."""
+    emails = set()
+    for commit in payload.get("commits", []):
+        email = commit.get("author", {}).get("email", "")
+        if email and not is_ignored_email(email):
+            emails.add(email)
+    head = payload.get("head_commit") or {}
+    email = head.get("author", {}).get("email", "")
+    if email and not is_ignored_email(email):
+        emails.add(email)
+    return emails
+
+
 def get_branch(payload: dict) -> str | None:
     """Extract branch name from push event ref."""
     ref = payload.get("ref", "")
@@ -69,8 +97,8 @@ def get_branch(payload: dict) -> str | None:
     return None
 
 
-def trigger_upsert(branch: str):
-    """Run dev-server-manager.sh upsert for a branch."""
+def trigger_upsert(branch: str, emails: set[str]):
+    """Run dev-server-manager.sh upsert for a branch, then set up email redirects."""
     log.info(f"Triggering upsert: branch={branch}")
     try:
         result = subprocess.run(
@@ -85,8 +113,24 @@ def trigger_upsert(branch: str):
             log.error(f"Upsert failed for {branch}: {result.stderr[-500:] if result.stderr else '(no stderr)'}")
     except subprocess.TimeoutExpired:
         log.error(f"Upsert timed out for {branch}")
+        return
     except Exception as e:
         log.error(f"Upsert error for {branch}: {e}")
+        return
+
+    # Set up email-slug -> branch-slug redirects for backward compatibility
+    for email in emails:
+        try:
+            result = subprocess.run(
+                ["bash", MANAGER_SCRIPT, "redirect", email, branch],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                log.warning(f"Redirect setup failed for {email}: {result.stderr[-200:]}")
+        except Exception as e:
+            log.warning(f"Redirect error for {email}: {e}")
 
 
 def deploy_production():
@@ -237,7 +281,9 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(b'{"status": "branch deleted"}')
             return
 
-        log.info(f"Push to {branch}")
+        # Extract author emails for redirect mapping
+        emails = extract_author_emails(payload)
+        log.info(f"Push to {branch} by {emails or '(no authors)'}")
 
         # Respond immediately, process in background
         self.send_response(202)
@@ -258,10 +304,11 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(json.dumps({
             "status": "accepted",
             "branch": branch,
+            "authors": list(emails),
         }).encode())
 
-        # Trigger one upsert per branch (not per author)
-        t = threading.Thread(target=trigger_upsert, args=(branch,))
+        # Trigger upsert + email redirects in background
+        t = threading.Thread(target=trigger_upsert, args=(branch, emails))
         t.daemon = True
         t.start()
 

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -4,7 +4,7 @@ GitHub webhook handler for the WhoeverWants droplet.
 
 Handles two types of push events:
 1. Push to `main` → auto-deploy production backend (git pull + docker compose rebuild)
-2. Push to any branch → update per-user dev servers based on commit author email
+2. Push to any other branch → update per-branch dev server (standalone build)
 
 Runs as a systemd service on the droplet, listening on port 9091.
 Caddy proxies hooks.api.whoeverwants.com -> localhost:9091.
@@ -27,13 +27,6 @@ SECRET_FILE = "/etc/dev-webhook-secret"
 MANAGER_SCRIPT = "/root/whoeverwants/scripts/dev-server-manager.sh"
 REPO_DIR = "/root/whoeverwants"
 DEPLOY_LOCK = "/tmp/production-deploy.lock"
-
-# Claude/bot email patterns to ignore
-IGNORE_PATTERNS = [
-    "@anthropic.com",
-    "noreply@github.com",
-    "actions@github.com",
-]
 
 logging.basicConfig(
     level=logging.INFO,
@@ -68,37 +61,6 @@ def verify_signature(payload: bytes, signature: str) -> bool:
     return hmac.compare_digest(f"sha256={expected}", signature)
 
 
-def is_ignored_email(email: str) -> bool:
-    """Check if an email should be ignored."""
-    email_lower = email.lower()
-    for pattern in IGNORE_PATTERNS:
-        if pattern in email_lower:
-            return True
-    return False
-
-
-def extract_author_emails(payload: dict) -> set[str]:
-    """Extract unique non-bot author emails from a push event."""
-    emails = set()
-
-    # Get author emails from all commits in the push
-    for commit in payload.get("commits", []):
-        author = commit.get("author", {})
-        email = author.get("email", "")
-        if email and not is_ignored_email(email):
-            emails.add(email)
-
-    # Also check head_commit
-    head = payload.get("head_commit", {})
-    if head:
-        author = head.get("author", {})
-        email = author.get("email", "")
-        if email and not is_ignored_email(email):
-            emails.add(email)
-
-    return emails
-
-
 def get_branch(payload: dict) -> str | None:
     """Extract branch name from push event ref."""
     ref = payload.get("ref", "")
@@ -107,24 +69,24 @@ def get_branch(payload: dict) -> str | None:
     return None
 
 
-def trigger_upsert(email: str, branch: str):
-    """Run dev-server-manager.sh upsert in background."""
-    log.info(f"Triggering upsert: email={email}, branch={branch}")
+def trigger_upsert(branch: str):
+    """Run dev-server-manager.sh upsert for a branch."""
+    log.info(f"Triggering upsert: branch={branch}")
     try:
         result = subprocess.run(
-            ["bash", MANAGER_SCRIPT, "upsert", email, branch],
+            ["bash", MANAGER_SCRIPT, "upsert", branch],
             capture_output=True,
             text=True,
             timeout=600,  # 10 minute timeout for npm ci + build
         )
         if result.returncode == 0:
-            log.info(f"Upsert succeeded for {email}: {result.stdout[-200:] if result.stdout else '(no output)'}")
+            log.info(f"Upsert succeeded for {branch}: {result.stdout[-200:] if result.stdout else '(no output)'}")
         else:
-            log.error(f"Upsert failed for {email}: {result.stderr[-500:] if result.stderr else '(no stderr)'}")
+            log.error(f"Upsert failed for {branch}: {result.stderr[-500:] if result.stderr else '(no stderr)'}")
     except subprocess.TimeoutExpired:
-        log.error(f"Upsert timed out for {email}")
+        log.error(f"Upsert timed out for {branch}")
     except Exception as e:
-        log.error(f"Upsert error for {email}: {e}")
+        log.error(f"Upsert error for {branch}: {e}")
 
 
 def deploy_production():
@@ -275,16 +237,7 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(b'{"status": "branch deleted"}')
             return
 
-        # Extract author emails
-        emails = extract_author_emails(payload)
-        if not emails:
-            log.info(f"No non-bot author emails in push to {branch}")
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{"status": "no authors"}')
-            return
-
-        log.info(f"Push to {branch} by {emails}")
+        log.info(f"Push to {branch}")
 
         # Respond immediately, process in background
         self.send_response(202)
@@ -305,14 +258,12 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(json.dumps({
             "status": "accepted",
             "branch": branch,
-            "authors": list(emails),
         }).encode())
 
-        # Trigger upsert for each author in background threads
-        for email in emails:
-            t = threading.Thread(target=trigger_upsert, args=(email, branch))
-            t.daemon = True
-            t.start()
+        # Trigger one upsert per branch (not per author)
+        t = threading.Thread(target=trigger_upsert, args=(branch,))
+        t.daemon = True
+        t.start()
 
     def do_GET(self):
         if self.path == "/health":


### PR DESCRIPTION
## Summary

- **Per-branch dev servers**: One dev server per branch instead of per commit author email. URL derived from branch name (e.g., `claude/fix-bug` → `fix-bug.dev.whoeverwants.com`)
- **Standalone builds**: `npm run build` + `node .next/standalone/server.js` (~50MB RAM vs ~300MB for `next dev`)
- **20x capacity**: Port range 3001-3099/8001-8099, MAX_DEV_SERVERS raised to 20 (from 3)
- **Idle suspension**: Servers idle >30min auto-suspended (0 RAM), instant resume on next push
- **Post-build cleanup**: `node_modules` and `.next/cache` deleted after build (~500MB saved per server)
- **Email URL backward compat**: Old email-based URLs reverse-proxy to the branch server (URL stays in browser)
- **Standalone API routing fix**: `next.config.ts` now only checks `process.env.VERCEL` (not `NODE_ENV`) to determine API routing — `NODE_ENV=production` during `npm run build` was causing standalone builds to route API calls to non-existent external URLs
- **Scroll lock safety net**: Proactive cleanup of stale `position: fixed` on body when create-poll modal closes

## Test plan
- [x] Dev server upsert creates standalone build (verified: 134MB disk, ~80MB RAM)
- [x] Suspend/resume works (instant restart from existing build)
- [x] Email-slug URLs reverse-proxy to branch server (200, no redirect)
- [x] API calls work through standalone rewrite (restaurant search, poll creation)
- [x] Idle suspension cron installed (every 10min, 30min threshold)
- [x] Webhook triggers branch-based upsert + email redirects

https://claude.ai/code/session_01DpPtrMoyPzKGeCPox1vyvm