### PR TITLE
Use "Time?" as autotitle for time polls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -940,6 +940,7 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **`formatDayLabel(dateStr)`** is the canonical day-label formatter in `lib/timeUtils.ts`. Use it in all time-related components instead of local copies.
 - **Availability cutoff requires `suggestion_deadline_minutes` to be set** on the poll — the endpoint enforces `suggestion_deadline IS NULL AND suggestion_deadline_minutes IS NOT NULL`. Polls created without this field will fail the cutoff endpoint with 400.
 - **`ChunkLoadError` after new builds**: the browser has stale cached chunks from the previous build. The lazy `CreatePollContent` import and the global `unhandledrejection` handler in `template.tsx` both auto-reload the page when this happens. The service worker uses network-first for JS chunks so new builds take effect immediately.
+- **Autotitle convention**: time polls use `"Time?"` as the autotitle (matching the `BUILT_IN_TYPES` label), not a bespoke prompt like "When works?". Every branch of `generateTitle()` in `app/create-poll/page.tsx` must call `appendFor(...)` on its return value so the "for X" suffix gets appended — the standalone `pollType === 'time'` fallback originally returned a raw string and silently dropped `forSuffix`.
 
 ### Service Worker Caching Strategy
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -205,7 +205,7 @@ export function CreatePollContent() {
         return '';
       }
       if (category === 'time') {
-        return appendFor("When works?");
+        return appendFor("Time?");
       }
       const shorten = isLocationLikeCategory(category) ? shortenLocation : shortenOption;
       const filled = options.filter(o => o.trim()).map(shorten);
@@ -234,7 +234,7 @@ export function CreatePollContent() {
     }
 
     // time
-    return "When works?";
+    return appendFor("Time?");
   }, [pollType, category, options, forField, locationMode, locationValue, locationOptions]);
 
   // Focus details textarea when opening


### PR DESCRIPTION
## Summary
- Replace `"When works?"` with `"Time?"` in `generateTitle()` so time polls follow the same autotitle convention as other built-in categories (Restaurant, Place, etc.), which all use their `BUILT_IN_TYPES` label.
- Fix a latent bug in the standalone `pollType === 'time'` fallback, which previously returned a raw string and silently dropped the `for X` suffix from the `forField`. It now goes through `appendFor(...)` like every other branch.
- Document the convention in CLAUDE.md under the Time Poll Type section.

## Test plan
- [ ] Open create modal in Time mode (`/?create=1&mode=time`) and confirm the title field is pre-filled with `Time?`
- [ ] Type into the `for` field and confirm the title updates to `Time for X?`
- [ ] Switch to a poll + category=time flow and confirm the same `Time?` / `Time for X?` behavior
- [ ] Verify existing categories (Restaurant, Place, etc.) still autotitle correctly