### PR TITLE
Add time poll type (scheduling polls)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -940,12 +940,24 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **ScrollWheel's `suppressScrollHandler` flag can get permanently stuck.** `recenterLoop()` sets the flag and schedules an rAF to clear it, but `correctPosition()` runs synchronously right after and bails out because the flag is still set. If a touch interaction then overwrites `scrollTimeout`, the clearing rAF/timeout is lost and the flag stays true forever — silencing all `onChange` calls. Fix: defer `correctPosition` via rAF when suppression is active, and add a safety timeout (500ms) that guarantees the flag gets cleared.
 - **Use refs (not render-scope variables) for state that multiple scroll events may read/write within a single React render cycle.** `handleHourChange` in `TimeCounterInput` captured `periodIndex` from the render scope. When two scroll events crossed the AM/PM boundary before React re-rendered, the second event used the stale value and emitted the wrong time. Track such state in a `useRef` and update it immediately in the handler.
 
+### Time Poll Type
+
+- **Two-phase flow**: availability phase (voters submit `voter_day_time_windows`) → preferences phase (voters submit `liked_slots`/`disliked_slots` after cutoff).
+- **Slot finalization at cutoff**: `_finalize_time_slots()` runs at availability cutoff, applies the threshold filter (`max_availability * (1 - threshold_pct)`), deduplicates via `_keep_longest_per_start_time()`, and writes the filtered slot list to `poll.options`. Everything downstream uses `poll.options` directly — no re-filtering at results time.
+- **`null` vs `[]` semantics for liked/disliked slots**: `null` = voter hasn't submitted preferences yet; `[]` = submitted with all bubbles neutral. The frontend uses this distinction to show an implicit edit prompt (hasNotReactedYet).
+- **Winner algorithm**: fewest dislikes → most likes → earliest slot key (chronological tiebreak). Implemented in `_pick_winner_from_reactions()` in `server/algorithms/time_poll.py`.
+- **Category "Time" in create form**: selecting it from the category dropdown keeps the standard form and injects `ParticipationConditions` + threshold slider + availability cutoff in place of options. Uses a single `{(pollType === 'time' || (pollType === 'poll' && category === 'time'))}` condition — do NOT add a separate duplicate block for each case.
+- **`formatDayLabel(dateStr)`** is the canonical day-label formatter in `lib/timeUtils.ts`. Use it in all time-related components instead of local copies.
+- **Availability cutoff requires `suggestion_deadline_minutes` to be set** on the poll — the endpoint enforces `suggestion_deadline IS NULL AND suggestion_deadline_minutes IS NOT NULL`. Polls created without this field will fail the cutoff endpoint with 400.
+- **`ChunkLoadError` after new builds**: the browser has stale cached chunks from the previous build. The lazy `CreatePollContent` import and the global `unhandledrejection` handler in `template.tsx` both auto-reload the page when this happens. The service worker uses network-first for JS chunks so new builds take effect immediately.
+
 ### Service Worker Caching Strategy
 
 - **Never use `url.pathname.startsWith('/')` in service worker URL matching** — it matches ALL paths. Use exact equality (`===`) or more specific prefixes like `/create-poll`.
 - **Use network-first for HTML navigation, cache-first only for immutable assets.** Cache-first for navigation causes the PWA to serve stale HTML that references old JS bundles (also cached), making it impossible for users to get new code. Network-first ensures fresh HTML on every load; cache is only a fallback for offline.
 - **Skip API requests in the service worker** — let them go directly to the network. Caching API responses causes stale poll data with no visible error.
 - **Bump `CACHE_NAME` version when changing caching strategy** to force old caches to be deleted on activation. Without this, users keep stale cached content indefinitely.
+- **JS chunks need network-first too** — even with content-hash filenames, the old manifest chunk references old chunk names. After a new build, the manifest is cached with old chunk references; network-first for `/_next/static/chunks/` ensures the manifest is always fresh.
 
 ### iOS PWA Safe Area Positioning
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -84,11 +84,13 @@ export function CreatePollContent() {
   const [voteFromSuggestion, setVoteFromSuggestion] = useState<string | null>(null);
 
   const [title, setTitle] = useState("");
-  const pollType = modeParam === 'participation' ? 'participation' : 'poll';
-  const setPollType = useCallback((type: 'poll' | 'participation') => {
+  const pollType = modeParam === 'participation' ? 'participation' : modeParam === 'time' ? 'time' : 'poll';
+  const setPollType = useCallback((type: 'poll' | 'participation' | 'time') => {
     const url = new URL(window.location.href);
     if (type === 'participation') {
       url.searchParams.set('mode', 'participation');
+    } else if (type === 'time') {
+      url.searchParams.set('mode', 'time');
     } else {
       url.searchParams.delete('mode');
     }
@@ -104,6 +106,7 @@ export function CreatePollContent() {
   const [durationMinEnabled, setDurationMinEnabled] = useState(true);
   const [durationMaxEnabled, setDurationMaxEnabled] = useState(true);
   const [dayTimeWindows, setDayTimeWindows] = useState<DayTimeWindow[]>([]);
+  const [availabilityThreshold, setAvailabilityThreshold] = useState<number>(5);
   const [deadlineOption, setDeadlineOption] = useState("10min");
   const [customDate, setCustomDate] = useState('');
   const [customTime, setCustomTime] = useState('');
@@ -215,14 +218,19 @@ export function CreatePollContent() {
     }
 
     // participation
-    if (locationMode === 'set' && locationValue.trim()) {
-      return `Who's going to ${shortenLocation(locationValue)}?`;
+    if (pollType === 'participation') {
+      if (locationMode === 'set' && locationValue.trim()) {
+        return `Who's going to ${shortenLocation(locationValue)}?`;
+      }
+      if (locationMode === 'preferences') {
+        const filled = locationOptions.filter(o => o.trim()).map(shortenLocation);
+        if (filled.length > 0) return buildFromOptions(filled, "Who's in?");
+      }
+      return "Who's in?";
     }
-    if (locationMode === 'preferences') {
-      const filled = locationOptions.filter(o => o.trim()).map(shortenLocation);
-      if (filled.length > 0) return buildFromOptions(filled, "Who's in?");
-    }
-    return "Who's in?";
+
+    // time
+    return "When works?";
   }, [pollType, category, options, forField, locationMode, locationValue, locationOptions]);
 
   // Focus details textarea when opening
@@ -435,9 +443,12 @@ export function CreatePollContent() {
   };
 
   // Determine poll type based on form selection and options
-  const getPollType = (): 'yes_no' | 'ranked_choice' | 'participation' => {
+  const getPollType = (): 'yes_no' | 'ranked_choice' | 'participation' | 'time' => {
     if (pollType === 'participation') {
       return 'participation';
+    }
+    if (pollType === 'time') {
+      return 'time';
     }
     if (category === 'yes_no') {
       return 'yes_no';
@@ -525,6 +536,28 @@ export function CreatePollContent() {
         return "Every selected day must have at least one time slot. Add time slots or remove empty days.";
       }
       // Check minimum duration on all time windows
+      if (durationMinEnabled && durationMinValue != null) {
+        const minDurMinutes = Math.round(durationMinValue * 60);
+        if (minDurMinutes > 0) {
+          const tooShort = dayTimeWindows.some(dtw =>
+            dtw.windows.some(w => windowDurationMinutes(w) < minDurMinutes)
+          );
+          if (tooShort) {
+            return `Each time window must be at least ${formatDurationLabel(minDurMinutes)} long (the minimum duration).`;
+          }
+        }
+      }
+    }
+
+    // Time poll: same day/window requirements as participation
+    if (dbPollType === 'time') {
+      if (dayTimeWindows.length === 0) {
+        return "Please select at least one day.";
+      }
+      const emptyDays = dayTimeWindows.filter(dtw => dtw.windows.length === 0);
+      if (emptyDays.length > 0) {
+        return "Every selected day must have at least one time slot. Add time slots or remove empty days.";
+      }
       if (durationMinEnabled && durationMinValue != null) {
         const minDurMinutes = Math.round(durationMinValue * 60);
         if (minDurMinutes > 0) {
@@ -695,6 +728,10 @@ export function CreatePollContent() {
               setMaxEnabled(false);
               setMaxParticipants(null);
             }
+          } else if (forkData.poll_type === 'time') {
+            setPollType('time');
+            setOptions(['']);
+            if (forkData.availability_threshold != null) setAvailabilityThreshold(forkData.availability_threshold);
           } else {
             // yes_no poll
             setPollType('poll');
@@ -1199,6 +1236,25 @@ export function CreatePollContent() {
         }
       }
 
+      // Add time poll specific fields
+      if (dbPollType === 'time') {
+        if (dayTimeWindows.length > 0) {
+          pollData.day_time_windows = dayTimeWindows;
+        }
+        if (durationMinEnabled || durationMaxEnabled) {
+          pollData.duration_window = {
+            minValue: durationMinValue,
+            maxValue: durationMaxValue,
+            minEnabled: durationMinEnabled,
+            maxEnabled: durationMaxEnabled
+          };
+        }
+        pollData.availability_threshold = availabilityThreshold;
+        // Availability phase uses suggestion_deadline_minutes (deferred until first submission)
+        const cutoffMinutes = getSuggestionCutoffMinutes();
+        pollData.suggestion_deadline_minutes = cutoffMinutes != null ? Math.round(cutoffMinutes) : 120;
+      }
+
       // Add location field for participation polls
       if (dbPollType === 'participation') {
         const addFieldData = (
@@ -1386,8 +1442,8 @@ export function CreatePollContent() {
           e.stopPropagation();
           // Do nothing - all submission is handled by button onClick
         }} className="space-y-4">
-          {/* Participation mode: show link back to preferences form */}
-          {pollType === 'participation' && (
+          {/* Non-default modes: show link back to preferences form */}
+          {(pollType === 'participation' || pollType === 'time') && (
             <div className="flex justify-center">
               <button
                 type="button"
@@ -1400,7 +1456,7 @@ export function CreatePollContent() {
           )}
 
           {/* Category and For fields for suggestion and poll types */}
-          {pollType !== 'participation' && (
+          {pollType === 'poll' && (
             <>
               <div>
                 <label htmlFor="category" className="block text-sm font-medium mb-1">
@@ -1476,6 +1532,187 @@ export function CreatePollContent() {
               onDayTimeWindowsChange={setDayTimeWindows}
               isCreationForm={true}
             />
+          )}
+
+          {/* Time poll: Duration + DayTimeWindows + threshold + deadlines */}
+          {pollType === 'time' && (
+            <>
+              <ParticipationConditions
+                hideParticipantCounters={true}
+                disabled={isLoading}
+                durationMinValue={durationMinValue}
+                durationMaxValue={durationMaxValue}
+                durationMinEnabled={durationMinEnabled}
+                durationMaxEnabled={durationMaxEnabled}
+                onDurationMinChange={setDurationMinValue}
+                onDurationMaxChange={setDurationMaxValue}
+                onDurationMinEnabledChange={setDurationMinEnabled}
+                onDurationMaxEnabledChange={setDurationMaxEnabled}
+                dayTimeWindows={dayTimeWindows}
+                onDayTimeWindowsChange={setDayTimeWindows}
+                isCreationForm={true}
+              />
+
+              {/* Availability Threshold */}
+              <div>
+                <label className="block text-sm font-medium">
+                  Availability Threshold:{' '}
+                  <span className="font-normal text-blue-600 dark:text-blue-400">
+                    {availabilityThreshold}%
+                  </span>
+                </label>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
+                  Include time slots where at least this percentage of the maximum responders are available.
+                </p>
+                <input
+                  type="range"
+                  min={0}
+                  max={50}
+                  step={1}
+                  value={availabilityThreshold}
+                  onChange={(e) => setAvailabilityThreshold(Number(e.target.value))}
+                  disabled={isLoading}
+                  className="w-full accent-blue-500 disabled:opacity-50"
+                />
+                <div className="flex justify-between text-xs text-gray-400 mt-0.5">
+                  <span>0% (max only)</span>
+                  <span>50%</span>
+                </div>
+              </div>
+
+              {/* Availability Phase Deadline */}
+              <div>
+                <label className="block text-sm font-medium cursor-pointer">
+                  <span>Availability Cutoff: </span>
+                  <span className="relative inline-flex">
+                    <span className="font-normal text-blue-600 dark:text-blue-400">
+                      {(() => {
+                        if (suggestionCutoff === 'custom') return 'Custom';
+                        const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+                        if (frac) {
+                          const votingMin = getVotingDeadlineMinutes();
+                          if (votingMin != null) return formatMinutesLabel(votingMin * frac.fraction);
+                          return `${frac.fraction}x`;
+                        }
+                        const absOpt = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+                        if (!absOpt) return suggestionCutoff;
+                        return formatDeadlineLabel(absOpt.minutes, absOpt.label);
+                      })()}
+                    </span>
+                    <select
+                      value={suggestionCutoff}
+                      onChange={(e) => setSuggestionCutoff(e.target.value)}
+                      disabled={isLoading}
+                      className="absolute inset-0 opacity-0 cursor-pointer"
+                      aria-label="Availability cutoff duration"
+                    >
+                      {getVotingDeadlineMinutes() != null && (
+                        <optgroup label="Relative to Preferences Cutoff">
+                          {FRACTIONAL_CUTOFF_OPTIONS.map(opt => {
+                            const votingMin = getVotingDeadlineMinutes()!;
+                            const mins = votingMin * opt.fraction;
+                            return (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.fraction}x ({formatMinutesLabel(mins)})
+                              </option>
+                            );
+                          })}
+                        </optgroup>
+                      )}
+                      <optgroup label="Fixed Duration">
+                        {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
+                          <option key={opt.value} value={opt.value}>
+                            {formatDeadlineLabel(opt.minutes, opt.label)}
+                          </option>
+                        ))}
+                      </optgroup>
+                      <option value="custom">Custom</option>
+                    </select>
+                  </span>
+                </label>
+                {suggestionCutoff === 'custom' && (
+                  <div className="mt-2 flex justify-between gap-2">
+                    <div className="w-auto">
+                      <label htmlFor="customSuggestionDate2" className="block text-xs text-gray-500 mb-1">Date</label>
+                      <input
+                        type="date"
+                        id="customSuggestionDate2"
+                        value={customSuggestionDate}
+                        onChange={(e) => setCustomSuggestionDate(e.target.value)}
+                        disabled={isLoading}
+                        min={isClient ? getTodayDate() : ''}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                      />
+                    </div>
+                    <div className="w-auto">
+                      <label htmlFor="customSuggestionTime2" className="block text-xs text-gray-500 mb-1 text-right">Time</label>
+                      <input
+                        type="time"
+                        id="customSuggestionTime2"
+                        value={customSuggestionTime}
+                        onChange={(e) => setCustomSuggestionTime(e.target.value)}
+                        disabled={isLoading}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Preferences Phase Deadline */}
+              <div>
+                <label className="block text-sm font-medium mb-1">Preferences Cutoff</label>
+                <select
+                  value={deadlineOption}
+                  onChange={(e) => setDeadlineOption(e.target.value)}
+                  disabled={isLoading}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                >
+                  {deadlineOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {isClient ? getTimeLabel(option.value) : option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {deadlineOption === 'custom' && (
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    Custom Preferences Deadline<span className="text-gray-500 font-normal">{getCustomDeadlineDisplay()}</span>
+                  </label>
+                  <div className="flex justify-between gap-2">
+                    <div className="w-auto">
+                      <label htmlFor="customDateTimePoll" className="block text-xs text-gray-500 mb-1">Date</label>
+                      <input
+                        type="date"
+                        id="customDateTimePoll"
+                        value={customDate}
+                        onChange={(e) => setCustomDate(e.target.value)}
+                        disabled={isLoading}
+                        min={isClient ? getTodayDate() : ''}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                      />
+                    </div>
+                    <div className="w-auto">
+                      <label htmlFor="customTimeTimePoll" className="block text-xs text-gray-500 mb-1 text-right">Time</label>
+                      <input
+                        type="time"
+                        id="customTimeTimePoll"
+                        value={customTime}
+                        onChange={(e) => setCustomTime(e.target.value)}
+                        disabled={isLoading}
+                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed text-xs text-center"
+                        style={{ fontSize: '14px' }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </>
           )}
 
           {/* Location field for participation polls */}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1455,19 +1455,6 @@ export function CreatePollContent() {
             </div>
           )}
 
-          {/* Default poll mode: offer scheduling poll option */}
-          {pollType === 'poll' && (
-            <div className="flex justify-center">
-              <button
-                type="button"
-                onClick={() => setPollType('time')}
-                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                Switch to Scheduling Poll
-              </button>
-            </div>
-          )}
-
           {/* Category and For fields for suggestion and poll types */}
           {pollType === 'poll' && (
             <>
@@ -1478,6 +1465,10 @@ export function CreatePollContent() {
                 <TypeFieldInput
                   value={category}
                   onChange={(val) => {
+                    if (val === 'scheduling') {
+                      setPollType('time');
+                      return;
+                    }
                     setCategory(val);
                     if (val === 'yes_no') {
                       setIsAutoTitle(false);

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -154,7 +154,7 @@ export function CreatePollContent() {
   const [showPreliminaryResults, setShowPreliminaryResults] = useState(true);
 
   const hasNoOptions = options.filter(o => o.trim()).length === 0;
-  const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && hasNoOptions;
+  const isSuggestionMode = pollType === 'poll' && category !== 'yes_no' && category !== 'time' && hasNoOptions;
 
   // Generate a title from the current form state
   const generateTitle = useCallback(() => {
@@ -202,6 +202,9 @@ export function CreatePollContent() {
     if (pollType === 'poll') {
       if (category === 'yes_no') {
         return '';
+      }
+      if (category === 'time') {
+        return appendFor("When works?");
       }
       const shorten = isLocationLikeCategory(category) ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
@@ -444,15 +447,9 @@ export function CreatePollContent() {
 
   // Determine poll type based on form selection and options
   const getPollType = (): 'yes_no' | 'ranked_choice' | 'participation' | 'time' => {
-    if (pollType === 'participation') {
-      return 'participation';
-    }
-    if (pollType === 'time') {
-      return 'time';
-    }
-    if (category === 'yes_no') {
-      return 'yes_no';
-    }
+    if (pollType === 'participation') return 'participation';
+    if (pollType === 'time' || category === 'time') return 'time';
+    if (category === 'yes_no') return 'yes_no';
     return 'ranked_choice';
   };
 
@@ -1465,10 +1462,6 @@ export function CreatePollContent() {
                 <TypeFieldInput
                   value={category}
                   onChange={(val) => {
-                    if (val === 'scheduling') {
-                      setPollType('time');
-                      return;
-                    }
                     setCategory(val);
                     if (val === 'yes_no') {
                       setIsAutoTitle(false);
@@ -1741,7 +1734,7 @@ export function CreatePollContent() {
           )}
 
           {/* Options field for poll type (ranked choice / suggestions) */}
-          {pollType === 'poll' && category !== 'yes_no' && (
+          {pollType === 'poll' && category !== 'yes_no' && category !== 'time' && (
             <>
               <OptionsInput
                 options={options}
@@ -1758,11 +1751,111 @@ export function CreatePollContent() {
             </>
           )}
 
+          {/* Time poll fields — injected in place of options when category is Time */}
+          {pollType === 'poll' && category === 'time' && (
+            <>
+              <ParticipationConditions
+                hideParticipantCounters={true}
+                disabled={isLoading}
+                durationMinValue={durationMinValue}
+                durationMaxValue={durationMaxValue}
+                durationMinEnabled={durationMinEnabled}
+                durationMaxEnabled={durationMaxEnabled}
+                onDurationMinChange={setDurationMinValue}
+                onDurationMaxChange={setDurationMaxValue}
+                onDurationMinEnabledChange={setDurationMinEnabled}
+                onDurationMaxEnabledChange={setDurationMaxEnabled}
+                dayTimeWindows={dayTimeWindows}
+                onDayTimeWindowsChange={setDayTimeWindows}
+                isCreationForm={true}
+              />
+
+              {/* Availability Threshold */}
+              <div>
+                <label className="block text-sm font-medium">
+                  Availability Threshold:{' '}
+                  <span className="font-normal text-blue-600 dark:text-blue-400">
+                    {availabilityThreshold}%
+                  </span>
+                </label>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
+                  Include time slots where at least this percentage of the maximum responders are available.
+                </p>
+                <input
+                  type="range"
+                  min={0}
+                  max={50}
+                  step={1}
+                  value={availabilityThreshold}
+                  onChange={(e) => setAvailabilityThreshold(Number(e.target.value))}
+                  disabled={isLoading}
+                  className="w-full accent-blue-500 disabled:opacity-50"
+                />
+                <div className="flex justify-between text-xs text-gray-400 mt-0.5">
+                  <span>0% (max only)</span>
+                  <span>50%</span>
+                </div>
+              </div>
+
+              {/* Availability Phase Deadline */}
+              <div>
+                <label className="block text-sm font-medium cursor-pointer">
+                  <span>Availability Cutoff: </span>
+                  <span className="relative inline-flex">
+                    <span className="font-normal text-blue-600 dark:text-blue-400">
+                      {(() => {
+                        if (suggestionCutoff === 'custom') return 'Custom';
+                        const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+                        if (frac) {
+                          const votingMin = getVotingDeadlineMinutes();
+                          if (votingMin != null) return formatMinutesLabel(votingMin * frac.fraction);
+                          return `${frac.fraction}x`;
+                        }
+                        const absOpt = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+                        if (!absOpt) return suggestionCutoff;
+                        return formatDeadlineLabel(absOpt.minutes, absOpt.label);
+                      })()}
+                    </span>
+                    <select
+                      value={suggestionCutoff}
+                      onChange={(e) => setSuggestionCutoff(e.target.value)}
+                      disabled={isLoading}
+                      className="absolute inset-0 opacity-0 cursor-pointer"
+                      aria-label="Availability cutoff duration"
+                    >
+                      {getVotingDeadlineMinutes() != null && (
+                        <optgroup label="Relative to Preferences Cutoff">
+                          {FRACTIONAL_CUTOFF_OPTIONS.map(opt => {
+                            const votingMin = getVotingDeadlineMinutes()!;
+                            const mins = votingMin * opt.fraction;
+                            return (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.fraction}x ({formatMinutesLabel(mins)})
+                              </option>
+                            );
+                          })}
+                        </optgroup>
+                      )}
+                      <optgroup label="Fixed Duration">
+                        {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
+                          <option key={opt.value} value={opt.value}>
+                            {formatDeadlineLabel(opt.minutes, opt.label)}
+                          </option>
+                        ))}
+                      </optgroup>
+                      <option value="custom">Custom</option>
+                    </select>
+                  </span>
+                </label>
+              </div>
+            </>
+          )}
+
           {/* Title for yes/no polls - rendered above voting cutoff */}
           {category === 'yes_no' && titleField}
 
           {/* Voting cutoff (yes/no and preference polls), min responses, suggestion cutoff */}
-          {pollType === 'poll' && (
+          {pollType === 'poll' && category !== 'time' && (
             <>
               <div>
                 <label className="block text-sm font-medium cursor-pointer">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1455,6 +1455,19 @@ export function CreatePollContent() {
             </div>
           )}
 
+          {/* Default poll mode: offer scheduling poll option */}
+          {pollType === 'poll' && (
+            <div className="flex justify-center">
+              <button
+                type="button"
+                onClick={() => setPollType('time')}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Switch to Scheduling Poll
+              </button>
+            </div>
+          )}
+
           {/* Category and For fields for suggestion and poll types */}
           {pollType === 'poll' && (
             <>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1532,7 +1532,7 @@ export function CreatePollContent() {
           )}
 
           {/* Time poll: Duration + DayTimeWindows + threshold + deadlines */}
-          {pollType === 'time' && (
+          {(pollType === 'time' || (pollType === 'poll' && category === 'time')) && (
             <>
               <ParticipationConditions
                 hideParticipantCounters={true}
@@ -1751,105 +1751,6 @@ export function CreatePollContent() {
             </>
           )}
 
-          {/* Time poll fields — injected in place of options when category is Time */}
-          {pollType === 'poll' && category === 'time' && (
-            <>
-              <ParticipationConditions
-                hideParticipantCounters={true}
-                disabled={isLoading}
-                durationMinValue={durationMinValue}
-                durationMaxValue={durationMaxValue}
-                durationMinEnabled={durationMinEnabled}
-                durationMaxEnabled={durationMaxEnabled}
-                onDurationMinChange={setDurationMinValue}
-                onDurationMaxChange={setDurationMaxValue}
-                onDurationMinEnabledChange={setDurationMinEnabled}
-                onDurationMaxEnabledChange={setDurationMaxEnabled}
-                dayTimeWindows={dayTimeWindows}
-                onDayTimeWindowsChange={setDayTimeWindows}
-                isCreationForm={true}
-              />
-
-              {/* Availability Threshold */}
-              <div>
-                <label className="block text-sm font-medium">
-                  Availability Threshold:{' '}
-                  <span className="font-normal text-blue-600 dark:text-blue-400">
-                    {availabilityThreshold}%
-                  </span>
-                </label>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
-                  Include time slots where at least this percentage of the maximum responders are available.
-                </p>
-                <input
-                  type="range"
-                  min={0}
-                  max={50}
-                  step={1}
-                  value={availabilityThreshold}
-                  onChange={(e) => setAvailabilityThreshold(Number(e.target.value))}
-                  disabled={isLoading}
-                  className="w-full accent-blue-500 disabled:opacity-50"
-                />
-                <div className="flex justify-between text-xs text-gray-400 mt-0.5">
-                  <span>0% (max only)</span>
-                  <span>50%</span>
-                </div>
-              </div>
-
-              {/* Availability Phase Deadline */}
-              <div>
-                <label className="block text-sm font-medium cursor-pointer">
-                  <span>Availability Cutoff: </span>
-                  <span className="relative inline-flex">
-                    <span className="font-normal text-blue-600 dark:text-blue-400">
-                      {(() => {
-                        if (suggestionCutoff === 'custom') return 'Custom';
-                        const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
-                        if (frac) {
-                          const votingMin = getVotingDeadlineMinutes();
-                          if (votingMin != null) return formatMinutesLabel(votingMin * frac.fraction);
-                          return `${frac.fraction}x`;
-                        }
-                        const absOpt = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
-                        if (!absOpt) return suggestionCutoff;
-                        return formatDeadlineLabel(absOpt.minutes, absOpt.label);
-                      })()}
-                    </span>
-                    <select
-                      value={suggestionCutoff}
-                      onChange={(e) => setSuggestionCutoff(e.target.value)}
-                      disabled={isLoading}
-                      className="absolute inset-0 opacity-0 cursor-pointer"
-                      aria-label="Availability cutoff duration"
-                    >
-                      {getVotingDeadlineMinutes() != null && (
-                        <optgroup label="Relative to Preferences Cutoff">
-                          {FRACTIONAL_CUTOFF_OPTIONS.map(opt => {
-                            const votingMin = getVotingDeadlineMinutes()!;
-                            const mins = votingMin * opt.fraction;
-                            return (
-                              <option key={opt.value} value={opt.value}>
-                                {opt.fraction}x ({formatMinutesLabel(mins)})
-                              </option>
-                            );
-                          })}
-                        </optgroup>
-                      )}
-                      <optgroup label="Fixed Duration">
-                        {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
-                          <option key={opt.value} value={opt.value}>
-                            {formatDeadlineLabel(opt.minutes, opt.label)}
-                          </option>
-                        ))}
-                      </optgroup>
-                      <option value="custom">Custom</option>
-                    </select>
-                  </span>
-                </label>
-              </div>
-            </>
-          )}
 
           {/* Title for yes/no polls - rendered above voting cutoff */}
           {category === 'yes_no' && titleField}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -23,7 +23,8 @@ import OptionLabel from "@/components/OptionLabel";
 import YesNoAbstainButtons from "@/components/YesNoAbstainButtons";
 import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults, OptionsMetadata, DayTimeWindow } from "@/lib/types";
-import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiCutoffSuggestions, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
+import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiCutoffSuggestions, apiCutoffAvailability, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
+import RankableOptions from "@/components/RankableOptions";
 
 import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
@@ -74,6 +75,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [isReopeningPoll, setIsReopeningPoll] = useState(false);
   const [isCuttingOffSuggestions, setIsCuttingOffSuggestions] = useState(false);
   const [showCutoffConfirmModal, setShowCutoffConfirmModal] = useState(false);
+  const [isCuttingOffAvailability, setIsCuttingOffAvailability] = useState(false);
+  const [showCutoffAvailabilityConfirmModal, setShowCutoffAvailabilityConfirmModal] = useState(false);
   const [suggestionDeadlineOverride, setSuggestionDeadlineOverride] = useState<string | null>(null);
   const [optionsOverride, setOptionsOverride] = useState<string[] | null>(null);
   const [pollClosed, setPollClosed] = useState(poll.is_closed ?? false);
@@ -108,6 +111,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const canSubmitRankings = poll.poll_type === 'ranked_choice' && (
     !hasSuggestionPhase || !inSuggestionPhase || poll.allow_pre_ranking !== false
   );
+
+  // Time poll phase helpers: availability phase while options haven't been generated yet
+  const inAvailabilityPhase = poll.poll_type === 'time' && (!optionsOverride?.length) && (!poll.options || poll.options.length === 0);
+  const availabilityTimerStarted = !!(suggestionDeadlineOverride || poll.suggestion_deadline);
+  const inActiveAvailabilityPhase = inAvailabilityPhase && (
+    !availabilityTimerStarted
+    || (currentTime ? currentTime < new Date((suggestionDeadlineOverride || poll.suggestion_deadline)!) : true)
+  );
   // Whether the user has completed ranking (or abstained) — for suggestion-phase polls,
   // this distinguishes "voted with suggestions only" from "voted with rankings"
   const hasCompletedRanking = !hasSuggestionPhase || userVoteData?.ranked_choices?.length > 0 || userVoteData?.is_abstain || userVoteData?.is_ranking_abstain;
@@ -140,12 +151,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const [durationMinEnabled, setDurationMinEnabled] = useState(poll.duration_window?.minEnabled ?? false);
   const [durationMaxEnabled, setDurationMaxEnabled] = useState(poll.duration_window?.maxEnabled ?? false);
 
-  // Restore ballot draft from localStorage on mount (participation polls only)
+  // Restore ballot draft from localStorage on mount (participation and time polls)
   const draftRestoredRef = useRef(false);
   useEffect(() => {
     if (draftRestoredRef.current) return;
     draftRestoredRef.current = true;
-    if (poll.poll_type !== 'participation') return;
+    if (poll.poll_type !== 'participation' && poll.poll_type !== 'time') return;
     try {
       const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
       if (votedPolls[poll.id]) return;
@@ -167,7 +178,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   // Persist ballot draft to localStorage (debounced to avoid rapid writes during wheel/counter interactions)
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (poll.poll_type !== 'participation' || hasVoted) return;
+    if ((poll.poll_type !== 'participation' && poll.poll_type !== 'time') || hasVoted) return;
     if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
     draftTimerRef.current = setTimeout(() => {
       saveBallotDraft(poll.id, {
@@ -626,7 +637,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     }
   }, [poll.id, poll.poll_type, hasVoted, hasVotedOnPoll, getStoredVoteId, fetchVoteData, fetchAggregatedVoteData, fetchLatestUserVote, isNewPoll]);
 
-  // Separate effect to fetch results when poll closes or for participation polls
+  // Separate effect to fetch results when poll closes or for participation/time polls
   useEffect(() => {
     // Fetch results if poll is closed (reactive to state changes)
     const isClosed = pollClosed || (poll.response_deadline && new Date(poll.response_deadline) <= new Date());
@@ -634,10 +645,13 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     // Also fetch results for participation polls when voted (to show condition status)
     const shouldFetchForParticipation = poll.poll_type === 'participation' && hasVoted && !isClosed;
 
-    if (isClosed || shouldFetchForParticipation) {
+    // Fetch results for time polls in preferences phase (to get availability_counts for caution symbols)
+    const shouldFetchForTimePoll = poll.poll_type === 'time' && !inAvailabilityPhase;
+
+    if (isClosed || shouldFetchForParticipation || shouldFetchForTimePoll) {
       fetchPollResults();
     }
-  }, [pollClosed, poll.response_deadline, poll.poll_type, hasVoted, fetchPollResults]);
+  }, [pollClosed, poll.response_deadline, poll.poll_type, hasVoted, fetchPollResults, inAvailabilityPhase]);
 
   // Load saved user name
   useEffect(() => {
@@ -789,6 +803,39 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     }
   };
 
+  // Format a time slot string "YYYY-MM-DD HH:MM-HH:MM" into a readable label
+  const formatTimeSlot = (slot: string): string => {
+    try {
+      const spaceIdx = slot.indexOf(' ');
+      const datePart = slot.slice(0, spaceIdx);
+      const timePart = slot.slice(spaceIdx + 1);
+      const dashIdx = timePart.indexOf('-');
+      const startStr = timePart.slice(0, dashIdx);
+      const endStr = timePart.slice(dashIdx + 1);
+      const [year, month, day] = datePart.split('-').map(Number);
+      const date = new Date(year, month - 1, day);
+      const dayLabel = date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+      const fmtTime = (t: string) => {
+        const [h, m] = t.split(':').map(Number);
+        const ampm = h < 12 ? 'AM' : 'PM';
+        const h12 = h % 12 === 0 ? 12 : h % 12;
+        return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;
+      };
+      const [sh, sm] = startStr.split(':').map(Number);
+      const [eh, em] = endStr.split(':').map(Number);
+      const startMins = sh * 60 + sm;
+      let endMins = eh * 60 + em;
+      if (endMins <= startMins) endMins += 24 * 60; // cross-midnight
+      const durMins = endMins - startMins;
+      const durH = Math.floor(durMins / 60);
+      const durM = durMins % 60;
+      const durLabel = durM === 0 ? `${durH}h` : `${durH}h ${durM}m`;
+      return `${dayLabel} • ${fmtTime(startStr)} – ${fmtTime(endStr)} (${durLabel})`;
+    } catch {
+      return slot;
+    }
+  };
+
   const handleCloseClick = () => {
     const isDev = process.env.NODE_ENV === 'development';
     
@@ -884,6 +931,41 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
       alert('Failed to cutoff suggestions. Please try again.');
     } finally {
       setIsCuttingOffSuggestions(false);
+    }
+  };
+
+  const handleCutoffAvailabilityClick = () => {
+    if (isCuttingOffAvailability || !isCreator) return;
+    const creatorSecret = getCreatorSecret(poll.id);
+    if (!creatorSecret) {
+      alert('You do not have permission to end the availability phase.');
+      return;
+    }
+    setShowCutoffAvailabilityConfirmModal(true);
+  };
+
+  const handleCutoffAvailability = async () => {
+    setShowCutoffAvailabilityConfirmModal(false);
+    if (isCuttingOffAvailability || !isCreator) return;
+    const creatorSecret = getCreatorSecret(poll.id);
+    if (!creatorSecret) return;
+
+    setIsCuttingOffAvailability(true);
+    try {
+      const updatedPoll = await apiCutoffAvailability(poll.id, creatorSecret);
+      if (updatedPoll) {
+        setSuggestionDeadlineOverride(updatedPoll.suggestion_deadline || new Date().toISOString());
+        if (updatedPoll.options) {
+          const opts = typeof updatedPoll.options === 'string' ? JSON.parse(updatedPoll.options) : updatedPoll.options;
+          setOptionsOverride(opts);
+        }
+        await fetchPollResults();
+      }
+    } catch (error) {
+      console.error('Error cutting off availability:', error);
+      alert('Failed to end availability phase. Please try again.');
+    } finally {
+      setIsCuttingOffAvailability(false);
     }
   };
 
@@ -1135,6 +1217,35 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           voter_name: voterName.trim() || null,
           options_metadata: filteredMetadata && Object.keys(filteredMetadata).length > 0 ? filteredMetadata : null,
         };
+      } else if (poll.poll_type === 'time') {
+        if (inAvailabilityPhase) {
+          voteData = {
+            vote_type: 'time' as const,
+            voter_day_time_windows: voterDayTimeWindows.length > 0 ? voterDayTimeWindows : null,
+            voter_duration: (durationMinEnabled || durationMaxEnabled) ? {
+              minValue: durationMinValue,
+              maxValue: durationMaxValue,
+              minEnabled: durationMinEnabled,
+              maxEnabled: durationMaxEnabled
+            } : null,
+            is_abstain: isAbstaining,
+            voter_name: voterName.trim() || null,
+          };
+        } else {
+          // Preferences phase: submit ranked_choices
+          const filteredRankedChoices = rankedChoices.filter(c => c && c.trim().length > 0);
+          if (filteredRankedChoices.length === 0 && !isAbstaining) {
+            setVoteError("Please rank at least one time slot or abstain");
+            setIsSubmitting(false);
+            return;
+          }
+          voteData = {
+            vote_type: 'time' as const,
+            ranked_choices: isAbstaining ? null : filteredRankedChoices,
+            is_abstain: isAbstaining,
+            voter_name: voterName.trim() || null,
+          };
+        }
       }
 
       let voteId: string | undefined;
@@ -1149,6 +1260,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null }
           : poll.poll_type === 'participation'
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null, min_participants: voterMinParticipants, max_participants: voterMaxEnabled ? voterMaxParticipants : null, voter_day_time_windows: voterDayTimeWindows.length > 0 ? voterDayTimeWindows : null, voter_duration: (durationMinEnabled || durationMaxEnabled) ? { minValue: durationMinValue, maxValue: durationMaxValue, minEnabled: durationMinEnabled, maxEnabled: durationMaxEnabled } : null }
+          : poll.poll_type === 'time'
+          ? { voter_day_time_windows: voteData.voter_day_time_windows, voter_duration: voteData.voter_duration, ranked_choices: voteData.ranked_choices, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null }
           : { ranked_choices: voteData.ranked_choices, suggestions: canSubmitSuggestions ? voteData.suggestions : undefined, is_abstain: voteData.is_abstain, is_ranking_abstain: voteData.is_ranking_abstain, voter_name: voterName.trim() || null };
         
         
@@ -1219,6 +1332,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
 
       // Trigger voter list refresh immediately
       setVoterListRefresh(prev => prev + 1);
+
+      // Start deferred availability deadline on first time poll availability submission
+      if (poll.poll_type === 'time' && inAvailabilityPhase && !availabilityTimerStarted && poll.suggestion_deadline_minutes && !isEditingVote) {
+        const newDeadline = new Date(Date.now() + poll.suggestion_deadline_minutes * 60 * 1000);
+        setSuggestionDeadlineOverride(newDeadline.toISOString());
+      }
 
       // Refresh suggestion list for polls with suggestion phase
       if (hasSuggestionPhase) {
@@ -1413,6 +1532,23 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                   <div className="mb-3 text-center">
                     <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">
                       Suggestions cutoff {durationLabel} after first suggestion
+                    </span>
+                  </div>
+                );
+              }
+            }
+            // Time poll in availability phase: show availability deadline
+            if (poll.poll_type === 'time' && inAvailabilityPhase) {
+              const effectiveAvailDeadline = suggestionDeadlineOverride || poll.suggestion_deadline;
+              if (effectiveAvailDeadline) {
+                return <Countdown deadline={effectiveAvailDeadline} label="Availability cutoff" />;
+              }
+              if (poll.suggestion_deadline_minutes) {
+                const durationLabel = formatDurationLabel(poll.suggestion_deadline_minutes);
+                return (
+                  <div className="mb-3 text-center">
+                    <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">
+                      Availability cutoff {durationLabel} after first response
                     </span>
                   </div>
                 );
@@ -1786,6 +1922,200 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                 </>
               )}
             </div>
+          ) : poll.poll_type === 'time' ? (
+            <div>
+              {isPollClosed ? (
+                <div className="py-6">
+                  {loadingResults ? (
+                    <div className="flex justify-center items-center py-8">
+                      <svg className="animate-spin h-8 w-8 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                    </div>
+                  ) : pollResults ? (
+                    <>
+                      {userVoteData?.is_abstain && (
+                        <div className="mt-4 flex justify-center">
+                          <div className="inline-flex items-center px-3 py-2 bg-yellow-100 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-700 rounded-full">
+                            <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">You Abstained</span>
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div className="text-center py-4">
+                      <p className="text-gray-600 dark:text-gray-400">Unable to load results.</p>
+                    </div>
+                  )}
+                </div>
+              ) : hasVoted && !isEditingVote ? (
+                <div className="py-3">
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="font-medium">{inAvailabilityPhase ? 'Your availability:' : 'Your ranking:'}</h4>
+                    {editVoteButton}
+                  </div>
+                  {isLoadingVoteData ? (
+                    <div className="flex items-center p-3 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+                      <svg className="animate-spin h-4 w-4 text-gray-600 dark:text-gray-400 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      <span className="font-medium text-gray-600 dark:text-gray-400">Loading your response...</span>
+                    </div>
+                  ) : userVoteData?.is_abstain ? (
+                    <div className="flex items-center p-3 bg-yellow-50 dark:bg-yellow-900 border border-yellow-200 dark:border-yellow-700 rounded-lg">
+                      <span className="font-medium text-yellow-800 dark:text-yellow-200">Abstained</span>
+                    </div>
+                  ) : inAvailabilityPhase && userVoteData?.voter_day_time_windows ? (
+                    <div className="p-3 bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 rounded-lg">
+                      <p className="text-sm text-green-800 dark:text-green-200">Availability submitted for {userVoteData.voter_day_time_windows.length} day(s).</p>
+                    </div>
+                  ) : !inAvailabilityPhase && userVoteData?.ranked_choices ? (
+                    <div className="space-y-2">
+                      {userVoteData.ranked_choices.map((slot: string, index: number) => (
+                        <div key={index} className="flex items-center gap-2">
+                          <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">{index + 1}</span>
+                          <div className="flex-1 flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded text-sm">
+                            {formatTimeSlot(slot)}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {!isPollClosed && hasVoted && !isLoadingVoteData && (
+                    <div className="mt-4">
+                      <VoterList pollId={poll.id} refreshTrigger={voterListRefresh} />
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <>
+                  {inAvailabilityPhase ? (
+                    <>
+                      {/* Availability phase: show time window picker */}
+                      <div className="mb-4">
+                        <h3 className="text-lg font-semibold mb-3 text-center">Your Availability</h3>
+                        <ParticipationConditions
+                          hideParticipantCounters={true}
+                          disabled={isSubmitting}
+                          durationMinValue={durationMinValue}
+                          durationMaxValue={durationMaxValue}
+                          durationMinEnabled={durationMinEnabled}
+                          durationMaxEnabled={durationMaxEnabled}
+                          onDurationMinChange={setDurationMinValue}
+                          onDurationMaxChange={setDurationMaxValue}
+                          onDurationMinEnabledChange={setDurationMinEnabled}
+                          onDurationMaxEnabledChange={setDurationMaxEnabled}
+                          dayTimeWindows={voterDayTimeWindows}
+                          onDayTimeWindowsChange={setVoterDayTimeWindows}
+                          pollDayTimeWindows={poll.day_time_windows || undefined}
+                          pollDurationWindow={poll.duration_window || undefined}
+                        />
+                      </div>
+
+                      {inActiveAvailabilityPhase && isCreator && (
+                        <div className="mb-3 flex justify-end">
+                          <button
+                            type="button"
+                            onClick={handleCutoffAvailabilityClick}
+                            disabled={isCuttingOffAvailability}
+                            className="px-3 py-1 text-sm bg-amber-500 hover:bg-amber-600 text-white rounded-md disabled:opacity-50"
+                          >
+                            {isCuttingOffAvailability ? 'Ending...' : 'End Availability Phase'}
+                          </button>
+                        </div>
+                      )}
+
+                      <AbstainButton isAbstaining={isAbstaining} onClick={handleAbstain} />
+
+                      {voteError && (
+                        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 rounded-md">
+                          <p className="text-sm text-red-800 dark:text-red-200">{voteError}</p>
+                        </div>
+                      )}
+
+                      <div className="mb-4">
+                        <CompactNameField name={voterName} setName={setVoterName} disabled={isSubmitting} maxLength={30} />
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={handleVoteClick}
+                        disabled={isSubmitting || (!isAbstaining && voterDayTimeWindows.filter(d => d.windows.length > 0).length === 0)}
+                        className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
+                      >
+                        {isSubmitting ? 'Submitting...' : 'Submit Availability'}
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      {/* Preferences phase: rank the generated time slots */}
+                      <div className="mb-4">
+                        <h3 className="text-lg font-semibold mb-2 text-center">Rank Your Preferences</h3>
+                        {pollResults?.max_availability != null && (
+                          <p className="text-xs text-gray-500 dark:text-gray-400 text-center mb-3">
+                            Slots are ordered by duration (longest first), then by time. Slots with a ⚠️ exclude some voters.
+                          </p>
+                        )}
+                        <RankableOptions
+                          options={pollOptions}
+                          onRankingChange={(ranked) => setRankedChoices(ranked)}
+                          initialRanking={rankedChoices}
+                          disabled={isSubmitting}
+                          storageKey={`time-ranking-${poll.id}`}
+                          renderOption={(slot) => {
+                            const count = pollResults?.availability_counts?.[slot];
+                            const maxAvail = pollResults?.max_availability;
+                            const threshold = poll.availability_threshold ?? 5;
+                            const minAcceptable = maxAvail != null ? Math.floor(maxAvail * (1 - threshold / 100)) : null;
+                            const excluded = maxAvail != null && count != null && count < maxAvail ? maxAvail - count : 0;
+                            const isUnderThreshold = minAcceptable != null && count != null && count < minAcceptable;
+                            return (
+                              <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                                {excluded > 0 && !isUnderThreshold && (
+                                  <span className="flex-shrink-0 text-red-500 text-sm" title={`Excludes ${excluded} voter(s)`}>
+                                    ⚠️{excluded}
+                                  </span>
+                                )}
+                                <span className="text-sm truncate">{formatTimeSlot(slot)}</span>
+                              </div>
+                            );
+                          }}
+                        />
+                      </div>
+
+                      <AbstainButton isAbstaining={isAbstaining} onClick={handleAbstain} />
+
+                      {voteError && (
+                        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 rounded-md">
+                          <p className="text-sm text-red-800 dark:text-red-200">{voteError}</p>
+                        </div>
+                      )}
+
+                      <div className="mb-4">
+                        <CompactNameField name={voterName} setName={setVoterName} disabled={isSubmitting} maxLength={30} />
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={handleVoteClick}
+                        disabled={isSubmitting || (!isAbstaining && rankedChoices.length === 0)}
+                        className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
+                      >
+                        {isSubmitting ? 'Submitting...' : 'Submit Preferences'}
+                      </button>
+                    </>
+                  )}
+
+                  <div className="mt-4">
+                    {poll.follow_up_to && <FollowUpHeader followUpToPollId={poll.follow_up_to} />}
+                    {poll.fork_of && <ForkHeader forkOfPollId={poll.fork_of} />}
+                  </div>
+                </>
+              )}
+            </div>
           ) : (
             <div>
               {isPollClosed ? (
@@ -2034,6 +2364,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         title="Cutoff Suggestions"
         message="Are you sure you want to end the suggestion phase now? No more suggestions will be accepted and ranking will begin immediately."
         confirmText="Cutoff Now"
+        cancelText="Cancel"
+        confirmButtonClass="bg-amber-500 hover:bg-amber-600 text-white"
+      />
+
+      <ConfirmationModal
+        isOpen={showCutoffAvailabilityConfirmModal}
+        onConfirm={handleCutoffAvailability}
+        onCancel={() => setShowCutoffAvailabilityConfirmModal(false)}
+        title="End Availability Phase"
+        message="Are you sure you want to end the availability phase now? Time slots will be generated and preference ranking will begin immediately."
+        confirmText="End Now"
         cancelText="Cancel"
         confirmButtonClass="bg-amber-500 hover:bg-amber-600 text-white"
       />

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -2060,7 +2060,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                           </p>
                         )}
                         <RankableOptions
-                          options={pollOptions}
+                          options={pollResults?.included_slots ?? pollOptions}
                           onRankingChange={(ranked) => setRankedChoices(ranked)}
                           initialRanking={rankedChoices}
                           disabled={isSubmitting}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -2054,21 +2054,27 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       {/* Preferences phase: rank the generated time slots */}
                       <div className="mb-4">
                         <h3 className="text-lg font-semibold mb-2 text-center">Rank Your Preferences</h3>
-                        {pollResults?.max_availability != null && (
+                        {pollResults == null ? (
+                          <div className="flex justify-center py-8">
+                            <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+                          </div>
+                        ) : (
+                        <>
+                        {pollResults.max_availability != null && (
                           <p className="text-xs text-gray-500 dark:text-gray-400 text-center mb-3">
                             Slots are ordered by duration (longest first), then by time. Slots with a ⚠️ exclude some voters.
                           </p>
                         )}
                         <RankableOptions
-                          options={pollResults?.included_slots ?? pollOptions}
+                          options={pollResults.included_slots ?? pollOptions}
                           onRankingChange={(ranked) => setRankedChoices(ranked)}
                           initialRanking={rankedChoices}
                           disabled={isSubmitting}
                           storageKey={`time-ranking-${poll.id}`}
                           preserveOrder={true}
                           renderOption={(slot) => {
-                            const count = pollResults?.availability_counts?.[slot];
-                            const maxAvail = pollResults?.max_availability;
+                            const count = pollResults.availability_counts?.[slot];
+                            const maxAvail = pollResults.max_availability;
                             const threshold = poll.availability_threshold ?? 5;
                             const minAcceptable = maxAvail != null ? Math.floor(maxAvail * (1 - threshold / 100)) : null;
                             const excluded = maxAvail != null && count != null && count < maxAvail ? maxAvail - count : 0;
@@ -2085,6 +2091,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             );
                           }}
                         />
+                        </>
+                        )}
                       </div>
 
                       <AbstainButton isAbstaining={isAbstaining} onClick={handleAbstain} />

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -2065,6 +2065,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                           initialRanking={rankedChoices}
                           disabled={isSubmitting}
                           storageKey={`time-ranking-${poll.id}`}
+                          preserveOrder={true}
                           renderOption={(slot) => {
                             const count = pollResults?.availability_counts?.[slot];
                             const maxAvail = pollResults?.max_availability;

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -25,6 +25,7 @@ import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults, OptionsMetadata, DayTimeWindow } from "@/lib/types";
 import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiCutoffSuggestions, apiCutoffAvailability, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
 import RankableOptions from "@/components/RankableOptions";
+import TimeSlotBubbles, { SlotState } from "@/components/TimeSlotBubbles";
 
 import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
 import { forgetPoll, hasPollData } from "@/lib/forgetPoll";
@@ -53,6 +54,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const isNewPoll = searchParams.get("new") === "true";
   const [pollUrl, setPollUrl] = useState("");
   const [rankedChoices, setRankedChoices] = useState<string[]>([]);
+  // Time poll preferences: liked/disliked slot sets (null = not yet submitted)
+  const [likedSlots, setLikedSlots] = useState<string[] | null>(null);
+  const [dislikedSlots, setDislikedSlots] = useState<string[] | null>(null);
   const [optionsInitialized, setOptionsInitialized] = useState(false);
   const [yesNoChoice, setYesNoChoice] = useState<'yes' | 'no' | null>(null);
   const [isAbstaining, setIsAbstaining] = useState(false);
@@ -626,6 +630,18 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             } else if (poll.poll_type === 'ranked_choice') {
               if (voteData.ranked_choices) setRankedChoices(voteData.ranked_choices);
               if (voteData.suggestions) setSuggestionChoices(voteData.suggestions);
+            } else if (poll.poll_type === 'time') {
+              // Restore time poll availability windows
+              if (voteData.voter_day_time_windows && Array.isArray(voteData.voter_day_time_windows)) {
+                setVoterDayTimeWindows(voteData.voter_day_time_windows);
+              }
+              // Restore preferences phase reactions (null = not yet submitted)
+              if (voteData.liked_slots !== null && voteData.liked_slots !== undefined) {
+                setLikedSlots(voteData.liked_slots);
+              }
+              if (voteData.disliked_slots !== null && voteData.disliked_slots !== undefined) {
+                setDislikedSlots(voteData.disliked_slots);
+              }
             }
           } else {
           }
@@ -1022,8 +1038,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     // Also applies after suggestion cutoff: user submitted suggestions but hasn't ranked yet.
     // Includes users who abstained from suggestions (is_abstain) — they should still be able to rank.
     const hasNotRankedYet = hasVoted && hasSuggestionPhase && !userVoteData?.ranked_choices?.length && !userVoteData?.is_ranking_abstain;
+    // For time polls in preferences phase: not yet reacted if liked_slots is still null
+    const hasNotReactedYet = poll.poll_type === 'time' && !inAvailabilityPhase && hasVoted
+      && userVoteData?.liked_slots === null && userVoteData?.disliked_slots === null && !userVoteData?.is_abstain;
     const isImplicitEdit = hasVoted && !isAnyEditing && (
-      (canSubmitSuggestions && canSubmitRankings) || hasNotRankedYet
+      (canSubmitSuggestions && canSubmitRankings) || hasNotRankedYet || hasNotReactedYet
     );
     if (isImplicitEdit) {
       setIsEditingVote(true);
@@ -1232,16 +1251,11 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             voter_name: voterName.trim() || null,
           };
         } else {
-          // Preferences phase: submit ranked_choices
-          const filteredRankedChoices = rankedChoices.filter(c => c && c.trim().length > 0);
-          if (filteredRankedChoices.length === 0 && !isAbstaining) {
-            setVoteError("Please rank at least one time slot or abstain");
-            setIsSubmitting(false);
-            return;
-          }
+          // Preferences phase: submit liked/disliked reactions
           voteData = {
             vote_type: 'time' as const,
-            ranked_choices: isAbstaining ? null : filteredRankedChoices,
+            liked_slots: isAbstaining ? null : (likedSlots ?? []),
+            disliked_slots: isAbstaining ? null : (dislikedSlots ?? []),
             is_abstain: isAbstaining,
             voter_name: voterName.trim() || null,
           };
@@ -1261,7 +1275,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           : poll.poll_type === 'participation'
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null, min_participants: voterMinParticipants, max_participants: voterMaxEnabled ? voterMaxParticipants : null, voter_day_time_windows: voterDayTimeWindows.length > 0 ? voterDayTimeWindows : null, voter_duration: (durationMinEnabled || durationMaxEnabled) ? { minValue: durationMinValue, maxValue: durationMaxValue, minEnabled: durationMinEnabled, maxEnabled: durationMaxEnabled } : null }
           : poll.poll_type === 'time'
-          ? { voter_day_time_windows: voteData.voter_day_time_windows, voter_duration: voteData.voter_duration, ranked_choices: voteData.ranked_choices, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null }
+          ? { voter_day_time_windows: voteData.voter_day_time_windows, voter_duration: voteData.voter_duration, liked_slots: voteData.liked_slots, disliked_slots: voteData.disliked_slots, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null }
           : { ranked_choices: voteData.ranked_choices, suggestions: canSubmitSuggestions ? voteData.suggestions : undefined, is_abstain: voteData.is_abstain, is_ranking_abstain: voteData.is_ranking_abstain, voter_name: voterName.trim() || null };
         
         
@@ -1952,14 +1966,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               ) : hasVoted && !isEditingVote ? (
                 <div className="py-3">
                   <div className="flex items-center justify-between mb-2">
-                    <h4 className="font-medium">{inAvailabilityPhase ? 'Your availability:' : 'Your ranking:'}</h4>
+                    <h4 className="font-medium">{inAvailabilityPhase ? 'Your availability:' : 'Your preferences:'}</h4>
                     {editVoteButton}
                   </div>
                   {isLoadingVoteData ? (
                     <div className="flex items-center p-3 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
                       <svg className="animate-spin h-4 w-4 text-gray-600 dark:text-gray-400 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>
                       <span className="font-medium text-gray-600 dark:text-gray-400">Loading your response...</span>
                     </div>
@@ -1971,16 +1985,17 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     <div className="p-3 bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 rounded-lg">
                       <p className="text-sm text-green-800 dark:text-green-200">Availability submitted for {userVoteData.voter_day_time_windows.length} day(s).</p>
                     </div>
-                  ) : !inAvailabilityPhase && userVoteData?.ranked_choices ? (
-                    <div className="space-y-2">
-                      {userVoteData.ranked_choices.map((slot: string, index: number) => (
-                        <div key={index} className="flex items-center gap-2">
-                          <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">{index + 1}</span>
-                          <div className="flex-1 flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded text-sm">
-                            {formatTimeSlot(slot)}
-                          </div>
-                        </div>
-                      ))}
+                  ) : !inAvailabilityPhase && (userVoteData?.liked_slots !== null || userVoteData?.disliked_slots !== null) ? (
+                    <div className="p-3 bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 rounded-lg text-sm text-green-800 dark:text-green-200">
+                      {(userVoteData?.liked_slots?.length ?? 0) > 0 && (
+                        <p>Liked: {userVoteData!.liked_slots!.map(formatTimeSlot).join(', ')}</p>
+                      )}
+                      {(userVoteData?.disliked_slots?.length ?? 0) > 0 && (
+                        <p>Disliked: {userVoteData!.disliked_slots!.map(formatTimeSlot).join(', ')}</p>
+                      )}
+                      {(userVoteData?.liked_slots?.length ?? 0) === 0 && (userVoteData?.disliked_slots?.length ?? 0) === 0 && (
+                        <p>Preferences submitted (all neutral).</p>
+                      )}
                     </div>
                   ) : null}
 
@@ -2051,39 +2066,28 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                     </>
                   ) : (
                     <>
-                      {/* Preferences phase: rank the generated time slots */}
+                      {/* Preferences phase: tap bubbles to like/dislike time slots */}
                       <div className="mb-4">
-                        <h3 className="text-lg font-semibold mb-2 text-center">Rank Your Preferences</h3>
-                        {pollResults?.max_availability != null && (
-                          <p className="text-xs text-gray-500 dark:text-gray-400 text-center mb-3">
-                            Slots are ordered by duration (longest first), then by time. Slots with a ⚠️ exclude some voters.
-                          </p>
-                        )}
-                        <RankableOptions
+                        <h3 className="text-lg font-semibold mb-3 text-center">Mark Your Preferences</h3>
+                        <TimeSlotBubbles
                           options={pollOptions}
-                          onRankingChange={(ranked) => setRankedChoices(ranked)}
-                          initialRanking={rankedChoices}
-                          disabled={isSubmitting}
-                          storageKey={`time-ranking-${poll.id}`}
-                          preserveOrder={true}
-                          renderOption={(slot) => {
-                            const count = pollResults?.availability_counts?.[slot];
-                            const maxAvail = pollResults?.max_availability;
-                            const threshold = poll.availability_threshold ?? 5;
-                            const minAcceptable = maxAvail != null ? Math.floor(maxAvail * (1 - threshold / 100)) : null;
-                            const excluded = maxAvail != null && count != null && count < maxAvail ? maxAvail - count : 0;
-                            const isUnderThreshold = minAcceptable != null && count != null && count < minAcceptable;
-                            return (
-                              <div className="flex items-center gap-1.5 min-w-0 flex-1">
-                                {excluded > 0 && !isUnderThreshold && (
-                                  <span className="flex-shrink-0 text-red-500 text-sm" title={`Excludes ${excluded} voter(s)`}>
-                                    ⚠️{excluded}
-                                  </span>
-                                )}
-                                <span className="text-sm truncate">{formatTimeSlot(slot)}</span>
-                              </div>
-                            );
+                          likedSlots={likedSlots ?? []}
+                          dislikedSlots={dislikedSlots ?? []}
+                          onToggle={(slot, nextState) => {
+                            setLikedSlots(prev => {
+                              const s = new Set(prev ?? []);
+                              if (nextState === 'liked') s.add(slot); else s.delete(slot);
+                              return Array.from(s);
+                            });
+                            setDislikedSlots(prev => {
+                              const s = new Set(prev ?? []);
+                              if (nextState === 'disliked') s.add(slot); else s.delete(slot);
+                              return Array.from(s);
+                            });
                           }}
+                          availabilityCounts={pollResults?.availability_counts}
+                          maxAvailability={pollResults?.max_availability}
+                          disabled={isSubmitting}
                         />
                       </div>
 
@@ -2102,7 +2106,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       <button
                         type="button"
                         onClick={handleVoteClick}
-                        disabled={isSubmitting || (!isAbstaining && rankedChoices.length === 0)}
+                        disabled={isSubmitting}
                         className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
                       >
                         {isSubmitting ? 'Submitting...' : 'Submit Preferences'}

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -2054,27 +2054,21 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                       {/* Preferences phase: rank the generated time slots */}
                       <div className="mb-4">
                         <h3 className="text-lg font-semibold mb-2 text-center">Rank Your Preferences</h3>
-                        {pollResults == null ? (
-                          <div className="flex justify-center py-8">
-                            <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
-                          </div>
-                        ) : (
-                        <>
-                        {pollResults.max_availability != null && (
+                        {pollResults?.max_availability != null && (
                           <p className="text-xs text-gray-500 dark:text-gray-400 text-center mb-3">
                             Slots are ordered by duration (longest first), then by time. Slots with a ⚠️ exclude some voters.
                           </p>
                         )}
                         <RankableOptions
-                          options={pollResults.included_slots ?? pollOptions}
+                          options={pollOptions}
                           onRankingChange={(ranked) => setRankedChoices(ranked)}
                           initialRanking={rankedChoices}
                           disabled={isSubmitting}
                           storageKey={`time-ranking-${poll.id}`}
                           preserveOrder={true}
                           renderOption={(slot) => {
-                            const count = pollResults.availability_counts?.[slot];
-                            const maxAvail = pollResults.max_availability;
+                            const count = pollResults?.availability_counts?.[slot];
+                            const maxAvail = pollResults?.max_availability;
                             const threshold = poll.availability_threshold ?? 5;
                             const minAcceptable = maxAvail != null ? Math.floor(maxAvail * (1 - threshold / 100)) : null;
                             const excluded = maxAvail != null && count != null && count < maxAvail ? maxAvail - count : 0;
@@ -2091,8 +2085,6 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             );
                           }}
                         />
-                        </>
-                        )}
                       </div>
 
                       <AbstainButton isAbstaining={isAbstaining} onClick={handleAbstain} />

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -10,7 +10,15 @@ import { useLongPress } from '@/lib/useLongPress';
 import { installClientLogForwarder } from '@/lib/clientLogForwarder';
 
 const LazyCreatePollContent = React.lazy(() =>
-  import('@/app/create-poll/page').then(m => ({ default: m.CreatePollContent }))
+  import('@/app/create-poll/page')
+    .then(m => ({ default: m.CreatePollContent }))
+    .catch((err) => {
+      // Stale cached chunk after a new deploy — reload to get fresh assets.
+      if (err?.name === 'ChunkLoadError' || err?.message?.includes('Failed to load chunk') || err?.message?.includes('Failed to fetch dynamically imported module')) {
+        window.location.reload();
+      }
+      throw err;
+    })
 );
 
 interface AppTemplateProps {
@@ -85,6 +93,16 @@ function TemplateInner({ children }: AppTemplateProps) {
   useEffect(() => {
     setIsMounted(true);
     installClientLogForwarder();
+
+    // Reload on ChunkLoadError — stale cached chunks after a new deploy.
+    const handleChunkError = (event: PromiseRejectionEvent) => {
+      const err = event.reason;
+      if (err?.name === 'ChunkLoadError' || err?.message?.includes('Failed to load chunk')) {
+        window.location.reload();
+      }
+    };
+    window.addEventListener('unhandledrejection', handleChunkError);
+    return () => window.removeEventListener('unhandledrejection', handleChunkError);
   }, []);
   
   // Determine initial state based on pathname to avoid layout shift

--- a/components/DayTimeWindowsInput.tsx
+++ b/components/DayTimeWindowsInput.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import TimeGridModal from './TimeGridModal';
-import { windowDurationMinutes } from '@/lib/timeUtils';
+import { windowDurationMinutes, formatDayLabel } from '@/lib/timeUtils';
 
 interface TimeWindow {
   min: string; // HH:MM format
@@ -31,14 +31,7 @@ function formatTime12Hour(time: string): { time: string; period: string } {
   };
 }
 
-// Format day display (e.g., "Mon, Jan 15")
-function formatDayDisplay(dateStr: string): string {
-  const date = new Date(dateStr + 'T00:00:00'); // Add time to avoid timezone issues
-  const weekday = date.toLocaleDateString('en-US', { weekday: 'short' });
-  const month = date.toLocaleDateString('en-US', { month: 'short' });
-  const day = date.getDate();
-  return `${weekday}, ${month} ${day}`;
-}
+
 
 function getRelativeDay(dateStr: string): string {
   const today = new Date();
@@ -120,7 +113,7 @@ export default function DayTimeWindowsInput({
       {/* Left: Day display */}
       <div className="min-w-[100px] self-start">
         <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
-          {formatDayDisplay(day)}
+          {formatDayLabel(day)}
         </div>
         <div className="text-xs text-blue-500 dark:text-blue-400">
           {getRelativeDay(day)}

--- a/components/ParticipationConditions.tsx
+++ b/components/ParticipationConditions.tsx
@@ -15,12 +15,13 @@ export interface DayTimeWindow {
 }
 
 interface ParticipationConditionsProps {
-  minValue: number | null;
-  maxValue: number | null;
-  maxEnabled: boolean;
-  onMinChange: (value: number | null) => void;
-  onMaxChange: (value: number | null) => void;
-  onMaxEnabledChange: (enabled: boolean) => void;
+  minValue?: number | null;
+  maxValue?: number | null;
+  maxEnabled?: boolean;
+  onMinChange?: (value: number | null) => void;
+  onMaxChange?: (value: number | null) => void;
+  onMaxEnabledChange?: (enabled: boolean) => void;
+  hideParticipantCounters?: boolean;
   disabled?: boolean;
   pollMinParticipants?: number | null;
   pollMaxParticipants?: number | null;
@@ -48,12 +49,13 @@ interface ParticipationConditionsProps {
 }
 
 export default function ParticipationConditions({
-  minValue,
-  maxValue,
-  maxEnabled,
+  minValue = null,
+  maxValue = null,
+  maxEnabled = false,
   onMinChange,
   onMaxChange,
   onMaxEnabledChange,
+  hideParticipantCounters = false,
   disabled = false,
   pollMinParticipants = null,
   pollMaxParticipants = null,
@@ -137,6 +139,7 @@ export default function ParticipationConditions({
   return (
     <div className="space-y-3" data-testid="participation-conditions">
       {/* Participants */}
+      {!hideParticipantCounters && (
       <div className="-mt-2 mb-1">
         <label className="block text-sm font-medium mb-1">
           Participants
@@ -146,9 +149,9 @@ export default function ParticipationConditions({
             minValue={minValue}
             maxValue={maxValue}
             maxEnabled={maxEnabled}
-            onMinChange={onMinChange}
-            onMaxChange={onMaxChange}
-            onMaxEnabledChange={onMaxEnabledChange}
+            onMinChange={onMinChange!}
+            onMaxChange={onMaxChange!}
+            onMaxEnabledChange={onMaxEnabledChange!}
             increment={1}
             minLimit={enforcedMinLimit}
             maxLimit={enforcedMaxLimit}
@@ -158,6 +161,7 @@ export default function ParticipationConditions({
           />
         </div>
       </div>
+      )}
 
       {/* Duration */}
       {onDurationMinChange && onDurationMaxChange && onDurationMinEnabledChange && onDurationMaxEnabledChange && (

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -640,9 +640,11 @@ function formatTimeSlot(slot: string): string {
 
 function TimeResults({ results, isPollClosed }: { results: PollResults; isPollClosed?: boolean }) {
   const winner = results.winner;
-  const includedSlots = results.included_slots;
+  const options = results.options ?? [];
   const availCounts = results.availability_counts;
   const maxAvail = results.max_availability;
+  const likeCounts = results.like_counts;
+  const dislikeCounts = results.dislike_counts;
 
   if (!isPollClosed) {
     return (
@@ -654,13 +656,24 @@ function TimeResults({ results, isPollClosed }: { results: PollResults; isPollCl
     );
   }
 
-  if (!winner && (!includedSlots || includedSlots.length === 0)) {
+  if (options.length === 0) {
     return (
       <div className="text-center py-4">
         <p className="text-gray-600 dark:text-gray-400">No time slots met the availability threshold.</p>
       </div>
     );
   }
+
+  // Sort options for display: fewest dislikes → most likes → earliest
+  const sorted = [...options].sort((a, b) => {
+    const da = dislikeCounts?.[a] ?? 0;
+    const db = dislikeCounts?.[b] ?? 0;
+    if (da !== db) return da - db;
+    const la = likeCounts?.[a] ?? 0;
+    const lb = likeCounts?.[b] ?? 0;
+    if (lb !== la) return lb - la;
+    return a < b ? -1 : 1; // chronological
+  });
 
   return (
     <div className="space-y-4">
@@ -672,40 +685,40 @@ function TimeResults({ results, isPollClosed }: { results: PollResults; isPollCl
               {formatTimeSlot(winner)}
             </span>
           </div>
-          {maxAvail != null && availCounts && availCounts[winner] != null && (
+          {maxAvail != null && availCounts?.[winner] != null && (
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1.5">
-              {availCounts[winner]} of {maxAvail} people available
+              {availCounts[winner]} of {maxAvail} available
             </p>
           )}
         </div>
       )}
 
-      {includedSlots && includedSlots.length > 1 && (
+      {sorted.length > 1 && (
         <div>
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-2 text-center">
-            All qualifying slots ({includedSlots.length})
+            All qualifying slots ({sorted.length})
           </p>
-          <div className="space-y-1 max-h-48 overflow-y-auto">
-            {includedSlots.map((slot) => {
-              const count = availCounts?.[slot] ?? 0;
+          <div className="space-y-1 max-h-56 overflow-y-auto">
+            {sorted.map((slot) => {
+              const likes = likeCounts?.[slot] ?? 0;
+              const dislikes = dislikeCounts?.[slot] ?? 0;
               const isWinner = slot === winner;
               return (
                 <div
                   key={slot}
-                  className={`flex items-center justify-between px-3 py-1.5 rounded-lg text-sm ${
+                  className={`flex items-center justify-between px-3 py-1.5 rounded-lg text-sm gap-2 ${
                     isWinner
                       ? 'bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800'
                       : 'bg-gray-50 dark:bg-gray-800'
                   }`}
                 >
-                  <span className={isWinner ? 'font-medium text-green-800 dark:text-green-200' : 'text-gray-700 dark:text-gray-300'}>
+                  <span className={`truncate ${isWinner ? 'font-medium text-green-800 dark:text-green-200' : 'text-gray-700 dark:text-gray-300'}`}>
                     {formatTimeSlot(slot)}
                   </span>
-                  {maxAvail != null && (
-                    <span className="text-xs text-gray-500 dark:text-gray-400 ml-2 flex-shrink-0">
-                      {count}/{maxAvail}
-                    </span>
-                  )}
+                  <span className="flex items-center gap-2 flex-shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                    {likes > 0 && <span className="text-green-600 dark:text-green-400">+{likes}</span>}
+                    {dislikes > 0 && <span className="text-red-500 dark:text-red-400">−{dislikes}</span>}
+                  </span>
                 </div>
               );
             })}

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -27,6 +27,10 @@ export default function PollResultsDisplay({ results, isPollClosed, userVoteData
     return <CompactRankedChoiceResults results={results} isPollClosed={isPollClosed} userVoteData={userVoteData} onFollowUpClick={onFollowUpClick} optionsMetadata={optionsMetadata} />;
   }
 
+  if (results.poll_type === 'time') {
+    return <TimeResults results={results} isPollClosed={isPollClosed} />;
+  }
+
   return null;
 }
 
@@ -597,6 +601,117 @@ function ParticipationResults({ results, isPollClosed, userVoteData, onFollowUpC
       <div className="text-gray-600 dark:text-gray-400 text-sm">
         Poll is still open - results will show when closed
       </div>
+    </div>
+  );
+}
+
+function formatTimeSlot(slot: string): string {
+  // "YYYY-MM-DD HH:MM-HH:MM" → "Mon Apr 28 • 10:00 AM – 10:30 AM (30m)"
+  try {
+    const [datePart, timePart] = slot.split(' ');
+    const [startStr, endStr] = timePart.split('-');
+    const [sy, sm, sd] = datePart.split('-').map(Number);
+    const [sh, smin] = startStr.split(':').map(Number);
+    const [eh, emin] = endStr.split(':').map(Number);
+
+    const date = new Date(sy, sm - 1, sd);
+    const weekday = date.toLocaleDateString('en-US', { weekday: 'short' });
+    const month = date.toLocaleDateString('en-US', { month: 'short' });
+
+    const fmt = (h: number, m: number) => {
+      const period = h < 12 ? 'AM' : 'PM';
+      const h12 = h % 12 || 12;
+      return `${h12}:${m.toString().padStart(2, '0')} ${period}`;
+    };
+
+    const startMins = sh * 60 + smin;
+    let endMins = eh * 60 + emin;
+    if (endMins <= startMins) endMins += 24 * 60;
+    const durMins = endMins - startMins;
+    const durStr = durMins >= 60
+      ? (durMins % 60 === 0 ? `${durMins / 60}h` : `${Math.floor(durMins / 60)}h ${durMins % 60}m`)
+      : `${durMins}m`;
+
+    return `${weekday} ${month} ${sd} • ${fmt(sh, smin)} – ${fmt(eh, emin)} (${durStr})`;
+  } catch {
+    return slot;
+  }
+}
+
+function TimeResults({ results, isPollClosed }: { results: PollResults; isPollClosed?: boolean }) {
+  const winner = results.winner;
+  const includedSlots = results.included_slots;
+  const availCounts = results.availability_counts;
+  const maxAvail = results.max_availability;
+
+  if (!isPollClosed) {
+    return (
+      <div className="text-center py-3">
+        <div className="text-gray-600 dark:text-gray-400 text-sm">
+          Results will show when the poll closes
+        </div>
+      </div>
+    );
+  }
+
+  if (!winner && (!includedSlots || includedSlots.length === 0)) {
+    return (
+      <div className="text-center py-4">
+        <p className="text-gray-600 dark:text-gray-400">No time slots met the availability threshold.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {winner && (
+        <div className="text-center">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Scheduled Time</p>
+          <div className="inline-flex items-center px-4 py-2 bg-green-100 dark:bg-green-900 border border-green-300 dark:border-green-700 rounded-xl">
+            <span className="text-sm font-semibold text-green-800 dark:text-green-200">
+              {formatTimeSlot(winner)}
+            </span>
+          </div>
+          {maxAvail != null && availCounts && availCounts[winner] != null && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1.5">
+              {availCounts[winner]} of {maxAvail} people available
+            </p>
+          )}
+        </div>
+      )}
+
+      {includedSlots && includedSlots.length > 1 && (
+        <div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2 text-center">
+            All qualifying slots ({includedSlots.length})
+          </p>
+          <div className="space-y-1 max-h-48 overflow-y-auto">
+            {includedSlots.map((slot) => {
+              const count = availCounts?.[slot] ?? 0;
+              const isWinner = slot === winner;
+              return (
+                <div
+                  key={slot}
+                  className={`flex items-center justify-between px-3 py-1.5 rounded-lg text-sm ${
+                    isWinner
+                      ? 'bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800'
+                      : 'bg-gray-50 dark:bg-gray-800'
+                  }`}
+                >
+                  <span className={isWinner ? 'font-medium text-green-800 dark:text-green-200' : 'text-gray-700 dark:text-gray-300'}>
+                    {formatTimeSlot(slot)}
+                  </span>
+                  {maxAvail != null && (
+                    <span className="text-xs text-gray-500 dark:text-gray-400 ml-2 flex-shrink-0">
+                      {count}/{maxAvail}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -20,9 +20,10 @@ interface RankableOptionsProps {
   initialRanking?: string[]; // Optional initial ranking to override saved state
   optionsMetadata?: OptionsMetadata | null;
   renderOption?: (option: string) => React.ReactNode;
+  preserveOrder?: boolean; // Skip initial shuffle (use for time slots, which have a natural order)
 }
 
-export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, optionsMetadata, renderOption }: RankableOptionsProps) {
+export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, optionsMetadata, renderOption, preserveOrder = false }: RankableOptionsProps) {
 
   // Load saved state from localStorage
   const loadSavedState = useCallback(() => {
@@ -554,9 +555,10 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           setMainList(positionedMainList);
           setNoPreferenceList(positionedNoPreferenceList);
         } else {
-          // Initialize with randomized order to prevent position bias
-          const shuffledOptions = shuffleArray(options);
-          const newRankedOptions = shuffledOptions.map((text, index) => ({
+          // Initialize with randomized order to prevent position bias,
+          // unless preserveOrder is set (e.g. time slots have a natural chronological order).
+          const orderedOptions = preserveOrder ? options : shuffleArray(options);
+          const newRankedOptions = orderedOptions.map((text, index) => ({
             id: `option-${index}`,
             text: text,
             top: index * totalItemHeight

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -19,9 +19,10 @@ interface RankableOptionsProps {
   storageKey?: string; // Optional key for localStorage persistence
   initialRanking?: string[]; // Optional initial ranking to override saved state
   optionsMetadata?: OptionsMetadata | null;
+  renderOption?: (option: string) => React.ReactNode;
 }
 
-export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, optionsMetadata }: RankableOptionsProps) {
+export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, optionsMetadata, renderOption }: RankableOptionsProps) {
 
   // Load saved state from localStorage
   const loadSavedState = useCallback(() => {
@@ -645,7 +646,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       >
         <div className="flex items-center justify-between h-full">
           <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
-            <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="min-w-0 overflow-hidden" />
+            {renderOption ? renderOption(draggedOption.text) : <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="min-w-0 overflow-hidden" />}
           </div>
           <div className="flex flex-col items-center justify-center ml-2 text-gray-500">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -1042,7 +1043,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                         ? 'text-gray-500 dark:text-gray-400'
                         : 'text-gray-900 dark:text-white'
                     }`}>
-                      <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />
+                      {renderOption ? renderOption(option.text) : <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />}
                     </div>
 
                     {/* Right side: combined drag handle with tap zones for reordering

--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * TimeSlotBubbles — compact day-row bubble grid for time poll preferences.
+ *
+ * Layout: one row per day, day label on the left, tappable time bubbles on the right.
+ * Each bubble cycles through: neutral → liked (green) → disliked (red) → neutral.
+ *
+ * Bubble labels use compressed notation to reduce visual clutter:
+ *   First bubble of day (or different AM/PM):  "9 AM", "1 PM"
+ *   Same AM/PM period but different hour:       "10", "11"
+ *   Same hour as previous bubble:               ":15", ":30", ":45"
+ *
+ * An orange badge (top-right) shows how many availability voters are excluded by that slot.
+ */
+
+import { useMemo } from "react";
+
+export type SlotState = "neutral" | "liked" | "disliked";
+
+interface TimeSlotBubblesProps {
+  /** Slot keys in display order, already filtered and sorted. */
+  options: string[];
+  likedSlots: string[];
+  dislikedSlots: string[];
+  onToggle: (slot: string, nextState: SlotState) => void;
+  /** availability_counts from results: slot_key → voter count */
+  availabilityCounts?: Record<string, number>;
+  maxAvailability?: number;
+  disabled?: boolean;
+}
+
+function parseSlotStart(slot: string): { h: number; m: number } {
+  // slot format: "YYYY-MM-DD HH:MM-HH:MM"
+  const startStr = slot.split(" ")[1].split("-")[0];
+  const [h, m] = startStr.split(":").map(Number);
+  return { h, m };
+}
+
+function parseSlotDate(slot: string): string {
+  return slot.split(" ")[0]; // "YYYY-MM-DD"
+}
+
+function formatDayLabel(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+  return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+function getBubbleLabel(slot: string, prevSlot: string | null): string {
+  const { h, m } = parseSlotStart(slot);
+  const period = h < 12 ? "AM" : "PM";
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+
+  if (prevSlot) {
+    const prev = parseSlotStart(prevSlot);
+    const prevPeriod = prev.h < 12 ? "AM" : "PM";
+    const prevH12 = prev.h % 12 === 0 ? 12 : prev.h % 12;
+
+    if (h12 === prevH12 && period === prevPeriod) {
+      // Same hour → show only :MM
+      return `:${String(m).padStart(2, "0")}`;
+    }
+    if (period === prevPeriod) {
+      // Same AM/PM → show hour, omit period
+      return String(h12);
+    }
+  }
+
+  // First bubble or period changed → full label
+  return `${h12} ${period}`;
+}
+
+export default function TimeSlotBubbles({
+  options,
+  likedSlots,
+  dislikedSlots,
+  onToggle,
+  availabilityCounts,
+  maxAvailability,
+  disabled = false,
+}: TimeSlotBubblesProps) {
+  const likedSet = useMemo(() => new Set(likedSlots), [likedSlots]);
+  const dislikedSet = useMemo(() => new Set(dislikedSlots), [dislikedSlots]);
+
+  // Group slots by date, preserving order
+  const days = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const slot of options) {
+      const date = parseSlotDate(slot);
+      if (!map.has(date)) map.set(date, []);
+      map.get(date)!.push(slot);
+    }
+    return Array.from(map.entries()); // [dateStr, slots[]]
+  }, [options]);
+
+  function getState(slot: string): SlotState {
+    if (likedSet.has(slot)) return "liked";
+    if (dislikedSet.has(slot)) return "disliked";
+    return "neutral";
+  }
+
+  function handleTap(slot: string) {
+    if (disabled) return;
+    const current = getState(slot);
+    const next: SlotState = current === "neutral" ? "liked" : current === "liked" ? "disliked" : "neutral";
+    onToggle(slot, next);
+  }
+
+  return (
+    <div className="space-y-3">
+      {days.map(([dateStr, slots]) => (
+        <div key={dateStr} className="flex gap-3 items-start">
+          {/* Day label */}
+          <div className="w-20 shrink-0 pt-1 text-xs font-medium text-gray-500 dark:text-gray-400 text-right leading-tight">
+            {formatDayLabel(dateStr)}
+          </div>
+
+          {/* Bubbles */}
+          <div className="flex flex-wrap gap-1.5">
+            {slots.map((slot, idx) => {
+              const state = getState(slot);
+              const label = getBubbleLabel(slot, idx > 0 ? slots[idx - 1] : null);
+              const excluded =
+                maxAvailability != null && availabilityCounts != null
+                  ? maxAvailability - (availabilityCounts[slot] ?? 0)
+                  : 0;
+
+              return (
+                <button
+                  key={slot}
+                  type="button"
+                  onClick={() => handleTap(slot)}
+                  disabled={disabled}
+                  title={slot}
+                  className={[
+                    "relative select-none rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
+                    "border focus:outline-none focus:ring-2 focus:ring-offset-1",
+                    disabled ? "cursor-default opacity-60" : "cursor-pointer active:scale-95",
+                    state === "liked"
+                      ? "bg-green-500 border-green-500 text-white focus:ring-green-400"
+                      : state === "disliked"
+                      ? "bg-red-500 border-red-500 text-white focus:ring-red-400"
+                      : "bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 focus:ring-blue-400",
+                  ].join(" ")}
+                >
+                  {label}
+                  {excluded > 0 && (
+                    <span className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-orange-500 text-[9px] font-bold text-white leading-none pointer-events-none">
+                      {excluded}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      {/* Legend */}
+      <div className="flex items-center gap-3 pt-1 text-xs text-gray-400 dark:text-gray-500">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-full bg-green-500" /> liked
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-full bg-red-500" /> disliked
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-full border border-gray-300 dark:border-gray-600" /> neutral
+        </span>
+        {maxAvailability != null && maxAvailability > 0 && (
+          <span className="flex items-center gap-1">
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-orange-500 text-[9px] font-bold text-white">N</span> excludes N voter(s)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useMemo } from "react";
+import { formatDayLabel } from "@/lib/timeUtils";
 
 export type SlotState = "neutral" | "liked" | "disliked";
 
@@ -41,11 +42,6 @@ function parseSlotDate(slot: string): string {
   return slot.split(" ")[0]; // "YYYY-MM-DD"
 }
 
-function formatDayLabel(dateStr: string): string {
-  const [year, month, day] = dateStr.split("-").map(Number);
-  const d = new Date(year, month - 1, day);
-  return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
-}
 
 function getBubbleLabel(slot: string, prevSlot: string | null): string {
   const { h, m } = parseSlotStart(slot);

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -10,7 +10,7 @@ export interface BuiltInType {
 
 const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "yes_no", label: "Yes / No", icon: "👍" },
-  { value: "scheduling", label: "Scheduling", icon: "📅" },
+  { value: "time", label: "Time", icon: "📅" },
   { value: "restaurant", label: "Restaurant", icon: "🍽️" },
   { value: "location", label: "Place", icon: "📍" },
   { value: "movie", label: "Movie", icon: "🎬" },
@@ -34,9 +34,9 @@ export function isLocationLikeCategory(category: string): boolean {
   return category === 'location' || category === 'restaurant';
 }
 
-/** Categories that use autocomplete search (any built-in type except yes_no and scheduling). */
+/** Categories that use autocomplete search (any built-in type except yes_no and time). */
 export function isAutocompleteCategory(category: string): boolean {
-  return category !== 'yes_no' && category !== 'scheduling' && BUILT_IN_TYPES.some((t) => t.value === category);
+  return category !== 'yes_no' && category !== 'time' && BUILT_IN_TYPES.some((t) => t.value === category);
 }
 
 interface TypeFieldInputProps {

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -10,6 +10,7 @@ export interface BuiltInType {
 
 const BUILT_IN_TYPES: BuiltInType[] = [
   { value: "yes_no", label: "Yes / No", icon: "👍" },
+  { value: "scheduling", label: "Scheduling", icon: "📅" },
   { value: "restaurant", label: "Restaurant", icon: "🍽️" },
   { value: "location", label: "Place", icon: "📍" },
   { value: "movie", label: "Movie", icon: "🎬" },
@@ -33,9 +34,9 @@ export function isLocationLikeCategory(category: string): boolean {
   return category === 'location' || category === 'restaurant';
 }
 
-/** Categories that use autocomplete search (any built-in type except yes_no). */
+/** Categories that use autocomplete search (any built-in type except yes_no and scheduling). */
 export function isAutocompleteCategory(category: string): boolean {
-  return category !== 'yes_no' && BUILT_IN_TYPES.some((t) => t.value === category);
+  return category !== 'yes_no' && category !== 'scheduling' && BUILT_IN_TYPES.some((t) => t.value === category);
 }
 
 interface TypeFieldInputProps {

--- a/database/migrations/087_add_time_poll_type_down.sql
+++ b/database/migrations/087_add_time_poll_type_down.sql
@@ -1,0 +1,33 @@
+-- Rollback: remove 'time' poll type additions
+
+ALTER TABLE polls DROP COLUMN IF EXISTS availability_threshold;
+
+-- Revert poll_type constraint (remove 'time')
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_type_check;
+ALTER TABLE polls ADD CONSTRAINT polls_poll_type_check
+  CHECK (poll_type IN ('yes_no', 'ranked_choice', 'participation'));
+
+-- Revert vote_type constraint (remove 'time')
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS votes_vote_type_check;
+ALTER TABLE votes ADD CONSTRAINT votes_vote_type_check
+  CHECK (vote_type IN ('yes_no', 'ranked_choice', 'participation'));
+
+-- Revert vote_structure_valid (remove 'time' case)
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_structure_valid;
+ALTER TABLE votes ADD CONSTRAINT vote_structure_valid CHECK (
+    (vote_type = 'yes_no' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'participation' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'ranked_choice' AND
+     yes_no_choice IS NULL AND
+     (
+       ((ranked_choices IS NOT NULL AND is_abstain = false) OR (ranked_choices IS NULL AND is_abstain = true)) OR
+       (suggestions IS NOT NULL AND array_length(suggestions, 1) > 0 AND is_abstain = false) OR
+       (is_abstain = true AND ranked_choices IS NULL AND (suggestions IS NULL OR array_length(suggestions, 1) IS NULL))
+     ))
+);

--- a/database/migrations/087_add_time_poll_type_up.sql
+++ b/database/migrations/087_add_time_poll_type_up.sql
@@ -1,0 +1,52 @@
+-- Add 'time' poll type for scheduling polls.
+-- Time polls have two phases:
+--   1. Availability: voters enter their day/time windows (uses suggestion_deadline columns)
+--   2. Preferences: voters rank generated time slots (uses ranked_choices)
+-- Resolution uses IRV on preference ballots filtered by availability threshold.
+
+-- Add availability_threshold: % below max availability still included (default 5%)
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS availability_threshold INTEGER DEFAULT 5;
+
+-- Update poll_type constraint to include 'time'
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS polls_poll_type_check;
+ALTER TABLE polls DROP CONSTRAINT IF EXISTS poll_type_check;
+ALTER TABLE polls ADD CONSTRAINT polls_poll_type_check
+  CHECK (poll_type IN ('yes_no', 'ranked_choice', 'participation', 'time'));
+
+-- Update vote_type constraint to include 'time'
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS votes_vote_type_check;
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_type_check;
+ALTER TABLE votes ADD CONSTRAINT votes_vote_type_check
+  CHECK (vote_type IN ('yes_no', 'ranked_choice', 'participation', 'time'));
+
+-- Update vote_structure_valid to include 'time' vote structure.
+-- Time poll votes can have:
+--   - voter_day_time_windows (availability phase)
+--   - ranked_choices (preferences phase, may coexist with day_time_windows)
+--   - is_abstain = true (abstain)
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_structure_valid;
+ALTER TABLE votes ADD CONSTRAINT vote_structure_valid CHECK (
+    (vote_type = 'yes_no' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'participation' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'ranked_choice' AND
+     yes_no_choice IS NULL AND
+     (
+       ((ranked_choices IS NOT NULL AND is_abstain = false) OR (ranked_choices IS NULL AND is_abstain = true)) OR
+       (suggestions IS NOT NULL AND array_length(suggestions, 1) > 0 AND is_abstain = false) OR
+       (is_abstain = true AND ranked_choices IS NULL AND (suggestions IS NULL OR array_length(suggestions, 1) IS NULL))
+     )) OR
+    (vote_type = 'time' AND
+     yes_no_choice IS NULL AND
+     suggestions IS NULL AND
+     (
+       (voter_day_time_windows IS NOT NULL AND is_abstain = false) OR
+       (ranked_choices IS NOT NULL AND is_abstain = false) OR
+       (is_abstain = true)
+     ))
+);

--- a/database/migrations/088_time_vote_reactions_down.sql
+++ b/database/migrations/088_time_vote_reactions_down.sql
@@ -1,0 +1,30 @@
+ALTER TABLE votes DROP COLUMN IF EXISTS liked_slots;
+ALTER TABLE votes DROP COLUMN IF EXISTS disliked_slots;
+
+-- Restore previous vote_structure_valid constraint
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_structure_valid;
+ALTER TABLE votes ADD CONSTRAINT vote_structure_valid CHECK (
+    (vote_type = 'yes_no' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'participation' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'ranked_choice' AND
+     yes_no_choice IS NULL AND
+     (
+       ((ranked_choices IS NOT NULL AND is_abstain = false) OR (ranked_choices IS NULL AND is_abstain = true)) OR
+       (suggestions IS NOT NULL AND array_length(suggestions, 1) > 0 AND is_abstain = false) OR
+       (is_abstain = true AND ranked_choices IS NULL AND (suggestions IS NULL OR array_length(suggestions, 1) IS NULL))
+     )) OR
+    (vote_type = 'time' AND
+     yes_no_choice IS NULL AND
+     suggestions IS NULL AND
+     (
+       (voter_day_time_windows IS NOT NULL AND is_abstain = false) OR
+       (ranked_choices IS NOT NULL AND is_abstain = false) OR
+       (is_abstain = true)
+     ))
+);

--- a/database/migrations/088_time_vote_reactions_up.sql
+++ b/database/migrations/088_time_vote_reactions_up.sql
@@ -1,0 +1,34 @@
+-- Replace IRV ranking with like/dislike reactions for time poll preferences.
+-- Voters tap slots to mark them liked (green) or disliked (red); neutral is the default.
+
+ALTER TABLE votes ADD COLUMN IF NOT EXISTS liked_slots jsonb;
+ALTER TABLE votes ADD COLUMN IF NOT EXISTS disliked_slots jsonb;
+
+-- Update vote_structure_valid to allow liked/disliked reactions for time poll preferences.
+ALTER TABLE votes DROP CONSTRAINT IF EXISTS vote_structure_valid;
+ALTER TABLE votes ADD CONSTRAINT vote_structure_valid CHECK (
+    (vote_type = 'yes_no' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'participation' AND
+     ((yes_no_choice IS NOT NULL AND is_abstain = false) OR (yes_no_choice IS NULL AND is_abstain = true)) AND
+     ranked_choices IS NULL AND
+     suggestions IS NULL) OR
+    (vote_type = 'ranked_choice' AND
+     yes_no_choice IS NULL AND
+     (
+       ((ranked_choices IS NOT NULL AND is_abstain = false) OR (ranked_choices IS NULL AND is_abstain = true)) OR
+       (suggestions IS NOT NULL AND array_length(suggestions, 1) > 0 AND is_abstain = false) OR
+       (is_abstain = true AND ranked_choices IS NULL AND (suggestions IS NULL OR array_length(suggestions, 1) IS NULL))
+     )) OR
+    (vote_type = 'time' AND
+     yes_no_choice IS NULL AND
+     suggestions IS NULL AND
+     (
+       (voter_day_time_windows IS NOT NULL AND is_abstain = false) OR
+       (liked_slots IS NOT NULL AND is_abstain = false) OR
+       (disliked_slots IS NOT NULL AND is_abstain = false) OR
+       (is_abstain = true)
+     ))
+);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -47,6 +47,8 @@ export interface ApiVote {
   max_participants: number | null;
   voter_day_time_windows: any[] | null;
   voter_duration: any | null;
+  liked_slots: string[] | null;
+  disliked_slots: string[] | null;
   created_at: string;
   updated_at: string;
 }
@@ -164,6 +166,8 @@ function toPollResults(data: any): PollResults & { ranked_choice_rounds?: ApiRan
     availability_counts: data.availability_counts ?? undefined,
     max_availability: data.max_availability ?? undefined,
     included_slots: data.included_slots ?? undefined,
+    like_counts: data.like_counts ?? undefined,
+    dislike_counts: data.dislike_counts ?? undefined,
   };
 }
 
@@ -268,6 +272,8 @@ export async function apiSubmitVote(pollId: string, params: {
   voter_day_time_windows?: any[] | null;
   voter_duration?: any | null;
   options_metadata?: OptionsMetadata | null;
+  liked_slots?: string[] | null;
+  disliked_slots?: string[] | null;
 }): Promise<ApiVote> {
   return apiFetch(`/${encodeURIComponent(pollId)}/votes`, {
     method: 'POST',
@@ -290,6 +296,8 @@ export async function apiEditVote(pollId: string, voteId: string, params: {
   max_participants?: number | null;
   voter_day_time_windows?: any[] | null;
   voter_duration?: any | null;
+  liked_slots?: string[] | null;
+  disliked_slots?: string[] | null;
 }): Promise<ApiVote> {
   return apiFetch(`/${encodeURIComponent(pollId)}/votes/${encodeURIComponent(voteId)}`, {
     method: 'PUT',

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -163,6 +163,7 @@ function toPollResults(data: any): PollResults & { ranked_choice_rounds?: ApiRan
     participating_voter_names: data.participating_voter_names ?? undefined,
     availability_counts: data.availability_counts ?? undefined,
     max_availability: data.max_availability ?? undefined,
+    included_slots: data.included_slots ?? undefined,
   };
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -133,6 +133,7 @@ function toPoll(data: any): Poll {
     min_responses: data.min_responses ?? undefined,
     show_preliminary_results: data.show_preliminary_results ?? true,
     response_count: data.response_count ?? undefined,
+    availability_threshold: data.availability_threshold ?? undefined,
   };
 }
 
@@ -160,6 +161,8 @@ function toPollResults(data: any): PollResults & { ranked_choice_rounds?: ApiRan
     time_slot_rounds: data.time_slot_rounds ?? undefined,
     participating_vote_ids: data.participating_vote_ids ?? undefined,
     participating_voter_names: data.participating_voter_names ?? undefined,
+    availability_counts: data.availability_counts ?? undefined,
+    max_availability: data.max_availability ?? undefined,
   };
 }
 
@@ -210,6 +213,9 @@ export async function apiCreatePoll(params: {
   reference_location_label?: string;
   min_responses?: number;
   show_preliminary_results?: boolean;
+  availability_threshold?: number;
+  suggestion_deadline_minutes?: number;
+  is_auto_title?: boolean;
 }): Promise<Poll> {
   const data = await apiFetch('', {
     method: 'POST',
@@ -315,6 +321,14 @@ export async function apiClosePoll(pollId: string, creatorSecret: string, closeR
 
 export async function apiCutoffSuggestions(pollId: string, creatorSecret: string): Promise<Poll> {
   const data = await apiFetch(`/${encodeURIComponent(pollId)}/cutoff-suggestions`, {
+    method: 'POST',
+    body: JSON.stringify({ creator_secret: creatorSecret }),
+  });
+  return toPoll(data);
+}
+
+export async function apiCutoffAvailability(pollId: string, creatorSecret: string): Promise<Poll> {
+  const data = await apiFetch(`/${encodeURIComponent(pollId)}/cutoff-availability`, {
     method: 'POST',
     body: JSON.stringify({ creator_secret: creatorSecret }),
   });

--- a/lib/timeUtils.ts
+++ b/lib/timeUtils.ts
@@ -1,3 +1,9 @@
+/** Format a "YYYY-MM-DD" date string as a short day label, e.g. "Mon, Jan 15" */
+export function formatDayLabel(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
 /** Convert "HH:MM" to total minutes since midnight */
 export function timeToMinutes(t: string): number {
   const [h, m] = t.split(':').map(Number);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -130,6 +130,8 @@ export interface PollResults {
   availability_counts?: Record<string, number>;
   max_availability?: number;
   included_slots?: string[];
+  like_counts?: Record<string, number>;
+  dislike_counts?: Record<string, number>;
   ranked_choice_rounds?: RankedChoiceRound[];
   ranked_choice_winner?: string;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -129,6 +129,7 @@ export interface PollResults {
   // Time poll fields
   availability_counts?: Record<string, number>;
   max_availability?: number;
+  included_slots?: string[];
   ranked_choice_rounds?: RankedChoiceRound[];
   ranked_choice_winner?: string;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,7 +22,7 @@ export type OptionsMetadata = Record<string, OptionMetadataEntry>;
 export interface Poll {
   id: string;
   title: string;
-  poll_type: 'yes_no' | 'ranked_choice' | 'participation';
+  poll_type: 'yes_no' | 'ranked_choice' | 'participation' | 'time';
   options?: string[];
   response_deadline?: string;
   created_at: string;
@@ -68,6 +68,7 @@ export interface Poll {
   min_responses?: number | null;
   show_preliminary_results?: boolean;
   response_count?: number | null;
+  availability_threshold?: number | null;
   results?: PollResults | null;
 }
 
@@ -104,7 +105,7 @@ export interface SuggestionCount {
 export interface PollResults {
   poll_id: string;
   title: string;
-  poll_type: 'yes_no' | 'ranked_choice' | 'participation';
+  poll_type: 'yes_no' | 'ranked_choice' | 'participation' | 'time';
   created_at: string;
   response_deadline?: string;
   options?: string[];
@@ -125,6 +126,11 @@ export interface PollResults {
   time_slot_rounds?: TimeSlotResult[];
   participating_vote_ids?: string[];
   participating_voter_names?: string[];
+  // Time poll fields
+  availability_counts?: Record<string, number>;
+  max_availability?: number;
+  ranked_choice_rounds?: RankedChoiceRound[];
+  ranked_choice_winner?: string;
 }
 
 export interface TimeSlotResult {

--- a/public/sw-mobile.js
+++ b/public/sw-mobile.js
@@ -1,5 +1,5 @@
 // Enhanced Service Worker for Mobile Instant Loading
-const CACHE_NAME = 'whoeverwants-mobile-v3';
+const CACHE_NAME = 'whoeverwants-mobile-v4';
 
 const STATIC_FILE_RE = /\.(json|png|svg|ico|woff2?)$/;
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,49 +1,78 @@
-const CACHE_NAME = 'whoeverwants-v1';
-const urlsToCache = [
-  '/',
-  '/static/js/bundle.js',
-  '/static/css/main.css',
-  '/manifest.json'
-];
+const CACHE_NAME = 'whoeverwants-v2';
 
-// Install event - cache resources
+// Install — cache only stable non-HTML assets
 self.addEventListener('install', function(event) {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(function(cache) {
-        console.log('Opened cache');
-        return cache.addAll(urlsToCache);
-      })
+    caches.open(CACHE_NAME).then(function(cache) {
+      return cache.addAll(['/manifest.json']);
+    })
   );
 });
 
-// Fetch event - serve cached content when offline
-self.addEventListener('fetch', function(event) {
-  event.respondWith(
-    caches.match(event.request)
-      .then(function(response) {
-        // Return cached version or fetch from network
-        if (response) {
-          return response;
-        }
-        return fetch(event.request);
-      }
-    )
-  );
-});
-
-// Activate event - cleanup old caches
+// Activate — delete old caches
 self.addEventListener('activate', function(event) {
   event.waitUntil(
     caches.keys().then(function(cacheNames) {
       return Promise.all(
         cacheNames.map(function(cacheName) {
           if (cacheName !== CACHE_NAME) {
-            console.log('Deleting old cache:', cacheName);
             return caches.delete(cacheName);
           }
         })
       );
     })
   );
+});
+
+// Fetch — network-first for navigation and JS chunks, cache-first only for immutable static assets
+self.addEventListener('fetch', function(event) {
+  var url = new URL(event.request.url);
+
+  // Only handle same-origin requests
+  if (url.origin !== location.origin) return;
+
+  // Skip API requests
+  if (url.pathname.startsWith('/api/')) return;
+
+  // Navigation (HTML) — always network-first so fresh chunk references are used
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(function() {
+        return caches.match(event.request).then(function(r) { return r || caches.match('/'); });
+      })
+    );
+    return;
+  }
+
+  // JS chunks — network-first (chunk hashes change on every build)
+  if (url.pathname.startsWith('/_next/static/chunks/')) {
+    event.respondWith(
+      fetch(event.request).then(function(response) {
+        if (response && response.status === 200) {
+          var clone = response.clone();
+          caches.open(CACHE_NAME).then(function(cache) { cache.put(event.request, clone); });
+        }
+        return response;
+      }).catch(function() {
+        return caches.match(event.request);
+      })
+    );
+    return;
+  }
+
+  // Other static assets with content hashes (CSS, fonts, etc.) — cache-first
+  if (url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(
+      caches.match(event.request).then(function(cached) {
+        return cached || fetch(event.request).then(function(response) {
+          if (response && response.status === 200) {
+            var clone = response.clone();
+            caches.open(CACHE_NAME).then(function(cache) { cache.put(event.request, clone); });
+          }
+          return response;
+        });
+      })
+    );
+    return;
+  }
 });

--- a/server/algorithms/time_poll.py
+++ b/server/algorithms/time_poll.py
@@ -122,6 +122,34 @@ def generate_time_poll_slots(poll: dict, votes: list[dict]) -> list[str]:
     ]
 
 
+def _keep_longest_per_start_time(slots: list[str]) -> list[str]:
+    """For each (date, start_time), keep only the slot with the longest duration.
+
+    When the poll allows a duration range (e.g. 30 min – 2 h), multiple slots
+    share the same start time but differ in end time.  Voters only need to rank
+    one representative per start time: the longest available option.  Shorter
+    variants are redundant — if a voter prefers a shorter meeting they can rank
+    that start time lower relative to other start times.
+
+    The original sort order (longest duration first, then earliest start) is
+    preserved in the returned list.
+    """
+    best: dict[tuple[str, int], tuple[str, int]] = {}  # (date, start_min) → (slot_str, duration)
+
+    for slot_str in slots:
+        date, start_min, end_min = parse_slot_key(slot_str)
+        dur = end_min - start_min
+        if dur <= 0:
+            dur += 24 * 60  # cross-midnight
+
+        key = (date, start_min)
+        if key not in best or dur > best[key][1]:
+            best[key] = (slot_str, dur)
+
+    best_set = {slot_str for slot_str, _ in best.values()}
+    return [s for s in slots if s in best_set]
+
+
 def compute_slot_availability(options: list[str], votes: list[dict]) -> dict[str, int]:
     """Count how many availability voters cover each time slot.
 
@@ -189,6 +217,10 @@ def calculate_time_poll_results(poll: dict, votes: list[dict]) -> dict:
 
     # Slots ordered as in poll.options (largest duration first, then earliest)
     included_slots = [s for s in options if availability_counts.get(s, 0) >= min_acceptable]
+
+    # For each start time, keep only the longest-duration slot so voters aren't
+    # presented with near-duplicate options (e.g. 09:00-10:00 vs 09:00-10:30).
+    included_slots = _keep_longest_per_start_time(included_slots)
 
     winner = None
     rc_rounds: list[dict] = []

--- a/server/algorithms/time_poll.py
+++ b/server/algorithms/time_poll.py
@@ -2,10 +2,10 @@
 
 Two-phase scheduling poll:
 1. Availability phase: voters enter day/time windows (stored in voter_day_time_windows)
-2. Preferences phase: voters rank generated time slots (stored in ranked_choices)
+2. Preferences phase: voters react to generated slots with liked_slots / disliked_slots
 
 Slots are generated from the poll creator's day_time_windows + duration_window.
-Resolution: filter slots by availability threshold, then run IRV on preference ballots.
+Resolution: fewest-dislikes → most-likes → earliest chronologically.
 
 Slot key format: "YYYY-MM-DD HH:MM-HH:MM"
   e.g. "2026-04-15 09:00-10:00" or "2026-04-15 23:00-01:00" (cross-midnight)
@@ -19,7 +19,6 @@ from algorithms.time_slots import (
     _voter_available_at,
     _window_effective_end,
 )
-from algorithms.ranked_choice import calculate_ranked_choice_winner
 
 
 def _minutes_to_time(minutes: int) -> str:
@@ -126,10 +125,8 @@ def _keep_longest_per_start_time(slots: list[str]) -> list[str]:
     """For each (date, start_time), keep only the slot with the longest duration.
 
     When the poll allows a duration range (e.g. 30 min – 2 h), multiple slots
-    share the same start time but differ in end time.  Voters only need to rank
-    one representative per start time: the longest available option.  Shorter
-    variants are redundant — if a voter prefers a shorter meeting they can rank
-    that start time lower relative to other start times.
+    share the same start time but differ in end time.  Voters only need to react
+    to one representative per start time: the longest available option.
 
     The original sort order (longest duration first, then earliest start) is
     preserved in the returned list.
@@ -172,31 +169,70 @@ def compute_slot_availability(options: list[str], votes: list[dict]) -> dict[str
     return counts
 
 
+def _pick_winner_from_reactions(options: list[str], votes: list[dict]) -> tuple[str | None, dict[str, int], dict[str, int]]:
+    """Pick the winning slot from like/dislike reactions.
+
+    Algorithm:
+    1. Fewest dislikes across all preference voters.
+    2. Most likes among those.
+    3. Earliest chronologically to break ties.
+
+    Returns (winner, like_counts, dislike_counts).
+    """
+    pref_votes = [
+        v for v in votes
+        if v.get("liked_slots") is not None or v.get("disliked_slots") is not None
+    ]
+
+    like_counts: dict[str, int] = {s: 0 for s in options}
+    dislike_counts: dict[str, int] = {s: 0 for s in options}
+
+    for v in pref_votes:
+        for s in (v.get("liked_slots") or []):
+            if s in like_counts:
+                like_counts[s] += 1
+        for s in (v.get("disliked_slots") or []):
+            if s in dislike_counts:
+                dislike_counts[s] += 1
+
+    if not options:
+        return None, like_counts, dislike_counts
+
+    # Step 1: fewest dislikes
+    min_dislikes = min(dislike_counts[s] for s in options)
+    candidates = [s for s in options if dislike_counts[s] == min_dislikes]
+
+    # Step 2: most likes
+    max_likes = max(like_counts[s] for s in candidates)
+    candidates = [s for s in candidates if like_counts[s] == max_likes]
+
+    # Step 3: earliest chronologically
+    candidates.sort(key=lambda s: parse_slot_key(s)[:2])  # (date, start_min)
+    winner = candidates[0] if candidates else None
+
+    return winner, like_counts, dislike_counts
+
+
 def calculate_time_poll_results(poll: dict, votes: list[dict]) -> dict:
     """Calculate results for a time poll.
 
-    Steps:
-    1. Compute slot availability counts from availability votes.
-    2. Find max_availability across all slots.
-    3. Filter to slots with count >= max * (1 - threshold/100).
-    4. Filter preference ballots to only included slots (preserving order).
-    5. Run IRV on filtered ballots.
+    poll.options already contains only the filtered, deduped slots (set at finalization).
 
     Returns dict with:
         availability_counts: {slot_key: count}
         max_availability: int
-        included_slots: [slot_key, ...]
         winner: slot_key | None
-        ranked_choice_rounds: [{round_number, option_name, vote_count, ...}, ...]
+        like_counts: {slot_key: count}
+        dislike_counts: {slot_key: count}
     """
     raw_options = poll.get("options")
     if raw_options is None:
         return {
             "availability_counts": {},
             "max_availability": 0,
-            "included_slots": [],
             "winner": None,
-            "ranked_choice_rounds": [],
+            "like_counts": {},
+            "dislike_counts": {},
         }
 
     options: list[str] = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
@@ -204,59 +240,20 @@ def calculate_time_poll_results(poll: dict, votes: list[dict]) -> dict:
         return {
             "availability_counts": {},
             "max_availability": 0,
-            "included_slots": [],
             "winner": None,
-            "ranked_choice_rounds": [],
+            "like_counts": {},
+            "dislike_counts": {},
         }
-
-    threshold_pct = (poll.get("availability_threshold") or 5) / 100.0
 
     availability_counts = compute_slot_availability(options, votes)
     max_avail = max(availability_counts.values(), default=0)
-    min_acceptable = max_avail * (1 - threshold_pct)
 
-    # Slots ordered as in poll.options (largest duration first, then earliest)
-    included_slots = [s for s in options if availability_counts.get(s, 0) >= min_acceptable]
-
-    # For each start time, keep only the longest-duration slot so voters aren't
-    # presented with near-duplicate options (e.g. 09:00-10:00 vs 09:00-10:30).
-    included_slots = _keep_longest_per_start_time(included_slots)
-
-    winner = None
-    rc_rounds: list[dict] = []
-
-    pref_votes = [v for v in votes if v.get("ranked_choices")]
-
-    if pref_votes and included_slots:
-        if len(included_slots) == 1:
-            winner = included_slots[0]
-        else:
-            included_set = set(included_slots)
-            # Pre-filter ballots to only included slots
-            filtered_votes = []
-            for v in pref_votes:
-                filtered = [s for s in (v.get("ranked_choices") or []) if s in included_set]
-                if filtered:
-                    filtered_votes.append({**dict(v), "ranked_choices": filtered})
-
-            if filtered_votes:
-                result = calculate_ranked_choice_winner(filtered_votes, included_slots)
-                winner = result.winner
-                for round_idx, round_entries in enumerate(result.rounds):
-                    for entry in round_entries:
-                        rc_rounds.append({
-                            "round_number": round_idx + 1,
-                            "option_name": entry.option_name,
-                            "vote_count": entry.vote_count,
-                            "is_eliminated": entry.is_eliminated,
-                            "borda_score": entry.borda_score,
-                            "tie_broken_by_borda": entry.tie_broken_by_borda,
-                        })
+    winner, like_counts, dislike_counts = _pick_winner_from_reactions(options, votes)
 
     return {
         "availability_counts": availability_counts,
         "max_availability": max_avail,
-        "included_slots": included_slots,
         "winner": winner,
-        "ranked_choice_rounds": rc_rounds,
+        "like_counts": like_counts,
+        "dislike_counts": dislike_counts,
     }

--- a/server/algorithms/time_poll.py
+++ b/server/algorithms/time_poll.py
@@ -1,0 +1,230 @@
+"""Time poll algorithm.
+
+Two-phase scheduling poll:
+1. Availability phase: voters enter day/time windows (stored in voter_day_time_windows)
+2. Preferences phase: voters rank generated time slots (stored in ranked_choices)
+
+Slots are generated from the poll creator's day_time_windows + duration_window.
+Resolution: filter slots by availability threshold, then run IRV on preference ballots.
+
+Slot key format: "YYYY-MM-DD HH:MM-HH:MM"
+  e.g. "2026-04-15 09:00-10:00" or "2026-04-15 23:00-01:00" (cross-midnight)
+"""
+
+import json
+
+from algorithms.time_slots import (
+    SLOT_INCREMENT_MINUTES,
+    _time_to_minutes,
+    _voter_available_at,
+    _window_effective_end,
+)
+from algorithms.ranked_choice import calculate_ranked_choice_winner
+
+
+def _minutes_to_time(minutes: int) -> str:
+    h = (minutes // 60) % 24
+    m = minutes % 60
+    return f"{h:02d}:{m:02d}"
+
+
+def parse_slot_key(slot_str: str) -> tuple[str, int, int]:
+    """Parse "YYYY-MM-DD HH:MM-HH:MM" → (date, start_minutes, end_minutes).
+
+    For cross-midnight slots end_minutes < start_minutes.
+    """
+    date, time_range = slot_str.split(" ")
+    start_str, end_str = time_range.split("-")
+    return date, _time_to_minutes(start_str), _time_to_minutes(end_str)
+
+
+def generate_time_poll_slots(poll: dict, votes: list[dict]) -> list[str]:
+    """Generate all candidate time slot strings for a time poll.
+
+    Generates slots from the creator's day_time_windows + duration_window at
+    15-minute increments. Only includes slots where at least one availability
+    voter is present (if any voters have submitted availability; otherwise
+    includes all possible slots).
+
+    Returns list of slot key strings sorted by:
+      1. Largest duration (desc)
+      2. Earliest date + start time (asc)
+    """
+    day_time_windows = poll.get("day_time_windows") or []
+    if isinstance(day_time_windows, str):
+        day_time_windows = json.loads(day_time_windows)
+    if not day_time_windows:
+        return []
+
+    duration_window = poll.get("duration_window")
+    if isinstance(duration_window, str):
+        duration_window = json.loads(duration_window)
+
+    # Determine duration range (in minutes)
+    min_dur = SLOT_INCREMENT_MINUTES
+    max_dur = 24 * 60
+
+    if duration_window:
+        if duration_window.get("minEnabled") and duration_window.get("minValue") is not None:
+            min_dur = max(SLOT_INCREMENT_MINUTES, int(duration_window["minValue"] * 60))
+        if duration_window.get("maxEnabled") and duration_window.get("maxValue") is not None:
+            max_dur = int(duration_window["maxValue"] * 60)
+
+    avail_votes = [v for v in votes if v.get("voter_day_time_windows")]
+
+    seen: set[tuple] = set()
+    slots: list[tuple[str, int, int, int]] = []  # (date, start_min, end_min_normalized, dur_min)
+
+    for dtw in day_time_windows:
+        date = dtw["day"]
+        windows = dtw.get("windows") or []
+        if not windows:
+            windows = [{"min": "00:00", "max": "23:59"}]
+
+        for window in windows:
+            w_start = _time_to_minutes(window["min"])
+            w_end = _time_to_minutes(window["max"])
+            eff_end = _window_effective_end(w_start, w_end)
+
+            dur = min_dur
+            while dur <= max_dur:
+                start = w_start
+                while start + dur <= eff_end:
+                    end_abs = start + dur  # may exceed 1440 for cross-midnight
+                    end_norm = end_abs % 1440
+
+                    key = (date, start, end_norm, dur)
+                    if key not in seen:
+                        # Check if at least one voter is available (skip if none have submitted)
+                        if avail_votes:
+                            available = any(
+                                _voter_available_at(
+                                    v["voter_day_time_windows"], date, start, end_abs
+                                )
+                                for v in avail_votes
+                            )
+                            if not available:
+                                start += SLOT_INCREMENT_MINUTES
+                                continue
+
+                        seen.add(key)
+                        slots.append((date, start, end_norm, dur))
+
+                    start += SLOT_INCREMENT_MINUTES
+                dur += SLOT_INCREMENT_MINUTES
+
+    # Sort: largest duration desc, then earliest date+start asc
+    slots.sort(key=lambda s: (-s[3], s[0], s[1]))
+
+    return [
+        f"{date} {_minutes_to_time(start)}-{_minutes_to_time(end)}"
+        for date, start, end, _ in slots
+    ]
+
+
+def compute_slot_availability(options: list[str], votes: list[dict]) -> dict[str, int]:
+    """Count how many availability voters cover each time slot.
+
+    Returns dict mapping slot_key → voter count.
+    """
+    avail_votes = [v for v in votes if v.get("voter_day_time_windows")]
+    counts: dict[str, int] = {}
+
+    for slot_str in options:
+        date, start_min, end_min = parse_slot_key(slot_str)
+        # Reconstruct absolute end for cross-midnight slots
+        eff_end = end_min if end_min > start_min else end_min + 24 * 60
+        count = sum(
+            1
+            for v in avail_votes
+            if _voter_available_at(v["voter_day_time_windows"], date, start_min, eff_end)
+        )
+        counts[slot_str] = count
+
+    return counts
+
+
+def calculate_time_poll_results(poll: dict, votes: list[dict]) -> dict:
+    """Calculate results for a time poll.
+
+    Steps:
+    1. Compute slot availability counts from availability votes.
+    2. Find max_availability across all slots.
+    3. Filter to slots with count >= max * (1 - threshold/100).
+    4. Filter preference ballots to only included slots (preserving order).
+    5. Run IRV on filtered ballots.
+
+    Returns dict with:
+        availability_counts: {slot_key: count}
+        max_availability: int
+        included_slots: [slot_key, ...]
+        winner: slot_key | None
+        ranked_choice_rounds: [{round_number, option_name, vote_count, ...}, ...]
+    """
+    raw_options = poll.get("options")
+    if raw_options is None:
+        return {
+            "availability_counts": {},
+            "max_availability": 0,
+            "included_slots": [],
+            "winner": None,
+            "ranked_choice_rounds": [],
+        }
+
+    options: list[str] = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
+    if not options:
+        return {
+            "availability_counts": {},
+            "max_availability": 0,
+            "included_slots": [],
+            "winner": None,
+            "ranked_choice_rounds": [],
+        }
+
+    threshold_pct = (poll.get("availability_threshold") or 5) / 100.0
+
+    availability_counts = compute_slot_availability(options, votes)
+    max_avail = max(availability_counts.values(), default=0)
+    min_acceptable = max_avail * (1 - threshold_pct)
+
+    # Slots ordered as in poll.options (largest duration first, then earliest)
+    included_slots = [s for s in options if availability_counts.get(s, 0) >= min_acceptable]
+
+    winner = None
+    rc_rounds: list[dict] = []
+
+    pref_votes = [v for v in votes if v.get("ranked_choices")]
+
+    if pref_votes and included_slots:
+        if len(included_slots) == 1:
+            winner = included_slots[0]
+        else:
+            included_set = set(included_slots)
+            # Pre-filter ballots to only included slots
+            filtered_votes = []
+            for v in pref_votes:
+                filtered = [s for s in (v.get("ranked_choices") or []) if s in included_set]
+                if filtered:
+                    filtered_votes.append({**dict(v), "ranked_choices": filtered})
+
+            if filtered_votes:
+                result = calculate_ranked_choice_winner(filtered_votes, included_slots)
+                winner = result.winner
+                for round_idx, round_entries in enumerate(result.rounds):
+                    for entry in round_entries:
+                        rc_rounds.append({
+                            "round_number": round_idx + 1,
+                            "option_name": entry.option_name,
+                            "vote_count": entry.vote_count,
+                            "is_eliminated": entry.is_eliminated,
+                            "borda_score": entry.borda_score,
+                            "tie_broken_by_borda": entry.tie_broken_by_borda,
+                        })
+
+    return {
+        "availability_counts": availability_counts,
+        "max_availability": max_avail,
+        "included_slots": included_slots,
+        "winner": winner,
+        "ranked_choice_rounds": rc_rounds,
+    }

--- a/server/algorithms/vote_validation.py
+++ b/server/algorithms/vote_validation.py
@@ -51,6 +51,8 @@ def validate_vote(
             yes_no_choice, ranked_choices, suggestions, is_abstain,
             is_ranking_abstain, has_suggestion_phase,
         )
+    elif poll_type == "time":
+        _validate_time_vote(yes_no_choice, ranked_choices, suggestions, is_abstain)
     else:
         raise VoteValidationError(f"Unknown poll type: {poll_type}")
 
@@ -121,3 +123,20 @@ def _validate_ranked_choice_vote(
         raise VoteValidationError(
             "ranked_choices or suggestions is required for ranked choice polls"
         )
+
+
+def _validate_time_vote(
+    yes_no_choice: str | None,
+    ranked_choices: list[str] | None,
+    suggestions: list[str] | None,
+    is_abstain: bool,
+) -> None:
+    if yes_no_choice:
+        raise VoteValidationError("yes_no_choice not allowed for time polls")
+    if suggestions:
+        raise VoteValidationError("suggestions not allowed for time polls")
+    if is_abstain:
+        return
+    # Must provide voter_day_time_windows (checked in router) or ranked_choices
+    # The DB constraint enforces the structure; here we just verify logical consistency.
+    # ranked_choices may be present (preferences phase) or absent (availability-only submission)

--- a/server/models.py
+++ b/server/models.py
@@ -84,6 +84,9 @@ class SubmitVoteRequest(BaseModel):
     voter_duration: dict | None = None
     # Metadata for suggested options (merged into poll's options_metadata)
     options_metadata: dict | None = None
+    # Time poll preference reactions
+    liked_slots: list[str] | None = None
+    disliked_slots: list[str] | None = None
 
 
 class EditVoteRequest(BaseModel):
@@ -97,6 +100,9 @@ class EditVoteRequest(BaseModel):
     max_participants: int | None = None
     voter_day_time_windows: list[dict] | None = None
     voter_duration: dict | None = None
+    # Time poll preference reactions
+    liked_slots: list[str] | None = None
+    disliked_slots: list[str] | None = None
 
 
 class ClosePollRequest(BaseModel):
@@ -197,6 +203,8 @@ class VoteResponse(BaseModel):
     max_participants: int | None = None
     voter_day_time_windows: list[dict] | None = None
     voter_duration: dict | None = None
+    liked_slots: list[str] | None = None
+    disliked_slots: list[str] | None = None
     created_at: str
     updated_at: str
 
@@ -244,7 +252,9 @@ class PollResultsResponse(BaseModel):
     # Time poll fields
     availability_counts: dict | None = None  # {slot_key: voter_count}
     max_availability: int | None = None
-    included_slots: list[str] | None = None  # slots passing availability threshold
+    included_slots: list[str] | None = None  # slots passing availability threshold (kept for compat)
+    like_counts: dict | None = None   # {slot_key: like_count}
+    dislike_counts: dict | None = None  # {slot_key: dislike_count}
 
 
 class ParticipantResponse(BaseModel):

--- a/server/models.py
+++ b/server/models.py
@@ -244,6 +244,7 @@ class PollResultsResponse(BaseModel):
     # Time poll fields
     availability_counts: dict | None = None  # {slot_key: voter_count}
     max_availability: int | None = None
+    included_slots: list[str] | None = None  # slots passing availability threshold
 
 
 class ParticipantResponse(BaseModel):

--- a/server/models.py
+++ b/server/models.py
@@ -10,6 +10,7 @@ class PollType(str, Enum):
     yes_no = "yes_no"
     ranked_choice = "ranked_choice"
     participation = "participation"
+    time = "time"
 
 
 class CloseReason(str, Enum):
@@ -65,6 +66,8 @@ class CreatePollRequest(BaseModel):
     min_responses: int | None = None
     # Whether to show preliminary results once min_responses is met
     show_preliminary_results: bool = True
+    # Availability threshold % for time polls (slots within X% of max availability are included)
+    availability_threshold: int = 5
 
 
 class SubmitVoteRequest(BaseModel):
@@ -176,6 +179,7 @@ class PollResponse(BaseModel):
     min_responses: int | None = None
     show_preliminary_results: bool = True
     response_count: int | None = None
+    availability_threshold: int | None = None
     results: "PollResultsResponse | None" = None
 
 
@@ -237,6 +241,9 @@ class PollResultsResponse(BaseModel):
     time_slot_rounds: list[TimeSlotResponse] | None = None
     participating_vote_ids: list[str] | None = None
     participating_voter_names: list[str] | None = None
+    # Time poll fields
+    availability_counts: dict | None = None  # {slot_key: voter_count}
+    max_availability: int | None = None
 
 
 class ParticipantResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -242,6 +242,8 @@ def _row_to_vote(row: dict) -> VoteResponse:
         max_participants=row.get("max_participants"),
         voter_day_time_windows=row.get("voter_day_time_windows"),
         voter_duration=row.get("voter_duration"),
+        liked_slots=row.get("liked_slots"),
+        disliked_slots=row.get("disliked_slots"),
         created_at=row["created_at"].isoformat() if isinstance(row["created_at"], datetime) else str(row["created_at"]),
         updated_at=row["updated_at"].isoformat() if isinstance(row["updated_at"], datetime) else str(row["updated_at"]),
     )
@@ -715,11 +717,13 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
                                suggestions, is_abstain, is_ranking_abstain, voter_name,
                                min_participants, max_participants,
                                voter_day_time_windows, voter_duration,
+                               liked_slots, disliked_slots,
                                created_at, updated_at)
             VALUES (%(poll_id)s, %(vote_type)s, %(yes_no_choice)s, %(ranked_choices)s,
                     %(suggestions)s, %(is_abstain)s, %(is_ranking_abstain)s, %(voter_name)s,
                     %(min_participants)s, %(max_participants)s,
                     %(voter_day_time_windows)s::jsonb, %(voter_duration)s::jsonb,
+                    %(liked_slots)s::jsonb, %(disliked_slots)s::jsonb,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -736,6 +740,8 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
                 "max_participants": req.max_participants,
                 "voter_day_time_windows": json.dumps(req.voter_day_time_windows) if req.voter_day_time_windows else None,
                 "voter_duration": json.dumps(req.voter_duration) if req.voter_duration else None,
+                "liked_slots": json.dumps(req.liked_slots) if req.liked_slots is not None else None,
+                "disliked_slots": json.dumps(req.disliked_slots) if req.disliked_slots is not None else None,
                 "now": now,
             },
         ).fetchone()
@@ -856,6 +862,8 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
                 max_participants = %(max_participants)s,
                 voter_day_time_windows = %(voter_day_time_windows)s::jsonb,
                 voter_duration = %(voter_duration)s::jsonb,
+                liked_slots = COALESCE(%(liked_slots)s::jsonb, liked_slots),
+                disliked_slots = COALESCE(%(disliked_slots)s::jsonb, disliked_slots),
                 updated_at = %(now)s
             WHERE id = %(vote_id)s AND poll_id = %(poll_id)s
             RETURNING *
@@ -871,6 +879,8 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
                 "max_participants": req.max_participants,
                 "voter_day_time_windows": json.dumps(req.voter_day_time_windows) if req.voter_day_time_windows else None,
                 "voter_duration": json.dumps(req.voter_duration) if req.voter_duration else None,
+                "liked_slots": json.dumps(req.liked_slots) if req.liked_slots is not None else None,
+                "disliked_slots": json.dumps(req.disliked_slots) if req.disliked_slots is not None else None,
                 "now": now,
                 "vote_id": vote_id,
                 "poll_id": poll_id,
@@ -1123,18 +1133,6 @@ def _compute_results(poll, votes) -> PollResultsResponse:
         vote_dicts = [dict(v) for v in votes]
         time_result = calculate_time_poll_results(dict(poll), vote_dicts)
 
-        rc_rounds = [
-            RankedChoiceRoundResponse(
-                round_number=r["round_number"],
-                option_name=r["option_name"],
-                vote_count=r["vote_count"],
-                is_eliminated=r["is_eliminated"],
-                borda_score=r.get("borda_score"),
-                tie_broken_by_borda=r.get("tie_broken_by_borda", False),
-            )
-            for r in time_result["ranked_choice_rounds"]
-        ]
-
         return PollResultsResponse(
             poll_id=str(poll["id"]),
             title=poll["title"],
@@ -1144,11 +1142,10 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             options=poll_options,
             total_votes=len(votes),
             winner=time_result["winner"],
-            ranked_choice_winner=time_result["winner"],
-            ranked_choice_rounds=rc_rounds if rc_rounds else None,
             availability_counts=time_result["availability_counts"],
             max_availability=time_result["max_availability"],
-            included_slots=time_result["included_slots"],
+            like_counts=time_result["like_counts"],
+            dislike_counts=time_result["dislike_counts"],
         )
 
     # For other poll types, return basic structure (to be extended in later phases)

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1133,6 +1133,7 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             ranked_choice_rounds=rc_rounds if rc_rounds else None,
             availability_counts=time_result["availability_counts"],
             max_availability=time_result["max_availability"],
+            included_slots=time_result["included_slots"],
         )
 
     # For other poll types, return basic structure (to be extended in later phases)

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -122,6 +122,41 @@ def _finalize_suggestion_options(conn, poll_id: str, now: datetime) -> None:
         )
 
 
+def _finalize_time_slots(conn, poll_id: str, now: datetime) -> None:
+    """Finalize time slots for a time poll after its availability deadline passes.
+
+    Generates all candidate time slots from the poll's day_time_windows + duration_window,
+    filtered to slots where at least one voter has submitted availability.
+    Stores the result in poll.options.
+    """
+    import json
+    from algorithms.time_poll import generate_time_poll_slots
+
+    poll = conn.execute(
+        "SELECT * FROM polls WHERE id = %(poll_id)s",
+        {"poll_id": poll_id},
+    ).fetchone()
+    if not poll or poll.get("options"):
+        return  # Already finalized or missing
+
+    votes = conn.execute(
+        "SELECT voter_day_time_windows, voter_duration FROM votes WHERE poll_id = %(poll_id)s",
+        {"poll_id": poll_id},
+    ).fetchall()
+
+    slots = generate_time_poll_slots(dict(poll), [dict(v) for v in votes])
+
+    if slots:
+        conn.execute(
+            """UPDATE polls SET options = %(options)s::jsonb, updated_at = %(now)s
+               WHERE id = %(poll_id)s""",
+            {
+                "options": json.dumps(slots),
+                "now": now,
+                "poll_id": poll_id,
+            },
+        )
+
 
 def _row_to_poll(row: dict) -> PollResponse:
     """Convert a database row to a PollResponse."""
@@ -172,6 +207,7 @@ def _row_to_poll(row: dict) -> PollResponse:
         is_auto_title=row.get("is_auto_title", False),
         min_responses=row.get("min_responses"),
         show_preliminary_results=row.get("show_preliminary_results", True),
+        availability_threshold=row.get("availability_threshold"),
     )
 
 
@@ -395,6 +431,7 @@ def create_poll(req: CreatePollRequest):
                                reference_location_label,
                                is_auto_title,
                                min_responses, show_preliminary_results,
+                               availability_threshold,
                                created_at, updated_at)
             VALUES (%(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
                     %(creator_secret)s, %(creator_name)s, %(follow_up_to)s,
@@ -415,6 +452,7 @@ def create_poll(req: CreatePollRequest):
                     %(reference_location_label)s,
                     %(is_auto_title)s,
                     %(min_responses)s, %(show_preliminary_results)s,
+                    %(availability_threshold)s,
                     %(now)s, %(now)s)
             RETURNING *
             """,
@@ -457,6 +495,7 @@ def create_poll(req: CreatePollRequest):
                 "is_auto_title": req.is_auto_title,
                 "min_responses": req.min_responses,
                 "show_preliminary_results": req.show_preliminary_results,
+                "availability_threshold": req.availability_threshold if req.poll_type == PollType.time else None,
                 "now": now,
             },
         ).fetchone()
@@ -589,11 +628,16 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
         if poll["is_closed"]:
             raise HTTPException(status_code=400, detail="Poll is closed")
 
-        # Deferred suggestion deadline: start timer on first suggestion
+        # Deferred suggestion/availability deadline: start timer on first submission
+        # For ranked_choice polls: triggered by first suggestion
+        # For time polls: triggered by first availability entry (voter_day_time_windows)
         has_deferred_deadline = (
             poll.get("suggestion_deadline_minutes")
             and not poll.get("suggestion_deadline")
-            and req.suggestions
+            and (
+                req.suggestions
+                or (poll["poll_type"] == "time" and req.voter_day_time_windows)
+            )
         )
         if has_deferred_deadline:
             new_deadline = now + timedelta(minutes=poll["suggestion_deadline_minutes"])
@@ -624,8 +668,13 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
             if not in_suggestion_phase and req.suggestions:
                 raise HTTPException(status_code=400, detail="Suggestions cutoff has passed")
 
-            # Reject rankings before cutoff if pre-ranking is disabled
-            if in_suggestion_phase and req.ranked_choices:
+            # For time polls: reject ranked_choices while still in availability phase
+            # (slots aren't finalized yet, so rankings can't be submitted)
+            if poll["poll_type"] == "time" and in_suggestion_phase and req.ranked_choices:
+                raise HTTPException(status_code=400, detail="Rankings not allowed until availability phase has closed")
+
+            # Reject rankings before cutoff if pre-ranking is disabled (ranked_choice polls)
+            if poll["poll_type"] != "time" and in_suggestion_phase and req.ranked_choices:
                 if not poll["allow_pre_ranking"]:
                     raise HTTPException(status_code=400, detail="Rankings not allowed until suggestions cutoff")
 
@@ -744,8 +793,12 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
             if not in_suggestion_phase and req.suggestions:
                 raise HTTPException(status_code=400, detail="Suggestions cutoff has passed")
 
-            # Reject rankings before cutoff if pre-ranking is disabled
-            if in_suggestion_phase and req.ranked_choices and not poll["allow_pre_ranking"]:
+            # For time polls: reject ranked_choices while still in availability phase
+            if poll["poll_type"] == "time" and in_suggestion_phase and req.ranked_choices:
+                raise HTTPException(status_code=400, detail="Rankings not allowed until availability phase has closed")
+
+            # Reject rankings before cutoff if pre-ranking is disabled (ranked_choice polls)
+            if poll["poll_type"] != "time" and in_suggestion_phase and req.ranked_choices and not poll["allow_pre_ranking"]:
                 raise HTTPException(status_code=400, detail="Rankings not allowed until suggestions cutoff")
 
             # Prevent unsuggesting options that others have ranked
@@ -838,6 +891,19 @@ def get_results(poll_id: str):
         ):
             _finalize_suggestion_options(conn, poll_id, now)
             # Re-read poll to get updated options
+            poll = conn.execute(
+                "SELECT * FROM polls WHERE id = %(poll_id)s",
+                {"poll_id": poll_id},
+            ).fetchone()
+
+        # For time polls: finalize time slot options when availability deadline passes
+        if (
+            poll["poll_type"] == "time"
+            and poll.get("suggestion_deadline")
+            and poll["suggestion_deadline"] <= now
+            and not poll.get("options")  # Not yet finalized
+        ):
+            _finalize_time_slots(conn, poll_id, now)
             poll = conn.execute(
                 "SELECT * FROM polls WHERE id = %(poll_id)s",
                 {"poll_id": poll_id},
@@ -1030,6 +1096,45 @@ def _compute_results(poll, votes) -> PollResultsResponse:
             participating_voter_names=[p.voter_name for p in participating if p.voter_name],
         )
 
+    if poll_type == "time":
+        import json
+        from algorithms.time_poll import calculate_time_poll_results
+
+        raw_options = poll.get("options")
+        poll_options = None
+        if raw_options:
+            poll_options = json.loads(raw_options) if isinstance(raw_options, str) else raw_options
+
+        vote_dicts = [dict(v) for v in votes]
+        time_result = calculate_time_poll_results(dict(poll), vote_dicts)
+
+        rc_rounds = [
+            RankedChoiceRoundResponse(
+                round_number=r["round_number"],
+                option_name=r["option_name"],
+                vote_count=r["vote_count"],
+                is_eliminated=r["is_eliminated"],
+                borda_score=r.get("borda_score"),
+                tie_broken_by_borda=r.get("tie_broken_by_borda", False),
+            )
+            for r in time_result["ranked_choice_rounds"]
+        ]
+
+        return PollResultsResponse(
+            poll_id=str(poll["id"]),
+            title=poll["title"],
+            poll_type=poll_type,
+            created_at=poll["created_at"].isoformat() if isinstance(poll["created_at"], datetime) else str(poll["created_at"]),
+            response_deadline=poll["response_deadline"].isoformat() if poll.get("response_deadline") else None,
+            options=poll_options,
+            total_votes=len(votes),
+            winner=time_result["winner"],
+            ranked_choice_winner=time_result["winner"],
+            ranked_choice_rounds=rc_rounds if rc_rounds else None,
+            availability_counts=time_result["availability_counts"],
+            max_availability=time_result["max_availability"],
+        )
+
     # For other poll types, return basic structure (to be extended in later phases)
     return PollResultsResponse(
         poll_id=str(poll["id"]),
@@ -1168,6 +1273,51 @@ def cutoff_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
 
         _finalize_suggestion_options(conn, poll_id, now)
 
+    return _row_to_poll(row)
+
+
+@router.post("/{poll_id}/cutoff-availability", response_model=PollResponse)
+def cutoff_availability(poll_id: str, req: CutoffSuggestionsRequest):
+    """End the availability phase of a time poll immediately. Requires creator_secret."""
+    now = datetime.now(timezone.utc)
+    with get_db() as conn:
+        # Verify it's a time poll and availability phase hasn't ended
+        row = conn.execute(
+            """
+            UPDATE polls
+            SET suggestion_deadline = %(now)s,
+                updated_at = %(now)s
+            WHERE id = %(poll_id)s
+              AND poll_type = 'time'
+              AND creator_secret = %(creator_secret)s
+              AND (
+                (suggestion_deadline IS NOT NULL AND suggestion_deadline > %(now)s)
+                OR (suggestion_deadline IS NULL AND suggestion_deadline_minutes IS NOT NULL)
+              )
+              AND EXISTS (
+                SELECT 1 FROM votes
+                WHERE poll_id = %(poll_id)s
+                  AND voter_day_time_windows IS NOT NULL
+              )
+            RETURNING *
+            """,
+            {
+                "poll_id": poll_id,
+                "creator_secret": req.creator_secret,
+                "now": now,
+            },
+        ).fetchone()
+        if not row:
+            raise HTTPException(
+                status_code=400,
+                detail="No availability entries to cutoff, invalid creator secret, or availability phase already ended"
+            )
+
+        _finalize_time_slots(conn, poll_id, now)
+
+    # Re-read to get updated options
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM polls WHERE id = %(poll_id)s", {"poll_id": poll_id}).fetchone()
     return _row_to_poll(row)
 
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -126,11 +126,15 @@ def _finalize_time_slots(conn, poll_id: str, now: datetime) -> None:
     """Finalize time slots for a time poll after its availability deadline passes.
 
     Generates all candidate time slots from the poll's day_time_windows + duration_window,
-    filtered to slots where at least one voter has submitted availability.
-    Stores the result in poll.options.
+    then applies the availability threshold filter and longest-per-start-time dedup so
+    poll.options contains only the slots voters will actually rank.
     """
     import json
-    from algorithms.time_poll import generate_time_poll_slots
+    from algorithms.time_poll import (
+        generate_time_poll_slots,
+        compute_slot_availability,
+        _keep_longest_per_start_time,
+    )
 
     poll = conn.execute(
         "SELECT * FROM polls WHERE id = %(poll_id)s",
@@ -143,8 +147,19 @@ def _finalize_time_slots(conn, poll_id: str, now: datetime) -> None:
         "SELECT voter_day_time_windows, voter_duration FROM votes WHERE poll_id = %(poll_id)s",
         {"poll_id": poll_id},
     ).fetchall()
+    votes_list = [dict(v) for v in votes]
 
-    slots = generate_time_poll_slots(dict(poll), [dict(v) for v in votes])
+    all_slots = generate_time_poll_slots(dict(poll), votes_list)
+
+    # Apply availability threshold filter
+    threshold_pct = (poll.get("availability_threshold") or 5) / 100.0
+    availability_counts = compute_slot_availability(all_slots, votes_list)
+    max_avail = max(availability_counts.values(), default=0)
+    min_acceptable = max_avail * (1 - threshold_pct)
+    slots = [s for s in all_slots if availability_counts.get(s, 0) >= min_acceptable]
+
+    # Keep only the longest-duration slot per start time
+    slots = _keep_longest_per_start_time(slots)
 
     if slots:
         conn.execute(


### PR DESCRIPTION
## Summary
- **New poll type**: time/scheduling polls with two phases — availability (voters submit day/time windows) and preferences (voters tap bubble grid to like/dislike generated slots)
- **Bubble UI**: compact day-row grid in `TimeSlotBubbles` component; tapping cycles neutral → liked (green) → disliked (red); orange badge shows excluded voters per slot
- **Winner algorithm**: fewest dislikes → most likes → earliest chronologically
- **Slot finalization**: threshold filtering + dedup baked into `poll.options` at availability cutoff time (not at results time)
- **Category integration**: selecting "📅 Time" from the category dropdown in the creation form injects scheduling fields inline (no form switch)
- **ChunkLoadError fix**: auto-reload on stale cached chunks after new builds; service worker updated to use network-first for JS chunks
- DB migrations 086–088: `is_ranking_abstain`, time poll type, `liked_slots`/`disliked_slots` vote columns

## Test plan
- [ ] Create a scheduling poll via the category dropdown (select "Time")
- [ ] Submit availability votes from multiple users
- [ ] Cut off availability phase and verify slots are finalized in `poll.options`
- [ ] Enter preferences phase: tap bubbles to like/dislike slots, verify green/red states
- [ ] Verify winner picks fewest-disliked, most-liked, then earliest
- [ ] Hard-refresh after a new deploy to confirm ChunkLoadError auto-reload works

https://claude.ai/code/session_015gX7GPUPeCZ3t4XCVtWsBG