### PR TITLE
Render ranking summary with tier-card style (no handles)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,7 @@ whoeverwants/
 │   ├── SuggestionVotingInterface.tsx # Suggestion poll voting
 │   ├── SuggestionsList.tsx         # Display suggestions with vote counts
 │   ├── CompactRankedChoiceResults.tsx # Ranked choice round display
+│   ├── ReadOnlyTierCards.tsx       # Read-only tier-card ranking display (shared)
 │   ├── MinMaxCounter.tsx           # Participation min/max selectors
 │   ├── ParticipationConditions.tsx # Voter condition UI
 │   ├── OptionsInput.tsx            # Poll options/suggestions input

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -25,6 +25,7 @@ import AbstainButton from "@/components/AbstainButton";
 import { Poll, PollResults, OptionsMetadata, DayTimeWindow } from "@/lib/types";
 import { apiGetPollResults, apiGetVotes, apiSubmitVote, apiEditVote, apiClosePoll, apiCutoffSuggestions, apiCutoffAvailability, apiReopenPoll, apiGetPollById, apiGetParticipants, ApiVote } from "@/lib/api";
 import RankableOptions from "@/components/RankableOptions";
+import ReadOnlyTierCards from "@/components/ReadOnlyTierCards";
 import TimeSlotBubbles, { SlotState } from "@/components/TimeSlotBubbles";
 
 import { isCreatedByThisBrowser, getCreatorSecret, recordPollCreation } from "@/lib/browserPollAccess";
@@ -2193,42 +2194,12 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             </span>
                             <span className="font-medium text-yellow-800 dark:text-yellow-200">Abstained</span>
                           </div>
-                        ) : (() => {
-                          // Render the user's ranking using the same tier-card
-                          // style as the drag-and-drop ballot (without handles).
-                          const tiersToRender: string[][] =
-                            rankedChoiceTiers && rankedChoiceTiers.length > 0
-                              ? rankedChoiceTiers
-                              : rankedChoices.map(c => [c]);
-                          let posSoFar = 0;
-                          return tiersToRender.map((tier, tierIdx) => {
-                            const rank = posSoFar + 1;
-                            posSoFar += tier.length;
-                            return (
-                              <div key={tierIdx} className="flex items-center gap-2">
-                                <div className="flex-shrink-0 flex items-center justify-center" style={{ width: '32px' }}>
-                                  <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                                    {rank}
-                                  </span>
-                                </div>
-                                <div className="flex-1 rounded-md shadow-sm bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-500 min-w-0">
-                                  {tier.map((choice, innerIdx) => (
-                                    <div key={`${tierIdx}-${innerIdx}`}>
-                                      {innerIdx > 0 && (
-                                        <div className="border-t border-gray-200 dark:border-gray-700 mx-3" />
-                                      )}
-                                      <div className="p-3 flex items-center min-w-0">
-                                        <div className="min-w-0 overflow-hidden text-gray-900 dark:text-white">
-                                          <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
-                                        </div>
-                                      </div>
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
-                            );
-                          });
-                        })()}
+                        ) : (
+                          <ReadOnlyTierCards
+                            tiers={rankedChoiceTiers && rankedChoiceTiers.length > 0 ? rankedChoiceTiers : rankedChoices.map(c => [c])}
+                            optionsMetadata={optionsMetadataLocal}
+                          />
+                        )}
                       </div>
                     ) : null}
                   </div>

--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -2194,10 +2194,8 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             <span className="font-medium text-yellow-800 dark:text-yellow-200">Abstained</span>
                           </div>
                         ) : (() => {
-                          // Render the user's ranking, collapsing tied ranks
-                          // into visually-grouped blocks with a shared rank
-                          // number. Falls back to singleton tiers when no
-                          // tiered data is present.
+                          // Render the user's ranking using the same tier-card
+                          // style as the drag-and-drop ballot (without handles).
                           const tiersToRender: string[][] =
                             rankedChoiceTiers && rankedChoiceTiers.length > 0
                               ? rankedChoiceTiers
@@ -2207,21 +2205,23 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
                             const rank = posSoFar + 1;
                             posSoFar += tier.length;
                             return (
-                              <div key={tierIdx} className="flex items-start gap-2">
-                                <div className="flex-shrink-0 flex items-center" style={{ width: '32px', minHeight: '2.5rem' }}>
+                              <div key={tierIdx} className="flex items-center gap-2">
+                                <div className="flex-shrink-0 flex items-center justify-center" style={{ width: '32px' }}>
                                   <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
                                     {rank}
                                   </span>
                                 </div>
-                                <div className="flex-1 flex flex-col gap-1 min-w-0">
+                                <div className="flex-1 rounded-md shadow-sm bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-500 min-w-0">
                                   {tier.map((choice, innerIdx) => (
-                                    <div key={`${tierIdx}-${innerIdx}`} className="flex items-center p-2 bg-gray-50 dark:bg-gray-800 rounded min-w-0">
-                                      <div className="min-w-0 overflow-hidden">
-                                        <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
-                                      </div>
-                                      {tier.length > 1 && innerIdx === 0 && (
-                                        <span className="ml-auto flex-shrink-0 text-xs text-blue-600 dark:text-blue-400 italic">tied</span>
+                                    <div key={`${tierIdx}-${innerIdx}`}>
+                                      {innerIdx > 0 && (
+                                        <div className="border-t border-gray-200 dark:border-gray-700 mx-3" />
                                       )}
+                                      <div className="p-3 flex items-center min-w-0">
+                                        <div className="min-w-0 overflow-hidden text-gray-900 dark:text-white">
+                                          <OptionLabel text={choice} metadata={optionsMetadataLocal?.[choice]} />
+                                        </div>
+                                      </div>
                                     </div>
                                   ))}
                                 </div>

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -5,6 +5,7 @@ import RankableOptions from "@/components/RankableOptions";
 import AbstainButton from "@/components/AbstainButton";
 import CompactNameField from "@/components/CompactNameField";
 import OptionLabel from "@/components/OptionLabel";
+import ReadOnlyTierCards from "@/components/ReadOnlyTierCards";
 import VoterList from "@/components/VoterList";
 import type { OptionsMetadata } from "@/lib/types";
 import type { ApiVote } from "@/lib/api";
@@ -141,50 +142,20 @@ export default function RankingSection({
       )}
 
       <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
-        {showSummary && hasSubmittedRankings && (() => {
-          const tiersToRender: string[][] =
-            userVoteData.ranked_choice_tiers && userVoteData.ranked_choice_tiers.length > 0
-              ? userVoteData.ranked_choice_tiers
-              : userVoteData.ranked_choices.map((c: string) => [c]);
-          let posSoFar = 0;
-          return (
-            <>
-              <div className="flex items-center justify-between mb-2">
-                <h4 className="text-base font-medium text-gray-900 dark:text-white">Your ranking:</h4>
-                {editButton}
-              </div>
-              <div className="space-y-2">
-                {tiersToRender.map((tier: string[], tierIdx: number) => {
-                  const rank = posSoFar + 1;
-                  posSoFar += tier.length;
-                  return (
-                    <div key={tierIdx} className="flex items-center gap-2">
-                      <div className="flex-shrink-0 flex items-center justify-center" style={{ width: '32px' }}>
-                        <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                          {rank}
-                        </span>
-                      </div>
-                      <div className="flex-1 rounded-md shadow-sm bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-500 min-w-0">
-                        {tier.map((choice: string, innerIdx: number) => (
-                          <div key={`${tierIdx}-${innerIdx}`}>
-                            {innerIdx > 0 && (
-                              <div className="border-t border-gray-200 dark:border-gray-700 mx-3" />
-                            )}
-                            <div className="p-3 flex items-center min-w-0">
-                              <div className="min-w-0 overflow-hidden text-gray-900 dark:text-white">
-                                <OptionLabel text={choice} metadata={optionsMetadata?.[choice]} />
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </>
-          );
-        })()}
+        {showSummary && hasSubmittedRankings && (
+          <>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-base font-medium text-gray-900 dark:text-white">Your ranking:</h4>
+              {editButton}
+            </div>
+            <div className="space-y-2">
+              <ReadOnlyTierCards
+                tiers={userVoteData.ranked_choice_tiers?.length > 0 ? userVoteData.ranked_choice_tiers : userVoteData.ranked_choices.map((c: string) => [c])}
+                optionsMetadata={optionsMetadata}
+              />
+            </div>
+          </>
+        )}
 
         {showSummary && abstainedNoRanking && !hasSubmittedRankings && (
           <div className="flex items-center justify-between">

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -141,30 +141,50 @@ export default function RankingSection({
       )}
 
       <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
-        {showSummary && hasSubmittedRankings && (
-          <>
-            <div className="flex items-center justify-between mb-2">
-              <h4 className="text-base font-medium text-gray-900 dark:text-white">Your ranking:</h4>
-              {editButton}
-            </div>
-            <div className="space-y-2">
-              {userVoteData.ranked_choices.map((choice: string, index: number) => (
-                <div key={index} className="flex items-center gap-2">
-                  <div className="flex-shrink-0" style={{ width: '32px' }}>
-                    <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
-                      {index + 1}
-                    </span>
-                  </div>
-                  <div className="flex-1 flex items-center p-2 bg-white dark:bg-gray-900 rounded min-w-0">
-                    <div className="min-w-0 overflow-hidden">
-                      <OptionLabel text={choice} metadata={optionsMetadata?.[choice]} />
+        {showSummary && hasSubmittedRankings && (() => {
+          const tiersToRender: string[][] =
+            userVoteData.ranked_choice_tiers && userVoteData.ranked_choice_tiers.length > 0
+              ? userVoteData.ranked_choice_tiers
+              : userVoteData.ranked_choices.map((c: string) => [c]);
+          let posSoFar = 0;
+          return (
+            <>
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-base font-medium text-gray-900 dark:text-white">Your ranking:</h4>
+                {editButton}
+              </div>
+              <div className="space-y-2">
+                {tiersToRender.map((tier: string[], tierIdx: number) => {
+                  const rank = posSoFar + 1;
+                  posSoFar += tier.length;
+                  return (
+                    <div key={tierIdx} className="flex items-center gap-2">
+                      <div className="flex-shrink-0 flex items-center justify-center" style={{ width: '32px' }}>
+                        <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                          {rank}
+                        </span>
+                      </div>
+                      <div className="flex-1 rounded-md shadow-sm bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-500 min-w-0">
+                        {tier.map((choice: string, innerIdx: number) => (
+                          <div key={`${tierIdx}-${innerIdx}`}>
+                            {innerIdx > 0 && (
+                              <div className="border-t border-gray-200 dark:border-gray-700 mx-3" />
+                            )}
+                            <div className="p-3 flex items-center min-w-0">
+                              <div className="min-w-0 overflow-hidden text-gray-900 dark:text-white">
+                                <OptionLabel text={choice} metadata={optionsMetadata?.[choice]} />
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </>
-        )}
+                  );
+                })}
+              </div>
+            </>
+          );
+        })()}
 
         {showSummary && abstainedNoRanking && !hasSubmittedRankings && (
           <div className="flex items-center justify-between">

--- a/components/ReadOnlyTierCards.tsx
+++ b/components/ReadOnlyTierCards.tsx
@@ -1,0 +1,38 @@
+import OptionLabel from './OptionLabel';
+import type { OptionsMetadata } from '@/lib/types';
+
+interface ReadOnlyTierCardsProps {
+  tiers: string[][];
+  optionsMetadata?: OptionsMetadata | null;
+}
+
+export default function ReadOnlyTierCards({ tiers, optionsMetadata }: ReadOnlyTierCardsProps) {
+  let posSoFar = 0;
+  return tiers.map((tier, tierIdx) => {
+    const rank = posSoFar + 1;
+    posSoFar += tier.length;
+    return (
+      <div key={tierIdx} className="flex items-center gap-2">
+        <div className="flex-shrink-0 flex items-center justify-center" style={{ width: '32px' }}>
+          <span className="w-6 h-6 flex-shrink-0 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+            {rank}
+          </span>
+        </div>
+        <div className="flex-1 rounded-md shadow-sm bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-500 min-w-0">
+          {tier.map((choice, innerIdx) => (
+            <div key={`${tierIdx}-${innerIdx}`}>
+              {innerIdx > 0 && (
+                <div className="border-t border-gray-200 dark:border-gray-700 mx-3" />
+              )}
+              <div className="p-3 flex items-center min-w-0">
+                <div className="min-w-0 overflow-hidden text-gray-900 dark:text-white">
+                  <OptionLabel text={choice} metadata={optionsMetadata?.[choice]} />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Renders the read-only "Your ranking" section using the same tier-card layout as the drag-and-drop ballot — tied items share a single card with divider lines, rank numbers use competition ranking (1, 3, 5)
- Removes the old "tied" text label (visual grouping makes it obvious)
- Extracts shared `ReadOnlyTierCards` component to deduplicate rendering between `PollPageClient.tsx` and `RankingSection.tsx`

## Test plan
- [ ] Create a ranked choice poll, submit a vote with tied rankings, verify the summary displays tier cards correctly
- [ ] Verify singleton (non-tied) rankings still display as individual cards
- [ ] Test suggestion poll flow — verify ranking summary in RankingSection uses the same card style
- [ ] Edit vote and re-submit — verify summary updates correctly

https://claude.ai/code/session_01YKKrtQFNNh1NPoH9xVeeyT