### PR TITLE
Fix input field width to fit existing text on focus

### DIFF
--- a/components/CategoryForLine.tsx
+++ b/components/CategoryForLine.tsx
@@ -269,15 +269,20 @@ export default function CategoryForLine({
 
   // While editing, keep field at least as wide as the placeholder so it doesn't
   // shrink when the user starts typing a short value — but only when the field
-  // was empty on focus. If the field already had custom text, fit to that text.
+  // was empty on focus. If the field already had custom text, fit to that text
+  // (using a minimal non-breaking space fallback if backspaced empty).
   const categoryMirrorText =
-    categoryFocused && !categoryHadValueOnFocusRef.current && categoryDisplayValue.length < CATEGORY_PLACEHOLDER.length
-      ? CATEGORY_PLACEHOLDER
-      : categoryDisplayValue || CATEGORY_PLACEHOLDER;
+    categoryFocused && categoryHadValueOnFocusRef.current
+      ? (categoryDisplayValue || "\u00A0")
+      : categoryFocused && categoryDisplayValue.length < CATEGORY_PLACEHOLDER.length
+        ? CATEGORY_PLACEHOLDER
+        : categoryDisplayValue || CATEGORY_PLACEHOLDER;
   const contextMirrorText =
-    contextFocused && !contextHadValueOnFocusRef.current && forField.length < CONTEXT_PLACEHOLDER.length
-      ? CONTEXT_PLACEHOLDER
-      : forField || CONTEXT_PLACEHOLDER;
+    contextFocused && contextHadValueOnFocusRef.current
+      ? (forField || "\u00A0")
+      : contextFocused && forField.length < CONTEXT_PLACEHOLDER.length
+        ? CONTEXT_PLACEHOLDER
+        : forField || CONTEXT_PLACEHOLDER;
 
   return (
     <div className="relative">
@@ -311,7 +316,7 @@ export default function CategoryForLine({
               ref={categoryInputRef}
               type="text"
               value={categoryDisplayValue}
-              placeholder={CATEGORY_PLACEHOLDER}
+              placeholder={categoryFocused && categoryHadValueOnFocusRef.current ? "" : CATEGORY_PLACEHOLDER}
               onChange={handleCategoryInputChange}
               onFocus={handleCategoryFocus}
               onBlur={handleCategoryBlur}
@@ -360,7 +365,7 @@ export default function CategoryForLine({
                   ref={contextInputRef}
                   type="text"
                   value={forField}
-                  placeholder={CONTEXT_PLACEHOLDER}
+                  placeholder={contextFocused && contextHadValueOnFocusRef.current ? "" : CONTEXT_PLACEHOLDER}
                   onChange={(e) => onForFieldChange(e.target.value)}
                   onFocus={() => {
                     setContextFocused(true);

--- a/components/CategoryForLine.tsx
+++ b/components/CategoryForLine.tsx
@@ -267,22 +267,30 @@ export default function CategoryForLine({
     return <div style={{ minHeight: `${MAX_FONT_PX + 8}px` }} />;
   }
 
-  // While editing, keep field at least as wide as the placeholder so it doesn't
-  // shrink when the user starts typing a short value — but only when the field
-  // was empty on focus. If the field already had custom text, fit to that text
-  // (using a minimal non-breaking space fallback if backspaced empty).
-  const categoryMirrorText =
-    categoryFocused && categoryHadValueOnFocusRef.current
-      ? (categoryDisplayValue || "\u00A0")
-      : categoryFocused && categoryDisplayValue.length < CATEGORY_PLACEHOLDER.length
-        ? CATEGORY_PLACEHOLDER
-        : categoryDisplayValue || CATEGORY_PLACEHOLDER;
-  const contextMirrorText =
-    contextFocused && contextHadValueOnFocusRef.current
-      ? (forField || "\u00A0")
-      : contextFocused && forField.length < CONTEXT_PLACEHOLDER.length
-        ? CONTEXT_PLACEHOLDER
-        : forField || CONTEXT_PLACEHOLDER;
+  // Mirror text controls the width of the inline-block sizer span.
+  // When the field was empty on focus, the placeholder width is the minimum.
+  // When the field had custom text on focus, width tracks the text exactly.
+  function mirrorText(
+    isFocused: boolean,
+    hadValueOnFocus: boolean,
+    displayValue: string,
+    placeholder: string,
+  ): string {
+    if (isFocused && hadValueOnFocus) return displayValue || "\u00A0";
+    if (isFocused && displayValue.length < placeholder.length) return placeholder;
+    return displayValue || placeholder;
+  }
+
+  const categoryMirrorText = mirrorText(
+    categoryFocused, categoryHadValueOnFocusRef.current, categoryDisplayValue, CATEGORY_PLACEHOLDER,
+  );
+  const contextMirrorText = mirrorText(
+    contextFocused, contextHadValueOnFocusRef.current, forField, CONTEXT_PLACEHOLDER,
+  );
+
+  // Suppress placeholder text while editing a field that started with content
+  const hideCategoryPlaceholder = categoryFocused && categoryHadValueOnFocusRef.current;
+  const hideContextPlaceholder = contextFocused && contextHadValueOnFocusRef.current;
 
   return (
     <div className="relative">
@@ -316,7 +324,7 @@ export default function CategoryForLine({
               ref={categoryInputRef}
               type="text"
               value={categoryDisplayValue}
-              placeholder={categoryFocused && categoryHadValueOnFocusRef.current ? "" : CATEGORY_PLACEHOLDER}
+              placeholder={hideCategoryPlaceholder ? "" : CATEGORY_PLACEHOLDER}
               onChange={handleCategoryInputChange}
               onFocus={handleCategoryFocus}
               onBlur={handleCategoryBlur}
@@ -365,7 +373,7 @@ export default function CategoryForLine({
                   ref={contextInputRef}
                   type="text"
                   value={forField}
-                  placeholder={contextFocused && contextHadValueOnFocusRef.current ? "" : CONTEXT_PLACEHOLDER}
+                  placeholder={hideContextPlaceholder ? "" : CONTEXT_PLACEHOLDER}
                   onChange={(e) => onForFieldChange(e.target.value)}
                   onFocus={() => {
                     setContextFocused(true);

--- a/components/CategoryForLine.tsx
+++ b/components/CategoryForLine.tsx
@@ -47,8 +47,8 @@ export default function CategoryForLine({
   // True when a built-in category hasn't been edited yet — first backspace clears it
   const categoryPristineRef = useRef(false);
   // Track whether field had a user value when focused — controls placeholder-as-minimum-width behavior
-  const categoryHadValueOnFocusRef = useRef(false);
-  const contextHadValueOnFocusRef = useRef(false);
+  const [categoryHadValueOnFocus, setCategoryHadValueOnFocus] = useState(false);
+  const [contextHadValueOnFocus, setContextHadValueOnFocus] = useState(false);
 
   // Initial delay (wait for modal slide-up animation)
   useEffect(() => {
@@ -169,7 +169,7 @@ export default function CategoryForLine({
 
   const handleCategoryFocus = () => {
     setCategoryFocused(true);
-    categoryHadValueOnFocusRef.current = categoryHasUserValue;
+    setCategoryHadValueOnFocus(categoryHasUserValue);
     if (categoryHasUserValue) {
       const label = builtIn?.label || category;
       setCategoryEditText(label);
@@ -282,15 +282,15 @@ export default function CategoryForLine({
   }
 
   const categoryMirrorText = mirrorText(
-    categoryFocused, categoryHadValueOnFocusRef.current, categoryDisplayValue, CATEGORY_PLACEHOLDER,
+    categoryFocused, categoryHadValueOnFocus, categoryDisplayValue, CATEGORY_PLACEHOLDER,
   );
   const contextMirrorText = mirrorText(
-    contextFocused, contextHadValueOnFocusRef.current, forField, CONTEXT_PLACEHOLDER,
+    contextFocused, contextHadValueOnFocus, forField, CONTEXT_PLACEHOLDER,
   );
 
   // Suppress placeholder text while editing a field that started with content
-  const hideCategoryPlaceholder = categoryFocused && categoryHadValueOnFocusRef.current;
-  const hideContextPlaceholder = contextFocused && contextHadValueOnFocusRef.current;
+  const hideCategoryPlaceholder = categoryFocused && categoryHadValueOnFocus;
+  const hideContextPlaceholder = contextFocused && contextHadValueOnFocus;
 
   return (
     <div className="relative">
@@ -377,7 +377,7 @@ export default function CategoryForLine({
                   onChange={(e) => onForFieldChange(e.target.value)}
                   onFocus={() => {
                     setContextFocused(true);
-                    contextHadValueOnFocusRef.current = !!forField.trim();
+                    setContextHadValueOnFocus(!!forField.trim());
                   }}
                   onBlur={() => {
                     setContextFocused(false);

--- a/components/CategoryForLine.tsx
+++ b/components/CategoryForLine.tsx
@@ -46,6 +46,9 @@ export default function CategoryForLine({
   const committedRef = useRef(false);
   // True when a built-in category hasn't been edited yet — first backspace clears it
   const categoryPristineRef = useRef(false);
+  // Track whether field had a user value when focused — controls placeholder-as-minimum-width behavior
+  const categoryHadValueOnFocusRef = useRef(false);
+  const contextHadValueOnFocusRef = useRef(false);
 
   // Initial delay (wait for modal slide-up animation)
   useEffect(() => {
@@ -166,6 +169,7 @@ export default function CategoryForLine({
 
   const handleCategoryFocus = () => {
     setCategoryFocused(true);
+    categoryHadValueOnFocusRef.current = categoryHasUserValue;
     if (categoryHasUserValue) {
       const label = builtIn?.label || category;
       setCategoryEditText(label);
@@ -264,13 +268,14 @@ export default function CategoryForLine({
   }
 
   // While editing, keep field at least as wide as the placeholder so it doesn't
-  // shrink when the user starts typing a short value
+  // shrink when the user starts typing a short value — but only when the field
+  // was empty on focus. If the field already had custom text, fit to that text.
   const categoryMirrorText =
-    categoryFocused && categoryDisplayValue.length < CATEGORY_PLACEHOLDER.length
+    categoryFocused && !categoryHadValueOnFocusRef.current && categoryDisplayValue.length < CATEGORY_PLACEHOLDER.length
       ? CATEGORY_PLACEHOLDER
       : categoryDisplayValue || CATEGORY_PLACEHOLDER;
   const contextMirrorText =
-    contextFocused && forField.length < CONTEXT_PLACEHOLDER.length
+    contextFocused && !contextHadValueOnFocusRef.current && forField.length < CONTEXT_PLACEHOLDER.length
       ? CONTEXT_PLACEHOLDER
       : forField || CONTEXT_PLACEHOLDER;
 
@@ -359,6 +364,7 @@ export default function CategoryForLine({
                   onChange={(e) => onForFieldChange(e.target.value)}
                   onFocus={() => {
                     setContextFocused(true);
+                    contextHadValueOnFocusRef.current = !!forField.trim();
                   }}
                   onBlur={() => {
                     setContextFocused(false);


### PR DESCRIPTION
## Summary
- Category and context input fields now keep their width fitted to existing text when focused, instead of expanding to placeholder width
- Placeholder text and width only appear after the field is unfocused (or when the field was empty on focus)
- Extracted shared `mirrorText()` helper to DRY up duplicated ternary logic

## Test plan
- [ ] Focus a category field with existing text (e.g. "Restaurant") — width should match the text, not expand to placeholder width
- [ ] Backspace to empty while focused — field stays narrow, no placeholder appears
- [ ] Blur the empty field — placeholder reappears with placeholder width
- [ ] Focus an empty category field — placeholder width acts as minimum while typing (existing behavior preserved)
- [ ] Same tests for the context ("for") field

https://claude.ai/code/session_01K3idRtsSpFq8H8sdrRLW6x