### PR TITLE
Use green for voting countdown text on poll cards

### DIFF
--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -105,7 +105,7 @@ function relativeTime(dateStr: string): string {
 }
 
 // Simple countdown component
-const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string }) => {
+const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:text-blue-400" }: { deadline: string; label: string; colorClass?: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
   const [isClient, setIsClient] = useState(false);
 
@@ -152,7 +152,7 @@ const SimpleCountdown = ({ deadline, label }: { deadline: string; label: string 
 
   return (
     <>
-      {label && `${label}: `}<span className="font-mono font-semibold text-blue-600 dark:text-blue-400">{timeLeft}</span>
+      {label && `${label}: `}<span className={`font-mono font-semibold ${colorClass}`}>{timeLeft}</span>
     </>
   );
 };
@@ -492,7 +492,7 @@ export default function PollList({ polls, showSections = true, sectionTitles = {
                                 return <span className="font-semibold text-blue-600 dark:text-blue-400">Taking Suggestions</span>;
                               }
                               if (poll.response_deadline) {
-                                return <SimpleCountdown deadline={poll.response_deadline} label="Voting" />;
+                                return <SimpleCountdown deadline={poll.response_deadline} label="Voting" colorClass="text-green-600 dark:text-green-400" />;
                               }
                               return null;
                             })()}


### PR DESCRIPTION
## Summary
- Voting/voting countdown text in the upper right of poll cards now uses green (`text-green-600`) instead of blue
- Suggestion-related text ("Suggestions" countdown and "Taking Suggestions") remains blue to visually distinguish the two phases
- Added optional `colorClass` prop to `SimpleCountdown` with blue as default for backward compatibility

## Test plan
- [x] Verified green voting countdown on yes/no poll card
- [x] Verified blue suggestion text on ranked choice suggestion poll card
- [x] Screenshot confirms correct color distinction

https://claude.ai/code/session_01Qdhb5wbkmm1jftBFXbN12W