### PR TITLE
Add equal ranking support to ranked choice polls

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/block-push-to-main.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-push-to-main.py\"",
             "timeout": 5
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ whoeverwants/
 | Type | Description | Vote Data |
 |------|-------------|-----------|
 | `yes_no` | Simple binary vote | `{ vote: "yes" \| "no" }` |
-| `ranked_choice` | Instant Runoff Voting (IRV) with Borda tiebreak | `{ rankings: string[] }` |
+| `ranked_choice` | Instant Runoff Voting (IRV) with Borda tiebreak; supports equal/tied rankings | `{ rankings: string[], ranked_choice_tiers?: string[][] }` |
 | `suggestion` | Suggest options, then vote on them | `{ suggestions: string[] }` |
 | `participation` | RSVP with min/max constraints & voter conditions | `{ participating: boolean, conditions: {...} }` |
 
@@ -1054,6 +1054,17 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **`touch-action: none` must only be on the drag handle, not the container.** Putting it on the outer container blocks all scrolling. Only the right-side handle element needs it.
 - **`setPointerCapture` routes events to the captured element.** Use it on `pointerdown` to prevent iOS SFSafariViewController's sheet dismiss gesture from intercepting downward drags.
 - **Handle tap zones extend beyond item bounds** via negative `top`/`bottom` offsets that account for both the item's padding (12px from `p-3`) and half the gap between items.
+
+### Equal/Tied Rankings (RankableOptions)
+
+- **Tier data model**: `ranked_choice_tiers JSONB` column (migration 089) stores `[["A"], ["B","C"], ["D"]]`-style tiered ballots alongside the flat `ranked_choices TEXT[]` for backwards compatibility. The IRV algorithm prefers tiers when present; falls back to singleton tiers from the flat list.
+- **IRV "duplicate vote" method**: When a ballot's highest-ranked active tier contains multiple options, each gets a full vote. Total votes per round can exceed ballot count. Win requires strict majority AND unique leader; if multiple candidates tie at the top with majorities, IRV continues eliminating. Borda tiebreak uses standard competition ranking (1,2,2,4).
+- **Linked pairs state**: `linkedPairs: Set<string>` stores canonical `pairKey(idA, idB)` strings for adjacent items that are tied. The set is persisted to localStorage alongside the ranking. `computeTierIndices()` walks the list and groups consecutive linked items into tiers.
+- **Merged tier cards**: Consecutive linked items render as a single card with divider lines between rows (compressed `groupedGapSize=0` gap). Each card has one shared drag handle (arrows + grip). Dividers are inset from both edges (`dividerInset` prop on `TierCardRows`).
+- **`computeDropTarget()` is a pure, exported function** for drop-target computation. For each valid insertion point (between non-dragged units), it computes the tier's natural layout center and picks the closest match to the visual center. This gives symmetric thresholds and treats groups as atomic. Verified by 15 simulation tests (`drag-threshold-simulation.test.ts`).
+- **Tap-to-reorder uses `moveTierByOneUnit`** which finds the full adjacent unit via `getTierRange()` and swaps atomically. This prevents singletons from landing inside groups and groups from splitting each other.
+- **Drag operations clear links on the moved item** (`clearLinksTouchingItem` / `dropLinkedPairsFor`) to prevent stale adjacency. But `moveTierByOneUnit` and tier-drag `finishDrag` preserve internal tier links since the items remain adjacent.
+- **Link icon styling**: chain-link SVG with background-colored drop-shadow contour (`LINK_CONTOUR_FILTER`), blue when active, gray when inactive. No circle/border — just the icon with a halo for contrast. Centered horizontally on the card via `left: 50%; transform: translateX(-50%)`.
 
 ### Textarea Sizing & Inline-Block Gaps
 

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -54,6 +54,10 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
   const isNewPoll = searchParams.get("new") === "true";
   const [pollUrl, setPollUrl] = useState("");
   const [rankedChoices, setRankedChoices] = useState<string[]>([]);
+  // Tiered ballot (equal-ranking groups). Each inner array is a tier of
+  // options tied for the same rank. When it has no ties, every inner array
+  // is a singleton and this is equivalent to rankedChoices.
+  const [rankedChoiceTiers, setRankedChoiceTiers] = useState<string[][]>([]);
   // Time poll preferences: liked/disliked slot sets (null = not yet submitted)
   const [likedSlots, setLikedSlots] = useState<string[] | null>(null);
   const [dislikedSlots, setDislikedSlots] = useState<string[] | null>(null);
@@ -629,6 +633,13 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
               }
             } else if (poll.poll_type === 'ranked_choice') {
               if (voteData.ranked_choices) setRankedChoices(voteData.ranked_choices);
+              if (voteData.ranked_choice_tiers) {
+                setRankedChoiceTiers(voteData.ranked_choice_tiers);
+              } else if (voteData.ranked_choices) {
+                // No tiers present — synthesize singleton tiers so the
+                // current state is internally consistent.
+                setRankedChoiceTiers(voteData.ranked_choices.map((c: string) => [c]));
+              }
               if (voteData.suggestions) setSuggestionChoices(voteData.suggestions);
             } else if (poll.poll_type === 'time') {
               // Restore time poll availability windows
@@ -759,8 +770,9 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
     };
   }, [poll.id, pollClosed, fetchPollResults]);
 
-  const handleRankingChange = useCallback((newRankedChoices: string[]) => {
+  const handleRankingChange = useCallback((newRankedChoices: string[], newTiers: string[][]) => {
     setRankedChoices(newRankedChoices);
+    setRankedChoiceTiers(newTiers);
     // Clear the flag when user interacts with rankings after cancelling abstain
     if (justCancelledAbstain) {
       setJustCancelledAbstain(false);
@@ -1155,6 +1167,15 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
         // Filter and validate ranked choices (No Preference items already filtered by RankableOptions)
         const filteredRankedChoices = rankedChoices.filter(choice => choice && choice.trim().length > 0);
         const filteredSuggestionsForValidation = suggestionChoices.filter(choice => choice && choice.trim().length > 0);
+        // Filter and validate tiers in lockstep with ranked_choices. Drop
+        // empty strings from each tier and drop empty tiers.
+        const filteredTiers: string[][] = rankedChoiceTiers
+          .map(tier => tier.filter(c => c && c.trim().length > 0))
+          .filter(tier => tier.length > 0);
+        // Only send tiers if they actually encode ties (at least one tier has
+        // size > 1). Otherwise the flat ranked_choices list is sufficient and
+        // we avoid storing redundant singleton tiers.
+        const hasTies = filteredTiers.some(tier => tier.length > 1);
 
         if (filteredRankedChoices.length === 0 && !isAbstaining && (!canSubmitSuggestions || filteredSuggestionsForValidation.length === 0)) {
           if (!canSubmitSuggestions) {
@@ -1197,6 +1218,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           poll_id: poll.id,
           vote_type: 'ranked_choice' as const,
           ranked_choices: isAbstaining || !hasRankings ? null : filteredRankedChoices,
+          ranked_choice_tiers:
+            isAbstaining || !hasRankings || !hasTies ? null : filteredTiers,
           suggestions: hasSuggestions ? filteredSuggestions : (hasPreviousSuggestions ? previousSuggestions : null),
           is_abstain: finalAbstain,
           is_ranking_abstain: rankingAbstain,
@@ -1243,7 +1266,7 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
           ? { yes_no_choice: isAbstaining ? null : yesNoChoice, is_abstain: isAbstaining, voter_name: voterName.trim() || null, min_participants: voterMinParticipants, max_participants: voterMaxEnabled ? voterMaxParticipants : null, voter_day_time_windows: voterDayTimeWindows.length > 0 ? voterDayTimeWindows : null, voter_duration: (durationMinEnabled || durationMaxEnabled) ? { minValue: durationMinValue, maxValue: durationMaxValue, minEnabled: durationMinEnabled, maxEnabled: durationMaxEnabled } : null }
           : poll.poll_type === 'time'
           ? { voter_day_time_windows: voteData.voter_day_time_windows, voter_duration: voteData.voter_duration, liked_slots: voteData.liked_slots, disliked_slots: voteData.disliked_slots, is_abstain: voteData.is_abstain, voter_name: voterName.trim() || null }
-          : { ranked_choices: voteData.ranked_choices, suggestions: canSubmitSuggestions ? voteData.suggestions : undefined, is_abstain: voteData.is_abstain, is_ranking_abstain: voteData.is_ranking_abstain, voter_name: voterName.trim() || null };
+          : { ranked_choices: voteData.ranked_choices, ranked_choice_tiers: voteData.ranked_choice_tiers, suggestions: canSubmitSuggestions ? voteData.suggestions : undefined, is_abstain: voteData.is_abstain, is_ranking_abstain: voteData.is_ranking_abstain, voter_name: voterName.trim() || null };
         
         
         
@@ -2170,22 +2193,42 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             </span>
                             <span className="font-medium text-yellow-800 dark:text-yellow-200">Abstained</span>
                           </div>
-                        ) : (
-                          rankedChoices.map((choice, index) => (
-                            <div key={index} className="flex items-center gap-2">
-                              <div className="flex-shrink-0" style={{ width: '32px' }}>
-                                <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                                  {index + 1}
-                                </span>
-                              </div>
-                              <div className="flex-1 flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0">
-                                <div className="min-w-0 overflow-hidden">
-                                  <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
+                        ) : (() => {
+                          // Render the user's ranking, collapsing tied ranks
+                          // into visually-grouped blocks with a shared rank
+                          // number. Falls back to singleton tiers when no
+                          // tiered data is present.
+                          const tiersToRender: string[][] =
+                            rankedChoiceTiers && rankedChoiceTiers.length > 0
+                              ? rankedChoiceTiers
+                              : rankedChoices.map(c => [c]);
+                          let posSoFar = 0;
+                          return tiersToRender.map((tier, tierIdx) => {
+                            const rank = posSoFar + 1;
+                            posSoFar += tier.length;
+                            return (
+                              <div key={tierIdx} className="flex items-start gap-2">
+                                <div className="flex-shrink-0 flex items-center" style={{ width: '32px', minHeight: '2.5rem' }}>
+                                  <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                                    {rank}
+                                  </span>
+                                </div>
+                                <div className="flex-1 flex flex-col gap-1 min-w-0">
+                                  {tier.map((choice, innerIdx) => (
+                                    <div key={`${tierIdx}-${innerIdx}`} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0">
+                                      <div className="min-w-0 overflow-hidden">
+                                        <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
+                                      </div>
+                                      {tier.length > 1 && innerIdx === 0 && (
+                                        <span className="ml-auto flex-shrink-0 text-xs text-blue-600 dark:text-blue-400 italic">tied</span>
+                                      )}
+                                    </div>
+                                  ))}
                                 </div>
                               </div>
-                            </div>
-                          ))
-                        )}
+                            );
+                          });
+                        })()}
                       </div>
                     ) : null}
                   </div>

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -274,6 +274,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   const itemHeight = hasLocationOptions ? 72 : 56;
   const gapSize = 8;
   const totalItemHeight = itemHeight + gapSize;
+  // Inside grouped (multi-item) tier cards rows abut directly with no gap,
+  // just a divider line between them. This keeps tied options looking tightly
+  // coupled compared to the normal inter-card gap.
+  const groupedGapSize = 0;
+  const groupedStepSize = itemHeight + groupedGapSize; // = itemHeight when gap is 0
 
   // DOM Refs
   const mainContainerRef = useRef<HTMLDivElement>(null);
@@ -934,7 +939,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     // grabbed item may not be the first tier member, so shift the stack up
     // by grabbedOffset rows.
     const grabbedIndex = items.findIndex(it => it.id === dragState.draggedId);
-    const y = mousePosition.y - mouseOffset.y - Math.max(0, grabbedIndex) * totalItemHeight;
+    const y = mousePosition.y - mouseOffset.y - Math.max(0, grabbedIndex) * groupedStepSize;
     const width = mainContainerRef.current ? mainContainerRef.current.offsetWidth : 300;
     const showInternalLinks = items.length > 1 && dragState.sourceList === 'main';
 
@@ -956,7 +961,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         <div
           className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md select-none relative"
           style={{
-            height: `${items.length * itemHeight + (items.length - 1) * gapSize}px`,
+            height: `${items.length > 1 ? items.length * itemHeight + (items.length - 1) * groupedGapSize : itemHeight}px`,
           }}
         >
           {items.map((item, i) => (
@@ -964,7 +969,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               <div
                 className="absolute left-0 right-0 p-3"
                 style={{
-                  top: `${i * totalItemHeight}px`,
+                  top: `${i * groupedStepSize}px`,
                   height: `${itemHeight}px`,
                 }}
               >
@@ -978,7 +983,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 <div
                   className="absolute pointer-events-none border-t border-blue-300 dark:border-blue-600"
                   style={{
-                    top: `${i * totalItemHeight + itemHeight + gapSize / 2}px`,
+                    top: `${i * groupedStepSize + itemHeight + groupedGapSize / 2}px`,
                     left: '12px',
                     right: '12px',
                   }}
@@ -987,7 +992,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             </React.Fragment>
           ))}
           {/* Single drag handle for the group, vertically centered */}
-          <div className="absolute right-1 top-1/2 -translate-y-1/2 flex flex-col items-center justify-center gap-0 text-gray-500">
+          <div className="absolute right-4 top-1/2 -translate-y-1/2 flex flex-col items-center justify-center gap-0 text-gray-500">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="18 15 12 9 6 15" />
             </svg>
@@ -999,7 +1004,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         {/* Internal tier links between the stacked items — same styling as
             the stationary link circles, positioned at the gap midpoints. */}
         {showInternalLinks && items.slice(0, -1).map((item, i) => {
-          const topCenter = (i + 1) * totalItemHeight - gapSize / 2;
+          const topCenter = (i + 1) * groupedStepSize - groupedGapSize / 2;
           return (
             <div
               key={`preview-link-${item.id}`}
@@ -1357,7 +1362,10 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               const size = tier.length;
               const rank = positionsSoFar + 1;
               const top = startIdx * totalItemHeight;
-              const height = size * itemHeight + (size - 1) * gapSize;
+              const isGrouped = size > 1;
+              const height = isGrouped
+                ? size * itemHeight + (size - 1) * groupedGapSize
+                : itemHeight;
               rankEntries.push({
                 rank,
                 top,
@@ -1423,20 +1431,41 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 key: string;
                 inDraggedTier: boolean;
               }[] = [];
-              const tierStart = dragState.tierStart;
-              const tierEnd = tierStart !== null ? tierStart + dragState.tierSize - 1 : -1;
+              const dragTierStart = dragState.tierStart;
+              const dragTierEnd = dragTierStart !== null ? dragTierStart + dragState.tierSize - 1 : -1;
+              // Pre-compute tiers so we can position intra-tier link circles
+              // using the compressed grouped layout.
+              const tiers = computeTierIndices(mainList, linkedPairs);
+              const itemToTierStart = new Map<number, number>();
+              for (const tier of tiers) {
+                for (const idx of tier) {
+                  itemToTierStart.set(idx, tier[0]);
+                }
+              }
               for (let i = 0; i < mainList.length - 1; i++) {
                 const a = mainList[i];
                 const b = mainList[i + 1];
+                const isLinked = linkedPairs.has(pairKey(a.id, b.id));
                 const inDraggedTier =
                   dragState.isDragging &&
                   dragState.sourceList === 'main' &&
-                  tierStart !== null &&
-                  i >= tierStart &&
-                  i < tierEnd;
+                  dragTierStart !== null &&
+                  i >= dragTierStart &&
+                  i < dragTierEnd;
+                // For intra-tier links, use compressed spacing so the circle
+                // sits at the divider line inside the merged card.
+                let topCenter: number;
+                if (isLinked) {
+                  const tStart = itemToTierStart.get(i) ?? i;
+                  const rowIdx = i - tStart; // 0-based row within the tier
+                  const cardTop = mainList[tStart].top;
+                  topCenter = cardTop + (rowIdx + 1) * groupedStepSize + groupedGapSize / 2;
+                } else {
+                  topCenter = (i + 1) * totalItemHeight - gapSize / 2;
+                }
                 entries.push({
-                  topCenter: (i + 1) * totalItemHeight - gapSize / 2,
-                  linked: linkedPairs.has(pairKey(a.id, b.id)),
+                  topCenter,
+                  linked: isLinked,
                   idA: a.id,
                   idB: b.id,
                   key: `link-${a.id}-${b.id}`,
@@ -1502,8 +1531,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
 
                 const firstItem = listItems[tierIndices[0]];
                 const size = tierIndices.length;
+                const isGrouped = size > 1;
                 const cardTop = firstItem.top;
-                const cardHeight = size * itemHeight + (size - 1) * gapSize;
+                const cardHeight = isGrouped
+                  ? size * itemHeight + (size - 1) * groupedGapSize
+                  : itemHeight;
 
                 return (
                   <div
@@ -1524,7 +1556,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                   >
                     {tierIndices.map((itemIdx, rowIdx) => {
                       const option = listItems[itemIdx];
-                      const rowTop = rowIdx * totalItemHeight;
+                      const rowTop = rowIdx * (isGrouped ? groupedStepSize : totalItemHeight);
                       const isLastRow = rowIdx === size - 1;
                       return (
                         <React.Fragment key={option.id}>
@@ -1585,7 +1617,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                             <div
                               className="absolute border-t border-gray-200 dark:border-gray-700 pointer-events-none"
                               style={{
-                                top: `${rowTop + itemHeight + gapSize / 2}px`,
+                                top: `${rowTop + itemHeight + groupedGapSize / 2}px`,
                                 left: '12px',
                                 right: '12px',
                               }}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -81,10 +81,6 @@ export function tiersFromList(
  */
 const LINK_CIRCLE_SIZE = 24; // diameter in px (15% smaller than previous 28)
 const LINK_ICON_SIZE = 15;   // chain glyph in px (15% smaller than previous 18)
-// Horizontal offset of the circle's left edge from the cards container's
-// left edge. A small positive offset keeps the circle fully inside the
-// cards, just to the right of their left edge.
-const LINK_CIRCLE_LEFT_OFFSET = 1;
 
 function LinkCircle({
   entry,
@@ -115,12 +111,14 @@ function LinkCircle({
             : 'cursor-pointer border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 dark:border-gray-600 dark:text-gray-500 dark:hover:border-blue-500 dark:hover:text-blue-400'
       }`}
       style={{
-        left: `${LINK_CIRCLE_LEFT_OFFSET}px`,
+        // Horizontally center on the cards container (which is the same as
+        // centering on the option cards since cards span the full width).
+        left: '50%',
         top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
         width: `${LINK_CIRCLE_SIZE}px`,
         height: `${LINK_CIRCLE_SIZE}px`,
         zIndex: 3,
-        transform: translateY ? `translateY(${translateY}px)` : undefined,
+        transform: `translateX(-50%)${translateY ? ` translateY(${translateY}px)` : ''}`,
       }}
       aria-label={linked ? 'Break tied ranking' : 'Tie these rankings together'}
       title={linked ? 'Break tied ranking' : 'Tie these rankings together'}
@@ -985,10 +983,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               key={`preview-link-${item.id}`}
               className="absolute flex items-center justify-center rounded-full border border-gray-300 bg-white text-blue-600 shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-blue-400"
               style={{
-                left: `${LINK_CIRCLE_LEFT_OFFSET}px`,
+                left: '50%',
                 top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
                 width: `${LINK_CIRCLE_SIZE}px`,
                 height: `${LINK_CIRCLE_SIZE}px`,
+                transform: 'translateX(-50%)',
               }}
             >
               <svg

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { flushSync } from 'react-dom';
 import { ClientOnlyDragDrop } from './ClientOnly';
 import type { OptionsMetadata } from '@/lib/types';
@@ -950,30 +950,50 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           overflow: 'visible',
         }}
       >
-        {items.map((item, i) => (
-          <div
-            key={item.id}
-            className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md p-3 select-none relative"
-            style={{
-              height: `${itemHeight}px`,
-              marginTop: i === 0 ? 0 : `${gapSize}px`,
-            }}
-          >
-            <div className="flex items-center justify-between h-full">
-              <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
-                {renderOption ? renderOption(item.text) : <OptionLabel text={item.text} metadata={optionsMetadata?.[item.text]} className="min-w-0 overflow-hidden" />}
+        {/* Merged card wrapper for dragged tier */}
+        <div
+          className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md select-none relative"
+          style={{
+            height: `${items.length * itemHeight + (items.length - 1) * gapSize}px`,
+          }}
+        >
+          {items.map((item, i) => (
+            <React.Fragment key={item.id}>
+              <div
+                className="absolute left-0 right-0 p-3"
+                style={{
+                  top: `${i * totalItemHeight}px`,
+                  height: `${itemHeight}px`,
+                }}
+              >
+                <div className="flex items-center justify-between h-full">
+                  <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
+                    {renderOption ? renderOption(item.text) : <OptionLabel text={item.text} metadata={optionsMetadata?.[item.text]} className="min-w-0 overflow-hidden" />}
+                  </div>
+                </div>
               </div>
-              <div className="flex flex-col items-center justify-center ml-2 text-gray-500">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                  <polyline points="18 15 12 9 6 15" />
-                </svg>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                  <polyline points="6 9 12 15 18 9" />
-                </svg>
-              </div>
-            </div>
+              {i < items.length - 1 && (
+                <div
+                  className="absolute pointer-events-none border-t border-blue-300 dark:border-blue-600"
+                  style={{
+                    top: `${i * totalItemHeight + itemHeight + gapSize / 2}px`,
+                    left: '12px',
+                    right: '12px',
+                  }}
+                />
+              )}
+            </React.Fragment>
+          ))}
+          {/* Single drag handle for the group, vertically centered */}
+          <div className="absolute right-1 top-1/2 -translate-y-1/2 flex flex-col items-center justify-center gap-0 text-gray-500">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="18 15 12 9 6 15" />
+            </svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
           </div>
-        ))}
+        </div>
         {/* Internal tier links between the stacked items — same styling as
             the stationary link circles, positioned at the gap midpoints. */}
         {showInternalLinks && items.slice(0, -1).map((item, i) => {
@@ -1447,120 +1467,190 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               </div>
             )}
 
-            {/* Render all items in this list */}
-            {listItems.map((option, index) => {
-              // Skip rendering items that are currently being dragged. For
-              // main-list drags, this includes *every* tier member so the
-              // whole tied group visually moves together.
-              if (dragState.isDragging && listType === dragState.sourceList) {
-                if (listType === 'main' && dragState.tierStart !== null) {
-                  const inTier =
-                    index >= dragState.tierStart &&
-                    index < dragState.tierStart + dragState.tierSize;
-                  if (inTier) return null;
-                } else if (option.id === dragState.draggedId) {
-                  return null;
+            {/* Render items grouped by tier. In the main list, consecutive
+                items tied together render as a single merged card with
+                horizontal dividers between rows. In the no-preference list
+                every item is its own singleton tier (same visual as before). */}
+            {(() => {
+              const displayTiers: number[][] = listType === 'main'
+                ? computeTierIndices(listItems, linkedPairs)
+                : listItems.map((_, i) => [i]);
+
+              return displayTiers.map((tierIndices, tierIdx) => {
+                // Skip the entire tier if it's the dragged tier (all its
+                // members are rendered in the floating drag preview).
+                if (dragState.isDragging && listType === dragState.sourceList) {
+                  if (listType === 'main' && dragState.tierStart !== null) {
+                    const draggedStart = dragState.tierStart;
+                    const draggedEnd = draggedStart + dragState.tierSize - 1;
+                    if (
+                      tierIndices[0] >= draggedStart &&
+                      tierIndices[tierIndices.length - 1] <= draggedEnd
+                    ) {
+                      return null;
+                    }
+                  } else if (
+                    tierIndices.length === 1 &&
+                    listItems[tierIndices[0]].id === dragState.draggedId
+                  ) {
+                    return null;
+                  }
                 }
-              }
 
-              return (
-                <div
-                  key={option.id}
-                  ref={el => {
-                    elementRefs.current[option.id] = el;
-                  }}
-                  className={`
-                    absolute left-0 right-0 rounded-md shadow-sm
-                    ${disabled ? 'cursor-not-allowed bg-gray-200 dark:bg-gray-600' : 'cursor-grab active:cursor-grabbing bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800'}
-                    ${keyboardMode && focusedItemId === option.id ? 'ring-2 ring-blue-500 ring-offset-2' : ''}
-                    border border-gray-300 dark:border-gray-500 p-3 select-none
-                  `}
-                  style={{
-                    top: `${option.top}px`,
-                    height: `${itemHeight}px`,
-                    transition: dragState.isDragging
-                      ? 'top 0.2s ease, background-color 0.15s, color 0.15s'
-                      : 'top 0.3s ease, background-color 0.15s, color 0.15s',
-                    zIndex: 1
-                  }}
-                  onKeyDown={!disabled ? (e) => handleKeyDown(e, option.id) : undefined}
-                  onContextMenu={(e) => e.preventDefault()}
-                  tabIndex={disabled ? -1 : 0}
-                  role="option"
-                  aria-selected={keyboardMode && focusedItemId === option.id}
-                  aria-label={`${option.text}, ${listType === 'main' ? `ranked ${index + 1}` : 'no preference'}`}
-                  aria-describedby={`${option.id}-instructions`}
-                >
-                  <div className="flex items-center justify-between h-full relative">
-                    {/* Content area - not draggable, allows normal scrolling */}
-                    <div className={`flex-1 flex items-center pr-12 min-w-0 ${
+                const firstItem = listItems[tierIndices[0]];
+                const size = tierIndices.length;
+                const cardTop = firstItem.top;
+                const cardHeight = size * itemHeight + (size - 1) * gapSize;
+
+                return (
+                  <div
+                    key={`tier-${firstItem.id}`}
+                    className={`absolute left-0 right-0 rounded-md shadow-sm select-none ${
                       disabled
-                        ? 'text-gray-500 dark:text-gray-400'
-                        : 'text-gray-900 dark:text-white'
-                    }`}>
-                      {renderOption ? renderOption(option.text) : <OptionLabel text={option.text} metadata={optionsMetadata?.[option.text]} className="min-w-0 overflow-hidden" />}
-                    </div>
+                        ? 'bg-gray-200 dark:bg-gray-600'
+                        : 'bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800'
+                    } border border-gray-300 dark:border-gray-500`}
+                    style={{
+                      top: `${cardTop}px`,
+                      height: `${cardHeight}px`,
+                      transition: dragState.isDragging
+                        ? 'top 0.2s ease, background-color 0.15s, color 0.15s'
+                        : 'top 0.3s ease, background-color 0.15s, color 0.15s',
+                      zIndex: 1,
+                    }}
+                  >
+                    {tierIndices.map((itemIdx, rowIdx) => {
+                      const option = listItems[itemIdx];
+                      const rowTop = rowIdx * totalItemHeight;
+                      const isLastRow = rowIdx === size - 1;
+                      return (
+                        <React.Fragment key={option.id}>
+                          <div
+                            ref={el => {
+                              elementRefs.current[option.id] = el;
+                            }}
+                            className={`absolute left-0 right-0 p-3 ${
+                              disabled
+                                ? 'cursor-not-allowed'
+                                : 'cursor-grab active:cursor-grabbing'
+                            } ${
+                              keyboardMode && focusedItemId === option.id
+                                ? 'ring-2 ring-blue-500 ring-offset-2 rounded-md'
+                                : ''
+                            }`}
+                            style={{
+                              top: `${rowTop}px`,
+                              height: `${itemHeight}px`,
+                            }}
+                            onKeyDown={!disabled ? (e) => handleKeyDown(e, option.id) : undefined}
+                            onContextMenu={(e) => e.preventDefault()}
+                            tabIndex={disabled ? -1 : 0}
+                            role="option"
+                            aria-selected={keyboardMode && focusedItemId === option.id}
+                            aria-label={`${option.text}, ${listType === 'main' ? `ranked ${itemIdx + 1}` : 'no preference'}`}
+                            aria-describedby={`${option.id}-instructions`}
+                          >
+                            <div className="flex items-center justify-between h-full relative">
+                              {/* Content area - not draggable, allows normal scrolling */}
+                              <div
+                                className={`flex-1 flex items-center pr-12 min-w-0 ${
+                                  disabled
+                                    ? 'text-gray-500 dark:text-gray-400'
+                                    : 'text-gray-900 dark:text-white'
+                                }`}
+                              >
+                                {renderOption
+                                  ? renderOption(option.text)
+                                  : (
+                                    <OptionLabel
+                                      text={option.text}
+                                      metadata={optionsMetadata?.[option.text]}
+                                      className="min-w-0 overflow-hidden"
+                                    />
+                                  )}
+                              </div>
 
-                    {/* Right side: combined drag handle with tap zones for reordering
-                         Drag starts on pointerdown; if released without moving, treated as tap */}
+                              {/* Per-row drag handle is hidden for multi-item
+                                  tiers — those get ONE shared handle on the
+                                  tier card instead (see below). For singleton
+                                  tiers and noPreference items, the per-row
+                                  handle is still used. */}
+                            </div>
+                          </div>
+                          {/* Divider between tied rows inside a merged card */}
+                          {!isLastRow && (
+                            <div
+                              className="absolute border-t border-gray-200 dark:border-gray-700 pointer-events-none"
+                              style={{
+                                top: `${rowTop + itemHeight + gapSize / 2}px`,
+                                left: '12px',
+                                right: '12px',
+                              }}
+                            />
+                          )}
+                          <div id={`${option.id}-instructions`} className="absolute -left-[10000px] w-1 h-1 overflow-hidden">
+                            {keyboardMode && focusedItemId === option.id
+                              ? `Selected for moving. Use arrow keys to move within list, left arrow to move to main list, right arrow to move to no preference, escape to cancel.`
+                              : `Press Enter or Space to select for moving. Use arrow keys to navigate between options.`
+                            }
+                          </div>
+                        </React.Fragment>
+                      );
+                    })}
+                    {/* Single drag handle for the entire tier card —
+                        vertically centered on the card. On tap (no drag),
+                        move the entire tier up/down. */}
                     {!disabled && (
                       <div
                         className="absolute -right-3 cursor-grab active:cursor-grabbing"
                         style={{
                           width: 'calc(14% + 0.525rem)',
-                          top: `-${12 + gapSize / 2}px`,
-                          bottom: `-${12 + gapSize / 2}px`,
+                          top: 0,
+                          bottom: 0,
                           touchAction: 'none',
                           zIndex: 2,
                         }}
-                        onPointerDown={!disabled ? (e) => {
-                          // Always start drag — tap detection happens on pointerup
-                          handlePointerStart(e, option.id);
-                        } : undefined}
-                        onPointerUp={!disabled ? (e) => {
-                          // If drag never started (pointer moved <8px), it's a tap
+                        onPointerDown={(e) => {
+                          handlePointerStart(e, firstItem.id);
+                        }}
+                        onPointerUp={(e) => {
                           const pending = pendingDragRef.current;
-                          if (pending && !pending.started && pending.id === option.id) {
-                            pendingDragRef.current = null; // Clear before document handler runs
-
+                          if (pending && !pending.started && pending.id === firstItem.id) {
+                            pendingDragRef.current = null;
                             const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
                             const relativeY = e.clientY - rect.top;
                             const half = rect.height / 2;
-
                             if (listType === 'noPreference') {
-                              moveItemBetweenLists(option.id, 'noPreference', index, 'main', mainList.length);
+                              moveItemBetweenLists(firstItem.id, 'noPreference', tierIndices[0], 'main', mainList.length);
                             } else if (relativeY < half) {
-                              if (index > 0) {
-                                moveItemInList(listType, index, index - 1);
+                              if (tierIndices[0] > 0) {
+                                moveItemInList(listType, tierIndices[0], tierIndices[0] - 1);
                               }
                             } else {
-                              if (index < listItems.length - 1) {
-                                moveItemInList(listType, index, index + 1);
+                              const lastIdx = tierIndices[tierIndices.length - 1];
+                              if (lastIdx < listItems.length - 1) {
+                                moveItemInList(listType, lastIdx, lastIdx + 1);
                               } else {
-                                moveItemBetweenLists(option.id, 'main', index, 'noPreference', noPreferenceList.length);
+                                moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);
                               }
                             }
                           }
-                        } : undefined}
+                        }}
                         title=""
                       >
-                        {/* Visual: arrows + drag handle */}
                         <div className="absolute right-4 top-1/2 -translate-y-1/2 flex flex-col items-center justify-center gap-0">
                           {listType === 'main' ? (
                             <>
-                              {/* Up arrow */}
                               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-                                className={index === 0 ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400 dark:text-gray-500'}
+                                className={tierIndices[0] === 0 ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400 dark:text-gray-500'}
                               >
                                 <polyline points="18 15 12 9 6 15" />
                               </svg>
-                              {/* Drag handle lines */}
                               <div className="flex flex-col items-center justify-center my-0.5">
                                 <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
                                 <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
                                 <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
                               </div>
-                              {/* Down arrow */}
                               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
                                 className="text-gray-400 dark:text-gray-500"
                               >
@@ -1569,20 +1659,17 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                             </>
                           ) : (
                             <>
-                              {/* Plus symbol above */}
                               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
                                 className="text-green-500 dark:text-green-400"
                               >
                                 <line x1="12" y1="5" x2="12" y2="19" />
                                 <line x1="5" y1="12" x2="19" y2="12" />
                               </svg>
-                              {/* Drag handle lines */}
                               <div className="flex flex-col items-center justify-center my-0.5">
                                 <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
                                 <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
                                 <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
                               </div>
-                              {/* Plus symbol below */}
                               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
                                 className="text-green-500 dark:text-green-400"
                               >
@@ -1595,15 +1682,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       </div>
                     )}
                   </div>
-                  <div id={`${option.id}-instructions`} className="absolute -left-[10000px] w-1 h-1 overflow-hidden">
-                    {keyboardMode && focusedItemId === option.id
-                      ? `Selected for moving. Use arrow keys to move within list, left arrow to move to main list, right arrow to move to no preference, escape to cancel.`
-                      : `Press Enter or Space to select for moving. Use arrow keys to navigate between options.`
-                    }
-                  </div>
-                </div>
-              );
-            })}
+                );
+              });
+            })()}
           </div>
         </div>
       </div>

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -425,36 +425,60 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           screenY >= mainRect.top && screenY <= extendedBottom) {
         const relativeY = screenY - mainRect.top;
 
-        // Compute the drop target using the "nearest slot" approach for ALL
-        // main-list drags (singletons and tiers alike). This reconstructs the
-        // tier's visual top from the cursor position and grab offset, then
-        // rounds to the nearest totalItemHeight grid position. The reorder
-        // fires at the midpoint between adjacent slots (~32px of dragging),
-        // giving symmetric thresholds in both directions.
+        // Compute the drop target using non-dragged "units" (singletons or
+        // linked groups) with their actual visual centers. The reorder fires
+        // when the dragged tier's visual center crosses the midpoint between
+        // two adjacent unit centers — giving natural, symmetric thresholds
+        // that treat groups as atomic and respect their compressed height.
         if (dragState.sourceList === 'main' && dragState.tierStart !== null) {
           const tStart = dragState.tierStart;
           const tSize = dragState.tierSize;
+          const tEnd = tStart + tSize - 1;
 
-          // Cursor offset from the tier's visual top edge:
-          //   (grabbed row within tier) * groupedStepSize + mouseOffsetY
+          // Dragged tier's visual extent
           const grabRow = (dragState.dragStartIndex ?? tStart) - tStart;
           const cursorOffsetFromTierTop = grabRow * groupedStepSize + dragState.mouseOffset.y;
-
-          // Tier's visual top in container coordinates
           const tierVisualTop = relativeY - cursorOffsetFromTierTop;
+          const tierVisualHeight = tSize > 1
+            ? tSize * itemHeight + (tSize - 1) * groupedGapSize
+            : itemHeight;
+          const tierVisualCenter = tierVisualTop + tierVisualHeight / 2;
 
-          // Nearest slot (each slot = totalItemHeight)
-          const slot = Math.round(tierVisualTop / totalItemHeight);
-          const maxSlot = mainList.length - tSize;
-          const clampedSlot = Math.max(0, Math.min(maxSlot, slot));
+          // Build non-dragged units with their natural visual centers
+          const allTiers = computeTierIndices(mainList, linkedPairs);
+          const units: { firstIdx: number; lastIdx: number; centerY: number }[] = [];
+          for (const tier of allTiers) {
+            const first = tier[0];
+            const last = tier[tier.length - 1];
+            // Skip the dragged tier
+            if (first >= tStart && last <= tEnd) continue;
+            const unitTop = first * totalItemHeight;
+            const unitH = tier.length > 1
+              ? tier.length * itemHeight + (tier.length - 1) * groupedGapSize
+              : itemHeight;
+            units.push({ firstIdx: first, lastIdx: last, centerY: unitTop + unitH / 2 });
+          }
 
-          // Convert slot to original list index. Slots below the tier's
-          // current start need to account for the tier's own indices.
-          const targetIdx = clampedSlot < tStart
-            ? clampedSlot           // moving up: slot IS the target index
-            : clampedSlot + tSize;  // moving down: shift past tier's indices
+          if (units.length === 0) {
+            return { list: 'main' as const, index: tStart };
+          }
 
-          return { list: 'main' as const, index: targetIdx };
+          // Before first unit
+          if (tierVisualCenter < units[0].centerY) {
+            return { list: 'main' as const, index: units[0].firstIdx };
+          }
+
+          // Between units — find the gap whose midpoint the tier center
+          // has crossed
+          for (let u = 0; u < units.length - 1; u++) {
+            const gapMid = (units[u].centerY + units[u + 1].centerY) / 2;
+            if (tierVisualCenter < gapMid) {
+              return { list: 'main' as const, index: units[u].lastIdx + 1 };
+            }
+          }
+
+          // After last unit
+          return { list: 'main' as const, index: units[units.length - 1].lastIdx + 1 };
         }
 
         // Fallback: uniform-grid index for drags originating from

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1609,7 +1609,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       gapSize={isGrouped ? groupedGapSize : gapSize}
                       itemHeight={itemHeight}
                       dividerClassName="border-gray-200 dark:border-gray-700"
-                      dividerInset={{ left: '38px', right: '38px' }}
+                      dividerInset={{ left: '19px', right: '38px' }}
                       renderContent={(item) => (
                         <div className={`flex-1 flex items-center pr-12 min-w-0 ${
                           disabled ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-white'

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -72,6 +72,75 @@ export function tiersFromList(
 }
 
 /**
+ * Small round button that toggles whether two adjacent items are tied.
+ * Uses the same chain-link glyph in both states — just blue when active
+ * (linked) and muted gray when inactive (unlinked).
+ *
+ * Centered on the left edge of the cards column so the circle overlaps the
+ * corners of the two items it sits between.
+ */
+const LINK_CIRCLE_SIZE = 28; // diameter in px
+const LINK_ICON_SIZE = 18;   // chain glyph in px (25% bigger than original 14px)
+
+function LinkCircle({
+  entry,
+  disabled,
+  onToggle,
+  translateY,
+}: {
+  entry: { topCenter: number; linked: boolean; idA: string; idB: string };
+  disabled: boolean;
+  onToggle: (idA: string, idB: string) => void;
+  translateY?: number;
+}) {
+  const { topCenter, linked, idA, idB } = entry;
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onToggle(idA, idB);
+      }}
+      className={`absolute rounded-full flex items-center justify-center border-2 shadow-sm transition-colors ${
+        disabled
+          ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-600'
+          : linked
+            ? 'cursor-pointer border-blue-600 bg-blue-600 text-white hover:bg-blue-700 dark:border-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400'
+            : 'cursor-pointer border-gray-300 bg-white text-gray-400 hover:border-blue-400 hover:text-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-500 dark:hover:border-blue-500 dark:hover:text-blue-400'
+      }`}
+      style={{
+        // Center the circle on the left edge of the cards container
+        // (x = 0 within the container, circle horizontal center = 0).
+        left: `-${LINK_CIRCLE_SIZE / 2}px`,
+        top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
+        width: `${LINK_CIRCLE_SIZE}px`,
+        height: `${LINK_CIRCLE_SIZE}px`,
+        zIndex: 3,
+        transform: translateY ? `translateY(${translateY}px)` : undefined,
+      }}
+      aria-label={linked ? 'Break tied ranking' : 'Tie these rankings together'}
+      title={linked ? 'Break tied ranking' : 'Tie these rankings together'}
+    >
+      <svg
+        width={LINK_ICON_SIZE}
+        height={LINK_ICON_SIZE}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </svg>
+    </button>
+  );
+}
+
+/**
  * Return `[tierStart, tierSize]` for the tier containing `index` in the
  * given list + links. A tier is a maximal run of consecutive items connected
  * by linked pairs. An untied item returns `[index, 1]`.
@@ -851,7 +920,8 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   };
 
   // Render dragged item(s) — for tied tiers, stack all members together so
-  // the whole group drags as a unit under the cursor.
+  // the whole group drags as a unit under the cursor. Internal tier links
+  // render between stacked items so they visibly drag with the group.
   const renderDraggedItem = () => {
     const items = getDraggedItems();
     if (items.length === 0) return null;
@@ -864,6 +934,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     const grabbedIndex = items.findIndex(it => it.id === dragState.draggedId);
     const y = mousePosition.y - mouseOffset.y - Math.max(0, grabbedIndex) * totalItemHeight;
     const width = mainContainerRef.current ? mainContainerRef.current.offsetWidth : 300;
+    const showInternalLinks = items.length > 1 && dragState.sourceList === 'main';
 
     return (
       <div
@@ -876,12 +947,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           pointerEvents: 'none',
           transform: 'scale(1.02)',
           filter: 'drop-shadow(0 8px 25px rgba(0,0,0,0.3))',
+          overflow: 'visible',
         }}
       >
         {items.map((item, i) => (
           <div
             key={item.id}
-            className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md p-3 select-none"
+            className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md p-3 select-none relative"
             style={{
               height: `${itemHeight}px`,
               marginTop: i === 0 ? 0 : `${gapSize}px`,
@@ -902,6 +974,37 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             </div>
           </div>
         ))}
+        {/* Internal tier links between the stacked items — same styling as
+            the stationary link circles, positioned at the gap midpoints. */}
+        {showInternalLinks && items.slice(0, -1).map((item, i) => {
+          const topCenter = (i + 1) * totalItemHeight - gapSize / 2;
+          return (
+            <div
+              key={`preview-link-${item.id}`}
+              className="absolute flex items-center justify-center rounded-full border-2 border-blue-600 bg-blue-600 text-white shadow-sm dark:border-blue-500 dark:bg-blue-500"
+              style={{
+                left: `-${LINK_CIRCLE_SIZE / 2}px`,
+                top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
+                width: `${LINK_CIRCLE_SIZE}px`,
+                height: `${LINK_CIRCLE_SIZE}px`,
+              }}
+            >
+              <svg
+                width={LINK_ICON_SIZE}
+                height={LINK_ICON_SIZE}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.25"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+              </svg>
+            </div>
+          );
+        })}
       </div>
     );
   };
@@ -1210,14 +1313,12 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         )}
 
         <div className="flex">
-          {/* Rank number + link column - only for main list.
+          {/* Rank number column — only for main list.
               Renders one rank number per tier, vertically centered on the
               tier's items, using standard competition ranking (1, 2, 2, 4).
-              Link icons sit between every pair of adjacent items, allowing
-              the user to toggle tied rankings. */}
+              Link circles live in the cards container below, so they can
+              overlap the left edge of the cards. */}
           {listType === 'main' && numberSlotCount > 0 && (() => {
-            // When dragging from noPreference INTO main, we reserve one extra
-            // slot at the bottom as a placeholder; tiers don't extend to it.
             const effectiveMainList = mainList;
             const tiers = computeTierIndices(effectiveMainList, linkedPairs);
             // Add the extra slot as its own singleton tier if needed
@@ -1225,55 +1326,32 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               tiers.push([effectiveMainList.length]);
             }
             // Build rank number entries with standard competition ranking
-            const rankEntries: { rank: number; top: number; height: number; width: number; key: string }[] = [];
+            const rankEntries: { rank: number; top: number; height: number; key: string }[] = [];
             let positionsSoFar = 0;
             tiers.forEach((tier, tierIdx) => {
               const startIdx = tier[0];
               const size = tier.length;
               const rank = positionsSoFar + 1;
-              // Center a rank pill that spans the tier's full visible height
               const top = startIdx * totalItemHeight;
               const height = size * itemHeight + (size - 1) * gapSize;
               rankEntries.push({
                 rank,
                 top,
                 height,
-                width: 0,
                 key: `rank-${tierIdx}-${startIdx}`,
               });
               positionsSoFar += size;
             });
-            // Build link icon entries between every pair of adjacent items
-            // (only within the actual main list, not the placeholder slot).
-            const linkEntries: {
-              topCenter: number;
-              linked: boolean;
-              idA: string;
-              idB: string;
-              key: string;
-            }[] = [];
-            for (let i = 0; i < effectiveMainList.length - 1; i++) {
-              const a = effectiveMainList[i];
-              const b = effectiveMainList[i + 1];
-              linkEntries.push({
-                // Midpoint of the gap between item i and item i+1
-                topCenter: (i + 1) * totalItemHeight - gapSize / 2,
-                linked: linkedPairs.has(pairKey(a.id, b.id)),
-                idA: a.id,
-                idB: b.id,
-                key: `link-${a.id}-${b.id}`,
-              });
-            }
             return (
               <div
                 className="flex-shrink-0 relative"
-                style={{ width: '48px', height: `${dynamicHeight}px`, minHeight: `${totalItemHeight}px` }}
+                style={{ width: '32px', height: `${dynamicHeight}px`, minHeight: `${totalItemHeight}px` }}
               >
                 {rankEntries.map(entry => (
                   <div
                     key={entry.key}
-                    className="absolute left-0 flex items-center justify-center pointer-events-none"
-                    style={{ top: `${entry.top}px`, height: `${entry.height}px`, width: '32px' }}
+                    className="absolute left-0 right-0 flex items-center justify-center pointer-events-none"
+                    style={{ top: `${entry.top}px`, height: `${entry.height}px` }}
                   >
                     <div className={`w-6 h-6 rounded-full flex items-center justify-center text-sm font-medium ${
                       disabled
@@ -1283,46 +1361,6 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       {entry.rank}
                     </div>
                   </div>
-                ))}
-                {!disableGrouping && !dragState.isDragging && linkEntries.map(entry => (
-                  <button
-                    key={entry.key}
-                    type="button"
-                    disabled={disabled}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      toggleLinkBetween(entry.idA, entry.idB);
-                    }}
-                    className={`absolute rounded-full flex items-center justify-center transition-colors ${
-                      disabled
-                        ? 'cursor-not-allowed text-gray-300 dark:text-gray-600'
-                        : entry.linked
-                          ? 'text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/40 cursor-pointer'
-                          : 'text-gray-300 dark:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-400 cursor-pointer'
-                    }`}
-                    style={{
-                      left: '30px',
-                      top: `${entry.topCenter - 10}px`,
-                      width: '18px',
-                      height: '20px',
-                    }}
-                    aria-label={entry.linked ? 'Break tied ranking' : 'Tie these rankings together'}
-                    title={entry.linked ? 'Break tied ranking' : 'Tie these rankings together'}
-                  >
-                    {entry.linked ? (
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                      </svg>
-                    ) : (
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M9 17H7a5 5 0 0 1-5-5a5 5 0 0 1 5-5h2" />
-                        <path d="M15 7h2a5 5 0 0 1 5 5a5 5 0 0 1-5 5h-2" />
-                        <line x1="8" y1="12" x2="16" y2="12" strokeDasharray="3 3" />
-                      </svg>
-                    )}
-                  </button>
                 ))}
               </div>
             );
@@ -1337,12 +1375,62 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             }`}
             style={{
               height: `${dynamicHeight}px`,
-              minHeight: `${totalItemHeight}px`
+              minHeight: `${totalItemHeight}px`,
+              // Link circles overflow the container's left edge so they
+              // can overlap the corners of the option cards.
+              overflow: 'visible',
             }}
             role="listbox"
             aria-label={listType === 'main' ? 'Ranked choice options' : 'No preference options'}
             aria-describedby={`${listType}-description`}
           >
+            {/* Link circles — for main list only. Rendered inside the cards
+                container (with overflow: visible) so they can overlap the
+                left edge of the cards. Each circle is centered on the gap
+                between two adjacent items. During a drag, links INTERNAL to
+                the dragged tier render inside the floating drag preview
+                instead; links OUTSIDE the tier stay stationary here. */}
+            {listType === 'main' && !disableGrouping && mainList.length > 1 && (() => {
+              const entries: {
+                topCenter: number;
+                linked: boolean;
+                idA: string;
+                idB: string;
+                key: string;
+                inDraggedTier: boolean;
+              }[] = [];
+              const tierStart = dragState.tierStart;
+              const tierEnd = tierStart !== null ? tierStart + dragState.tierSize - 1 : -1;
+              for (let i = 0; i < mainList.length - 1; i++) {
+                const a = mainList[i];
+                const b = mainList[i + 1];
+                const inDraggedTier =
+                  dragState.isDragging &&
+                  dragState.sourceList === 'main' &&
+                  tierStart !== null &&
+                  i >= tierStart &&
+                  i < tierEnd;
+                entries.push({
+                  topCenter: (i + 1) * totalItemHeight - gapSize / 2,
+                  linked: linkedPairs.has(pairKey(a.id, b.id)),
+                  idA: a.id,
+                  idB: b.id,
+                  key: `link-${a.id}-${b.id}`,
+                  inDraggedTier,
+                });
+              }
+              return entries
+                .filter(e => !e.inDraggedTier)
+                .map(entry => (
+                  <LinkCircle
+                    key={entry.key}
+                    entry={entry}
+                    disabled={disabled}
+                    onToggle={toggleLinkBetween}
+                  />
+                ));
+            })()}
+
             {/* Show empty state message if list is empty */}
             {listItems.length === 0 && (
               <div className="absolute inset-0 flex items-center justify-center">

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1429,6 +1429,32 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     }
   }, [updateItemPositions, animateWithFLIP, mainList, noPreferenceList, clearLinksTouchingItem]);
 
+  /**
+   * Move an entire tier (contiguous group of linked items) up or down by one
+   * position in the main list. The tier's internal linked pairs are preserved;
+   * the single item it swaps with stays ungrouped.
+   */
+  const moveTierInList = useCallback((tierStart: number, tierSize: number, direction: 'up' | 'down') => {
+    if (direction === 'up' && tierStart <= 0) return;
+    if (direction === 'down' && tierStart + tierSize >= mainList.length) return;
+
+    animateWithFLIP(() => {
+      setMainList(prev => {
+        const newList = [...prev];
+        if (direction === 'up') {
+          // Swap the item above the tier with the tier's first member
+          const [above] = newList.splice(tierStart - 1, 1);
+          newList.splice(tierStart + tierSize - 1, 0, above);
+        } else {
+          // Swap the item below the tier with the tier's last member
+          const [below] = newList.splice(tierStart + tierSize, 1);
+          newList.splice(tierStart, 0, below);
+        }
+        return updateItemPositions(newList);
+      });
+    });
+  }, [updateItemPositions, animateWithFLIP, mainList.length]);
+
   // Helper function to move items between lists (with FLIP animation)
   const moveItemBetweenLists = useCallback((
     itemId: string,
@@ -1772,11 +1798,24 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                             if (listType === 'noPreference') {
                               moveItemBetweenLists(firstItem.id, 'noPreference', tierIndices[0], 'main', mainList.length);
                             } else if (relativeY < half) {
-                              if (tierIndices[0] > 0) moveItemInList(listType, tierIndices[0], tierIndices[0] - 1);
+                              if (tierIndices[0] > 0) {
+                                if (isGrouped) {
+                                  moveTierInList(tierIndices[0], size, 'up');
+                                } else {
+                                  moveItemInList(listType, tierIndices[0], tierIndices[0] - 1);
+                                }
+                              }
                             } else {
                               const lastIdx = tierIndices[tierIndices.length - 1];
-                              if (lastIdx < listItems.length - 1) moveItemInList(listType, lastIdx, lastIdx + 1);
-                              else moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);
+                              if (lastIdx < listItems.length - 1) {
+                                if (isGrouped) {
+                                  moveTierInList(tierIndices[0], size, 'down');
+                                } else {
+                                  moveItemInList(listType, lastIdx, lastIdx + 1);
+                                }
+                              } else {
+                                moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);
+                              }
                             }
                           }
                         }}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -425,19 +425,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           screenY >= mainRect.top && screenY <= extendedBottom) {
         const relativeY = screenY - mainRect.top;
 
-        // When dragging a multi-item tier within the main list, find which
-        // "slot" the tier is closest to by computing the tier's visual top
-        // from the cursor position and grab offset, then rounding to the
-        // nearest totalItemHeight grid position. This gives a natural
-        // "least overlap" trigger: the reorder fires when the tier is
-        // closer to the swapped position than to its current one — roughly
-        // half a slot height (~32px) of dragging regardless of tier size
-        // or which item within the tier was grabbed.
-        if (
-          dragState.sourceList === 'main' &&
-          dragState.tierStart !== null &&
-          dragState.tierSize > 1
-        ) {
+        // Compute the drop target using the "nearest slot" approach for ALL
+        // main-list drags (singletons and tiers alike). This reconstructs the
+        // tier's visual top from the cursor position and grab offset, then
+        // rounds to the nearest totalItemHeight grid position. The reorder
+        // fires at the midpoint between adjacent slots (~32px of dragging),
+        // giving symmetric thresholds in both directions.
+        if (dragState.sourceList === 'main' && dragState.tierStart !== null) {
           const tStart = dragState.tierStart;
           const tSize = dragState.tierSize;
 
@@ -463,32 +457,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           return { list: 'main' as const, index: targetIdx };
         }
 
-        // Standard uniform-grid index for single-item drags
+        // Fallback: uniform-grid index for drags originating from
+        // noPreference into main (the nearest-slot path above handles
+        // all main→main drags).
         const allowAppend = dragState.sourceList === 'noPreference';
-        let index = getIndexFromY(relativeY, mainList.length, allowAppend);
-
-        // Snap the target out of any non-dragged group. The uniform grid
-        // can land between two members of a linked tier — dropping there
-        // would split the group. Snap to whichever edge (before / after
-        // the group) the cursor is closer to.
-        if (dragState.sourceList === 'main') {
-          const tiers = computeTierIndices(mainList, linkedPairs);
-          const dragStart = dragState.dragStartIndex ?? -1;
-          for (const tier of tiers) {
-            if (tier.length <= 1) continue;
-            const tFirst = tier[0];
-            const tLast = tier[tier.length - 1];
-            // Skip the dragged item's own tier
-            if (dragStart >= tFirst && dragStart <= tLast) continue;
-            // If index lands strictly inside this tier (not at its edges)
-            if (index > tFirst && index <= tLast) {
-              const tierMidY = ((tFirst + tLast) / 2) * totalItemHeight + itemHeight / 2;
-              index = relativeY < tierMidY ? tFirst : tLast + 1;
-              break;
-            }
-          }
-        }
-
+        const index = getIndexFromY(relativeY, mainList.length, allowAppend);
         return { list: 'main' as const, index };
       }
     }

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -176,6 +176,7 @@ function TierCardRows({
                   top: `${rowTop + rowHeight + innerGap / 2}px`,
                   left: '12px',
                   right: '12px',
+                  transform: 'translateY(-0.5px)',
                 }}
               />
             )}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { flushSync } from 'react-dom';
 import { ClientOnlyDragDrop } from './ClientOnly';
 import type { OptionsMetadata } from '@/lib/types';
@@ -1498,6 +1498,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     }
   }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP, dropLinkedPairsFor]);
 
+  // Memoize the tier structure so it's computed once per render, not once
+  // per section (rank numbers, link circles, tier cards all use it).
+  const mainTiers = useMemo(
+    () => computeTierIndices(mainList, linkedPairs),
+    [mainList, linkedPairs],
+  );
+
   // Render a single list container (main or no preference)
   const renderListContainer = (
     listItems: RankableOption[],
@@ -1539,7 +1546,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               overlap the left edge of the cards. */}
           {listType === 'main' && numberSlotCount > 0 && (() => {
             const effectiveMainList = mainList;
-            const tiers = computeTierIndices(effectiveMainList, linkedPairs);
+            const tiers = [...mainTiers]; // mutable copy for placeholder slot
             // Add the extra slot as its own singleton tier if needed
             if (numberSlotCount > effectiveMainList.length) {
               tiers.push([effectiveMainList.length]);
@@ -1623,11 +1630,8 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               }[] = [];
               const dragTierStart = dragState.tierStart;
               const dragTierEnd = dragTierStart !== null ? dragTierStart + dragState.tierSize - 1 : -1;
-              // Pre-compute tiers so we can position intra-tier link circles
-              // using the compressed grouped layout.
-              const tiers = computeTierIndices(mainList, linkedPairs);
               const itemToTierStart = new Map<number, number>();
-              for (const tier of tiers) {
+              for (const tier of mainTiers) {
                 for (const idx of tier) {
                   itemToTierStart.set(idx, tier[0]);
                 }
@@ -1695,7 +1699,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 every item is its own singleton tier (same visual as before). */}
             {(() => {
               const displayTiers: number[][] = listType === 'main'
-                ? computeTierIndices(listItems, linkedPairs)
+                ? mainTiers
                 : listItems.map((_, i) => [i]);
 
               return displayTiers.map((tierIndices, tierIdx) => {

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -79,8 +79,112 @@ export function tiersFromList(
  * Centered on the left edge of the cards column so the circle overlaps the
  * corners of the two items it sits between.
  */
-const LINK_CIRCLE_SIZE = 24; // diameter in px (15% smaller than previous 28)
-const LINK_ICON_SIZE = 15;   // chain glyph in px (15% smaller than previous 18)
+const LINK_CIRCLE_SIZE = 24;
+const LINK_ICON_SIZE = 15;
+const LINK_CONTOUR_FILTER = 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))';
+
+/** The chain-link SVG glyph reused in link circles and drag preview links. */
+function LinkIcon({ size = LINK_ICON_SIZE }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+/** The up/down arrows + grip lines used in both live and preview drag handles. */
+function DragHandleVisual({ dimUp = false, variant = 'main' }: { dimUp?: boolean; variant?: 'main' | 'noPreference' }) {
+  if (variant === 'noPreference') {
+    return (
+      <div className="flex flex-col items-center justify-center gap-0">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-green-500 dark:text-green-400">
+          <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        <GripLines />
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-green-500 dark:text-green-400">
+          <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col items-center justify-center gap-0">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className={dimUp ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400 dark:text-gray-500'}>
+        <polyline points="18 15 12 9 6 15" />
+      </svg>
+      <GripLines />
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 dark:text-gray-500">
+        <polyline points="6 9 12 15 18 9" />
+      </svg>
+    </div>
+  );
+}
+
+function GripLines() {
+  return (
+    <div className="flex flex-col items-center justify-center my-0.5">
+      <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5" />
+      <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5" />
+      <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600" />
+    </div>
+  );
+}
+
+/**
+ * Renders the interior of a tier card: rows of option content with divider
+ * lines between them. Used by both the live ballot and the floating drag
+ * preview so the visual structure stays in sync.
+ */
+function TierCardRows({
+  items,
+  stepSize,
+  gapSize: innerGap,
+  itemHeight: rowHeight,
+  dividerClassName,
+  renderContent,
+  rowProps,
+}: {
+  items: { id: string; text: string }[];
+  stepSize: number;
+  gapSize: number;
+  itemHeight: number;
+  dividerClassName: string;
+  renderContent: (item: { id: string; text: string }, index: number) => React.ReactNode;
+  rowProps?: (item: { id: string; text: string }, rowIdx: number) => Record<string, unknown>;
+}) {
+  return (
+    <>
+      {items.map((item, rowIdx) => {
+        const rowTop = rowIdx * stepSize;
+        const extra = rowProps?.(item, rowIdx) ?? {};
+        return (
+          <React.Fragment key={item.id}>
+            <div
+              className="absolute left-0 right-0 p-3"
+              style={{ top: `${rowTop}px`, height: `${rowHeight}px` }}
+              {...extra}
+            >
+              <div className="flex items-center justify-between h-full">
+                {renderContent(item, rowIdx)}
+              </div>
+            </div>
+            {rowIdx < items.length - 1 && (
+              <div
+                className={`absolute pointer-events-none border-t ${dividerClassName}`}
+                style={{
+                  top: `${rowTop + rowHeight + innerGap / 2}px`,
+                  left: '12px',
+                  right: '12px',
+                }}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+}
 
 function LinkCircle({
   entry,
@@ -120,24 +224,12 @@ function LinkCircle({
         // Background-colored contour around the icon for contrast against
         // the card surface it overlaps. Stacked drop-shadows thicken the
         // halo because a single pass is too faint.
-        filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
+        filter: LINK_CONTOUR_FILTER,
       }}
       aria-label={linked ? 'Break tied ranking' : 'Tie these rankings together'}
       title={linked ? 'Break tied ranking' : 'Tie these rankings together'}
     >
-      <svg
-        width={LINK_ICON_SIZE}
-        height={LINK_ICON_SIZE}
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.25"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-      </svg>
+      <LinkIcon />
     </button>
   );
 }
@@ -935,102 +1027,56 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
 
     const { mousePosition, mouseOffset } = dragState;
     const x = mousePosition.x - mouseOffset.x;
-    // Offset the stack so the grabbed item sits where the cursor is. The
-    // grabbed item may not be the first tier member, so shift the stack up
-    // by grabbedOffset rows.
     const grabbedIndex = items.findIndex(it => it.id === dragState.draggedId);
     const y = mousePosition.y - mouseOffset.y - Math.max(0, grabbedIndex) * groupedStepSize;
     const width = mainContainerRef.current ? mainContainerRef.current.offsetWidth : 300;
-    const showInternalLinks = items.length > 1 && dragState.sourceList === 'main';
+    const isGrouped = items.length > 1;
+    const cardH = isGrouped
+      ? items.length * itemHeight + (items.length - 1) * groupedGapSize
+      : itemHeight;
 
     return (
       <div
         style={{
-          position: 'fixed',
-          left: `${x}px`,
-          top: `${y}px`,
-          width: `${width}px`,
-          zIndex: 1000,
-          pointerEvents: 'none',
-          transform: 'scale(1.02)',
-          filter: 'drop-shadow(0 8px 25px rgba(0,0,0,0.3))',
-          overflow: 'visible',
+          position: 'fixed', left: `${x}px`, top: `${y}px`, width: `${width}px`,
+          zIndex: 1000, pointerEvents: 'none', transform: 'scale(1.02)',
+          filter: 'drop-shadow(0 8px 25px rgba(0,0,0,0.3))', overflow: 'visible',
         }}
       >
-        {/* Merged card wrapper for dragged tier */}
         <div
           className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md select-none relative"
-          style={{
-            height: `${items.length > 1 ? items.length * itemHeight + (items.length - 1) * groupedGapSize : itemHeight}px`,
-          }}
+          style={{ height: `${cardH}px` }}
         >
-          {items.map((item, i) => (
-            <React.Fragment key={item.id}>
-              <div
-                className="absolute left-0 right-0 p-3"
-                style={{
-                  top: `${i * groupedStepSize}px`,
-                  height: `${itemHeight}px`,
-                }}
-              >
-                <div className="flex items-center justify-between h-full">
-                  <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
-                    {renderOption ? renderOption(item.text) : <OptionLabel text={item.text} metadata={optionsMetadata?.[item.text]} className="min-w-0 overflow-hidden" />}
-                  </div>
-                </div>
+          <TierCardRows
+            items={items}
+            stepSize={groupedStepSize}
+            gapSize={groupedGapSize}
+            itemHeight={itemHeight}
+            dividerClassName="border-blue-300 dark:border-blue-600"
+            renderContent={(item) => (
+              <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
+                {renderOption ? renderOption(item.text) : <OptionLabel text={item.text} metadata={optionsMetadata?.[item.text]} className="min-w-0 overflow-hidden" />}
               </div>
-              {i < items.length - 1 && (
-                <div
-                  className="absolute pointer-events-none border-t border-blue-300 dark:border-blue-600"
-                  style={{
-                    top: `${i * groupedStepSize + itemHeight + groupedGapSize / 2}px`,
-                    left: '12px',
-                    right: '12px',
-                  }}
-                />
-              )}
-            </React.Fragment>
-          ))}
-          {/* Single drag handle for the group, vertically centered */}
-          <div className="absolute right-4 top-1/2 -translate-y-1/2 flex flex-col items-center justify-center gap-0 text-gray-500">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="18 15 12 9 6 15" />
-            </svg>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="6 9 12 15 18 9" />
-            </svg>
+            )}
+          />
+          <div className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500">
+            <DragHandleVisual />
           </div>
         </div>
-        {/* Internal tier links between the stacked items — same styling as
-            the stationary link circles, positioned at the gap midpoints. */}
-        {showInternalLinks && items.slice(0, -1).map((item, i) => {
+        {/* Internal tier links */}
+        {isGrouped && dragState.sourceList === 'main' && items.slice(0, -1).map((item, i) => {
           const topCenter = (i + 1) * groupedStepSize - groupedGapSize / 2;
           return (
             <div
               key={`preview-link-${item.id}`}
               className="absolute flex items-center justify-center text-blue-600 dark:text-blue-400"
               style={{
-                left: '50%',
-                top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
-                width: `${LINK_CIRCLE_SIZE}px`,
-                height: `${LINK_CIRCLE_SIZE}px`,
-                transform: 'translateX(-50%)',
-                filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
+                left: '50%', top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
+                width: `${LINK_CIRCLE_SIZE}px`, height: `${LINK_CIRCLE_SIZE}px`,
+                transform: 'translateX(-50%)', filter: LINK_CONTOUR_FILTER,
               }}
             >
-              <svg
-                width={LINK_ICON_SIZE}
-                height={LINK_ICON_SIZE}
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.25"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-              </svg>
+              <LinkIcon />
             </div>
           );
         })}
@@ -1554,100 +1600,56 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       zIndex: 1,
                     }}
                   >
-                    {tierIndices.map((itemIdx, rowIdx) => {
-                      const option = listItems[itemIdx];
-                      const rowTop = rowIdx * (isGrouped ? groupedStepSize : totalItemHeight);
-                      const isLastRow = rowIdx === size - 1;
-                      return (
-                        <React.Fragment key={option.id}>
-                          <div
-                            ref={el => {
-                              elementRefs.current[option.id] = el;
-                            }}
-                            className={`absolute left-0 right-0 p-3 ${
-                              disabled
-                                ? 'cursor-not-allowed'
-                                : 'cursor-grab active:cursor-grabbing'
-                            } ${
-                              keyboardMode && focusedItemId === option.id
-                                ? 'ring-2 ring-blue-500 ring-offset-2 rounded-md'
-                                : ''
-                            }`}
-                            style={{
-                              top: `${rowTop}px`,
-                              height: `${itemHeight}px`,
-                            }}
-                            onKeyDown={!disabled ? (e) => handleKeyDown(e, option.id) : undefined}
-                            onContextMenu={(e) => e.preventDefault()}
-                            tabIndex={disabled ? -1 : 0}
-                            role="option"
-                            aria-selected={keyboardMode && focusedItemId === option.id}
-                            aria-label={`${option.text}, ${listType === 'main' ? `ranked ${itemIdx + 1}` : 'no preference'}`}
-                            aria-describedby={`${option.id}-instructions`}
-                          >
-                            <div className="flex items-center justify-between h-full relative">
-                              {/* Content area - not draggable, allows normal scrolling */}
-                              <div
-                                className={`flex-1 flex items-center pr-12 min-w-0 ${
-                                  disabled
-                                    ? 'text-gray-500 dark:text-gray-400'
-                                    : 'text-gray-900 dark:text-white'
-                                }`}
-                              >
-                                {renderOption
-                                  ? renderOption(option.text)
-                                  : (
-                                    <OptionLabel
-                                      text={option.text}
-                                      metadata={optionsMetadata?.[option.text]}
-                                      className="min-w-0 overflow-hidden"
-                                    />
-                                  )}
-                              </div>
-
-                              {/* Per-row drag handle is hidden for multi-item
-                                  tiers — those get ONE shared handle on the
-                                  tier card instead (see below). For singleton
-                                  tiers and noPreference items, the per-row
-                                  handle is still used. */}
-                            </div>
-                          </div>
-                          {/* Divider between tied rows inside a merged card */}
-                          {!isLastRow && (
-                            <div
-                              className="absolute border-t border-gray-200 dark:border-gray-700 pointer-events-none"
-                              style={{
-                                top: `${rowTop + itemHeight + groupedGapSize / 2}px`,
-                                left: '12px',
-                                right: '12px',
-                              }}
-                            />
+                    <TierCardRows
+                      items={tierIndices.map(i => listItems[i])}
+                      stepSize={isGrouped ? groupedStepSize : totalItemHeight}
+                      gapSize={isGrouped ? groupedGapSize : gapSize}
+                      itemHeight={itemHeight}
+                      dividerClassName="border-gray-200 dark:border-gray-700"
+                      renderContent={(item) => (
+                        <div className={`flex-1 flex items-center pr-12 min-w-0 ${
+                          disabled ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-white'
+                        }`}>
+                          {renderOption ? renderOption(item.text) : (
+                            <OptionLabel text={item.text} metadata={optionsMetadata?.[item.text]} className="min-w-0 overflow-hidden" />
                           )}
-                          <div id={`${option.id}-instructions`} className="absolute -left-[10000px] w-1 h-1 overflow-hidden">
-                            {keyboardMode && focusedItemId === option.id
-                              ? `Selected for moving. Use arrow keys to move within list, left arrow to move to main list, right arrow to move to no preference, escape to cancel.`
-                              : `Press Enter or Space to select for moving. Use arrow keys to navigate between options.`
-                            }
-                          </div>
-                        </React.Fragment>
+                        </div>
+                      )}
+                      rowProps={(item, rowIdx) => {
+                        const itemIdx = tierIndices[rowIdx];
+                        return {
+                          ref: (el: HTMLDivElement | null) => { elementRefs.current[item.id] = el; },
+                          className: `absolute left-0 right-0 p-3 ${
+                            disabled ? 'cursor-not-allowed' : 'cursor-grab active:cursor-grabbing'
+                          } ${keyboardMode && focusedItemId === item.id ? 'ring-2 ring-blue-500 ring-offset-2 rounded-md' : ''}`,
+                          onKeyDown: !disabled ? (e: React.KeyboardEvent) => handleKeyDown(e, item.id) : undefined,
+                          onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+                          tabIndex: disabled ? -1 : 0,
+                          role: 'option',
+                          'aria-selected': keyboardMode && focusedItemId === item.id,
+                          'aria-label': `${item.text}, ${listType === 'main' ? `ranked ${itemIdx + 1}` : 'no preference'}`,
+                          'aria-describedby': `${item.id}-instructions`,
+                        };
+                      }}
+                    />
+                    {/* Accessibility instructions (screen-reader only) */}
+                    {tierIndices.map(itemIdx => {
+                      const option = listItems[itemIdx];
+                      return (
+                        <div key={`instr-${option.id}`} id={`${option.id}-instructions`} className="absolute -left-[10000px] w-1 h-1 overflow-hidden">
+                          {keyboardMode && focusedItemId === option.id
+                            ? 'Selected for moving. Use arrow keys to move within list, left arrow to move to main list, right arrow to move to no preference, escape to cancel.'
+                            : 'Press Enter or Space to select for moving. Use arrow keys to navigate between options.'
+                          }
+                        </div>
                       );
                     })}
-                    {/* Single drag handle for the entire tier card —
-                        vertically centered on the card. On tap (no drag),
-                        move the entire tier up/down. */}
+                    {/* Single drag handle for the entire tier card */}
                     {!disabled && (
                       <div
                         className="absolute -right-3 cursor-grab active:cursor-grabbing"
-                        style={{
-                          width: 'calc(14% + 0.525rem)',
-                          top: 0,
-                          bottom: 0,
-                          touchAction: 'none',
-                          zIndex: 2,
-                        }}
-                        onPointerDown={(e) => {
-                          handlePointerStart(e, firstItem.id);
-                        }}
+                        style={{ width: 'calc(14% + 0.525rem)', top: 0, bottom: 0, touchAction: 'none', zIndex: 2 }}
+                        onPointerDown={(e) => handlePointerStart(e, firstItem.id)}
                         onPointerUp={(e) => {
                           const pending = pendingDragRef.current;
                           if (pending && !pending.started && pending.id === firstItem.id) {
@@ -1658,61 +1660,18 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                             if (listType === 'noPreference') {
                               moveItemBetweenLists(firstItem.id, 'noPreference', tierIndices[0], 'main', mainList.length);
                             } else if (relativeY < half) {
-                              if (tierIndices[0] > 0) {
-                                moveItemInList(listType, tierIndices[0], tierIndices[0] - 1);
-                              }
+                              if (tierIndices[0] > 0) moveItemInList(listType, tierIndices[0], tierIndices[0] - 1);
                             } else {
                               const lastIdx = tierIndices[tierIndices.length - 1];
-                              if (lastIdx < listItems.length - 1) {
-                                moveItemInList(listType, lastIdx, lastIdx + 1);
-                              } else {
-                                moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);
-                              }
+                              if (lastIdx < listItems.length - 1) moveItemInList(listType, lastIdx, lastIdx + 1);
+                              else moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);
                             }
                           }
                         }}
                         title=""
                       >
-                        <div className="absolute right-4 top-1/2 -translate-y-1/2 flex flex-col items-center justify-center gap-0">
-                          {listType === 'main' ? (
-                            <>
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-                                className={tierIndices[0] === 0 ? 'text-gray-300 dark:text-gray-600' : 'text-gray-400 dark:text-gray-500'}
-                              >
-                                <polyline points="18 15 12 9 6 15" />
-                              </svg>
-                              <div className="flex flex-col items-center justify-center my-0.5">
-                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
-                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
-                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
-                              </div>
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-                                className="text-gray-400 dark:text-gray-500"
-                              >
-                                <polyline points="6 9 12 15 18 9" />
-                              </svg>
-                            </>
-                          ) : (
-                            <>
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-                                className="text-green-500 dark:text-green-400"
-                              >
-                                <line x1="12" y1="5" x2="12" y2="19" />
-                                <line x1="5" y1="12" x2="19" y2="12" />
-                              </svg>
-                              <div className="flex flex-col items-center justify-center my-0.5">
-                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
-                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600 mb-0.5"></div>
-                                <div className="w-3.5 h-0.5 bg-gray-300 dark:bg-gray-600"></div>
-                              </div>
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-                                className="text-green-500 dark:text-green-400"
-                              >
-                                <line x1="12" y1="5" x2="12" y2="19" />
-                                <line x1="5" y1="12" x2="19" y2="12" />
-                              </svg>
-                            </>
-                          )}
+                        <div className="absolute right-4 top-1/2 -translate-y-1/2">
+                          <DragHandleVisual dimUp={tierIndices[0] === 0} variant={listType === 'main' ? 'main' : 'noPreference'} />
                         </div>
                       </div>
                     )}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1609,7 +1609,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       gapSize={isGrouped ? groupedGapSize : gapSize}
                       itemHeight={itemHeight}
                       dividerClassName="border-gray-200 dark:border-gray-700"
-                      dividerInset={{ left: '12px', right: '38px' }}
+                      dividerInset={{ left: '38px', right: '38px' }}
                       renderContent={(item) => (
                         <div className={`flex-1 flex items-center pr-12 min-w-0 ${
                           disabled ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-white'

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -238,6 +238,83 @@ function LinkCircle({
 }
 
 /**
+ * Pure, testable drop-target computation for main-list drags. Given the
+ * dragged tier's visual center (from cursor + grab offset) and the list
+ * layout, returns the original-list index where the tier should land.
+ *
+ * Algorithm: for every valid insertion point (between non-dragged units
+ * or at the edges), compute where the tier's center would be in the
+ * resulting layout. Return the insertion point whose layout center is
+ * closest to the tier's actual visual center. This naturally gives
+ * symmetric thresholds (midpoint between two adjacent layout centers)
+ * and treats linked groups as atomic.
+ */
+export function computeDropTarget(
+  itemIds: readonly string[],
+  linkedPairs: ReadonlySet<string>,
+  tierStart: number,
+  tierSize: number,
+  tierVisualCenter: number,
+  itemHeight: number,
+  groupedGapSize: number,
+  totalItemHeight: number,
+): number {
+  const tEnd = tierStart + tierSize - 1;
+  const tierH = tierSize > 1
+    ? tierSize * itemHeight + (tierSize - 1) * groupedGapSize
+    : itemHeight;
+
+  // Build non-dragged unit groups
+  const allTiers = computeTierIndices(
+    itemIds.map(id => ({ id })),
+    linkedPairs,
+  );
+
+  // Collect valid target indices (boundaries between non-dragged units)
+  const validTargets: number[] = [];
+  for (const tier of allTiers) {
+    const first = tier[0];
+    const last = tier[tier.length - 1];
+    if (first >= tierStart && last <= tEnd) continue; // skip dragged tier
+    validTargets.push(first); // insert-before-this-unit position
+  }
+  // After the last non-dragged unit
+  const lastNonDragged = allTiers.filter(
+    t => !(t[0] >= tierStart && t[t.length - 1] <= tEnd),
+  );
+  if (lastNonDragged.length > 0) {
+    const last = lastNonDragged[lastNonDragged.length - 1];
+    validTargets.push(last[last.length - 1] + 1);
+  }
+
+  if (validTargets.length === 0) return tierStart;
+
+  // For each valid target, compute the tier's "natural center" in the
+  // resulting layout. Each item takes one totalItemHeight slot. The tier
+  // occupies tierSize slots starting at "slot = number of non-dragged
+  // items before the insertion point".
+  let bestTarget = validTargets[0];
+  let bestDist = Infinity;
+
+  for (const target of validTargets) {
+    // Count non-dragged items whose original index < target
+    let itemsBefore = 0;
+    for (let i = 0; i < itemIds.length; i++) {
+      if (i >= tierStart && i <= tEnd) continue;
+      if (i < target) itemsBefore++;
+    }
+    const tierNaturalCenter = itemsBefore * totalItemHeight + tierH / 2;
+    const dist = Math.abs(tierVisualCenter - tierNaturalCenter);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestTarget = target;
+    }
+  }
+
+  return bestTarget;
+}
+
+/**
  * Return `[tierStart, tierSize]` for the tier containing `index` in the
  * given list + links. A tier is a maximal run of consecutive items connected
  * by linked pairs. An untied item returns `[index, 1]`.
@@ -425,17 +502,12 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           screenY >= mainRect.top && screenY <= extendedBottom) {
         const relativeY = screenY - mainRect.top;
 
-        // Compute the drop target using non-dragged "units" (singletons or
-        // linked groups) with their actual visual centers. The reorder fires
-        // when the dragged tier's visual center crosses the midpoint between
-        // two adjacent unit centers — giving natural, symmetric thresholds
-        // that treat groups as atomic and respect their compressed height.
+        // Use the pure computeDropTarget for all main-list drags.
         if (dragState.sourceList === 'main' && dragState.tierStart !== null) {
           const tStart = dragState.tierStart;
           const tSize = dragState.tierSize;
-          const tEnd = tStart + tSize - 1;
 
-          // Dragged tier's visual extent
+          // Reconstruct tier's visual center from cursor
           const grabRow = (dragState.dragStartIndex ?? tStart) - tStart;
           const cursorOffsetFromTierTop = grabRow * groupedStepSize + dragState.mouseOffset.y;
           const tierVisualTop = relativeY - cursorOffsetFromTierTop;
@@ -444,41 +516,17 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             : itemHeight;
           const tierVisualCenter = tierVisualTop + tierVisualHeight / 2;
 
-          // Build non-dragged units with their natural visual centers
-          const allTiers = computeTierIndices(mainList, linkedPairs);
-          const units: { firstIdx: number; lastIdx: number; centerY: number }[] = [];
-          for (const tier of allTiers) {
-            const first = tier[0];
-            const last = tier[tier.length - 1];
-            // Skip the dragged tier
-            if (first >= tStart && last <= tEnd) continue;
-            const unitTop = first * totalItemHeight;
-            const unitH = tier.length > 1
-              ? tier.length * itemHeight + (tier.length - 1) * groupedGapSize
-              : itemHeight;
-            units.push({ firstIdx: first, lastIdx: last, centerY: unitTop + unitH / 2 });
-          }
-
-          if (units.length === 0) {
-            return { list: 'main' as const, index: tStart };
-          }
-
-          // Before first unit
-          if (tierVisualCenter < units[0].centerY) {
-            return { list: 'main' as const, index: units[0].firstIdx };
-          }
-
-          // Between units — find the gap whose midpoint the tier center
-          // has crossed
-          for (let u = 0; u < units.length - 1; u++) {
-            const gapMid = (units[u].centerY + units[u + 1].centerY) / 2;
-            if (tierVisualCenter < gapMid) {
-              return { list: 'main' as const, index: units[u].lastIdx + 1 };
-            }
-          }
-
-          // After last unit
-          return { list: 'main' as const, index: units[units.length - 1].lastIdx + 1 };
+          const target = computeDropTarget(
+            mainList.map(m => m.id),
+            linkedPairs,
+            tStart,
+            tSize,
+            tierVisualCenter,
+            itemHeight,
+            groupedGapSize,
+            totalItemHeight,
+          );
+          return { list: 'main' as const, index: target };
         }
 
         // Fallback: uniform-grid index for drags originating from

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -425,14 +425,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           screenY >= mainRect.top && screenY <= extendedBottom) {
         const relativeY = screenY - mainRect.top;
 
-        // When dragging a multi-item tier within the main list, compute the
-        // target by checking cursor position against the ORIGINAL midpoints
-        // of non-dragged items (not their shifted visual positions). Using
-        // original positions means the cursor needs to travel roughly one
-        // item height past the tier's edge to trigger a reorder — matching
-        // the standard single-item drag feel. Shifted positions would
-        // trigger almost immediately because the first non-dragged item
-        // slides up to where the cursor already is.
+        // When dragging a multi-item tier within the main list, find which
+        // "slot" the tier is closest to by computing the tier's visual top
+        // from the cursor position and grab offset, then rounding to the
+        // nearest totalItemHeight grid position. This gives a natural
+        // "least overlap" trigger: the reorder fires when the tier is
+        // closer to the swapped position than to its current one — roughly
+        // half a slot height (~32px) of dragging regardless of tier size
+        // or which item within the tier was grabbed.
         if (
           dragState.sourceList === 'main' &&
           dragState.tierStart !== null &&
@@ -440,34 +440,27 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         ) {
           const tStart = dragState.tierStart;
           const tSize = dragState.tierSize;
-          const tEnd = tStart + tSize - 1;
 
-          // Build ORIGINAL (pre-shift) midpoints of non-dragged items.
-          const slots: { origIdx: number; midY: number }[] = [];
-          for (let i = 0; i < mainList.length; i++) {
-            if (i >= tStart && i <= tEnd) continue;
-            slots.push({ origIdx: i, midY: i * totalItemHeight + itemHeight / 2 });
-          }
+          // Cursor offset from the tier's visual top edge:
+          //   (grabbed row within tier) * groupedStepSize + mouseOffsetY
+          const grabRow = (dragState.dragStartIndex ?? tStart) - tStart;
+          const cursorOffsetFromTierTop = grabRow * groupedStepSize + dragState.mouseOffset.y;
 
-          if (slots.length === 0) {
-            return { list: 'main' as const, index: tStart };
-          }
+          // Tier's visual top in container coordinates
+          const tierVisualTop = relativeY - cursorOffsetFromTierTop;
 
-          // Cursor above the first non-dragged item → insert before it
-          if (relativeY < slots[0].midY) {
-            return { list: 'main' as const, index: slots[0].origIdx };
-          }
+          // Nearest slot (each slot = totalItemHeight)
+          const slot = Math.round(tierVisualTop / totalItemHeight);
+          const maxSlot = mainList.length - tSize;
+          const clampedSlot = Math.max(0, Math.min(maxSlot, slot));
 
-          // Walk through gaps between non-dragged items
-          for (let g = 0; g < slots.length - 1; g++) {
-            const gapMid = (slots[g].midY + slots[g + 1].midY) / 2;
-            if (relativeY < gapMid) {
-              return { list: 'main' as const, index: slots[g].origIdx + 1 };
-            }
-          }
+          // Convert slot to original list index. Slots below the tier's
+          // current start need to account for the tier's own indices.
+          const targetIdx = clampedSlot < tStart
+            ? clampedSlot           // moving up: slot IS the target index
+            : clampedSlot + tSize;  // moving down: shift past tier's indices
 
-          // Past the last non-dragged item → insert after it
-          return { list: 'main' as const, index: slots[slots.length - 1].origIdx + 1 };
+          return { list: 'main' as const, index: targetIdx };
         }
 
         // Standard uniform-grid index for single-item drags

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1431,49 +1431,36 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
 
   /**
    * Move an entire tier (contiguous group of linked items) up or down by one
-   * position in the main list. The tier's internal linked pairs are preserved;
-   * the single item it swaps with stays ungrouped.
+   * UNIT in the main list. A "unit" is the adjacent group or singleton. This
+   * ensures that tapping up/down never splits an adjacent group — both the
+   * dragged tier and the adjacent unit stay intact.
    */
-  const moveTierInList = useCallback((tierStart: number, tierSize: number, direction: 'up' | 'down') => {
+  const moveTierByOneUnit = useCallback((tierStart: number, tierSize: number, direction: 'up' | 'down') => {
     if (direction === 'up' && tierStart <= 0) return;
     if (direction === 'down' && tierStart + tierSize >= mainList.length) return;
+
+    // Find the adjacent unit (group or singleton) in the given direction
+    const adjIdx = direction === 'up' ? tierStart - 1 : tierStart + tierSize;
+    const [adjStart, adjSize] = getTierRange(mainList, linkedPairs, adjIdx);
 
     animateWithFLIP(() => {
       setMainList(prev => {
         const newList = [...prev];
         if (direction === 'up') {
-          // Swap the item above the tier with the tier's first member
-          const [above] = newList.splice(tierStart - 1, 1);
-          newList.splice(tierStart + tierSize - 1, 0, above);
+          // Extract the adjacent unit above and re-insert after the tier
+          const above = newList.splice(adjStart, adjSize);
+          // After removal, the tier shifted down by adjSize, so it now starts
+          // at tierStart - adjSize. Insert after the tier's new end.
+          newList.splice(tierStart - adjSize + tierSize, 0, ...above);
         } else {
-          // Swap the item below the tier with the tier's last member
-          const [below] = newList.splice(tierStart + tierSize, 1);
-          newList.splice(tierStart, 0, below);
+          // Extract the adjacent unit below and re-insert before the tier
+          const below = newList.splice(tierStart + tierSize, adjSize);
+          newList.splice(tierStart, 0, ...below);
         }
         return updateItemPositions(newList);
       });
     });
-  }, [updateItemPositions, animateWithFLIP, mainList.length]);
-
-  /**
-   * Move a single main-list item from `fromIndex` to `toIndex`, preserving
-   * all linked pairs (unlike moveItemInList which clears them). Used by
-   * the tap-to-reorder handler so singletons can jump over groups without
-   * breaking those groups.
-   */
-  const moveItemToIndex = useCallback((fromIndex: number, toIndex: number) => {
-    if (fromIndex === toIndex) return;
-    animateWithFLIP(() => {
-      setMainList(prev => {
-        const newList = [...prev];
-        const [item] = newList.splice(fromIndex, 1);
-        // Adjust target for the removal
-        const adjusted = toIndex > fromIndex ? toIndex - 1 : toIndex;
-        newList.splice(adjusted, 0, item);
-        return updateItemPositions(newList);
-      });
-    });
-  }, [updateItemPositions, animateWithFLIP]);
+  }, [updateItemPositions, animateWithFLIP, mainList, linkedPairs]);
 
   // Helper function to move items between lists (with FLIP animation)
   const moveItemBetweenLists = useCallback((
@@ -1819,24 +1806,12 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                               moveItemBetweenLists(firstItem.id, 'noPreference', tierIndices[0], 'main', mainList.length);
                             } else if (relativeY < half) {
                               if (tierIndices[0] > 0) {
-                                if (isGrouped) {
-                                  moveTierInList(tierIndices[0], size, 'up');
-                                } else {
-                                  // Jump over the adjacent group/item above
-                                  const [adjStart] = getTierRange(listItems, linkedPairs, tierIndices[0] - 1);
-                                  moveItemToIndex(tierIndices[0], adjStart);
-                                }
+                                moveTierByOneUnit(tierIndices[0], size, 'up');
                               }
                             } else {
                               const lastIdx = tierIndices[tierIndices.length - 1];
                               if (lastIdx < listItems.length - 1) {
-                                if (isGrouped) {
-                                  moveTierInList(tierIndices[0], size, 'down');
-                                } else {
-                                  // Jump over the adjacent group/item below
-                                  const [adjStart, adjSize] = getTierRange(listItems, linkedPairs, lastIdx + 1);
-                                  moveItemToIndex(tierIndices[0], adjStart + adjSize);
-                                }
+                                moveTierByOneUnit(tierIndices[0], size, 'down');
                               } else {
                                 moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);
                               }

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -120,7 +120,7 @@ function LinkCircle({
         // Background-colored contour around the icon for contrast against
         // the card surface it overlaps. Stacked drop-shadows thicken the
         // halo because a single pass is too faint.
-        filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
+        filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
       }}
       aria-label={linked ? 'Break tied ranking' : 'Tie these rankings together'}
       title={linked ? 'Break tied ranking' : 'Tie these rankings together'}
@@ -1010,7 +1010,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 width: `${LINK_CIRCLE_SIZE}px`,
                 height: `${LINK_CIRCLE_SIZE}px`,
                 transform: 'translateX(-50%)',
-                filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
+                filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
               }}
             >
               <svg

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1455,6 +1455,26 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     });
   }, [updateItemPositions, animateWithFLIP, mainList.length]);
 
+  /**
+   * Move a single main-list item from `fromIndex` to `toIndex`, preserving
+   * all linked pairs (unlike moveItemInList which clears them). Used by
+   * the tap-to-reorder handler so singletons can jump over groups without
+   * breaking those groups.
+   */
+  const moveItemToIndex = useCallback((fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex) return;
+    animateWithFLIP(() => {
+      setMainList(prev => {
+        const newList = [...prev];
+        const [item] = newList.splice(fromIndex, 1);
+        // Adjust target for the removal
+        const adjusted = toIndex > fromIndex ? toIndex - 1 : toIndex;
+        newList.splice(adjusted, 0, item);
+        return updateItemPositions(newList);
+      });
+    });
+  }, [updateItemPositions, animateWithFLIP]);
+
   // Helper function to move items between lists (with FLIP animation)
   const moveItemBetweenLists = useCallback((
     itemId: string,
@@ -1802,7 +1822,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                                 if (isGrouped) {
                                   moveTierInList(tierIndices[0], size, 'up');
                                 } else {
-                                  moveItemInList(listType, tierIndices[0], tierIndices[0] - 1);
+                                  // Jump over the adjacent group/item above
+                                  const [adjStart] = getTierRange(listItems, linkedPairs, tierIndices[0] - 1);
+                                  moveItemToIndex(tierIndices[0], adjStart);
                                 }
                               }
                             } else {
@@ -1811,7 +1833,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                                 if (isGrouped) {
                                   moveTierInList(tierIndices[0], size, 'down');
                                 } else {
-                                  moveItemInList(listType, lastIdx, lastIdx + 1);
+                                  // Jump over the adjacent group/item below
+                                  const [adjStart, adjSize] = getTierRange(listItems, linkedPairs, lastIdx + 1);
+                                  moveItemToIndex(tierIndices[0], adjStart + adjSize);
                                 }
                               } else {
                                 moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -72,6 +72,30 @@ export function tiersFromList(
 }
 
 /**
+ * Return `[tierStart, tierSize]` for the tier containing `index` in the
+ * given list + links. A tier is a maximal run of consecutive items connected
+ * by linked pairs. An untied item returns `[index, 1]`.
+ */
+export function getTierRange(
+  list: readonly { id: string }[],
+  linkedPairs: ReadonlySet<string>,
+  index: number,
+): [number, number] {
+  if (index < 0 || index >= list.length) return [index, 1];
+  // Walk backward while the previous pair is linked
+  let start = index;
+  while (start > 0 && linkedPairs.has(pairKey(list[start - 1].id, list[start].id))) {
+    start--;
+  }
+  // Walk forward while the next pair is linked
+  let end = index;
+  while (end < list.length - 1 && linkedPairs.has(pairKey(list[end].id, list[end + 1].id))) {
+    end++;
+  }
+  return [start, end - start + 1];
+}
+
+/**
  * Compute standard-competition ranks for a tiered ballot (1, 2, 2, 4).
  * Returns one integer per tier: the display rank for that tier.
  */
@@ -156,6 +180,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     isDragging: false,
     draggedId: null as string | null,
     dragStartIndex: null as number | null,
+    // For main-list drags, the tier (group of tied items) the dragged item
+    // belongs to. A singleton tier is just the item itself. Tied items move
+    // together during the drag.
+    tierStart: null as number | null,   // Index of the first item in the tier
+    tierSize: 1,                          // Number of items in the tier (1 = untied)
     targetIndex: null as number | null,
     sourceList: null as 'main' | 'noPreference' | null,
     targetList: null as 'main' | 'noPreference' | null,
@@ -318,11 +347,19 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
 
     const rect = element.getBoundingClientRect();
 
+    // For main-list drags, compute the tier (group of tied items) so they
+    // can move together as one unit. No-preference items never have tiers.
+    const [tierStart, tierSize] = sourceList === 'main'
+      ? getTierRange(mainList, linkedPairs, itemIndex)
+      : [itemIndex, 1];
+
     // Store drag state
     setDragState({
       isDragging: true,
       draggedId: id,
       dragStartIndex: itemIndex,
+      tierStart,
+      tierSize,
       targetIndex: itemIndex,
       sourceList,
       targetList: sourceList,
@@ -332,7 +369,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       },
       mousePosition: { x: clientX, y: clientY }
     });
-  }, [disabled, dragState.isDragging, mainList, noPreferenceList]);
+  }, [disabled, dragState.isDragging, mainList, noPreferenceList, linkedPairs]);
 
   // Handle drag movement
   const handleDragMove = useCallback((e: PointerEvent) => {
@@ -366,6 +403,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         if (newTargetList !== dragState.targetList || newTargetIndex !== dragState.targetIndex) {
           const sourceList = dragState.sourceList!;
           const startIndex = dragState.dragStartIndex!;
+          // Main-list drags carry the whole tier (group of tied items) with
+          // them. No-preference items never have tiers so tierSize is 1.
+          const tierStart = dragState.tierStart ?? startIndex;
+          const tierSize = dragState.tierSize;
+          const tierEnd = tierStart + tierSize - 1;
 
           // Update main list positions
           setMainList(prev => {
@@ -374,22 +416,34 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               item.top = index * totalItemHeight;
             });
 
-            // If dragging from main list and targeting main list
-            if (sourceList === 'main' && newTargetList === 'main' && startIndex !== newTargetIndex && newTargetIndex !== null) {
-              if (startIndex < newTargetIndex) {
-                for (let i = startIndex + 1; i <= newTargetIndex; i++) {
-                  updatedList[i].top = (i - 1) * totalItemHeight;
+            // If dragging from main list and targeting main list.
+            // The entire tier moves as one unit — shift intervening items
+            // by tierSize positions so the tier can slot in.
+            if (sourceList === 'main' && newTargetList === 'main' && newTargetIndex !== null) {
+              // Clamp target to exclude slots inside the tier's current range
+              // (those are no-ops) — anything in [tierStart+1..tierEnd] is
+              // effectively a no-move.
+              if (newTargetIndex > tierEnd) {
+                // Tier moves DOWN. Items between tierEnd+1 and newTargetIndex
+                // shift UP by tierSize.
+                for (let i = tierEnd + 1; i <= newTargetIndex; i++) {
+                  if (i < updatedList.length) {
+                    updatedList[i].top = (i - tierSize) * totalItemHeight;
+                  }
                 }
-              } else {
-                for (let i = newTargetIndex; i < startIndex; i++) {
-                  updatedList[i].top = (i + 1) * totalItemHeight;
+              } else if (newTargetIndex < tierStart) {
+                // Tier moves UP. Items in [newTargetIndex..tierStart-1]
+                // shift DOWN by tierSize.
+                for (let i = newTargetIndex; i < tierStart; i++) {
+                  updatedList[i].top = (i + tierSize) * totalItemHeight;
                 }
               }
             }
-            // If dragging from main to no preference, shift items up to fill gap
+            // If dragging from main to no preference, the whole tier leaves
+            // the main list — shift items after the tier up by tierSize.
             else if (sourceList === 'main' && newTargetList === 'noPreference') {
-              for (let i = startIndex + 1; i < updatedList.length; i++) {
-                updatedList[i].top = (i - 1) * totalItemHeight;
+              for (let i = tierEnd + 1; i < updatedList.length; i++) {
+                updatedList[i].top = (i - tierSize) * totalItemHeight;
               }
             }
             // If dragging from no preference to main, shift items down to make space
@@ -409,7 +463,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               item.top = index * totalItemHeight;
             });
 
-            // If dragging within no preference list
+            // If dragging within no preference list (never tiered, so tierSize=1)
             if (sourceList === 'noPreference' && newTargetList === 'noPreference' && startIndex !== newTargetIndex && newTargetIndex !== null) {
               if (startIndex < newTargetIndex) {
                 for (let i = startIndex + 1; i <= newTargetIndex; i++) {
@@ -427,10 +481,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 updatedList[i].top = (i - 1) * totalItemHeight;
               }
             }
-            // If dragging from main to no preference, shift items down to make space
+            // If dragging from main to no preference, shift items down to
+            // make space for the full tier (all tied items move together).
             else if (sourceList === 'main' && newTargetList === 'noPreference' && newTargetIndex !== null) {
               for (let i = newTargetIndex; i < updatedList.length; i++) {
-                updatedList[i].top = (i + 1) * totalItemHeight;
+                updatedList[i].top = (i + tierSize) * totalItemHeight;
               }
             }
 
@@ -445,35 +500,49 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   const finishDrag = useCallback(() => {
     if (!dragState.isDragging) return;
 
-    const { draggedId, dragStartIndex, targetIndex, sourceList, targetList } = dragState;
+    const { draggedId, dragStartIndex, tierStart, tierSize, targetIndex, sourceList, targetList } = dragState;
 
     if (draggedId && dragStartIndex !== null && targetIndex !== null && sourceList && targetList) {
       // Find the dragged item
       const sourceListRef = sourceList === 'main' ? mainList : noPreferenceList;
       const draggedItem = sourceListRef.find(item => item.id === draggedId);
-      
+
       if (draggedItem) {
+        // Tier range (for main-list drags). For noPreference, always single.
+        const effectiveTierStart = sourceList === 'main' && tierStart !== null ? tierStart : dragStartIndex;
+        const effectiveTierSize = sourceList === 'main' ? tierSize : 1;
+        const tierEnd = effectiveTierStart + effectiveTierSize - 1;
+
+        // For intra-main drags, a target within (or just after) the tier
+        // is a no-op (the tier stays put).
+        const isNoOp =
+          sourceList === targetList &&
+          sourceList === 'main' &&
+          targetIndex >= effectiveTierStart &&
+          targetIndex <= tierEnd + 1;
+
         // Handle cross-list movement or reordering within the same list
-        if (sourceList !== targetList || dragStartIndex !== targetIndex) {
+        if (!isNoOp && (sourceList !== targetList || dragStartIndex !== targetIndex)) {
           // Handle cross-list movement with atomic state updates
           if (sourceList !== targetList) {
             // Moving between lists - update both lists atomically
             if (sourceList === 'main' && targetList === 'noPreference') {
-              // Remove from main list
+              // Move the whole tier out of main into noPreference. The
+              // tier's internal linked pairs are dropped since noPreference
+              // items don't have tiers.
+              const tierItems = mainList.slice(effectiveTierStart, effectiveTierStart + effectiveTierSize);
               setMainList(prev => {
                 const newList = [...prev];
-                newList.splice(dragStartIndex, 1);
+                newList.splice(effectiveTierStart, effectiveTierSize);
                 return updateItemPositions(newList);
               });
-              // Add to no preference list
               setNoPreferenceList(prev => {
                 const newList = [...prev];
-                newList.splice(targetIndex, 0, draggedItem);
+                newList.splice(targetIndex, 0, ...tierItems);
                 return updateItemPositions(newList);
               });
-              // Item left the ranked list entirely — drop any tied-rank
-              // groupings that involved it.
-              dropLinkedPairsFor(draggedItem.id);
+              // Drop linked-pair entries for every tier member
+              tierItems.forEach(it => dropLinkedPairsFor(it.id));
             } else if (sourceList === 'noPreference' && targetList === 'main') {
               // Remove from no preference list
               setNoPreferenceList(prev => {
@@ -491,15 +560,22 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           } else {
             // Reordering within the same list
             if (sourceList === 'main') {
+              // Move the whole tier as one unit. Adjust target index to
+              // account for the items being spliced out.
+              const adjustedTarget =
+                targetIndex <= effectiveTierStart
+                  ? targetIndex
+                  : targetIndex - effectiveTierSize;
               setMainList(prev => {
                 const newList = [...prev];
-                const [movedItem] = newList.splice(dragStartIndex, 1);
-                newList.splice(targetIndex, 0, movedItem);
+                const tierItems = newList.splice(effectiveTierStart, effectiveTierSize);
+                newList.splice(adjustedTarget, 0, ...tierItems);
                 return updateItemPositions(newList);
               });
-              // Drop tied-rank links touching the moved item so its new
-              // neighbors aren't implicitly grouped with it.
-              clearLinksTouchingItem(draggedItem.id);
+              // The tier's internal links are preserved (the items remain
+              // adjacent after the splice). Links touching the tier from
+              // *outside* (there should be none by definition of a tier,
+              // but belt-and-suspenders) are not affected.
             } else {
               setNoPreferenceList(prev => {
                 const newList = [...prev];
@@ -524,13 +600,15 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       isDragging: false,
       draggedId: null,
       dragStartIndex: null,
+      tierStart: null,
+      tierSize: 1,
       targetIndex: null,
       sourceList: null,
       targetList: null,
       mouseOffset: { x: 0, y: 0 },
       mousePosition: { x: 0, y: 0 }
     });
-  }, [dragState, mainList, noPreferenceList, updateItemPositions, dropLinkedPairsFor, clearLinksTouchingItem]);
+  }, [dragState, mainList, noPreferenceList, updateItemPositions, dropLinkedPairsFor]);
 
   // Set up event listeners
   useEffect(() => {
@@ -761,50 +839,69 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     return noPreferenceList.find(option => option.id === dragState.draggedId) || null;
   };
 
-  // Get style for the dragged item
-  const getDraggedItemStyle = () => {
-    const { mousePosition, mouseOffset } = dragState;
-
-    const x = mousePosition.x - mouseOffset.x;
-    const y = mousePosition.y - mouseOffset.y;
-    const width = mainContainerRef.current ? mainContainerRef.current.offsetWidth : 300;
-
-    return {
-      position: 'fixed' as const,
-      left: `${x}px`,
-      top: `${y}px`,
-      width: `${width}px`,
-      height: `${itemHeight}px`,
-      zIndex: 1000,
-      pointerEvents: 'none' as const,
-      transform: 'scale(1.02)',
-      boxShadow: '0 8px 25px rgba(0,0,0,0.3)'
-    };
+  // Get the list of items currently being dragged. Includes all tier members
+  // (for main-list drags of tied items) so they visually move together.
+  const getDraggedItems = (): RankableOption[] => {
+    if (!dragState.draggedId) return [];
+    if (dragState.sourceList === 'main' && dragState.tierStart !== null && dragState.tierSize > 1) {
+      return mainList.slice(dragState.tierStart, dragState.tierStart + dragState.tierSize);
+    }
+    const single = getDraggedOption();
+    return single ? [single] : [];
   };
 
-  // Render dragged item
+  // Render dragged item(s) — for tied tiers, stack all members together so
+  // the whole group drags as a unit under the cursor.
   const renderDraggedItem = () => {
-    const draggedOption = getDraggedOption();
-    if (!draggedOption) return null;
+    const items = getDraggedItems();
+    if (items.length === 0) return null;
+
+    const { mousePosition, mouseOffset } = dragState;
+    const x = mousePosition.x - mouseOffset.x;
+    // Offset the stack so the grabbed item sits where the cursor is. The
+    // grabbed item may not be the first tier member, so shift the stack up
+    // by grabbedOffset rows.
+    const grabbedIndex = items.findIndex(it => it.id === dragState.draggedId);
+    const y = mousePosition.y - mouseOffset.y - Math.max(0, grabbedIndex) * totalItemHeight;
+    const width = mainContainerRef.current ? mainContainerRef.current.offsetWidth : 300;
 
     return (
       <div
-        className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md p-3 select-none"
-        style={getDraggedItemStyle()}
+        style={{
+          position: 'fixed',
+          left: `${x}px`,
+          top: `${y}px`,
+          width: `${width}px`,
+          zIndex: 1000,
+          pointerEvents: 'none',
+          transform: 'scale(1.02)',
+          filter: 'drop-shadow(0 8px 25px rgba(0,0,0,0.3))',
+        }}
       >
-        <div className="flex items-center justify-between h-full">
-          <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
-            {renderOption ? renderOption(draggedOption.text) : <OptionLabel text={draggedOption.text} metadata={optionsMetadata?.[draggedOption.text]} className="min-w-0 overflow-hidden" />}
+        {items.map((item, i) => (
+          <div
+            key={item.id}
+            className="bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-600 rounded-md p-3 select-none"
+            style={{
+              height: `${itemHeight}px`,
+              marginTop: i === 0 ? 0 : `${gapSize}px`,
+            }}
+          >
+            <div className="flex items-center justify-between h-full">
+              <div className="flex items-center min-w-0 flex-1 text-gray-900 dark:text-white">
+                {renderOption ? renderOption(item.text) : <OptionLabel text={item.text} metadata={optionsMetadata?.[item.text]} className="min-w-0 overflow-hidden" />}
+              </div>
+              <div className="flex flex-col items-center justify-center ml-2 text-gray-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="18 15 12 9 6 15" />
+                </svg>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </div>
+            </div>
           </div>
-          <div className="flex flex-col items-center justify-center ml-2 text-gray-500">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="18 15 12 9 6 15" />
-            </svg>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="6 9 12 15 18 9" />
-            </svg>
-          </div>
-        </div>
+        ))}
       </div>
     );
   };
@@ -826,16 +923,18 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       };
     }
 
-    // Only apply height changes when dragging between different lists
+    // Only apply height changes when dragging between different lists.
+    // For main→noPreference drags of a tied tier, `dragState.tierSize`
+    // tells us how many items are moving together.
     if (dragState.targetList && dragState.sourceList !== dragState.targetList) {
-      // Cross-list drag: asymmetric behavior for better UX
+      const tierSize = dragState.sourceList === 'main' ? dragState.tierSize : 1;
       let newMainHeight = baseMainHeight;
       let newNoPreferenceHeight = baseNoPreferenceHeight;
 
       if (dragState.sourceList === 'main' && dragState.targetList === 'noPreference') {
         // Dragging from main to no preference - DON'T shrink main (keep stable), but grow no preference
         newMainHeight = baseMainHeight; // Keep main list at original size during preview
-        newNoPreferenceHeight = Math.max((noPreferenceList.length + 1) * totalItemHeight - gapSize, totalItemHeight);
+        newNoPreferenceHeight = Math.max((noPreferenceList.length + tierSize) * totalItemHeight - gapSize, totalItemHeight);
       } else if (dragState.sourceList === 'noPreference' && dragState.targetList === 'main') {
         // Dragging from no preference to main - grow main, shrink no preference (real-time feedback)
         newMainHeight = Math.max((mainList.length + 1) * totalItemHeight - gapSize, totalItemHeight);
@@ -1261,9 +1360,18 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
 
             {/* Render all items in this list */}
             {listItems.map((option, index) => {
-              // Skip rendering the item in its original position if it's being dragged
-              if (dragState.isDragging && option.id === dragState.draggedId) {
-                return null;
+              // Skip rendering items that are currently being dragged. For
+              // main-list drags, this includes *every* tier member so the
+              // whole tied group visually moves together.
+              if (dragState.isDragging && listType === dragState.sourceList) {
+                if (listType === 'main' && dragState.tierStart !== null) {
+                  const inTier =
+                    index >= dragState.tierStart &&
+                    index < dragState.tierStart + dragState.tierSize;
+                  if (inTier) return null;
+                } else if (option.id === dragState.draggedId) {
+                  return null;
+                }
               }
 
               return (

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -591,13 +591,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             // The entire tier moves as one unit — shift intervening items
             // by tierSize positions so the tier can slot in.
             if (sourceList === 'main' && newTargetList === 'main' && newTargetIndex !== null) {
-              // Clamp target to exclude slots inside the tier's current range
-              // (those are no-ops) — anything in [tierStart+1..tierEnd] is
-              // effectively a no-move.
-              if (newTargetIndex > tierEnd) {
-                // Tier moves DOWN. Items between tierEnd+1 and newTargetIndex
-                // shift UP by tierSize.
-                for (let i = tierEnd + 1; i <= newTargetIndex; i++) {
+              // Targets inside [tierStart..tierEnd+1] are no-ops (the tier
+              // would land back in its current position). Only shift items
+              // for targets strictly outside that range.
+              if (newTargetIndex > tierEnd + 1) {
+                // Tier moves DOWN. Items at indices tierEnd+1 through
+                // newTargetIndex-1 shift UP by tierSize (they get "passed
+                // over" by the tier). The item AT newTargetIndex stays put.
+                for (let i = tierEnd + 1; i < newTargetIndex; i++) {
                   if (i < updatedList.length) {
                     updatedList[i].top = (i - tierSize) * totalItemHeight;
                   }

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -79,8 +79,12 @@ export function tiersFromList(
  * Centered on the left edge of the cards column so the circle overlaps the
  * corners of the two items it sits between.
  */
-const LINK_CIRCLE_SIZE = 28; // diameter in px
-const LINK_ICON_SIZE = 18;   // chain glyph in px (25% bigger than original 14px)
+const LINK_CIRCLE_SIZE = 24; // diameter in px (15% smaller than previous 28)
+const LINK_ICON_SIZE = 15;   // chain glyph in px (15% smaller than previous 18)
+// Horizontal offset of the circle's left edge from the cards container's
+// left edge. A small positive offset keeps the circle fully inside the
+// cards, just to the right of their left edge.
+const LINK_CIRCLE_LEFT_OFFSET = 1;
 
 function LinkCircle({
   entry,
@@ -103,17 +107,15 @@ function LinkCircle({
         e.stopPropagation();
         onToggle(idA, idB);
       }}
-      className={`absolute rounded-full flex items-center justify-center border-2 shadow-sm transition-colors ${
+      className={`absolute rounded-full flex items-center justify-center border bg-white dark:bg-gray-900 shadow-sm transition-colors ${
         disabled
-          ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-600'
+          ? 'cursor-not-allowed border-gray-200 text-gray-400 dark:border-gray-700 dark:text-gray-600'
           : linked
-            ? 'cursor-pointer border-blue-600 bg-blue-600 text-white hover:bg-blue-700 dark:border-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400'
-            : 'cursor-pointer border-gray-300 bg-white text-gray-400 hover:border-blue-400 hover:text-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-500 dark:hover:border-blue-500 dark:hover:text-blue-400'
+            ? 'cursor-pointer border-gray-300 text-blue-600 hover:border-blue-400 dark:border-gray-600 dark:text-blue-400 dark:hover:border-blue-500'
+            : 'cursor-pointer border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 dark:border-gray-600 dark:text-gray-500 dark:hover:border-blue-500 dark:hover:text-blue-400'
       }`}
       style={{
-        // Center the circle on the left edge of the cards container
-        // (x = 0 within the container, circle horizontal center = 0).
-        left: `-${LINK_CIRCLE_SIZE / 2}px`,
+        left: `${LINK_CIRCLE_LEFT_OFFSET}px`,
         top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
         width: `${LINK_CIRCLE_SIZE}px`,
         height: `${LINK_CIRCLE_SIZE}px`,
@@ -981,9 +983,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           return (
             <div
               key={`preview-link-${item.id}`}
-              className="absolute flex items-center justify-center rounded-full border-2 border-blue-600 bg-blue-600 text-white shadow-sm dark:border-blue-500 dark:bg-blue-500"
+              className="absolute flex items-center justify-center rounded-full border border-gray-300 bg-white text-blue-600 shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-blue-400"
               style={{
-                left: `-${LINK_CIRCLE_SIZE / 2}px`,
+                left: `${LINK_CIRCLE_LEFT_OFFSET}px`,
                 top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
                 width: `${LINK_CIRCLE_SIZE}px`,
                 height: `${LINK_CIRCLE_SIZE}px`,

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -142,6 +142,7 @@ function TierCardRows({
   gapSize: innerGap,
   itemHeight: rowHeight,
   dividerClassName,
+  dividerInset = { left: '12px', right: '12px' },
   renderContent,
   rowProps,
 }: {
@@ -150,6 +151,7 @@ function TierCardRows({
   gapSize: number;
   itemHeight: number;
   dividerClassName: string;
+  dividerInset?: { left: string; right: string };
   renderContent: (item: { id: string; text: string }, index: number) => React.ReactNode;
   rowProps?: (item: { id: string; text: string }, rowIdx: number) => Record<string, unknown>;
 }) {
@@ -174,8 +176,8 @@ function TierCardRows({
                 className={`absolute pointer-events-none border-t ${dividerClassName}`}
                 style={{
                   top: `${rowTop + rowHeight + innerGap / 2}px`,
-                  left: '12px',
-                  right: '12px',
+                  left: dividerInset.left,
+                  right: dividerInset.right,
                   transform: 'translateY(-0.5px)',
                 }}
               />
@@ -1607,6 +1609,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                       gapSize={isGrouped ? groupedGapSize : gapSize}
                       itemHeight={itemHeight}
                       dividerClassName="border-gray-200 dark:border-gray-700"
+                      dividerInset={{ left: '12px', right: '38px' }}
                       renderContent={(item) => (
                         <div className={`flex-1 flex items-center pr-12 min-w-0 ${
                           disabled ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-white'

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -14,21 +14,83 @@ interface RankableOption {
 
 interface RankableOptionsProps {
   options: string[];
-  onRankingChange: (rankedOptions: string[]) => void;
+  /**
+   * Called when the user's ranking changes.
+   * - rankedOptions: flat ordering (top-to-bottom) from the main list
+   * - tiers: tiered ordering respecting equal-rank groupings
+   *          (e.g. [["A"], ["B", "C"], ["D"]])
+   */
+  onRankingChange: (rankedOptions: string[], tiers: string[][]) => void;
   disabled?: boolean;
   storageKey?: string; // Optional key for localStorage persistence
   initialRanking?: string[]; // Optional initial ranking to override saved state
+  initialTiers?: string[][]; // Optional initial tiers (for edit mode)
   optionsMetadata?: OptionsMetadata | null;
   renderOption?: (option: string) => React.ReactNode;
   preserveOrder?: boolean; // Skip initial shuffle (use for time slots, which have a natural order)
+  /** Disable the equal-ranking link UI (e.g. for time slot polls) */
+  disableGrouping?: boolean;
 }
 
-export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, optionsMetadata, renderOption, preserveOrder = false }: RankableOptionsProps) {
+/**
+ * Canonical key for a pair of item ids, order-independent. Used so that
+ * linked-pair membership survives when a linked-group is reordered end-to-end.
+ */
+export const pairKey = (a: string, b: string): string => (a < b ? `${a}|${b}` : `${b}|${a}`);
+
+/**
+ * Compute tier boundaries from a flat list + set of linked pairs.
+ * Returns an array of tiers, where each tier is a list of indices into the
+ * main list that belong to that tier.
+ */
+export function computeTierIndices(
+  list: readonly { id: string }[],
+  linkedPairs: ReadonlySet<string>,
+): number[][] {
+  if (list.length === 0) return [];
+  const tiers: number[][] = [[0]];
+  for (let i = 1; i < list.length; i++) {
+    const prev = list[i - 1];
+    const curr = list[i];
+    if (linkedPairs.has(pairKey(prev.id, curr.id))) {
+      tiers[tiers.length - 1].push(i);
+    } else {
+      tiers.push([i]);
+    }
+  }
+  return tiers;
+}
+
+/** Convert tier index ranges into the `[["A"], ["B","C"], ...]` shape. */
+export function tiersFromList(
+  list: readonly { id: string; text: string }[],
+  linkedPairs: ReadonlySet<string>,
+): string[][] {
+  return computeTierIndices(list, linkedPairs).map(tier =>
+    tier.map(i => list[i].text),
+  );
+}
+
+/**
+ * Compute standard-competition ranks for a tiered ballot (1, 2, 2, 4).
+ * Returns one integer per tier: the display rank for that tier.
+ */
+export function tierRanks(tiers: readonly (readonly unknown[])[]): number[] {
+  const ranks: number[] = [];
+  let pos = 0;
+  for (const tier of tiers) {
+    ranks.push(pos + 1);
+    pos += tier.length;
+  }
+  return ranks;
+}
+
+export default function RankableOptions({ options, onRankingChange, disabled = false, storageKey, initialRanking, initialTiers, optionsMetadata, renderOption, preserveOrder = false, disableGrouping = false }: RankableOptionsProps) {
 
   // Load saved state from localStorage
   const loadSavedState = useCallback(() => {
     if (!storageKey || typeof window === 'undefined') return null;
-    
+
     try {
       const saved = localStorage.getItem(storageKey);
       if (saved) {
@@ -36,8 +98,8 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         // Validate that saved options match current options
         const allSavedTexts = [...parsed.mainList, ...parsed.noPreferenceList].map((opt: RankableOption) => opt.text).sort();
         const currentTexts = [...options].sort();
-        
-        if (allSavedTexts.length === currentTexts.length && 
+
+        if (allSavedTexts.length === currentTexts.length &&
             allSavedTexts.every((text: string, index: number) => text === currentTexts[index])) {
           return parsed;
         }
@@ -49,13 +111,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   }, [storageKey, options]);
 
   // Save state to localStorage
-  const saveState = useCallback((mainList: RankableOption[], noPreferenceList: RankableOption[]) => {
+  const saveState = useCallback((mainList: RankableOption[], noPreferenceList: RankableOption[], linkedPairs: Set<string>) => {
     if (!storageKey || typeof window === 'undefined') return;
-    
+
     try {
       localStorage.setItem(storageKey, JSON.stringify({
         mainList,
         noPreferenceList,
+        linkedPairs: Array.from(linkedPairs),
         timestamp: Date.now()
       }));
     } catch (e) {
@@ -85,6 +148,10 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   // State management - separate lists for main ranking and no preference
   const [mainList, setMainList] = useState<RankableOption[]>([]);
   const [noPreferenceList, setNoPreferenceList] = useState<RankableOption[]>([]);
+  // Linked pairs for equal/tied ranking. Keys are canonical pairKey(id1, id2)
+  // strings. Two main-list items at adjacent visual positions are considered
+  // grouped (tied) if their pair is in this set.
+  const [linkedPairs, setLinkedPairs] = useState<Set<string>>(() => new Set());
   const [dragState, setDragState] = useState({
     isDragging: false,
     draggedId: null as string | null,
@@ -181,6 +248,56 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     
     return null;
   }, [getIndexFromY, mainList.length, noPreferenceList.length, dragState.sourceList]);
+
+  /**
+   * Toggle the "linked" (equal-rank) state between two adjacent main-list items.
+   * This is the click handler for the chain/broken-chain icons rendered in
+   * the rank-number column between items.
+   */
+  const toggleLinkBetween = useCallback((id1: string, id2: string) => {
+    if (disabled || disableGrouping) return;
+    setLinkedPairs(prev => {
+      const key = pairKey(id1, id2);
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, [disabled, disableGrouping]);
+
+  /**
+   * When a main-list item is moved out of the main list (to noPreference),
+   * its grouping no longer makes sense — remove any linkedPairs entries that
+   * reference it. Leaves other groupings intact.
+   */
+  const dropLinkedPairsFor = useCallback((itemId: string) => {
+    setLinkedPairs(prev => {
+      const next = new Set<string>();
+      let changed = false;
+      for (const key of prev) {
+        const [a, b] = key.split('|');
+        if (a === itemId || b === itemId) {
+          changed = true;
+          continue;
+        }
+        next.add(key);
+      }
+      return changed ? next : prev;
+    });
+  }, []);
+
+  /**
+   * When an item is reordered within the main list (drag or tap-to-move), its
+   * previous adjacencies no longer make sense. Drop any link entries that
+   * involved this item so the user's new ordering starts ungrouped with
+   * respect to its neighbors. Other groupings are preserved.
+   */
+  const clearLinksTouchingItem = useCallback((itemId: string) => {
+    dropLinkedPairsFor(itemId);
+  }, [dropLinkedPairsFor]);
 
   // Start dragging an item (called after pointer has moved beyond threshold)
   const startDrag = useCallback((clientX: number, clientY: number, id: string) => {
@@ -354,6 +471,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 newList.splice(targetIndex, 0, draggedItem);
                 return updateItemPositions(newList);
               });
+              // Item left the ranked list entirely — drop any tied-rank
+              // groupings that involved it.
+              dropLinkedPairsFor(draggedItem.id);
             } else if (sourceList === 'noPreference' && targetList === 'main') {
               // Remove from no preference list
               setNoPreferenceList(prev => {
@@ -377,6 +497,9 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 newList.splice(targetIndex, 0, movedItem);
                 return updateItemPositions(newList);
               });
+              // Drop tied-rank links touching the moved item so its new
+              // neighbors aren't implicitly grouped with it.
+              clearLinksTouchingItem(draggedItem.id);
             } else {
               setNoPreferenceList(prev => {
                 const newList = [...prev];
@@ -407,7 +530,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       mouseOffset: { x: 0, y: 0 },
       mousePosition: { x: 0, y: 0 }
     });
-  }, [dragState, mainList, noPreferenceList, updateItemPositions]);
+  }, [dragState, mainList, noPreferenceList, updateItemPositions, dropLinkedPairsFor, clearLinksTouchingItem]);
 
   // Set up event listeners
   useEffect(() => {
@@ -487,36 +610,33 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   const hasMountedRef = useRef(false);
   const previousOptionsRef = useRef<string[]>([]);
   
-  // Notify parent component when main list changes (only main list matters for voting)
+  // Notify parent component when the main list OR tier structure changes.
+  // We send both the flat order AND the tiered structure; the backend IRV
+  // algorithm prefers the tiered form when present.
   useEffect(() => {
-    // Skip the first render to avoid triggering on initialization
+    const flat = mainList.map(option => option.text);
+    const tiers = tiersFromList(mainList, linkedPairs);
     if (!hasMountedRef.current) {
       hasMountedRef.current = true;
-      // Still notify parent with initial ranking
-      const initialRanking = mainList.map(option => option.text);
-      onRankingChange(initialRanking);
-      return;
     }
-    
-    const newRanking = mainList.map(option => option.text);
-    onRankingChange(newRanking);
-  }, [mainList, onRankingChange]);
+    onRankingChange(flat, tiers);
+  }, [mainList, linkedPairs, onRankingChange]);
 
   // Track previous initialRanking to detect changes
   const previousInitialRankingRef = useRef<string[] | undefined>(undefined);
-  
+
   // Initialize positions on mount and when options or initialRanking change
   useEffect(() => {
     // Check if options have actually changed
-    const optionsChanged = 
+    const optionsChanged =
       previousOptionsRef.current.length !== options.length ||
       !previousOptionsRef.current.every((opt, index) => opt === options[index]);
-      
+
     // Check if initialRanking has changed
-    const initialRankingChanged = 
+    const initialRankingChanged =
       previousInitialRankingRef.current !== initialRanking &&
       JSON.stringify(previousInitialRankingRef.current) !== JSON.stringify(initialRanking);
-    
+
     if (optionsChanged || initialRankingChanged) {
       // Check if we have an initial ranking provided (e.g., for edit mode)
       if (initialRanking && initialRanking.length > 0) {
@@ -526,7 +646,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           text: text,
           top: index * totalItemHeight
         }));
-        
+
         // Put any remaining options (not in initialRanking) into no preference
         const remainingOptions = options.filter(opt => !initialRanking.includes(opt));
         const noPreferenceOptions = remainingOptions.map((text, index) => ({
@@ -534,13 +654,33 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           text: text,
           top: index * totalItemHeight
         }));
-        
+
         setMainList(rankedOptions);
         setNoPreferenceList(noPreferenceOptions);
+
+        // If tiers were passed in (edit mode with existing tied rankings),
+        // convert them to linkedPairs state. Tiers reference option texts,
+        // so we map to the newly-created item IDs.
+        if (initialTiers && initialTiers.length > 0) {
+          const textToId = new Map<string, string>();
+          rankedOptions.forEach(opt => textToId.set(opt.text, opt.id));
+          const newLinked = new Set<string>();
+          for (const tier of initialTiers) {
+            if (tier.length < 2) continue;
+            for (let i = 0; i < tier.length - 1; i++) {
+              const id1 = textToId.get(tier[i]);
+              const id2 = textToId.get(tier[i + 1]);
+              if (id1 && id2) newLinked.add(pairKey(id1, id2));
+            }
+          }
+          setLinkedPairs(newLinked);
+        } else {
+          setLinkedPairs(new Set());
+        }
       } else {
         // Try to load saved state first
         const savedState = loadSavedState();
-        
+
         if (savedState) {
           // Apply positions to saved state
           const positionedMainList = savedState.mainList.map((item: RankableOption, index: number) => ({
@@ -551,9 +691,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
             ...item,
             top: index * totalItemHeight
           }));
-          
+
           setMainList(positionedMainList);
           setNoPreferenceList(positionedNoPreferenceList);
+          // Restore linked pairs if the saved state has them (older saved
+          // states just don't have the field — default to empty).
+          setLinkedPairs(
+            new Set(Array.isArray(savedState.linkedPairs) ? savedState.linkedPairs : []),
+          );
         } else {
           // Initialize with randomized order to prevent position bias,
           // unless preserveOrder is set (e.g. time slots have a natural chronological order).
@@ -565,20 +710,21 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           }));
           setMainList(newRankedOptions);
           setNoPreferenceList([]);
+          setLinkedPairs(new Set());
         }
       }
-      
+
       previousOptionsRef.current = options;
       previousInitialRankingRef.current = initialRanking;
     }
-  }, [options, initialRanking, totalItemHeight, loadSavedState, shuffleArray]);
+  }, [options, initialRanking, initialTiers, totalItemHeight, loadSavedState, shuffleArray, preserveOrder]);
 
-  // Save state whenever lists change
+  // Save state whenever lists or linked pairs change
   useEffect(() => {
     if (hasMountedRef.current && storageKey) {
-      saveState(mainList, noPreferenceList);
+      saveState(mainList, noPreferenceList, linkedPairs);
     }
-  }, [mainList, noPreferenceList, saveState, storageKey]);
+  }, [mainList, noPreferenceList, linkedPairs, saveState, storageKey]);
 
   // Reset to random order (for testing/debugging)
   const resetToRandomOrder = useCallback(() => {
@@ -877,6 +1023,10 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   // Helper function to move items within the same list (with FLIP animation)
   const moveItemInList = useCallback((listType: 'main' | 'noPreference', fromIndex: number, toIndex: number) => {
     const setter = listType === 'main' ? setMainList : setNoPreferenceList;
+    // Capture the moved item id BEFORE we run state updates so we can drop
+    // any stale linked pairs that referenced it at its old position.
+    const currentList = listType === 'main' ? mainList : noPreferenceList;
+    const movedId = currentList[fromIndex]?.id;
 
     animateWithFLIP(() => {
       setter(prev => {
@@ -886,7 +1036,10 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         return updateItemPositions(newList);
       });
     });
-  }, [updateItemPositions, animateWithFLIP]);
+    if (listType === 'main' && movedId) {
+      clearLinksTouchingItem(movedId);
+    }
+  }, [updateItemPositions, animateWithFLIP, mainList, noPreferenceList, clearLinksTouchingItem]);
 
   // Helper function to move items between lists (with FLIP animation)
   const moveItemBetweenLists = useCallback((
@@ -916,7 +1069,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         return updateItemPositions(newList);
       });
     });
-  }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP]);
+    // If the item left the main list entirely, drop any tied-rank entries
+    // that involved it. If it's being moved INTO main from noPreference,
+    // there are no pre-existing links to worry about.
+    if (sourceList === 'main' && targetList !== 'main') {
+      dropLinkedPairsFor(item.id);
+    }
+  }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP, dropLinkedPairsFor]);
 
   // Render a single list container (main or no preference)
   const renderListContainer = (
@@ -952,26 +1111,123 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         )}
 
         <div className="flex">
-          {/* Static rank numbers column - only for main list */}
-          {listType === 'main' && numberSlotCount > 0 && (
-            <div className="flex-shrink-0 relative" style={{ width: '32px', height: `${dynamicHeight}px`, minHeight: `${totalItemHeight}px` }}>
-              {Array.from({ length: numberSlotCount }, (_, i) => (
-                <div
-                  key={i}
-                  className="absolute left-0 right-0 flex items-center justify-center"
-                  style={{ top: `${i * totalItemHeight}px`, height: `${itemHeight}px` }}
-                >
-                  <div className={`w-6 h-6 rounded-full flex items-center justify-center text-sm font-medium ${
-                    disabled
-                      ? 'bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400'
-                      : 'bg-blue-600 text-white'
-                  }`}>
-                    {i + 1}
+          {/* Rank number + link column - only for main list.
+              Renders one rank number per tier, vertically centered on the
+              tier's items, using standard competition ranking (1, 2, 2, 4).
+              Link icons sit between every pair of adjacent items, allowing
+              the user to toggle tied rankings. */}
+          {listType === 'main' && numberSlotCount > 0 && (() => {
+            // When dragging from noPreference INTO main, we reserve one extra
+            // slot at the bottom as a placeholder; tiers don't extend to it.
+            const effectiveMainList = mainList;
+            const tiers = computeTierIndices(effectiveMainList, linkedPairs);
+            // Add the extra slot as its own singleton tier if needed
+            if (numberSlotCount > effectiveMainList.length) {
+              tiers.push([effectiveMainList.length]);
+            }
+            // Build rank number entries with standard competition ranking
+            const rankEntries: { rank: number; top: number; height: number; width: number; key: string }[] = [];
+            let positionsSoFar = 0;
+            tiers.forEach((tier, tierIdx) => {
+              const startIdx = tier[0];
+              const size = tier.length;
+              const rank = positionsSoFar + 1;
+              // Center a rank pill that spans the tier's full visible height
+              const top = startIdx * totalItemHeight;
+              const height = size * itemHeight + (size - 1) * gapSize;
+              rankEntries.push({
+                rank,
+                top,
+                height,
+                width: 0,
+                key: `rank-${tierIdx}-${startIdx}`,
+              });
+              positionsSoFar += size;
+            });
+            // Build link icon entries between every pair of adjacent items
+            // (only within the actual main list, not the placeholder slot).
+            const linkEntries: {
+              topCenter: number;
+              linked: boolean;
+              idA: string;
+              idB: string;
+              key: string;
+            }[] = [];
+            for (let i = 0; i < effectiveMainList.length - 1; i++) {
+              const a = effectiveMainList[i];
+              const b = effectiveMainList[i + 1];
+              linkEntries.push({
+                // Midpoint of the gap between item i and item i+1
+                topCenter: (i + 1) * totalItemHeight - gapSize / 2,
+                linked: linkedPairs.has(pairKey(a.id, b.id)),
+                idA: a.id,
+                idB: b.id,
+                key: `link-${a.id}-${b.id}`,
+              });
+            }
+            return (
+              <div
+                className="flex-shrink-0 relative"
+                style={{ width: '48px', height: `${dynamicHeight}px`, minHeight: `${totalItemHeight}px` }}
+              >
+                {rankEntries.map(entry => (
+                  <div
+                    key={entry.key}
+                    className="absolute left-0 flex items-center justify-center pointer-events-none"
+                    style={{ top: `${entry.top}px`, height: `${entry.height}px`, width: '32px' }}
+                  >
+                    <div className={`w-6 h-6 rounded-full flex items-center justify-center text-sm font-medium ${
+                      disabled
+                        ? 'bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400'
+                        : 'bg-blue-600 text-white'
+                    }`}>
+                      {entry.rank}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          )}
+                ))}
+                {!disableGrouping && !dragState.isDragging && linkEntries.map(entry => (
+                  <button
+                    key={entry.key}
+                    type="button"
+                    disabled={disabled}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      toggleLinkBetween(entry.idA, entry.idB);
+                    }}
+                    className={`absolute rounded-full flex items-center justify-center transition-colors ${
+                      disabled
+                        ? 'cursor-not-allowed text-gray-300 dark:text-gray-600'
+                        : entry.linked
+                          ? 'text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/40 cursor-pointer'
+                          : 'text-gray-300 dark:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-400 cursor-pointer'
+                    }`}
+                    style={{
+                      left: '30px',
+                      top: `${entry.topCenter - 10}px`,
+                      width: '18px',
+                      height: '20px',
+                    }}
+                    aria-label={entry.linked ? 'Break tied ranking' : 'Tie these rankings together'}
+                    title={entry.linked ? 'Break tied ranking' : 'Tie these rankings together'}
+                  >
+                    {entry.linked ? (
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                      </svg>
+                    ) : (
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M9 17H7a5 5 0 0 1-5-5a5 5 0 0 1 5-5h2" />
+                        <path d="M15 7h2a5 5 0 0 1 5 5a5 5 0 0 1-5 5h-2" />
+                        <line x1="8" y1="12" x2="16" y2="12" strokeDasharray="3 3" />
+                      </svg>
+                    )}
+                  </button>
+                ))}
+              </div>
+            );
+          })()}
 
           <div
             ref={containerRef}

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1059,7 +1059,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
               </div>
             )}
           />
-          <div className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500">
+          <div className="absolute right-6 top-1/2 -translate-y-1/2 text-gray-500">
             <DragHandleVisual />
           </div>
         </div>
@@ -1670,7 +1670,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                         }}
                         title=""
                       >
-                        <div className="absolute right-4 top-1/2 -translate-y-1/2">
+                        <div className="absolute right-6 top-1/2 -translate-y-1/2">
                           <DragHandleVisual dimUp={tierIndices[0] === 0} variant={listType === 'main' ? 'main' : 'noPreference'} />
                         </div>
                       </div>

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -120,7 +120,7 @@ function LinkCircle({
         // Background-colored contour around the icon for contrast against
         // the card surface it overlaps. Stacked drop-shadows thicken the
         // halo because a single pass is too faint.
-        filter: 'drop-shadow(0 0 2px var(--background)) drop-shadow(0 0 2px var(--background))',
+        filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
       }}
       aria-label={linked ? 'Break tied ranking' : 'Tie these rankings together'}
       title={linked ? 'Break tied ranking' : 'Tie these rankings together'}
@@ -1010,7 +1010,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                 width: `${LINK_CIRCLE_SIZE}px`,
                 height: `${LINK_CIRCLE_SIZE}px`,
                 transform: 'translateX(-50%)',
-                filter: 'drop-shadow(0 0 2px var(--background)) drop-shadow(0 0 2px var(--background))',
+                filter: 'drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background)) drop-shadow(0 0 3px var(--background))',
               }}
             >
               <svg

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -420,11 +420,58 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
       const mainRect = mainContainer.getBoundingClientRect();
       // Extend main list drop zone downward (toward divider) when dragging from no preference
       const extendedBottom = dragState.sourceList === 'noPreference' ? mainRect.bottom + dropZoneBuffer : mainRect.bottom;
-      
-      if (screenX >= mainRect.left && screenX <= mainRect.right && 
+
+      if (screenX >= mainRect.left && screenX <= mainRect.right &&
           screenY >= mainRect.top && screenY <= extendedBottom) {
         const relativeY = screenY - mainRect.top;
-        // Allow appending to main list when dragging from noPreference list
+
+        // When dragging a multi-item tier within the main list, compute the
+        // target by checking cursor position against the visual midpoints of
+        // non-dragged items (which have shifted to fill the tier's gap).
+        // This avoids the uniform-grid assumption that creates a dead zone
+        // as wide as the tier itself.
+        if (
+          dragState.sourceList === 'main' &&
+          dragState.tierStart !== null &&
+          dragState.tierSize > 1
+        ) {
+          const tStart = dragState.tierStart;
+          const tSize = dragState.tierSize;
+          const tEnd = tStart + tSize - 1;
+
+          // Build visual positions of non-dragged items. Items before the
+          // tier stay at natural positions; items after shift up by tierSize.
+          const slots: { origIdx: number; midY: number }[] = [];
+          for (let i = 0; i < mainList.length; i++) {
+            if (i >= tStart && i <= tEnd) continue;
+            const visualTop = i < tStart
+              ? i * totalItemHeight
+              : (i - tSize) * totalItemHeight;
+            slots.push({ origIdx: i, midY: visualTop + itemHeight / 2 });
+          }
+
+          if (slots.length === 0) {
+            return { list: 'main' as const, index: tStart };
+          }
+
+          // Cursor above the first non-dragged item → insert before it
+          if (relativeY < slots[0].midY) {
+            return { list: 'main' as const, index: slots[0].origIdx };
+          }
+
+          // Walk through gaps between non-dragged items
+          for (let g = 0; g < slots.length - 1; g++) {
+            const gapMid = (slots[g].midY + slots[g + 1].midY) / 2;
+            if (relativeY < gapMid) {
+              return { list: 'main' as const, index: slots[g].origIdx + 1 };
+            }
+          }
+
+          // Past the last non-dragged item → insert after it
+          return { list: 'main' as const, index: slots[slots.length - 1].origIdx + 1 };
+        }
+
+        // Standard uniform-grid index for single-item drags
         const allowAppend = dragState.sourceList === 'noPreference';
         const index = getIndexFromY(relativeY, mainList.length, allowAppend);
         return { list: 'main' as const, index };
@@ -447,7 +494,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     }
     
     return null;
-  }, [getIndexFromY, mainList.length, noPreferenceList.length, dragState.sourceList]);
+  }, [getIndexFromY, mainList.length, noPreferenceList.length, dragState.sourceList, dragState.tierStart, dragState.tierSize, mainList, totalItemHeight, itemHeight]);
 
   /**
    * Toggle the "linked" (equal-rank) state between two adjacent main-list items.

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -103,22 +103,24 @@ function LinkCircle({
         e.stopPropagation();
         onToggle(idA, idB);
       }}
-      className={`absolute rounded-full flex items-center justify-center border bg-white dark:bg-gray-900 shadow-sm transition-colors ${
+      className={`absolute flex items-center justify-center transition-colors ${
         disabled
-          ? 'cursor-not-allowed border-gray-200 text-gray-400 dark:border-gray-700 dark:text-gray-600'
+          ? 'cursor-not-allowed text-gray-400 dark:text-gray-600'
           : linked
-            ? 'cursor-pointer border-gray-300 text-blue-600 hover:border-blue-400 dark:border-gray-600 dark:text-blue-400 dark:hover:border-blue-500'
-            : 'cursor-pointer border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 dark:border-gray-600 dark:text-gray-500 dark:hover:border-blue-500 dark:hover:text-blue-400'
+            ? 'cursor-pointer text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300'
+            : 'cursor-pointer text-gray-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400'
       }`}
       style={{
-        // Horizontally center on the cards container (which is the same as
-        // centering on the option cards since cards span the full width).
         left: '50%',
         top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
         width: `${LINK_CIRCLE_SIZE}px`,
         height: `${LINK_CIRCLE_SIZE}px`,
         zIndex: 3,
         transform: `translateX(-50%)${translateY ? ` translateY(${translateY}px)` : ''}`,
+        // Background-colored contour around the icon for contrast against
+        // the card surface it overlaps. Stacked drop-shadows thicken the
+        // halo because a single pass is too faint.
+        filter: 'drop-shadow(0 0 2px var(--background)) drop-shadow(0 0 2px var(--background))',
       }}
       aria-label={linked ? 'Break tied ranking' : 'Tie these rankings together'}
       title={linked ? 'Break tied ranking' : 'Tie these rankings together'}
@@ -1001,13 +1003,14 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           return (
             <div
               key={`preview-link-${item.id}`}
-              className="absolute flex items-center justify-center rounded-full border border-gray-300 bg-white text-blue-600 shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-blue-400"
+              className="absolute flex items-center justify-center text-blue-600 dark:text-blue-400"
               style={{
                 left: '50%',
                 top: `${topCenter - LINK_CIRCLE_SIZE / 2}px`,
                 width: `${LINK_CIRCLE_SIZE}px`,
                 height: `${LINK_CIRCLE_SIZE}px`,
                 transform: 'translateX(-50%)',
+                filter: 'drop-shadow(0 0 2px var(--background)) drop-shadow(0 0 2px var(--background))',
               }}
             >
               <svg

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -426,10 +426,13 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         const relativeY = screenY - mainRect.top;
 
         // When dragging a multi-item tier within the main list, compute the
-        // target by checking cursor position against the visual midpoints of
-        // non-dragged items (which have shifted to fill the tier's gap).
-        // This avoids the uniform-grid assumption that creates a dead zone
-        // as wide as the tier itself.
+        // target by checking cursor position against the ORIGINAL midpoints
+        // of non-dragged items (not their shifted visual positions). Using
+        // original positions means the cursor needs to travel roughly one
+        // item height past the tier's edge to trigger a reorder — matching
+        // the standard single-item drag feel. Shifted positions would
+        // trigger almost immediately because the first non-dragged item
+        // slides up to where the cursor already is.
         if (
           dragState.sourceList === 'main' &&
           dragState.tierStart !== null &&
@@ -439,15 +442,11 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           const tSize = dragState.tierSize;
           const tEnd = tStart + tSize - 1;
 
-          // Build visual positions of non-dragged items. Items before the
-          // tier stay at natural positions; items after shift up by tierSize.
+          // Build ORIGINAL (pre-shift) midpoints of non-dragged items.
           const slots: { origIdx: number; midY: number }[] = [];
           for (let i = 0; i < mainList.length; i++) {
             if (i >= tStart && i <= tEnd) continue;
-            const visualTop = i < tStart
-              ? i * totalItemHeight
-              : (i - tSize) * totalItemHeight;
-            slots.push({ origIdx: i, midY: visualTop + itemHeight / 2 });
+            slots.push({ origIdx: i, midY: i * totalItemHeight + itemHeight / 2 });
           }
 
           if (slots.length === 0) {

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -465,7 +465,30 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
 
         // Standard uniform-grid index for single-item drags
         const allowAppend = dragState.sourceList === 'noPreference';
-        const index = getIndexFromY(relativeY, mainList.length, allowAppend);
+        let index = getIndexFromY(relativeY, mainList.length, allowAppend);
+
+        // Snap the target out of any non-dragged group. The uniform grid
+        // can land between two members of a linked tier — dropping there
+        // would split the group. Snap to whichever edge (before / after
+        // the group) the cursor is closer to.
+        if (dragState.sourceList === 'main') {
+          const tiers = computeTierIndices(mainList, linkedPairs);
+          const dragStart = dragState.dragStartIndex ?? -1;
+          for (const tier of tiers) {
+            if (tier.length <= 1) continue;
+            const tFirst = tier[0];
+            const tLast = tier[tier.length - 1];
+            // Skip the dragged item's own tier
+            if (dragStart >= tFirst && dragStart <= tLast) continue;
+            // If index lands strictly inside this tier (not at its edges)
+            if (index > tFirst && index <= tLast) {
+              const tierMidY = ((tFirst + tLast) / 2) * totalItemHeight + itemHeight / 2;
+              index = relativeY < tierMidY ? tFirst : tLast + 1;
+              break;
+            }
+          }
+        }
+
         return { list: 'main' as const, index };
       }
     }
@@ -486,7 +509,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     }
     
     return null;
-  }, [getIndexFromY, mainList.length, noPreferenceList.length, dragState.sourceList, dragState.tierStart, dragState.tierSize, mainList, totalItemHeight, itemHeight]);
+  }, [getIndexFromY, mainList.length, noPreferenceList.length, dragState.sourceList, dragState.tierStart, dragState.tierSize, dragState.dragStartIndex, dragState.mouseOffset.y, mainList, linkedPairs, totalItemHeight, itemHeight, groupedStepSize]);
 
   /**
    * Toggle the "linked" (equal-rank) state between two adjacent main-list items.

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -14,7 +14,7 @@ interface RankingSectionProps {
   pollId: string;
   pollOptions: string[];
   rankedChoices: string[];
-  handleRankingChange: (choices: string[]) => void;
+  handleRankingChange: (choices: string[], tiers: string[][]) => void;
   isAbstaining: boolean;
   setIsAbstaining: (val: boolean) => void;
   handleAbstain: () => void;
@@ -191,7 +191,9 @@ export default function RankingSection({
                       key={option}
                       onClick={(e) => {
                         if ((e.target as HTMLElement).closest?.('[data-place-name]')) return;
-                        handleRankingChange([option]);
+                        // Two-option polls: a single tap picks one. Pass
+                        // the flat list and a singleton tier (no ties).
+                        handleRankingChange([option], [[option]]);
                         setIsAbstaining(false);
                       }}
                       disabled={isSubmitting || isAbstaining}
@@ -219,6 +221,7 @@ export default function RankingSection({
                     disabled={isSubmitting || isAbstaining}
                     storageKey={pollId ? `poll-ranking-${pollId}` : undefined}
                     initialRanking={isEditingRanking && userVoteData?.ranked_choices ? userVoteData.ranked_choices : undefined}
+                    initialTiers={isEditingRanking && userVoteData?.ranked_choice_tiers ? userVoteData.ranked_choice_tiers : undefined}
                     optionsMetadata={optionsMetadata}
                   />
                 )}

--- a/database/migrations/089_add_ranked_choice_tiers_down.sql
+++ b/database/migrations/089_add_ranked_choice_tiers_down.sql
@@ -1,0 +1,2 @@
+-- Revert: remove ranked_choice_tiers column.
+ALTER TABLE votes DROP COLUMN IF EXISTS ranked_choice_tiers;

--- a/database/migrations/089_add_ranked_choice_tiers_up.sql
+++ b/database/migrations/089_add_ranked_choice_tiers_up.sql
@@ -1,0 +1,18 @@
+-- Add ranked_choice_tiers column for equal (tied) rankings support.
+--
+-- This column stores a tiered ballot as JSONB: a list of tiers, where each
+-- tier is a list of option names ranked equally. Example:
+--   [["A"], ["B", "C"], ["D"]]
+-- means A is 1st, B and C are tied for 2nd, and D is 4th.
+--
+-- For backwards compatibility, the existing flat ranked_choices column is
+-- still populated (with a tier-flattened version of the ballot). Votes with
+-- no ties leave ranked_choice_tiers NULL and the backend falls back to
+-- treating ranked_choices as singleton tiers.
+
+ALTER TABLE votes ADD COLUMN IF NOT EXISTS ranked_choice_tiers JSONB;
+
+-- No CHECK constraint changes needed: the existing vote_structure_valid
+-- constraint from migration 084 only requires that ranked_choices is
+-- populated (or is_abstain/is_ranking_abstain is set) — ranked_choice_tiers
+-- is purely additive metadata.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -39,6 +39,7 @@ export interface ApiVote {
   vote_type: string;
   yes_no_choice: string | null;
   ranked_choices: string[] | null;
+  ranked_choice_tiers: string[][] | null;
   suggestions: string[] | null;
   is_abstain: boolean;
   is_ranking_abstain: boolean;
@@ -263,6 +264,7 @@ export async function apiSubmitVote(pollId: string, params: {
   vote_type: string;
   yes_no_choice?: string | null;
   ranked_choices?: string[] | null;
+  ranked_choice_tiers?: string[][] | null;
   suggestions?: string[] | null;
   is_abstain?: boolean;
   is_ranking_abstain?: boolean;
@@ -288,6 +290,7 @@ export async function apiGetVotes(pollId: string): Promise<ApiVote[]> {
 export async function apiEditVote(pollId: string, voteId: string, params: {
   yes_no_choice?: string | null;
   ranked_choices?: string[] | null;
+  ranked_choice_tiers?: string[][] | null;
   suggestions?: string[] | null;
   is_abstain?: boolean;
   is_ranking_abstain?: boolean;

--- a/server/algorithms/ranked_choice.py
+++ b/server/algorithms/ranked_choice.py
@@ -1,9 +1,18 @@
-"""Ranked choice (IRV) vote counting algorithm.
+"""Ranked choice (IRV) vote counting algorithm with equal-ranking support.
 
-Implements Instant Runoff Voting with Borda count tiebreaker.
-Eliminates last-place candidate each round until one achieves majority.
-Exhausted ballots (no remaining non-eliminated candidates) are excluded
-from the majority threshold calculation.
+Implements Instant Runoff Voting with Borda count tiebreaker. Supports tied
+rankings via tiered ballots: each ballot is a list of tiers, where each tier
+is a list of options ranked equally.
+
+Vote tallying uses the "duplicate vote" method for ties: when a ballot's
+highest-ranked active tier contains multiple options, *each* option in that
+tier receives a full vote from that ballot. This means the total vote count in
+a round may exceed the number of active ballots.
+
+Eliminates last-place candidate each round until one achieves a strict
+majority as the unique leader, or only one candidate remains. Exhausted
+ballots (no remaining non-eliminated candidates) are excluded from the
+majority threshold calculation.
 
 Reference: database/migrations/046_fix_majority_calculation_for_exhausted_ballots_up.sql
 """
@@ -27,33 +36,61 @@ class RankedChoiceResult:
     rounds: list[list[RoundEntry]] = field(default_factory=list)
 
 
+def _normalize_ballot(vote: dict) -> list[list[str]] | None:
+    """Extract a tiered ballot from a vote dict.
+
+    Prefers ``ranked_choice_tiers`` when present; otherwise falls back to
+    ``ranked_choices`` (each option as its own singleton tier).
+
+    Returns None if the vote has no usable data.
+    """
+    tiers_raw = vote.get("ranked_choice_tiers")
+    if tiers_raw is not None:
+        if not isinstance(tiers_raw, list):
+            return None
+        cleaned_tiers: list[list[str]] = []
+        for tier in tiers_raw:
+            if not isinstance(tier, list):
+                continue
+            cleaned_tier = [c for c in tier if isinstance(c, str) and c]
+            if cleaned_tier:
+                cleaned_tiers.append(cleaned_tier)
+        return cleaned_tiers or None
+
+    choices = vote.get("ranked_choices")
+    if not choices or not isinstance(choices, list):
+        return None
+    cleaned = [c for c in choices if isinstance(c, str) and c]
+    if not cleaned:
+        return None
+    return [[c] for c in cleaned]
+
+
 def calculate_ranked_choice_winner(
     votes: list[dict],
     options: list[str],
 ) -> RankedChoiceResult:
-    """Run IRV algorithm on ranked choice votes.
+    """Run IRV algorithm on ranked choice votes with tied-rank support.
 
     Args:
-        votes: List of vote dicts, each with:
-            - ranked_choices: list[str] ordered by preference
-            - is_abstain: bool (optional)
+        votes: List of vote dicts, each with either:
+            - ranked_choice_tiers: list[list[str]] — tiered ballot (preferred)
+            - ranked_choices: list[str] — flat ballot (legacy)
+          plus optional ``is_abstain`` / ``is_ranking_abstain`` flags.
         options: List of all candidate names from the poll.
 
     Returns:
         RankedChoiceResult with winner, round count, and per-round data.
     """
     # Filter to valid, non-abstain ballots
-    ballots: list[list[str]] = []
+    ballots: list[list[list[str]]] = []
     for vote in votes:
         if vote.get("is_abstain", False) or vote.get("is_ranking_abstain", False):
             continue
-        choices = vote.get("ranked_choices")
-        if not choices or not isinstance(choices, list):
+        normalized = _normalize_ballot(vote)
+        if normalized is None:
             continue
-        # Filter out empty strings and None
-        cleaned = [c for c in choices if c]
-        if cleaned:
-            ballots.append(cleaned)
+        ballots.append(normalized)
 
     if not ballots:
         return RankedChoiceResult(winner=None, total_rounds=0)
@@ -62,42 +99,36 @@ def calculate_ranked_choice_winner(
     eliminated: set[str] = set()
     rounds: list[list[RoundEntry]] = []
     max_rounds = 50
+    last_winner: str | None = None
 
     for round_num in range(1, max_rounds + 1):
         active_options = [o for o in options if o not in eliminated]
+        remaining_options = len(active_options)
 
-        # Find each ballot's top non-eliminated choice
-        top_choices: list[str] = []
-        for ballot in ballots:
-            for choice in ballot:
-                if choice not in eliminated:
-                    top_choices.append(choice)
-                    break
-            # If no non-eliminated choice found, ballot is exhausted
-
-        active_ballots = len(top_choices)
-        if active_ballots == 0:
-            break
-
-        # Count first-place votes for each active option
+        # Tally votes: each ballot contributes to every active option in its
+        # highest-ranked tier that contains at least one non-eliminated option.
         vote_counts: dict[str, int] = {o: 0 for o in active_options}
-        for choice in top_choices:
-            if choice in vote_counts:
-                vote_counts[choice] += 1
+        active_ballot_count = 0  # ballots that still have at least one active option
+        for ballot in ballots:
+            for tier in ballot:
+                active_in_tier = [o for o in tier if o not in eliminated]
+                if active_in_tier:
+                    active_ballot_count += 1
+                    for opt in active_in_tier:
+                        vote_counts[opt] += 1
+                    break
 
-        # Check for winner: majority of active ballots
-        majority_threshold = (active_ballots // 2) + 1
+        if active_ballot_count == 0:
+            break
 
         # Sort by vote count desc, then alphabetically for determinism
         sorted_options = sorted(
             active_options, key=lambda o: (-vote_counts[o], o)
         )
         max_votes = vote_counts[sorted_options[0]]
-        winning_option = sorted_options[0]
+        leader_count = sum(1 for o in active_options if vote_counts[o] == max_votes)
+        majority_threshold = (active_ballot_count // 2) + 1
 
-        remaining_options = len(active_options)
-
-        # Build round entries (not yet marking eliminations)
         round_entries = [
             RoundEntry(
                 option_name=o,
@@ -107,46 +138,46 @@ def calculate_ranked_choice_winner(
             for o in sorted_options
         ]
 
-        # Check win conditions
-        if max_votes >= majority_threshold or remaining_options <= 1:
+        # Win condition: either only one candidate remains, OR
+        # the leader has a strict majority AND is the unique top.
+        # (If multiple candidates tie at the top with duplicate-vote majorities,
+        #  we continue IRV to break the tie between them.)
+        if remaining_options <= 1 or (
+            max_votes >= majority_threshold and leader_count == 1
+        ):
+            winning_option = sorted_options[0]
             rounds.append(round_entries)
             return RankedChoiceResult(
                 winner=winning_option,
                 total_rounds=round_num,
                 rounds=rounds,
             )
+        last_winner = sorted_options[0]
 
         # Find minimum vote count
         min_votes = min(vote_counts[o] for o in active_options)
-
-        # Get candidates tied for last place
         tied_candidates = [
             o for o in active_options if vote_counts[o] == min_votes
         ]
 
         if len(tied_candidates) == 1:
             to_eliminate = tied_candidates[0]
-            # Mark elimination in round entries
             for entry in round_entries:
                 if entry.option_name == to_eliminate:
                     entry.is_eliminated = True
             eliminated.add(to_eliminate)
         else:
-            # Borda count tiebreaker
+            # Borda count tiebreaker across tied last-place candidates
             borda_scores = _calculate_borda_scores(
                 ballots, tied_candidates, total_candidates
             )
-
-            # Find minimum Borda score
             min_borda = min(borda_scores.values())
             lowest_borda = [
                 c for c in tied_candidates if borda_scores[c] == min_borda
             ]
-
             # Alphabetical tiebreaker: eliminate the last one alphabetically
             to_eliminate = sorted(lowest_borda)[-1]
 
-            # Store Borda scores and mark elimination
             for entry in round_entries:
                 if entry.option_name in tied_candidates:
                     entry.borda_score = borda_scores.get(entry.option_name, 0)
@@ -158,31 +189,36 @@ def calculate_ranked_choice_winner(
 
         rounds.append(round_entries)
 
-    # Safety: should not reach here normally
+    # Safety: exited via max_rounds (shouldn't happen for well-formed inputs)
     return RankedChoiceResult(
-        winner=winning_option if active_ballots > 0 else None,
+        winner=last_winner,
         total_rounds=len(rounds),
         rounds=rounds,
     )
 
 
 def _calculate_borda_scores(
-    ballots: list[list[str]],
+    ballots: list[list[list[str]]],
     candidates: list[str],
     total_candidates: int,
 ) -> dict[str, int]:
     """Calculate Borda count scores for a subset of candidates.
 
-    For n total candidates: 1st choice = n points, 2nd = n-1, ..., nth = 1.
-    Unranked candidates get 0 points.
+    Uses standard competition ranking (1-2-2-4) for ties: a tier of size k at
+    position p consumes positions p..p+k-1 before the next tier starts.
+
+    For n total candidates: rank 0 = n points, rank 1 = n-1 points, ... rank
+    n-1 = 1 point. Unranked candidates get 0 points.
     """
     scores: dict[str, int] = {c: 0 for c in candidates}
     candidate_set = set(candidates)
 
     for ballot in ballots:
-        for rank, choice in enumerate(ballot):
-            if choice in candidate_set:
-                # Borda points: total_candidates - rank (0-indexed)
-                scores[choice] += total_candidates - rank
+        position = 0  # 0-indexed standard-competition rank for this tier
+        for tier in ballot:
+            for choice in tier:
+                if choice in candidate_set:
+                    scores[choice] += total_candidates - position
+            position += len(tier)
 
     return scores

--- a/server/algorithms/vote_validation.py
+++ b/server/algorithms/vote_validation.py
@@ -23,6 +23,7 @@ def validate_vote(
     vote_type: str,
     yes_no_choice: str | None = None,
     ranked_choices: list[str] | None = None,
+    ranked_choice_tiers: list[list[str]] | None = None,
     suggestions: list[str] | None = None,
     is_abstain: bool = False,
     is_ranking_abstain: bool = False,
@@ -45,13 +46,17 @@ def validate_vote(
             )
 
     if poll_type == "yes_no" or poll_type == "participation":
+        if ranked_choice_tiers:
+            raise VoteValidationError("ranked_choice_tiers not allowed for yes/no or participation polls")
         _validate_yes_no_vote(yes_no_choice, ranked_choices, suggestions, is_abstain)
     elif poll_type == "ranked_choice":
         _validate_ranked_choice_vote(
-            yes_no_choice, ranked_choices, suggestions, is_abstain,
-            is_ranking_abstain, has_suggestion_phase,
+            yes_no_choice, ranked_choices, ranked_choice_tiers, suggestions,
+            is_abstain, is_ranking_abstain, has_suggestion_phase,
         )
     elif poll_type == "time":
+        if ranked_choice_tiers:
+            raise VoteValidationError("ranked_choice_tiers not allowed for time polls")
         _validate_time_vote(yes_no_choice, ranked_choices, suggestions, is_abstain)
     else:
         raise VoteValidationError(f"Unknown poll type: {poll_type}")
@@ -83,6 +88,7 @@ def _validate_yes_no_vote(
 def _validate_ranked_choice_vote(
     yes_no_choice: str | None,
     ranked_choices: list[str] | None,
+    ranked_choice_tiers: list[list[str]] | None,
     suggestions: list[str] | None,
     is_abstain: bool,
     is_ranking_abstain: bool = False,
@@ -99,6 +105,22 @@ def _validate_ranked_choice_vote(
     if is_ranking_abstain and not has_suggestion_phase:
         raise VoteValidationError("is_ranking_abstain not allowed for ranked choice polls without a suggestion phase")
 
+    # ranked_choice_tiers structural check: must be a list of non-empty lists
+    # of strings when present.
+    if ranked_choice_tiers is not None:
+        if not isinstance(ranked_choice_tiers, list):
+            raise VoteValidationError("ranked_choice_tiers must be a list of tiers")
+        seen: set[str] = set()
+        for tier in ranked_choice_tiers:
+            if not isinstance(tier, list) or not tier:
+                raise VoteValidationError("each tier in ranked_choice_tiers must be a non-empty list")
+            for opt in tier:
+                if not isinstance(opt, str) or not opt:
+                    raise VoteValidationError("ranked_choice_tiers options must be non-empty strings")
+                if opt in seen:
+                    raise VoteValidationError(f"option '{opt}' appears in multiple tiers")
+                seen.add(opt)
+
     if is_abstain:
         return
 
@@ -109,14 +131,16 @@ def _validate_ranked_choice_vote(
             raise VoteValidationError(
                 "is_ranking_abstain requires suggestions (use is_abstain for full abstain)"
             )
-        if ranked_choices:
+        if ranked_choices or ranked_choice_tiers:
             raise VoteValidationError(
                 "ranked_choices not allowed when is_ranking_abstain is true"
             )
         return
 
     # Must have at least one of ranked_choices or suggestions
-    has_rankings = ranked_choices and len(ranked_choices) > 0
+    has_rankings = (ranked_choices and len(ranked_choices) > 0) or (
+        ranked_choice_tiers and len(ranked_choice_tiers) > 0
+    )
     has_suggestions = suggestions and len(suggestions) > 0
 
     if not has_rankings and not has_suggestions:

--- a/server/models.py
+++ b/server/models.py
@@ -74,6 +74,11 @@ class SubmitVoteRequest(BaseModel):
     vote_type: str
     yes_no_choice: str | None = None
     ranked_choices: list[str] | None = None
+    # Tiered ballot for equal/tied rankings: list of tiers, each a list of
+    # equally-ranked options. E.g. [["A"], ["B", "C"]] means A is 1st and
+    # B and C are tied for 2nd. Optional — when absent, ranked_choices is
+    # used as a flat ordering.
+    ranked_choice_tiers: list[list[str]] | None = None
     suggestions: list[str] | None = None
     is_abstain: bool = False
     is_ranking_abstain: bool = False
@@ -92,6 +97,7 @@ class SubmitVoteRequest(BaseModel):
 class EditVoteRequest(BaseModel):
     yes_no_choice: str | None = None
     ranked_choices: list[str] | None = None
+    ranked_choice_tiers: list[list[str]] | None = None
     suggestions: list[str] | None = None
     is_abstain: bool = False
     is_ranking_abstain: bool = False
@@ -195,6 +201,7 @@ class VoteResponse(BaseModel):
     vote_type: str
     yes_no_choice: str | None = None
     ranked_choices: list[str] | None = None
+    ranked_choice_tiers: list[list[str]] | None = None
     suggestions: list[str] | None = None
     is_abstain: bool = False
     is_ranking_abstain: bool = False

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -234,6 +234,7 @@ def _row_to_vote(row: dict) -> VoteResponse:
         vote_type=row["vote_type"],
         yes_no_choice=row.get("yes_no_choice"),
         ranked_choices=row.get("ranked_choices"),
+        ranked_choice_tiers=row.get("ranked_choice_tiers"),
         suggestions=row.get("suggestions"),
         is_abstain=row.get("is_abstain", False),
         is_ranking_abstain=row.get("is_ranking_abstain", False),
@@ -702,6 +703,7 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
                 vote_type=req.vote_type,
                 yes_no_choice=req.yes_no_choice,
                 ranked_choices=req.ranked_choices,
+                ranked_choice_tiers=req.ranked_choice_tiers,
                 suggestions=req.suggestions,
                 is_abstain=req.is_abstain,
                 is_ranking_abstain=req.is_ranking_abstain,
@@ -714,12 +716,14 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
         row = conn.execute(
             """
             INSERT INTO votes (poll_id, vote_type, yes_no_choice, ranked_choices,
+                               ranked_choice_tiers,
                                suggestions, is_abstain, is_ranking_abstain, voter_name,
                                min_participants, max_participants,
                                voter_day_time_windows, voter_duration,
                                liked_slots, disliked_slots,
                                created_at, updated_at)
             VALUES (%(poll_id)s, %(vote_type)s, %(yes_no_choice)s, %(ranked_choices)s,
+                    %(ranked_choice_tiers)s::jsonb,
                     %(suggestions)s, %(is_abstain)s, %(is_ranking_abstain)s, %(voter_name)s,
                     %(min_participants)s, %(max_participants)s,
                     %(voter_day_time_windows)s::jsonb, %(voter_duration)s::jsonb,
@@ -732,6 +736,7 @@ def submit_vote(poll_id: str, req: SubmitVoteRequest):
                 "vote_type": req.vote_type,
                 "yes_no_choice": req.yes_no_choice,
                 "ranked_choices": req.ranked_choices,
+                "ranked_choice_tiers": json.dumps(req.ranked_choice_tiers) if req.ranked_choice_tiers is not None else None,
                 "suggestions": req.suggestions,
                 "is_abstain": req.is_abstain,
                 "is_ranking_abstain": req.is_ranking_abstain,
@@ -854,6 +859,7 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
             UPDATE votes
             SET yes_no_choice = %(yes_no_choice)s,
                 ranked_choices = %(ranked_choices)s,
+                ranked_choice_tiers = %(ranked_choice_tiers)s::jsonb,
                 suggestions = COALESCE(%(suggestions)s, suggestions),
                 is_abstain = %(is_abstain)s,
                 is_ranking_abstain = %(is_ranking_abstain)s,
@@ -871,6 +877,7 @@ def edit_vote(poll_id: str, vote_id: str, req: EditVoteRequest):
             {
                 "yes_no_choice": req.yes_no_choice,
                 "ranked_choices": req.ranked_choices,
+                "ranked_choice_tiers": json.dumps(req.ranked_choice_tiers) if req.ranked_choice_tiers is not None else None,
                 "suggestions": req.suggestions,
                 "is_abstain": req.is_abstain,
                 "is_ranking_abstain": req.is_ranking_abstain,
@@ -1028,10 +1035,15 @@ def _compute_results(poll, votes) -> PollResultsResponse:
                 suggestion_counts=suggestion_counts_data,
             )
 
-        # Only compute ranked choice results if there are options to rank
+        # Only compute ranked choice results if there are options to rank.
+        # A vote counts as having rankings if it has either a flat list or a
+        # tiered ballot.
         rc_rounds = []
         rc_winner = None
-        ranking_votes = [v for v in votes if v.get("ranked_choices")]
+        ranking_votes = [
+            v for v in votes
+            if v.get("ranked_choices") or v.get("ranked_choice_tiers")
+        ]
         if poll_options and len(poll_options) >= 2 and ranking_votes:
             result = calculate_ranked_choice_winner(ranking_votes, poll_options)
             rc_winner = result.winner

--- a/server/tests/test_ranked_choice.py
+++ b/server/tests/test_ranked_choice.py
@@ -470,3 +470,298 @@ class TestReverseOrder:
             ("B", 2, False),
             ("A", 1, False),
         ])
+
+
+def _make_tiered_votes(tier_lists: list[list[list[str]]]) -> list[dict]:
+    """Helper to create vote dicts from tiered ballots."""
+    return [{"ranked_choice_tiers": t} for t in tier_lists]
+
+
+class TestEqualRankings:
+    """Tests for the 'duplicate vote' method of handling equal rankings.
+
+    When a ballot's highest-ranked active tier contains multiple options,
+    each option in that tier receives a full vote from that ballot.
+    """
+
+    def test_simple_tie_at_top_gives_both_full_votes(self):
+        # A single ballot with A and B tied at top gives both a full vote.
+        # C gets 0. With 1 ballot total, majority threshold = 1.
+        # But A and B both have 1 vote (no unique leader), so IRV continues.
+        # C eliminated first, then Borda breaks A-B tie alphabetically.
+        votes = _make_tiered_votes([
+            [["A", "B"], ["C"]],
+        ])
+        result = calculate_ranked_choice_winner(votes, ["A", "B", "C"])
+        # Round 1: A=1, B=1, C=0. No unique leader. Eliminate C (last place).
+        _assert_round(result, 0, [
+            ("A", 1, False),
+            ("B", 1, False),
+            ("C", 0, True),
+        ])
+        # Round 2: A=1, B=1 still tied. Borda tied (both rank 0). Alphabetical
+        # eliminates B (last alphabetically).
+        # Round 3: only A remains -> winner.
+        assert result.winner == "A"
+
+    def test_tie_vote_duplication_across_multiple_ballots(self):
+        # 3 ballots, each with A=B tied at top, C third.
+        # Round 1: A=3, B=3, C=0 (duplicate votes). No unique leader.
+        # Eliminate C, then Borda/alpha breaks A-B tie.
+        votes = _make_tiered_votes([
+            [["A", "B"], ["C"]],
+            [["A", "B"], ["C"]],
+            [["A", "B"], ["C"]],
+        ])
+        result = calculate_ranked_choice_winner(votes, ["A", "B", "C"])
+        _assert_round(result, 0, [
+            ("A", 3, False),
+            ("B", 3, False),
+            ("C", 0, True),
+        ])
+        assert result.winner == "A"
+
+    def test_tie_loses_when_another_candidate_has_strict_majority(self):
+        # 5 ballots: 3 put (A,B) tied at top, 2 put C alone at top.
+        # Round 1: A=3, B=3, C=2. A and B are both leaders at 3.
+        # Threshold = 3 (majority of 5). A&B both exceed it but no unique leader.
+        # Eliminate C (lowest). Then A=3, B=3. Borda/alpha picks winner.
+        votes = _make_tiered_votes([
+            [["A", "B"]],
+            [["A", "B"]],
+            [["A", "B"]],
+            [["C"]],
+            [["C"]],
+        ])
+        result = calculate_ranked_choice_winner(votes, ["A", "B", "C"])
+        _assert_round(result, 0, [
+            ("A", 3, False),
+            ("B", 3, False),
+            ("C", 2, True),
+        ])
+        # After C elimination: A=3, B=3 (still duplicated from (A,B) ballots).
+        # Borda tied, alpha eliminates B. Then A wins alone.
+        assert result.winner == "A"
+
+    def test_eliminating_one_tied_option_does_not_transfer_to_partner(self):
+        # Key insight: eliminating one member of a tied tier does NOT
+        # transfer votes to the partner (partner already had the vote).
+        # Ballot: (A,B), then C. If A eliminated, B stays with its existing vote.
+        votes = _make_tiered_votes([
+            [["A", "B"], ["C"]],
+            [["A", "B"], ["C"]],
+            [["C"], ["A"], ["B"]],
+            [["C"], ["A"], ["B"]],
+            [["C"], ["A"], ["B"]],
+        ])
+        # Round 1: A=2, B=2, C=3. C leads with 3/5, threshold=3, UNIQUE leader.
+        # C wins immediately.
+        result = calculate_ranked_choice_winner(votes, ["A", "B", "C"])
+        assert result.winner == "C"
+        _assert_round(result, 0, [
+            ("C", 3, False),
+            ("A", 2, False),
+            ("B", 2, False),
+        ])
+        assert result.total_rounds == 1
+
+    def test_strict_majority_with_unique_leader_wins_immediately(self):
+        # Voter 1: A tied with B. Voters 2-5: A first.
+        # Round 1: A=5, B=1. A has 5/5 = unique majority. Winner A.
+        votes = _make_tiered_votes([
+            [["A", "B"]],
+            [["A"], ["B"]],
+            [["A"], ["B"]],
+            [["A"], ["B"]],
+            [["A"], ["B"]],
+        ])
+        result = calculate_ranked_choice_winner(votes, ["A", "B"])
+        assert result.winner == "A"
+        assert result.total_rounds == 1
+        _assert_round(result, 0, [
+            ("A", 5, False),
+            ("B", 1, False),
+        ])
+
+    def test_three_way_tie_at_top(self):
+        # One ballot with A=B=C all tied. All three get 1 vote from it.
+        # Another ballot with D alone. Total: A=1, B=1, C=1, D=1.
+        votes = _make_tiered_votes([
+            [["A", "B", "C"]],
+            [["D"]],
+        ])
+        result = calculate_ranked_choice_winner(
+            votes, ["A", "B", "C", "D"]
+        )
+        # All tied at 1 vote. Borda:
+        # Ballot 1: A,B,C at tier 0 (rank 0) -> 4-0=4 each, D unranked -> 0
+        # Ballot 2: D at tier 0 -> 4, others 0
+        # Candidate totals: A=4, B=4, C=4, D=4. All tied.
+        # Alphabetically last (D) is eliminated first.
+        _assert_round(result, 0, [
+            ("A", 1, False),
+            ("B", 1, False),
+            ("C", 1, False),
+            ("D", 1, True),
+        ])
+
+    def test_tier_drops_to_next_when_all_members_eliminated(self):
+        # Ballot: (A,B), (C,D). After A and B both eliminated, C and D
+        # should each get 1 vote from this ballot.
+        votes = _make_tiered_votes([
+            [["A", "B"], ["C", "D"]],
+            [["A"], ["B"], ["C"], ["D"]],  # prefers A
+            [["B"], ["A"], ["C"], ["D"]],  # prefers B
+        ])
+        result = calculate_ranked_choice_winner(
+            votes, ["A", "B", "C", "D"]
+        )
+        # Round 1: A=2 (ballot 1 tier 0 + ballot 2), B=2 (ballot 1 tier 0 + ballot 3),
+        # C=0, D=0. Eliminate D (last alpha among 0-vote).
+        _assert_round(result, 0, [
+            ("A", 2, False),
+            ("B", 2, False),
+            ("C", 0, False),
+            ("D", 0, True),
+        ])
+
+    def test_mixed_tiered_and_flat_ballots(self):
+        # Mixing flat ranked_choices and tiered ranked_choice_tiers in the
+        # same election. Flat ballots are treated as singleton tiers.
+        votes = [
+            {"ranked_choices": ["A", "B", "C"]},
+            {"ranked_choices": ["B", "A", "C"]},
+            {"ranked_choice_tiers": [["A", "B"], ["C"]]},
+        ]
+        result = calculate_ranked_choice_winner(votes, ["A", "B", "C"])
+        # Round 1: A=2 (v1 + v3), B=2 (v2 + v3), C=0. Eliminate C (alpha last).
+        _assert_round(result, 0, [
+            ("A", 2, False),
+            ("B", 2, False),
+            ("C", 0, True),
+        ])
+
+    def test_all_equal_ballot_exhausts_after_eliminations(self):
+        # A ballot with everything tied at one level supplies a vote to every
+        # active candidate in every round until it's exhausted. Verify the
+        # algorithm terminates and counts correctly.
+        votes = _make_tiered_votes([
+            [["A", "B", "C"]],
+            [["A"]],
+            [["B"]],
+        ])
+        result = calculate_ranked_choice_winner(votes, ["A", "B", "C"])
+        # Round 1: A=2, B=2, C=1. Eliminate C (lowest).
+        _assert_round(result, 0, [
+            ("A", 2, False),
+            ("B", 2, False),
+            ("C", 1, True),
+        ])
+        # Round 2: tier 0 of ballot 1 still contains A and B (both active),
+        # so A=2, B=2. Still tied. Borda tiebreaker, alpha eliminates B.
+        _assert_round(result, 1, [
+            ("A", 2, False),
+            ("B", 2, True),
+        ])
+        assert result.winner == "A"
+
+    def test_tied_ranking_abstain_excluded(self):
+        votes = [
+            {"ranked_choice_tiers": [["A", "B"]], "is_abstain": True},
+            {"ranked_choice_tiers": [["A"]]},
+        ]
+        result = calculate_ranked_choice_winner(votes, ["A", "B"])
+        assert result.winner == "A"
+
+    def test_empty_tiers_filtered(self):
+        votes = [
+            {"ranked_choice_tiers": [[], ["A"], ["", "B"]]},
+            {"ranked_choice_tiers": [["A"]]},
+        ]
+        result = calculate_ranked_choice_winner(votes, ["A", "B"])
+        # Ballot 1 cleans to [["A"], ["B"]] -> prefers A. Ballot 2 -> A.
+        # A=2, B=0. A wins.
+        assert result.winner == "A"
+
+    def test_malformed_tiers_returns_no_winner(self):
+        votes = [
+            {"ranked_choice_tiers": "not a list"},
+            {"ranked_choice_tiers": [[], []]},
+        ]
+        result = calculate_ranked_choice_winner(votes, ["A", "B"])
+        assert result.winner is None
+        assert result.total_rounds == 0
+
+    def test_tiered_ballot_with_later_tier_tie(self):
+        # Ballot with distinct first choice but tied second tier. The tie at
+        # the second tier only matters if the first-choice option is eliminated.
+        votes = _make_tiered_votes([
+            [["A"], ["B", "C"], ["D"]],
+            [["A"], ["B", "C"], ["D"]],
+            [["D"]],
+            [["D"]],
+        ])
+        result = calculate_ranked_choice_winner(
+            votes, ["A", "B", "C", "D"]
+        )
+        # Round 1: A=2, D=2, B=0, C=0. No winner (A, D tied, threshold=3).
+        # Min=0 (B, C). Borda tiebreak across {B, C}:
+        #   Ballot 1 (4 cands): B at rank 1 -> 3, C at rank 1 -> 3
+        #   Ballot 2: same. Totals: B=6, C=6. Tied, alpha -> C eliminated.
+        _assert_round(result, 0, [
+            ("A", 2, False),
+            ("D", 2, False),
+            ("B", 0, False),
+            ("C", 0, True),
+        ])
+
+    def test_duplicate_method_documentation(self):
+        # Documentation-as-test: 2 voters, A=B tied.
+        # Vote counts: A=2, B=2 (duplicated), total vote tally = 4 > ballots = 2.
+        # This is intentional: the duplicate-vote method means both tied options
+        # receive full credit from each voter.
+        votes = _make_tiered_votes([
+            [["A", "B"]],
+            [["A", "B"]],
+        ])
+        result = calculate_ranked_choice_winner(votes, ["A", "B"])
+        # A=2, B=2 - tied at max. No unique leader.
+        _assert_round(result, 0, [
+            ("A", 2, False),
+            ("B", 2, True),  # B eliminated alphabetically after Borda tie
+        ])
+        assert result.winner == "A"
+
+
+class TestBordaWithTiers:
+    """Borda count with tiered ballots uses standard competition ranking."""
+
+    def test_standard_competition_ranking(self):
+        # Ballot 1: [A], [B, C], [D] — ranks are 0, 1, 1, 3 (not 0, 1, 1, 2).
+        #   With 7 total candidates: A=7, B=6, C=6, D=4 (= 7 - 3).
+        # Ballots 2-4: E, F, G (all singleton, to spread votes so none reaches
+        # majority and B/C/D get pushed into Borda tiebreak).
+        votes = _make_tiered_votes([
+            [["A"], ["B", "C"], ["D"]],
+            [["E"]],
+            [["F"]],
+            [["G"]],
+        ])
+        result = calculate_ranked_choice_winner(
+            votes, ["A", "B", "C", "D", "E", "F", "G"]
+        )
+        # Round 1: A=1, E=1, F=1, G=1, B=C=D=0.
+        # Threshold=3 (4//2+1). Max=1 < 3. Eliminate: min=0, tied {B,C,D}.
+        # Borda across tied {B,C,D} from ballot 1 only (no other ballot ranks them):
+        #   B=6, C=6, D=4. Min = 4 -> D eliminated.
+        round_0 = result.rounds[0]
+        d_entry = next(e for e in round_0 if e.option_name == "D")
+        assert d_entry.is_eliminated is True
+        assert d_entry.borda_score == 4
+        assert d_entry.tie_broken_by_borda is True
+        b_entry = next(e for e in round_0 if e.option_name == "B")
+        assert b_entry.borda_score == 6
+        assert b_entry.tie_broken_by_borda is True
+        c_entry = next(e for e in round_0 if e.option_name == "C")
+        assert c_entry.borda_score == 6
+        assert c_entry.tie_broken_by_borda is True

--- a/server/tests/test_vote_validation.py
+++ b/server/tests/test_vote_validation.py
@@ -119,6 +119,89 @@ class TestRankedChoiceValidation:
         )
 
 
+class TestRankedChoiceTiersValidation:
+    def test_valid_tiers(self):
+        validate_vote(
+            "ranked_choice", "ranked_choice",
+            ranked_choice_tiers=[["a"], ["b", "c"], ["d"]],
+        )
+
+    def test_valid_tiers_alongside_flat(self):
+        """Tiers and flat list can coexist (tiers takes precedence server-side)."""
+        validate_vote(
+            "ranked_choice", "ranked_choice",
+            ranked_choices=["a", "b", "c", "d"],
+            ranked_choice_tiers=[["a"], ["b", "c"], ["d"]],
+        )
+
+    def test_tiers_not_a_list(self):
+        with pytest.raises(VoteValidationError, match="must be a list of tiers"):
+            validate_vote(
+                "ranked_choice", "ranked_choice",
+                ranked_choice_tiers="not a list",  # type: ignore[arg-type]
+            )
+
+    def test_tier_not_a_list(self):
+        with pytest.raises(VoteValidationError, match="non-empty list"):
+            validate_vote(
+                "ranked_choice", "ranked_choice",
+                ranked_choice_tiers=["not-a-list"],  # type: ignore[list-item]
+            )
+
+    def test_empty_tier(self):
+        with pytest.raises(VoteValidationError, match="non-empty list"):
+            validate_vote(
+                "ranked_choice", "ranked_choice",
+                ranked_choice_tiers=[[]],
+            )
+
+    def test_duplicate_option_across_tiers(self):
+        with pytest.raises(VoteValidationError, match="appears in multiple tiers"):
+            validate_vote(
+                "ranked_choice", "ranked_choice",
+                ranked_choice_tiers=[["a"], ["a", "b"]],
+            )
+
+    def test_duplicate_option_within_tier(self):
+        with pytest.raises(VoteValidationError, match="appears in multiple tiers"):
+            validate_vote(
+                "ranked_choice", "ranked_choice",
+                ranked_choice_tiers=[["a", "a"]],
+            )
+
+    def test_empty_string_in_tier(self):
+        with pytest.raises(VoteValidationError, match="non-empty strings"):
+            validate_vote(
+                "ranked_choice", "ranked_choice",
+                ranked_choice_tiers=[[""]],
+            )
+
+    def test_tiers_forbidden_for_yes_no(self):
+        with pytest.raises(VoteValidationError, match="ranked_choice_tiers not allowed"):
+            validate_vote(
+                "yes_no", "yes_no",
+                yes_no_choice="yes",
+                ranked_choice_tiers=[["a"]],
+            )
+
+    def test_tiers_forbidden_for_time(self):
+        with pytest.raises(VoteValidationError, match="ranked_choice_tiers not allowed"):
+            validate_vote(
+                "time", "time",
+                ranked_choice_tiers=[["a"]],
+            )
+
+    def test_tiers_forbidden_with_ranking_abstain(self):
+        with pytest.raises(VoteValidationError, match="ranked_choices not allowed"):
+            validate_vote(
+                "ranked_choice", "ranked_choice",
+                ranked_choice_tiers=[["a"]],
+                suggestions=["a"],
+                is_ranking_abstain=True,
+                has_suggestion_phase=True,
+            )
+
+
 class TestUnknownPollType:
     def test_unknown_poll_type(self):
         with pytest.raises(VoteValidationError, match="Unknown poll type"):

--- a/tests/__tests__/ranked-choice/drag-threshold-simulation.test.ts
+++ b/tests/__tests__/ranked-choice/drag-threshold-simulation.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pairKey,
+  computeDropTarget,
+} from '@/components/RankableOptions';
+
+// --- Test helpers ---
+
+/** Build an item ID list: ['a', 'b', 'c', ...] */
+const ids = (n: number) => Array.from({ length: n }, (_, i) => String.fromCharCode(97 + i));
+
+/** Build linked pairs for consecutive indices forming a group */
+function linkGroup(itemIds: string[], start: number, size: number): Set<string> {
+  const pairs = new Set<string>();
+  for (let i = start; i < start + size - 1; i++) {
+    pairs.add(pairKey(itemIds[i], itemIds[i + 1]));
+  }
+  return pairs;
+}
+
+/** Merge multiple pair sets */
+function mergeLinks(...sets: Set<string>[]): Set<string> {
+  const merged = new Set<string>();
+  for (const s of sets) for (const v of s) merged.add(v);
+  return merged;
+}
+
+// --- Layout constants (match RankableOptions defaults for non-location items) ---
+const ITEM_HEIGHT = 56;
+const GAP = 8;
+const TOTAL = ITEM_HEIGHT + GAP; // 64
+const GROUPED_GAP = 0;
+
+/** Tier visual height */
+function tierH(size: number): number {
+  return size > 1 ? size * ITEM_HEIGHT + (size - 1) * GROUPED_GAP : ITEM_HEIGHT;
+}
+
+/**
+ * Simulate a drag: for a tier starting at `tierStart` of `tierSize`, with
+ * the cursor grabbed at the tier's center, sweep the cursor from startY to
+ * endY and return the cursorY at which the target first differs from the
+ * initial no-op target. Returns null if no change occurs.
+ */
+function findTriggerY(
+  itemIds: string[],
+  linked: Set<string>,
+  tierStart: number,
+  tierSize: number,
+  startY: number,
+  endY: number,
+  step: number = 1,
+): number | null {
+  const initial = computeDropTarget(
+    itemIds, linked, tierStart, tierSize, startY,
+    ITEM_HEIGHT, GROUPED_GAP, TOTAL,
+  );
+  const dir = endY > startY ? 1 : -1;
+  for (let y = startY + dir * step; dir > 0 ? y <= endY : y >= endY; y += dir * step) {
+    const target = computeDropTarget(
+      itemIds, linked, tierStart, tierSize, y,
+      ITEM_HEIGHT, GROUPED_GAP, TOTAL,
+    );
+    if (target !== initial) return y;
+  }
+  return null;
+}
+
+/** Natural center of a tier at its current position */
+function naturalCenter(tierStart: number, tierSize: number): number {
+  return tierStart * TOTAL + tierH(tierSize) / 2;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('computeDropTarget', () => {
+  describe('no-op at rest', () => {
+    it('singleton returns its own position when at natural center', () => {
+      // [A, B, C]
+      const items = ids(3);
+      const center = naturalCenter(1, 1); // B at index 1
+      const target = computeDropTarget(items, new Set(), 1, 1, center, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+      // Target should map back to B's current position (no-op)
+      // B is at index 1. Target could be 1 or 2 (both no-op due to finishDrag)
+      expect(target === 1 || target === 2).toBe(true);
+    });
+
+    it('group-of-2 returns its own position at natural center', () => {
+      // [A-B(group), C]
+      const items = ids(3);
+      const linked = linkGroup(items, 0, 2);
+      const center = naturalCenter(0, 2); // group at [0,1]
+      const target = computeDropTarget(items, linked, 0, 2, center, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+      // Should be a no-op (target maps to current position)
+      expect(target <= 2).toBe(true); // 0, 1, or 2 are all in the no-op zone
+    });
+  });
+
+  describe('singleton past singleton: symmetry', () => {
+    it('equal trigger distance for A-down and B-up in [A, B]', () => {
+      const items = ids(2);
+      const centerA = naturalCenter(0, 1); // 28
+      const centerB = naturalCenter(1, 1); // 92
+
+      // A dragging down
+      const triggerDown = findTriggerY(items, new Set(), 0, 1, centerA, centerB + 50);
+      // B dragging up
+      const triggerUp = findTriggerY(items, new Set(), 1, 1, centerB, centerA - 50);
+
+      expect(triggerDown).not.toBeNull();
+      expect(triggerUp).not.toBeNull();
+
+      // Trigger distances should be equal (±1px for rounding)
+      const distDown = triggerDown! - centerA;
+      const distUp = centerB - triggerUp!;
+      expect(Math.abs(distDown - distUp)).toBeLessThanOrEqual(1);
+    });
+
+    it('trigger distance is roughly half a slot height', () => {
+      const items = ids(2);
+      const centerA = naturalCenter(0, 1);
+      const triggerDown = findTriggerY(items, new Set(), 0, 1, centerA, 300);
+      expect(triggerDown).not.toBeNull();
+      const dist = triggerDown! - centerA;
+      // Should be approximately TOTAL/2 = 32
+      expect(dist).toBeGreaterThanOrEqual(30);
+      expect(dist).toBeLessThanOrEqual(34);
+    });
+  });
+
+  describe('singleton past group-of-2: symmetry', () => {
+    it('[A, B-C]: A down past group vs [B-C, D]: D up past group', () => {
+      // Case 1: A(singleton) above B-C(group), drag A down
+      const items1 = ids(3); // a, b, c
+      const linked1 = linkGroup(items1, 1, 2); // b-c linked
+      const centerA = naturalCenter(0, 1);
+      const triggerDown = findTriggerY(items1, linked1, 0, 1, centerA, 400);
+
+      // Case 2: B-C(group) above D(singleton), drag D up
+      const items2 = ids(3); // a, b, c where a-b linked, c is singleton
+      const linked2 = linkGroup(items2, 0, 2);
+      const centerD = naturalCenter(2, 1);
+      const triggerUp = findTriggerY(items2, linked2, 2, 1, centerD, -100);
+
+      expect(triggerDown).not.toBeNull();
+      expect(triggerUp).not.toBeNull();
+
+      const distDown = triggerDown! - centerA;
+      const distUp = centerD - triggerUp!;
+      expect(Math.abs(distDown - distUp)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('group-of-2 past singleton: symmetry', () => {
+    it('[A-B, C]: group down past C vs [C, A-B]: group up past C', () => {
+      // Case 1: A-B(group) above C(singleton), drag group down
+      const items1 = ids(3);
+      const linked1 = linkGroup(items1, 0, 2);
+      const center1 = naturalCenter(0, 2);
+      const triggerDown = findTriggerY(items1, linked1, 0, 2, center1, 400);
+
+      // Case 2: C(singleton) above A-B(group), drag group up
+      const items2 = ids(3);
+      const linked2 = linkGroup(items2, 1, 2);
+      const center2 = naturalCenter(1, 2);
+      const triggerUp = findTriggerY(items2, linked2, 1, 2, center2, -100);
+
+      expect(triggerDown).not.toBeNull();
+      expect(triggerUp).not.toBeNull();
+
+      const distDown = triggerDown! - center1;
+      const distUp = center2 - triggerUp!;
+      expect(Math.abs(distDown - distUp)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('group-of-2 past group-of-2: symmetry', () => {
+    it('[A-B, C-D]: first group down vs second group up', () => {
+      const items = ids(4);
+      const linked = mergeLinks(linkGroup(items, 0, 2), linkGroup(items, 2, 2));
+
+      const center1 = naturalCenter(0, 2);
+      const triggerDown = findTriggerY(items, linked, 0, 2, center1, 400);
+
+      const center2 = naturalCenter(2, 2);
+      const triggerUp = findTriggerY(items, linked, 2, 2, center2, -100);
+
+      expect(triggerDown).not.toBeNull();
+      expect(triggerUp).not.toBeNull();
+
+      const distDown = triggerDown! - center1;
+      const distUp = center2 - triggerUp!;
+      expect(Math.abs(distDown - distUp)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('group-of-3 past singleton: symmetry', () => {
+    it('[A-B-C, D]: group down vs [D, A-B-C]: group up', () => {
+      const items1 = ids(4);
+      const linked1 = linkGroup(items1, 0, 3);
+      const center1 = naturalCenter(0, 3);
+      const triggerDown = findTriggerY(items1, linked1, 0, 3, center1, 400);
+
+      const items2 = ids(4);
+      const linked2 = linkGroup(items2, 1, 3);
+      const center2 = naturalCenter(1, 3);
+      const triggerUp = findTriggerY(items2, linked2, 1, 3, center2, -100);
+
+      expect(triggerDown).not.toBeNull();
+      expect(triggerUp).not.toBeNull();
+
+      const distDown = triggerDown! - center1;
+      const distUp = center2 - triggerUp!;
+      expect(Math.abs(distDown - distUp)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('singleton past group-of-3: symmetry', () => {
+    it('[A, B-C-D]: A down vs [B-C-D, E]: E up', () => {
+      const items1 = ids(4);
+      const linked1 = linkGroup(items1, 1, 3);
+      const centerA = naturalCenter(0, 1);
+      const triggerDown = findTriggerY(items1, linked1, 0, 1, centerA, 500);
+
+      const items2 = ids(4);
+      const linked2 = linkGroup(items2, 0, 3);
+      const centerE = naturalCenter(3, 1);
+      const triggerUp = findTriggerY(items2, linked2, 3, 1, centerE, -100);
+
+      expect(triggerDown).not.toBeNull();
+      expect(triggerUp).not.toBeNull();
+
+      const distDown = triggerDown! - centerA;
+      const distUp = centerE - triggerUp!;
+      expect(Math.abs(distDown - distUp)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('group-of-2 past group-of-3: symmetry', () => {
+    it('[A-B, C-D-E]: group-2 down vs [C-D-E, A-B]: group-2 up', () => {
+      const items1 = ids(5);
+      const linked1 = mergeLinks(linkGroup(items1, 0, 2), linkGroup(items1, 2, 3));
+      const center1 = naturalCenter(0, 2);
+      const triggerDown = findTriggerY(items1, linked1, 0, 2, center1, 500);
+
+      const items2 = ids(5);
+      const linked2 = mergeLinks(linkGroup(items2, 0, 3), linkGroup(items2, 3, 2));
+      const center2 = naturalCenter(3, 2);
+      const triggerUp = findTriggerY(items2, linked2, 3, 2, center2, -100);
+
+      expect(triggerDown).not.toBeNull();
+      expect(triggerUp).not.toBeNull();
+
+      const distDown = triggerDown! - center1;
+      const distUp = center2 - triggerUp!;
+      expect(Math.abs(distDown - distUp)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('groups are atomic (no splitting)', () => {
+    it('singleton cannot land inside a group-of-2', () => {
+      // [A, B-C, D] — drag A to every possible Y, target should never be 2
+      const items = ids(4);
+      const linked = linkGroup(items, 1, 2);
+      for (let y = -100; y <= 500; y += 5) {
+        const target = computeDropTarget(items, linked, 0, 1, y, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+        // Target should be 0 (before A), 1 (before B-C), 3 (after B-C), or 4 (after D)
+        // Never 2 (inside B-C)
+        expect(target).not.toBe(2);
+      }
+    });
+
+    it('singleton cannot land inside a group-of-3', () => {
+      // [A, B-C-D, E] — drag A
+      const items = ids(5);
+      const linked = linkGroup(items, 1, 3);
+      for (let y = -100; y <= 600; y += 5) {
+        const target = computeDropTarget(items, linked, 0, 1, y, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+        expect(target).not.toBe(2);
+        expect(target).not.toBe(3);
+      }
+    });
+  });
+
+  describe('overlap reduction: reorder only when beneficial', () => {
+    it('does not trigger when dragged item has not moved enough', () => {
+      // [A, B] — A barely moved down should stay as no-op
+      const items = ids(2);
+      const center = naturalCenter(0, 1); // 28
+      // Move 10px (well under half a slot = 32)
+      const target = computeDropTarget(items, new Set(), 0, 1, center + 10, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+      // Should still map to current position
+      const targetAtRest = computeDropTarget(items, new Set(), 0, 1, center, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+      expect(target).toBe(targetAtRest);
+    });
+
+    it('does trigger when dragged item has moved past midpoint', () => {
+      // [A, B] — A moved well past midpoint should reorder
+      const items = ids(2);
+      const center = naturalCenter(0, 1);
+      const target = computeDropTarget(items, new Set(), 0, 1, center + 40, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+      const targetAtRest = computeDropTarget(items, new Set(), 0, 1, center, ITEM_HEIGHT, GROUPED_GAP, TOTAL);
+      expect(target).not.toBe(targetAtRest);
+    });
+  });
+
+  describe('multi-item list: drag past multiple items', () => {
+    it('[A, B, C, D, E]: A can reach every position', () => {
+      const items = ids(5);
+      const targets = new Set<number>();
+      for (let y = -100; y <= 500; y += 1) {
+        targets.add(computeDropTarget(items, new Set(), 0, 1, y, ITEM_HEIGHT, GROUPED_GAP, TOTAL));
+      }
+      // Should be able to reach positions 0 (no-op), 2, 3, 4, 5
+      // (1 maps to same slot as 0 for the dragged item)
+      expect(targets.size).toBeGreaterThanOrEqual(4);
+    });
+  });
+});

--- a/tests/__tests__/ranked-choice/equal-rankings-helpers.test.ts
+++ b/tests/__tests__/ranked-choice/equal-rankings-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   computeTierIndices,
   tiersFromList,
   tierRanks,
+  getTierRange,
 } from '@/components/RankableOptions';
 
 describe('pairKey', () => {
@@ -106,6 +107,62 @@ describe('tierRanks (standard competition ranking)', () => {
 
   it('returns empty array for no tiers', () => {
     expect(tierRanks([])).toEqual([]);
+  });
+});
+
+describe('getTierRange', () => {
+  const mk = (...ids: string[]) => ids.map(id => ({ id }));
+
+  it('returns [index, 1] for an untied item', () => {
+    const list = mk('a', 'b', 'c');
+    expect(getTierRange(list, new Set(), 1)).toEqual([1, 1]);
+  });
+
+  it('returns full tier range when item is in the middle of a tier', () => {
+    const list = mk('a', 'b', 'c', 'd', 'e');
+    // a-b-c are tied
+    const linked = new Set([pairKey('a', 'b'), pairKey('b', 'c')]);
+    // Grab the middle item
+    expect(getTierRange(list, linked, 1)).toEqual([0, 3]);
+  });
+
+  it('returns full tier range when grabbing the tier head', () => {
+    const list = mk('a', 'b', 'c');
+    const linked = new Set([pairKey('a', 'b'), pairKey('b', 'c')]);
+    expect(getTierRange(list, linked, 0)).toEqual([0, 3]);
+  });
+
+  it('returns full tier range when grabbing the tier tail', () => {
+    const list = mk('a', 'b', 'c');
+    const linked = new Set([pairKey('a', 'b'), pairKey('b', 'c')]);
+    expect(getTierRange(list, linked, 2)).toEqual([0, 3]);
+  });
+
+  it('handles a two-item tier', () => {
+    const list = mk('a', 'b', 'c', 'd');
+    // b-c are tied
+    const linked = new Set([pairKey('b', 'c')]);
+    expect(getTierRange(list, linked, 1)).toEqual([1, 2]);
+    expect(getTierRange(list, linked, 2)).toEqual([1, 2]);
+    // Outside the tier
+    expect(getTierRange(list, linked, 0)).toEqual([0, 1]);
+    expect(getTierRange(list, linked, 3)).toEqual([3, 1]);
+  });
+
+  it('does not cross a tier boundary when adjacent tiers exist', () => {
+    const list = mk('a', 'b', 'c', 'd');
+    // a-b tied, c-d tied, but b-c NOT tied
+    const linked = new Set([pairKey('a', 'b'), pairKey('c', 'd')]);
+    expect(getTierRange(list, linked, 0)).toEqual([0, 2]);
+    expect(getTierRange(list, linked, 1)).toEqual([0, 2]);
+    expect(getTierRange(list, linked, 2)).toEqual([2, 2]);
+    expect(getTierRange(list, linked, 3)).toEqual([2, 2]);
+  });
+
+  it('returns [index, 1] for out-of-bounds indices', () => {
+    const list = mk('a', 'b');
+    expect(getTierRange(list, new Set(), -1)).toEqual([-1, 1]);
+    expect(getTierRange(list, new Set(), 5)).toEqual([5, 1]);
   });
 });
 

--- a/tests/__tests__/ranked-choice/equal-rankings-helpers.test.ts
+++ b/tests/__tests__/ranked-choice/equal-rankings-helpers.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pairKey,
+  computeTierIndices,
+  tiersFromList,
+  tierRanks,
+} from '@/components/RankableOptions';
+
+describe('pairKey', () => {
+  it('returns the same key regardless of argument order', () => {
+    expect(pairKey('a', 'b')).toBe(pairKey('b', 'a'));
+  });
+  it('uses lexicographic ordering for canonical form', () => {
+    expect(pairKey('z', 'a')).toBe('a|z');
+  });
+  it('handles identical ids (shouldn\'t happen in practice)', () => {
+    expect(pairKey('a', 'a')).toBe('a|a');
+  });
+});
+
+describe('computeTierIndices', () => {
+  const mk = (...ids: string[]) => ids.map(id => ({ id }));
+
+  it('returns empty tiers for empty list', () => {
+    expect(computeTierIndices([], new Set())).toEqual([]);
+  });
+
+  it('returns one tier per item when nothing is linked', () => {
+    const list = mk('a', 'b', 'c');
+    expect(computeTierIndices(list, new Set())).toEqual([[0], [1], [2]]);
+  });
+
+  it('groups items linked to their next neighbor', () => {
+    const list = mk('a', 'b', 'c');
+    const linked = new Set([pairKey('a', 'b')]);
+    expect(computeTierIndices(list, linked)).toEqual([[0, 1], [2]]);
+  });
+
+  it('chains multiple consecutive links into one tier', () => {
+    const list = mk('a', 'b', 'c', 'd');
+    const linked = new Set([pairKey('a', 'b'), pairKey('b', 'c')]);
+    expect(computeTierIndices(list, linked)).toEqual([[0, 1, 2], [3]]);
+  });
+
+  it('breaks a chain where a non-link gap exists', () => {
+    const list = mk('a', 'b', 'c', 'd', 'e');
+    // link a-b and d-e, not b-c or c-d
+    const linked = new Set([pairKey('a', 'b'), pairKey('d', 'e')]);
+    expect(computeTierIndices(list, linked)).toEqual([[0, 1], [2], [3, 4]]);
+  });
+
+  it('ignores stale pair entries when items are no longer adjacent', () => {
+    const list = mk('a', 'b', 'c');
+    // Originally a-c were linked (unusual), but the visual order places b
+    // between them. Since we only check adjacent pairs, the a-c entry is
+    // ignored and we end up with three singletons.
+    const linked = new Set([pairKey('a', 'c')]);
+    expect(computeTierIndices(list, linked)).toEqual([[0], [1], [2]]);
+  });
+});
+
+describe('tiersFromList', () => {
+  const mkFull = (...items: [string, string][]) =>
+    items.map(([id, text]) => ({ id, text }));
+
+  it('converts linked indices into text-based tiers', () => {
+    const list = mkFull(['i1', 'Alice'], ['i2', 'Bob'], ['i3', 'Carol']);
+    const linked = new Set([pairKey('i2', 'i3')]);
+    expect(tiersFromList(list, linked)).toEqual([['Alice'], ['Bob', 'Carol']]);
+  });
+
+  it('returns singleton tiers when nothing is linked', () => {
+    const list = mkFull(['i1', 'Alice'], ['i2', 'Bob']);
+    expect(tiersFromList(list, new Set())).toEqual([['Alice'], ['Bob']]);
+  });
+
+  it('handles all items grouped into one tier', () => {
+    const list = mkFull(['i1', 'A'], ['i2', 'B'], ['i3', 'C']);
+    const linked = new Set([pairKey('i1', 'i2'), pairKey('i2', 'i3')]);
+    expect(tiersFromList(list, linked)).toEqual([['A', 'B', 'C']]);
+  });
+});
+
+describe('tierRanks (standard competition ranking)', () => {
+  it('returns [1] for a single tier', () => {
+    expect(tierRanks([[0]])).toEqual([1]);
+  });
+
+  it('returns sequential ranks for all singletons', () => {
+    expect(tierRanks([[0], [1], [2]])).toEqual([1, 2, 3]);
+  });
+
+  it('skips ranks after a multi-item tier (1, 2, 2, 4 pattern)', () => {
+    expect(tierRanks([[0], [1, 2], [3]])).toEqual([1, 2, 4]);
+  });
+
+  it('handles a 3-item tied block', () => {
+    // Tiers: [A], [B, C, D], [E] -> ranks 1, 2, 5
+    expect(tierRanks([[0], [1, 2, 3], [4]])).toEqual([1, 2, 5]);
+  });
+
+  it('handles multiple tied blocks', () => {
+    // Tiers: [A, B], [C], [D, E, F] -> ranks 1, 3, 4
+    expect(tierRanks([[0, 1], [2], [3, 4, 5]])).toEqual([1, 3, 4]);
+  });
+
+  it('returns empty array for no tiers', () => {
+    expect(tierRanks([])).toEqual([]);
+  });
+});
+
+describe('round-trip: list + pairs -> tiers -> rank display', () => {
+  it('matches the spec example [A], [B, C], [D] -> ranks 1, 2, 4', () => {
+    const list = [
+      { id: 'o1', text: 'A' },
+      { id: 'o2', text: 'B' },
+      { id: 'o3', text: 'C' },
+      { id: 'o4', text: 'D' },
+    ];
+    const linked = new Set([pairKey('o2', 'o3')]);
+    const tiers = tiersFromList(list, linked);
+    expect(tiers).toEqual([['A'], ['B', 'C'], ['D']]);
+    expect(tierRanks(tiers)).toEqual([1, 2, 4]);
+  });
+});


### PR DESCRIPTION
## Summary
- Voters can tie options at the same rank via chain-link icons between items. Tied items render as merged cards with divider lines and a single drag handle. Dragging moves the entire group as one unit.
- The IRV backend uses the **duplicate vote** method: each option in a ballot's highest-ranked active tier gets a full vote. Win requires strict majority AND unique leader. Borda tiebreak uses standard competition ranking (1,2,2,4).
- New `ranked_choice_tiers JSONB` column (migration 089) stores tiered ballots alongside the existing flat `ranked_choices` for backwards compatibility. Frontend sends tiers only when ties exist.
- Pure `computeDropTarget()` function gives symmetric drag thresholds for all unit-size combinations. Groups are atomic in both drag-and-drop and tap-to-reorder.

## Test plan
- [x] 42 backend IRV tests (15 new for tied rankings) — all pass
- [x] 10 new vote validation tests for `ranked_choice_tiers` — all pass
- [x] 26 frontend helper tests (`pairKey`, `computeTierIndices`, `tiersFromList`, `tierRanks`, `getTierRange`) — all pass
- [x] 15 drag-threshold simulation tests verifying symmetry across singleton↔singleton, singleton↔group(2), singleton↔group(3), group(2)↔group(2), group(2)↔group(3), group(3)↔singleton — all pass
- [x] Full frontend suite: 131 tests pass, Next.js build succeeds
- [x] Full backend suite: 174 tests pass
- [x] Demo poll live at dev server with 5 voters using mixed tiered/flat ballots

https://claude.ai/code/session_01SjY4TjsdzVBqneKYBK7H5m