### PR TITLE
Fix dev server system: serialize builds, robust production deploy, auto-reload webhook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -976,6 +976,9 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Standalone server is a single `node` process** (not a process chain like `npm run dev`). PID management is simpler and more reliable.
 - **Dev server shows stale commit info** when the build/restart fails silently. Always check `dev-server-manager.sh list` for `DOWN` or `SUSPENDED` status after a push if the commit info doesn't update.
 - **Suspended servers use 0 RAM** but keep the build on disk (~200MB). Resume is instant (just restarts processes). A full upsert re-clones, rebuilds, and reinstalls.
+- **Two concurrent builds on the 1GB droplet will spike RAM** to ~850MB used + ~800MB swap (`npm ci` alone uses ~500MB). Builds are serialized via a global `flock` semaphore in `dev-server-manager.sh`; git fetch, migrations, and server startup still run concurrently.
+- **The `/root/whoeverwants` repo must stay on `main`**. If it drifts to a feature branch (e.g., someone ran git commands manually on the droplet), production deploys fail. `dev-webhook.py` uses `git checkout -B main origin/main` (not `git pull`) so it's robust regardless of current branch state.
+- **`systemctl restart dev-webhook` kills the calling process**. Any code after that call in `deploy_production()` is dead. Log completion *before* calling restart, not after.
 
 ### Nominatim / Location Search
 

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -532,6 +532,9 @@ cmd_upsert() {
     return 0
   fi
 
+  # Global build semaphore opened here, acquired just before the heavy build steps below.
+  local build_lock="${LOCK_DIR}/_build.lock"
+
   log "=== Upsert dev server: branch=$branch (slug: $slug) ==="
 
   local dir="${DEV_DIR}/${slug}"
@@ -622,6 +625,11 @@ cmd_upsert() {
   stop_api "$slug"
   stop_nextjs "$slug"
 
+  # --- Acquire global build semaphore (max 1 concurrent npm/next build, each ~500MB RAM) ---
+  exec 201>"$build_lock"
+  log "Waiting for build slot..."
+  flock 201
+
   # --- Install JS deps (needed for build) ---
   if [ "$needs_npm_install" = true ] || [ ! -d "${dir}/node_modules" ]; then
     log "--- Installing JS dependencies ---"
@@ -631,6 +639,9 @@ cmd_upsert() {
   # --- Build Next.js standalone ---
   log "--- Building Next.js standalone ---"
   build_nextjs "$slug" "$api_port"
+
+  # --- Release build semaphore (allow next queued build to start) ---
+  flock --unlock 201
 
   # --- Post-build cleanup: delete node_modules and build cache to free disk ---
   log "--- Post-build cleanup ---"

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -148,24 +148,48 @@ def deploy_production():
         return
 
     try:
-        # 1. Git pull
-        log.info("--- Pulling latest main ---")
+        # 1. Fetch and reset to origin/main (avoids diverged branch issues)
+        log.info("--- Fetching latest main ---")
         result = subprocess.run(
-            ["git", "pull", "origin", "main"],
+            ["git", "fetch", "origin", "main"],
             cwd=REPO_DIR,
             capture_output=True,
             text=True,
             timeout=60,
         )
         if result.returncode != 0:
-            log.error(f"Git pull failed: {result.stderr}")
+            log.error(f"Git fetch failed: {result.stderr}")
             return
-        log.info(f"Git pull: {result.stdout.strip()}")
 
-        # If nothing changed, skip rebuild
-        if "Already up to date" in result.stdout:
+        # Check if there are new commits
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD", "origin/main"],
+            cwd=REPO_DIR,
+            capture_output=True,
+            text=True,
+        )
+        commits = result.stdout.strip().split("\n")
+        if len(commits) == 2 and commits[0] == commits[1]:
             log.info("No changes, skipping rebuild")
             return
+
+        log.info("--- Resetting to origin/main ---")
+        result = subprocess.run(
+            ["git", "checkout", "main"],
+            cwd=REPO_DIR,
+            capture_output=True,
+            text=True,
+        )
+        result = subprocess.run(
+            ["git", "reset", "--hard", "origin/main"],
+            cwd=REPO_DIR,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            log.error(f"Git reset failed: {result.stderr}")
+            return
+        log.info(f"Reset to: {result.stdout.strip()}")
 
         # 2. Check if server/ files changed (optimize: skip rebuild if only frontend changed)
         # Always rebuild to be safe — Docker layer caching makes no-op rebuilds fast

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -222,7 +222,18 @@ def deploy_production():
         else:
             log.info(f"Migrations: {result.stdout.strip()[-200:]}")
 
-        # 4. Verify health
+        # 4. Restart webhook service if the webhook script itself changed
+        # (The service reads the script at startup, so changes require a restart)
+        log.info("--- Restarting webhook service to pick up script changes ---")
+        subprocess.run(
+            ["systemctl", "restart", "dev-webhook"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        # Note: after restart, this thread is killed. Health check happens in new process.
+
+        # 5. Verify health
         import urllib.request
         try:
             resp = urllib.request.urlopen("http://127.0.0.1:8000/health", timeout=10)

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -168,26 +168,23 @@ def deploy_production():
             capture_output=True,
             text=True,
         )
-        commits = result.stdout.strip().split("\n")
-        if len(commits) == 2 and commits[0] == commits[1]:
+        if result.returncode != 0:
+            log.error(f"Git rev-parse failed: {result.stderr}")
+            return
+        shas = result.stdout.strip().split("\n")
+        if len(shas) == 2 and shas[0] == shas[1]:
             log.info("No changes, skipping rebuild")
             return
 
         log.info("--- Resetting to origin/main ---")
         result = subprocess.run(
-            ["git", "checkout", "main"],
-            cwd=REPO_DIR,
-            capture_output=True,
-            text=True,
-        )
-        result = subprocess.run(
-            ["git", "reset", "--hard", "origin/main"],
+            ["git", "checkout", "-B", "main", "origin/main"],
             cwd=REPO_DIR,
             capture_output=True,
             text=True,
         )
         if result.returncode != 0:
-            log.error(f"Git reset failed: {result.stderr}")
+            log.error(f"Git checkout failed: {result.stderr}")
             return
         log.info(f"Reset to: {result.stdout.strip()}")
 
@@ -222,27 +219,15 @@ def deploy_production():
         else:
             log.info(f"Migrations: {result.stdout.strip()[-200:]}")
 
-        # 4. Restart webhook service if the webhook script itself changed
-        # (The service reads the script at startup, so changes require a restart)
-        log.info("--- Restarting webhook service to pick up script changes ---")
+        # 4. Restart webhook service to pick up any script changes.
+        # This kills the current process, so log completion before restarting.
+        log.info("=== Production deploy complete — restarting webhook service ===")
         subprocess.run(
             ["systemctl", "restart", "dev-webhook"],
             capture_output=True,
             text=True,
             timeout=15,
         )
-        # Note: after restart, this thread is killed. Health check happens in new process.
-
-        # 5. Verify health
-        import urllib.request
-        try:
-            resp = urllib.request.urlopen("http://127.0.0.1:8000/health", timeout=10)
-            if resp.status == 200:
-                log.info("=== Production deploy complete — health check OK ===")
-            else:
-                log.error(f"Health check returned {resp.status}")
-        except Exception as e:
-            log.error(f"Health check failed: {e}")
 
     except subprocess.TimeoutExpired as e:
         log.error(f"Production deploy timed out: {e}")


### PR DESCRIPTION
## Summary

- **Serialize concurrent builds** — two simultaneous `npm ci` + `next build` runs spike to ~850MB RAM + 800MB swap on the 1GB droplet. Added a global `flock` semaphore in `dev-server-manager.sh` that serializes the heavy build phase while letting git fetch, migrations, and server startup run concurrently.
- **Robust production deploy** — `git pull` fails when `/root/whoeverwants` has drifted to a feature branch. Replaced with `git fetch` + `git checkout -B main origin/main`, which works regardless of the repo's current branch.
- **Auto-reload webhook after deploy** — `dev-webhook.py` runs as a persistent systemd service, so changes weren't picked up until manual restart. Production deploys now end with `systemctl restart dev-webhook`.
- **Dead code removed** — health check after `systemctl restart` was unreachable (systemd kills the calling process). Moved completion log before restart.
- **Error handling** — added `returncode` check on `git rev-parse` before parsing output.

## Test plan
- [x] Pushed branch → webhook received, dev server created at `test-dev-server-system-krz1u.dev.whoeverwants.com`
- [x] Second push → existing server updated (git fetch only, no re-clone)
- [x] Frontend and API both return HTTP 200
- [x] Two dev servers running concurrently on separate ports

https://claude.ai/code/session_01Lg15TAWrEg9WBkszPsMeLV