### PR TITLE
Fix doubled section divider lines in poll list

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -456,7 +456,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
               return (
                 <React.Fragment key={poll.id}>
                   {isFirstVoted && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-y border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
                       Already Voted
                     </div>
                   )}
@@ -524,7 +524,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
       {/* Closed Polls Section */}
       {closedPolls.length > 0 && (
         <div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-y border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30">
+          <div className={`text-xs text-gray-500 dark:text-gray-400 font-medium px-4 py-1.5 border-b ${openPolls.length === 0 ? 'border-t' : ''} border-gray-200 dark:border-gray-700 mx-1.5 bg-gray-50 dark:bg-gray-800/30`}>
             Closed
           </div>
           <div>


### PR DESCRIPTION
## Summary
- Section headers ("Already Voted", "Closed") used `border-y` which added both top and bottom borders. Since the poll item above already has `border-b`, the two adjacent borders stacked to create a visually thicker line above the section header.
- Changed section headers to `border-b` only, relying on the preceding item's bottom border for the top line.
- "Closed" header conditionally adds `border-t` only when there are no open polls above it (so it's not missing a top border when it's the first element).

## Test plan
- [ ] Open home page with both open and closed polls — verify the line above "Closed" header is the same thickness as the line below it
- [ ] Vote on some open polls so "Already Voted" section appears — verify its top divider matches the bottom divider thickness
- [ ] View home page with only closed polls (no open) — verify "Closed" header still has a top border

https://claude.ai/code/session_01ENxDUdukpgULniV2vPhvgx