### PR TITLE
Fix RCV percentages exceeding 100% with equal rankings

### DIFF
--- a/components/CompactRankedChoiceResults.tsx
+++ b/components/CompactRankedChoiceResults.tsx
@@ -135,6 +135,9 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
           // Get user's preference for this round (before any eliminations in this round)
           const userPreference = getUserPreferenceForRound(roundNum, eliminatedSoFar);
           
+          // Total votes in this round (can exceed ballot count with equal rankings)
+          const roundTotalVotes = currentRoundData.reduce((sum, r) => sum + r.vote_count, 0);
+
           // Check for ties in the final round
           const isFinalRound = roundNum === totalRounds;
           
@@ -184,7 +187,7 @@ export default function CompactRankedChoiceResults({ results, isPollClosed, user
               return {
                 name: round.option_name,
                 votes: round.vote_count,
-                percentage: results.total_votes > 0 ? Math.round((round.vote_count / results.total_votes) * 100) : 0,
+                percentage: roundTotalVotes > 0 ? Math.round((round.vote_count / roundTotalVotes) * 100) : 0,
                 previousVotes: roundNum > 1 ? previousVotes : undefined,
                 donatedVotes: donatedVotes > 0 ? donatedVotes : undefined,
                 isEliminated: isEliminated,


### PR DESCRIPTION
## Summary
- RCV round percentages used total ballot count as denominator, but with equal/tied rankings a ballot can give a full vote to multiple candidates — making percentages sum to well over 100%
- Changed denominator from total ballots to sum of vote counts in the round, so percentages always sum to ~100%
- Example: 4 ballots with ties produced 9 votes in round 1 — old: 75%+50%+50%+50%=225%, new: 33%+22%+22%+22%=99%

## Test plan
- [x] Created RCV poll with equal rankings on dev server and verified percentages sum correctly
- [ ] Verify RCV polls without equal rankings still show correct percentages
- [ ] Verify tie/elimination display is unaffected

https://claude.ai/code/session_01XQgsiosBojXicPDiq4Zik3