### PR TITLE
Fix grouped options not moving together to exclusion zone

### DIFF
--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1356,18 +1356,18 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
           // Move from no preference to main
           const noPreferenceIndex = noPreferenceList.findIndex(item => item.id === id);
           if (noPreferenceIndex !== -1) {
-            moveItemBetweenLists(id, 'noPreference', noPreferenceIndex, 'main', mainList.length);
+            moveTierBetweenLists('noPreference', noPreferenceIndex, 1, 'main', mainList.length);
           }
         }
         break;
-        
+
       case 'ArrowRight':
         e.preventDefault();
         if (keyboardMode && focusedItemId === id) {
           // Move from main to no preference
           const mainIndex = mainList.findIndex(item => item.id === id);
           if (mainIndex !== -1) {
-            moveItemBetweenLists(id, 'main', mainIndex, 'noPreference', noPreferenceList.length);
+            moveTierBetweenLists('main', mainIndex, 1, 'noPreference', noPreferenceList.length);
           }
         }
         break;
@@ -1463,41 +1463,6 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
   }, [updateItemPositions, animateWithFLIP, mainList, linkedPairs]);
 
   // Helper function to move items between lists (with FLIP animation)
-  const moveItemBetweenLists = useCallback((
-    itemId: string,
-    sourceList: 'main' | 'noPreference',
-    sourceIndex: number,
-    targetList: 'main' | 'noPreference',
-    targetIndex: number
-  ) => {
-    const sourceListRef = sourceList === 'main' ? mainList : noPreferenceList;
-    const item = sourceListRef[sourceIndex];
-
-    if (!item) return;
-
-    const sourceSetter = sourceList === 'main' ? setMainList : setNoPreferenceList;
-    const targetSetter = targetList === 'main' ? setMainList : setNoPreferenceList;
-
-    animateWithFLIP(() => {
-      sourceSetter(prev => {
-        const newList = [...prev];
-        newList.splice(sourceIndex, 1);
-        return updateItemPositions(newList);
-      });
-      targetSetter(prev => {
-        const newList = [...prev];
-        newList.splice(targetIndex, 0, item);
-        return updateItemPositions(newList);
-      });
-    });
-    // If the item left the main list entirely, drop any tied-rank entries
-    // that involved it. If it's being moved INTO main from noPreference,
-    // there are no pre-existing links to worry about.
-    if (sourceList === 'main' && targetList !== 'main') {
-      dropLinkedPairsFor(item.id);
-    }
-  }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP, dropLinkedPairsFor]);
-
   /** Move a contiguous tier (one or more grouped items) between lists. */
   const moveTierBetweenLists = useCallback((
     sourceList: 'main' | 'noPreference',
@@ -1525,13 +1490,20 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
         return updateItemPositions(newList);
       });
     });
-    // Drop linked pairs for all moved items leaving main
     if (sourceList === 'main' && targetList !== 'main') {
-      for (const item of items) {
-        dropLinkedPairsFor(item.id);
-      }
+      const ids = new Set(items.map(item => item.id));
+      setLinkedPairs(prev => {
+        const next = new Set<string>();
+        let changed = false;
+        for (const key of prev) {
+          const [a, b] = key.split('|');
+          if (ids.has(a) || ids.has(b)) { changed = true; continue; }
+          next.add(key);
+        }
+        return changed ? next : prev;
+      });
     }
-  }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP, dropLinkedPairsFor]);
+  }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP]);
 
   // Memoize the tier structure so it's computed once per render, not once
   // per section (rank numbers, link circles, tier cards all use it).

--- a/components/RankableOptions.tsx
+++ b/components/RankableOptions.tsx
@@ -1498,6 +1498,41 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
     }
   }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP, dropLinkedPairsFor]);
 
+  /** Move a contiguous tier (one or more grouped items) between lists. */
+  const moveTierBetweenLists = useCallback((
+    sourceList: 'main' | 'noPreference',
+    sourceStart: number,
+    tierSize: number,
+    targetList: 'main' | 'noPreference',
+    targetIndex: number
+  ) => {
+    const sourceListRef = sourceList === 'main' ? mainList : noPreferenceList;
+    const items = sourceListRef.slice(sourceStart, sourceStart + tierSize);
+    if (items.length === 0) return;
+
+    const sourceSetter = sourceList === 'main' ? setMainList : setNoPreferenceList;
+    const targetSetter = targetList === 'main' ? setMainList : setNoPreferenceList;
+
+    animateWithFLIP(() => {
+      sourceSetter(prev => {
+        const newList = [...prev];
+        newList.splice(sourceStart, tierSize);
+        return updateItemPositions(newList);
+      });
+      targetSetter(prev => {
+        const newList = [...prev];
+        newList.splice(targetIndex, 0, ...items);
+        return updateItemPositions(newList);
+      });
+    });
+    // Drop linked pairs for all moved items leaving main
+    if (sourceList === 'main' && targetList !== 'main') {
+      for (const item of items) {
+        dropLinkedPairsFor(item.id);
+      }
+    }
+  }, [mainList, noPreferenceList, updateItemPositions, animateWithFLIP, dropLinkedPairsFor]);
+
   // Memoize the tier structure so it's computed once per render, not once
   // per section (rank numbers, link circles, tier cards all use it).
   const mainTiers = useMemo(
@@ -1807,7 +1842,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                             const relativeY = e.clientY - rect.top;
                             const half = rect.height / 2;
                             if (listType === 'noPreference') {
-                              moveItemBetweenLists(firstItem.id, 'noPreference', tierIndices[0], 'main', mainList.length);
+                              moveTierBetweenLists('noPreference', tierIndices[0], size, 'main', mainList.length);
                             } else if (relativeY < half) {
                               if (tierIndices[0] > 0) {
                                 moveTierByOneUnit(tierIndices[0], size, 'up');
@@ -1817,7 +1852,7 @@ export default function RankableOptions({ options, onRankingChange, disabled = f
                               if (lastIdx < listItems.length - 1) {
                                 moveTierByOneUnit(tierIndices[0], size, 'down');
                               } else {
-                                moveItemBetweenLists(firstItem.id, 'main', tierIndices[0], 'noPreference', noPreferenceList.length);
+                                moveTierBetweenLists('main', tierIndices[0], size, 'noPreference', noPreferenceList.length);
                               }
                             }
                           }


### PR DESCRIPTION
## Summary
- When a tier (grouped/linked options) was at the bottom of the ranked list and the user tapped the down arrow, only the first item moved to the "No Preference" exclusion zone — the rest stayed behind, breaking the group
- Added `moveTierBetweenLists()` that moves all items in a tier as a unit between ranked and exclusion zones
- Deleted the now-redundant `moveItemBetweenLists()` (strict subset of the new function with tierSize=1) and updated keyboard navigation to use `moveTierBetweenLists` directly
- Batched N separate `setLinkedPairs` state updates into a single pass with a `Set<string>` of IDs, avoiding N re-renders when moving grouped items

## Test plan
- [ ] Create a ranked choice poll with 4+ options
- [ ] Group two options together using the link/tie button
- [ ] Move the group to the bottom of the ranked list
- [ ] Tap the down arrow — both items should move to "No Preference" together
- [ ] Tap the up arrow on the items in "No Preference" — they should move back to ranked list
- [ ] Verify keyboard navigation (ArrowLeft/ArrowRight) still moves single items between lists
- [ ] Verify drag-to-reorder still works correctly for grouped and ungrouped items

https://claude.ai/code/session_01UizEa9KXpvr4BXaGysBXKs