### PR TITLE
Time poll autotitle + Minimum Participation field rework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1056,6 +1056,12 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Poll data snapshots (fork/duplicate/follow-up)** are passed between pages via localStorage. When adding new poll fields, update `buildPollSnapshot()` in `lib/pollCreator.ts` — it's used by `FollowUpModal.tsx`, `DuplicateButton.tsx`, and `ForkButton.tsx`.
 - **PWA clients cache old JS bundles** — snapshot structure changes (new fields in `buildPollSnapshot`) won't take effect until users get new JS. Always add backward-compatible detection in the consumer (create-poll page) rather than relying solely on snapshot fields. The `is_auto_title` detection uses a ref-based comparison against `generateTitle()` output to handle old snapshots that lack the field.
 
+### Edit-in-Modal Pattern for Form Fields
+
+- **Extract edit modals to their own component with local draft state.** When a form field opens a modal for editing (e.g., a range slider), keep the draft value as local state inside the modal component, and only propagate to the parent via `onSave`. This isolates high-frequency updates (slider drags at 60Hz, number input keystrokes) from the parent form, which may have dozens of other `useState` hooks. An inline modal with draft state in the parent component will re-render the entire form on every slider tick.
+- **Sync the draft to the committed value via `useEffect([isOpen, value])`.** When the modal opens, reset the draft to match the current committed value. Don't rely on mounting alone — if the modal component stays mounted across open/close cycles, the draft state becomes stale.
+- **Don't duplicate `document.body.style.overflow = 'hidden'`** when opening a modal inside the create-poll modal. The parent sheet already locks body scroll via `position: fixed`, and stacking another `overflow: hidden` can clobber the restored state when only one of them unmounts.
+
 ### Drag-to-Reorder & Tap-to-Move (RankableOptions)
 
 - **Delay drag start until pointer moves >8px.** On `pointerdown`, save intent in a ref (`pendingDragRef`) but don't call `startDrag`. On `pointermove`, if threshold exceeded, start the actual drag. On `pointerup`, if drag never started, it's a tap. This avoids React's async state update issue: `pointerup` fires before `isDragging` state is processed, leaving drag state stuck.

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -2012,11 +2012,9 @@ export function CreatePollContent() {
         )}
 
       {showMinParticipationModal && (() => {
-        const parsed = parseInt(minParticipationInput, 10);
-        const isValid = !isNaN(parsed) && parsed >= 50 && parsed <= 100;
+        const current = parseInt(minParticipationInput, 10);
         const save = () => {
-          if (!isValid) return;
-          setMinimumParticipation(parsed);
+          setMinimumParticipation(current);
           setShowMinParticipationModal(false);
         };
         return (
@@ -2028,33 +2026,27 @@ export function CreatePollContent() {
               <div className="absolute inset-0 bg-black/50 dark:bg-black/70" />
               <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-sm w-full p-5">
                 <h3 className="text-base font-semibold mb-2 text-gray-900 dark:text-white">
-                  Minimum Participation
+                  Minimum Participation:{' '}
+                  <span className="font-normal text-blue-600 dark:text-blue-400">
+                    {current}%
+                  </span>
                 </h3>
                 <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
-                  Include time slots where at least this percentage of the maximum responders are available. Enter a value between 50 and 100.
+                  Include time slots where at least this percentage of the maximum responders are available.
                 </p>
-                <div className="flex items-center gap-2 mb-4">
-                  <input
-                    type="number"
-                    min={50}
-                    max={100}
-                    step={1}
-                    value={minParticipationInput}
-                    onChange={(e) => setMinParticipationInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') save();
-                      else if (e.key === 'Escape') setShowMinParticipationModal(false);
-                    }}
-                    autoFocus
-                    className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-900 dark:text-white text-base"
-                  />
-                  <span className="text-base text-gray-700 dark:text-gray-300">%</span>
+                <input
+                  type="range"
+                  min={50}
+                  max={100}
+                  step={1}
+                  value={current}
+                  onChange={(e) => setMinParticipationInput(e.target.value)}
+                  className="w-full accent-blue-500"
+                />
+                <div className="flex justify-between text-xs text-gray-400 mt-0.5 mb-4">
+                  <span>50%</span>
+                  <span>100% (max only)</span>
                 </div>
-                {!isValid && minParticipationInput !== '' && (
-                  <p className="text-xs text-red-500 dark:text-red-400 mb-2">
-                    Must be a whole number between 50 and 100.
-                  </p>
-                )}
                 <div className="flex justify-end gap-2">
                   <button
                     type="button"
@@ -2066,8 +2058,7 @@ export function CreatePollContent() {
                   <button
                     type="button"
                     onClick={save}
-                    disabled={!isValid}
-                    className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+                    className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium"
                   >
                     Save
                   </button>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -21,6 +21,7 @@ import CompactMinResponsesField from "@/components/CompactMinResponsesField";
 import { VOTING_CUTOFF_OPTIONS } from "@/components/VotingCutoffConditionsModal";
 import VotingCutoffField from "@/components/VotingCutoffField";
 import MinMaxCounter from "@/components/MinMaxCounter";
+import ModalPortal from "@/components/ModalPortal";
 import ParticipationConditions, { DayTimeWindow } from "@/components/ParticipationConditions";
 import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
 import ReferenceLocationInput from "@/components/ReferenceLocationInput";
@@ -107,7 +108,9 @@ export function CreatePollContent() {
   const [durationMinEnabled, setDurationMinEnabled] = useState(true);
   const [durationMaxEnabled, setDurationMaxEnabled] = useState(true);
   const [dayTimeWindows, setDayTimeWindows] = useState<DayTimeWindow[]>([]);
-  const [availabilityThreshold, setAvailabilityThreshold] = useState<number>(5);
+  const [minimumParticipation, setMinimumParticipation] = useState<number>(95);
+  const [showMinParticipationModal, setShowMinParticipationModal] = useState(false);
+  const [minParticipationInput, setMinParticipationInput] = useState<string>("95");
   const [deadlineOption, setDeadlineOption] = useState("10min");
   const [customDate, setCustomDate] = useState('');
   const [customTime, setCustomTime] = useState('');
@@ -729,7 +732,9 @@ export function CreatePollContent() {
           } else if (forkData.poll_type === 'time') {
             setPollType('time');
             setOptions(['']);
-            if (forkData.availability_threshold != null) setAvailabilityThreshold(forkData.availability_threshold);
+            if (forkData.availability_threshold != null) {
+              setMinimumParticipation(Math.max(50, Math.min(100, 100 - forkData.availability_threshold)));
+            }
           } else {
             // yes_no poll
             setPollType('poll');
@@ -1247,7 +1252,7 @@ export function CreatePollContent() {
             maxEnabled: durationMaxEnabled
           };
         }
-        pollData.availability_threshold = availabilityThreshold;
+        pollData.availability_threshold = 100 - minimumParticipation;
         // Availability phase uses suggestion_deadline_minutes (deferred until first submission)
         const cutoffMinutes = getSuggestionCutoffMinutes();
         pollData.suggestion_deadline_minutes = cutoffMinutes != null ? Math.round(cutoffMinutes) : 120;
@@ -1551,31 +1556,22 @@ export function CreatePollContent() {
                 isCreationForm={true}
               />
 
-              {/* Availability Threshold */}
+              {/* Minimum Participation */}
               <div>
                 <label className="block text-sm font-medium">
-                  Availability Threshold:{' '}
-                  <span className="font-normal text-blue-600 dark:text-blue-400">
-                    {availabilityThreshold}%
-                  </span>
+                  <span>Minimum Participation: </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMinParticipationInput(String(minimumParticipation));
+                      setShowMinParticipationModal(true);
+                    }}
+                    disabled={isLoading}
+                    className="font-normal text-blue-600 dark:text-blue-400 disabled:opacity-50 cursor-pointer"
+                  >
+                    {minimumParticipation}%
+                  </button>
                 </label>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-1.5">
-                  Include time slots where at least this percentage of the maximum responders are available.
-                </p>
-                <input
-                  type="range"
-                  min={0}
-                  max={50}
-                  step={1}
-                  value={availabilityThreshold}
-                  onChange={(e) => setAvailabilityThreshold(Number(e.target.value))}
-                  disabled={isLoading}
-                  className="w-full accent-blue-500 disabled:opacity-50"
-                />
-                <div className="flex justify-between text-xs text-gray-400 mt-0.5">
-                  <span>0% (max only)</span>
-                  <span>50%</span>
-                </div>
               </div>
 
               {/* Availability Phase Deadline */}
@@ -2014,7 +2010,74 @@ export function CreatePollContent() {
             Private until you share the link
           </p>
         )}
-      
+
+      {showMinParticipationModal && (() => {
+        const parsed = parseInt(minParticipationInput, 10);
+        const isValid = !isNaN(parsed) && parsed >= 50 && parsed <= 100;
+        const save = () => {
+          if (!isValid) return;
+          setMinimumParticipation(parsed);
+          setShowMinParticipationModal(false);
+        };
+        return (
+          <ModalPortal>
+            <div
+              className="fixed inset-0 z-[70] flex items-center justify-center p-4"
+              onClick={(e) => { if (e.target === e.currentTarget) setShowMinParticipationModal(false); }}
+            >
+              <div className="absolute inset-0 bg-black/50 dark:bg-black/70" />
+              <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-sm w-full p-5">
+                <h3 className="text-base font-semibold mb-2 text-gray-900 dark:text-white">
+                  Minimum Participation
+                </h3>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                  Include time slots where at least this percentage of the maximum responders are available. Enter a value between 50 and 100.
+                </p>
+                <div className="flex items-center gap-2 mb-4">
+                  <input
+                    type="number"
+                    min={50}
+                    max={100}
+                    step={1}
+                    value={minParticipationInput}
+                    onChange={(e) => setMinParticipationInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') save();
+                      else if (e.key === 'Escape') setShowMinParticipationModal(false);
+                    }}
+                    autoFocus
+                    className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-900 dark:text-white text-base"
+                  />
+                  <span className="text-base text-gray-700 dark:text-gray-300">%</span>
+                </div>
+                {!isValid && minParticipationInput !== '' && (
+                  <p className="text-xs text-red-500 dark:text-red-400 mb-2">
+                    Must be a whole number between 50 and 100.
+                  </p>
+                )}
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowMinParticipationModal(false)}
+                    className="px-4 py-2 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 font-medium"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={save}
+                    disabled={!isValid}
+                    className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+          </ModalPortal>
+        );
+      })()}
+
     </div>
   );
 }

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -21,7 +21,7 @@ import CompactMinResponsesField from "@/components/CompactMinResponsesField";
 import { VOTING_CUTOFF_OPTIONS } from "@/components/VotingCutoffConditionsModal";
 import VotingCutoffField from "@/components/VotingCutoffField";
 import MinMaxCounter from "@/components/MinMaxCounter";
-import ModalPortal from "@/components/ModalPortal";
+import MinimumParticipationModal from "@/components/MinimumParticipationModal";
 import ParticipationConditions, { DayTimeWindow } from "@/components/ParticipationConditions";
 import LocationTimeFieldConfig from "@/components/LocationTimeFieldConfig";
 import ReferenceLocationInput from "@/components/ReferenceLocationInput";
@@ -110,7 +110,6 @@ export function CreatePollContent() {
   const [dayTimeWindows, setDayTimeWindows] = useState<DayTimeWindow[]>([]);
   const [minimumParticipation, setMinimumParticipation] = useState<number>(95);
   const [showMinParticipationModal, setShowMinParticipationModal] = useState(false);
-  const [minParticipationInput, setMinParticipationInput] = useState<string>("95");
   const [deadlineOption, setDeadlineOption] = useState("10min");
   const [customDate, setCustomDate] = useState('');
   const [customTime, setCustomTime] = useState('');
@@ -1562,10 +1561,7 @@ export function CreatePollContent() {
                   <span>Minimum Participation: </span>
                   <button
                     type="button"
-                    onClick={() => {
-                      setMinParticipationInput(String(minimumParticipation));
-                      setShowMinParticipationModal(true);
-                    }}
+                    onClick={() => setShowMinParticipationModal(true)}
                     disabled={isLoading}
                     className="font-normal text-blue-600 dark:text-blue-400 disabled:opacity-50 cursor-pointer"
                   >
@@ -2011,63 +2007,12 @@ export function CreatePollContent() {
           </p>
         )}
 
-      {showMinParticipationModal && (() => {
-        const current = parseInt(minParticipationInput, 10);
-        const save = () => {
-          setMinimumParticipation(current);
-          setShowMinParticipationModal(false);
-        };
-        return (
-          <ModalPortal>
-            <div
-              className="fixed inset-0 z-[70] flex items-center justify-center p-4"
-              onClick={(e) => { if (e.target === e.currentTarget) setShowMinParticipationModal(false); }}
-            >
-              <div className="absolute inset-0 bg-black/50 dark:bg-black/70" />
-              <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-sm w-full p-5">
-                <h3 className="text-base font-semibold mb-2 text-gray-900 dark:text-white">
-                  Minimum Participation:{' '}
-                  <span className="font-normal text-blue-600 dark:text-blue-400">
-                    {current}%
-                  </span>
-                </h3>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
-                  Include time slots where at least this percentage of the maximum responders are available.
-                </p>
-                <input
-                  type="range"
-                  min={50}
-                  max={100}
-                  step={1}
-                  value={current}
-                  onChange={(e) => setMinParticipationInput(e.target.value)}
-                  className="w-full accent-blue-500"
-                />
-                <div className="flex justify-between text-xs text-gray-400 mt-0.5 mb-4">
-                  <span>50%</span>
-                  <span>100% (max only)</span>
-                </div>
-                <div className="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setShowMinParticipationModal(false)}
-                    className="px-4 py-2 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 font-medium"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={save}
-                    className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium"
-                  >
-                    Save
-                  </button>
-                </div>
-              </div>
-            </div>
-          </ModalPortal>
-        );
-      })()}
+      <MinimumParticipationModal
+        isOpen={showMinParticipationModal}
+        value={minimumParticipation}
+        onSave={setMinimumParticipation}
+        onClose={() => setShowMinParticipationModal(false)}
+      />
 
     </div>
   );

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -205,7 +205,7 @@ export function CreatePollContent() {
         return '';
       }
       if (category === 'time') {
-        return appendFor("When works?");
+        return appendFor("Time?");
       }
       const shorten = isLocationLikeCategory(category) ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
@@ -234,7 +234,7 @@ export function CreatePollContent() {
     }
 
     // time
-    return "When works?";
+    return appendFor("Time?");
   }, [pollType, category, options, forField, locationMode, locationValue, locationOptions]);
 
   // Focus details textarea when opening

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -433,7 +433,9 @@ function TemplateInner({ children }: AppTemplateProps) {
       ['create', 'followUpTo', 'fork', 'duplicate', 'voteFromSuggestion', 'mode']
         .forEach(p => params.delete(p));
       const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname);
+      const target = qs ? `${pathname}?${qs}` : pathname;
+      console.log('[CLOSE] navigate', { pathname, currentSearch: searchParams.toString(), qs, target });
+      router.replace(target);
     };
   }, [router, pathname, searchParams]);
 

--- a/components/MinimumParticipationModal.tsx
+++ b/components/MinimumParticipationModal.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ModalPortal from "./ModalPortal";
+
+interface MinimumParticipationModalProps {
+  isOpen: boolean;
+  value: number;
+  onSave: (value: number) => void;
+  onClose: () => void;
+}
+
+export default function MinimumParticipationModal({
+  isOpen,
+  value,
+  onSave,
+  onClose,
+}: MinimumParticipationModalProps) {
+  // Local draft state isolates slider drag re-renders from the parent form.
+  const [draft, setDraft] = useState(value);
+
+  useEffect(() => {
+    if (isOpen) setDraft(value);
+  }, [isOpen, value]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalPortal>
+      <div
+        className="fixed inset-0 z-[70] flex items-center justify-center p-4"
+        onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      >
+        <div className="absolute inset-0 bg-black/50 dark:bg-black/70" />
+        <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-sm w-full p-5">
+          <h3 className="text-base font-semibold mb-2 text-gray-900 dark:text-white">
+            Minimum Participation:{' '}
+            <span className="font-normal text-blue-600 dark:text-blue-400">
+              {draft}%
+            </span>
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            Include time slots where at least this percentage of the maximum responders are available.
+          </p>
+          <input
+            type="range"
+            min={50}
+            max={100}
+            step={1}
+            value={draft}
+            onChange={(e) => setDraft(Number(e.target.value))}
+            className="w-full accent-blue-500"
+          />
+          <div className="flex justify-between text-xs text-gray-400 mt-0.5 mb-4">
+            <span>50%</span>
+            <span>100% (max only)</span>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => { onSave(draft); onClose(); }}
+              className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}


### PR DESCRIPTION
## Summary

- **Time poll autotitle** now uses the category label ("Time?") instead of "When works?", matching how other categories generate titles (e.g., "Food?", "Place?").
- **"Availability Threshold" → "Minimum Participation"**: inverted the value (default 95% instead of 5%) so the label reads naturally. The backend field is unchanged — conversion happens at the UI boundary (`availability_threshold = 100 - minimumParticipation`).
- **Compact field with edit-in-modal pattern**: replaced the inline slider with a single-line header showing the percentage as a tappable blue value. Tapping opens a modal with a 50–100 range slider.
- **New `MinimumParticipationModal` component** with local draft state, so slider drags don't re-render the ~50-useState parent form. Adds Escape key handling matching `ConfirmationModal`.
- **CLAUDE.md**: documented the edit-in-modal pattern (extract modals, use local draft state, sync via `useEffect`) for future form fields.

## Test plan

- [ ] Open `/?create=1&mode=time` — title field shows "Time?"
- [ ] Field renders as "Minimum Participation: 95%" (blue, tappable), no inline slider
- [ ] Tapping 95% opens a modal with a slider; dragging updates the header live
- [ ] Cancel → percentage unchanged; Save → percentage updates on the form
- [ ] Escape key closes the modal
- [ ] Create a time poll and verify the stored `availability_threshold` equals `100 - minimumParticipation`
- [ ] Fork a time poll with a non-default threshold; the "Minimum Participation" field loads the inverted value (clamped 50–100)

https://claude.ai/code/session_01WSXJ4ZCBdRLdSdhVqpF6i1