### PR TITLE
Threaded messaging UI: group polls into follow-up chains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ whoeverwants/
 │   ├── p/[shortId]/                # Dynamic poll page (UUID-based routing)
 │   │   ├── page.tsx                # Poll loader with access control
 │   │   └── PollPageClient.tsx      # Full poll view (voting, results, management)
+│   ├── thread/[threadId]/page.tsx   # Thread view (polls in follow-up chain)
 │   ├── poll/page.tsx               # Alternate poll endpoint
 │   ├── profile/page.tsx            # User profile (name management)
 │   └── api/                        # Server-side API routes
@@ -231,7 +232,8 @@ whoeverwants/
 │   ├── OptionsInput.tsx            # Poll options/suggestions input
 │   ├── Countdown.tsx               # Deadline countdown timer
 │   ├── ConfirmationModal.tsx       # Confirm destructive actions
-│   ├── FollowUpModal.tsx           # Create follow-up poll modal
+│   ├── ThreadList.tsx              # Home page thread list (messaging-style)
+│   ├── FollowUpModal.tsx           # Create follow-up poll modal (showForkButton prop)
 │   ├── FollowUpHeader.tsx          # Header showing parent poll link
 │   ├── ForkHeader.tsx              # Header showing forked-from link
 │   ├── FollowUpButton.tsx          # Create follow-up button
@@ -248,13 +250,16 @@ whoeverwants/
 │   ├── CommitInfo.tsx              # Commit info modal (GitHub API, relative time)
 │   └── CounterInput.tsx            # Numeric counter input
 │
-├── lib/                            # 16 utility modules
+├── lib/                            # 19 utility modules
 │   ├── api.ts                      # Python API client (fetch-based)
 │   ├── types.ts                    # Poll, Vote, PollResults type definitions
 │   ├── simplePollQueries.ts        # getAccessiblePolls, getPollWithAccess
 │   ├── pollCreator.ts              # Poll creation & creator secret management
 │   ├── browserPollAccess.ts        # localStorage-based poll access tracking
 │   ├── pollAccess.ts               # Database-backed poll access tracking
+│   ├── threadUtils.ts              # Thread grouping/sorting from follow_up_to chains
+│   ├── pollListUtils.ts            # Shared poll display utilities (relativeTime, badges, icons)
+│   ├── votedPollsStorage.ts        # localStorage voted/abstained poll parsing
 │   ├── pollDiscovery.ts            # Discover follow-up/fork relationships
 │   ├── userProfile.ts              # User name get/save (localStorage)
 │   ├── forgetPoll.ts               # Remove poll from browser's access list
@@ -348,6 +353,16 @@ whoeverwants/
 - Poll URLs grant access: visiting `/p/[id]` registers access
 - Creator authentication via `creator_secret` (stored in localStorage)
 - Database-level RLS (Row Level Security) policies on all tables
+
+### Threaded Messaging UI
+
+- **Main page shows threads**, not individual polls. A thread is a chain of polls linked by `follow_up_to`. `lib/threadUtils.ts` groups polls into threads client-side.
+- **Thread title** is an auto-generated, deduplicated list of participant names (`creator_name` + `voter_names` from the API).
+- **Thread sorting**: threads with unvoted open polls first (by soonest deadline), then threads with no unvoted polls (by most recent activity).
+- **Thread view** (`/thread/[threadId]`) shows polls oldest-first (messaging order). Long-press modal shows only Blank + Copy (no Fork), controlled by `FollowUpModal`'s `showForkButton` prop.
+- **Bottom bar "+" auto-follows-up** when on a thread page via `document.body.getAttribute('data-thread-latest-poll-id')` — the thread page sets this attribute on mount.
+- **Shared utilities**: `lib/pollListUtils.ts` (relativeTime, getCategoryIcon, badges), `lib/votedPollsStorage.ts` (loadVotedPolls). PollList keeps its own full-featured `getResultBadge` with user-specific participation messages.
+- **Backend**: `voter_names` field on accessible polls response — extracted from already-fetched votes when possible, DB query only for remaining open polls.
 
 ### Data Flow
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import Link from "next/link";
-
-import { useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { Poll } from "@/lib/types";
 import { getAccessiblePolls } from "@/lib/simplePollQueries";
 import { discoverRelatedPolls } from "@/lib/pollDiscovery";
 import { apiGetAllPollIds } from "@/lib/api";
 import { addAccessiblePollId } from "@/lib/browserPollAccess";
-import PollList from "@/components/PollList";
+import ThreadList from "@/components/ThreadList";
 
 // Fun activity phrases (max 25 chars)
 const activityPhrases = [
@@ -36,7 +33,6 @@ const activityPhrases = [
 ];
 
 export default function Home() {
-  const router = useRouter();
   const [polls, setPolls] = useState<Poll[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -231,7 +227,7 @@ export default function Home() {
       )}
 
       {!loading && !error && (
-        <PollList polls={polls} showSections={true} />
+        <ThreadList polls={polls} />
       )}
 
     </>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -908,7 +908,7 @@ function TemplateInner({ children }: AppTemplateProps) {
         {/* Back/home button in upper left — PWA standalone mode only.
              In regular browser tabs, the browser's own back button handles navigation.
              Shows back arrow if user has navigated within the app, home icon otherwise. */}
-        {isStandalone && (isPollPage || isProfilePage) && (
+        {isStandalone && (isPollPage || isProfilePage || isThreadPage) && (
           <div className="fixed left-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
             {hasAppHistory ? (
               <button

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -908,7 +908,7 @@ function TemplateInner({ children }: AppTemplateProps) {
         {/* Back/home button in upper left — PWA standalone mode only.
              In regular browser tabs, the browser's own back button handles navigation.
              Shows back arrow if user has navigated within the app, home icon otherwise. */}
-        {isStandalone && (isPollPage || isProfilePage || isThreadPage) && (
+        {(isPollPage || isProfilePage || isThreadPage) && (
           <div className="fixed left-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
             {hasAppHistory ? (
               <button

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -403,6 +403,7 @@ function TemplateInner({ children }: AppTemplateProps) {
   }, [isIOSPWA]);
 
   const isPollPage = pathname.startsWith('/p/');
+  const isThreadPage = pathname.startsWith('/thread/');
   const isCreateModalOpen = searchParams.has('create');
   const isProfilePage = pathname === '/profile' || pathname === '/profile/';
   const [modalClosing, setModalClosing] = useState(false);
@@ -660,8 +661,8 @@ function TemplateInner({ children }: AppTemplateProps) {
         document.body
       )}
 
-      {/* Fixed Header - skip for poll, create poll, profile, and home pages */}
-      {!isPollPage && !isProfilePage && pathname !== '/' && (
+      {/* Fixed Header - skip for poll, create poll, profile, thread, and home pages */}
+      {!isPollPage && !isThreadPage && !isProfilePage && pathname !== '/' && (
         <div className="flex-shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700" 
              style={{ paddingTop: 'env(safe-area-inset-top)' }}>
           <div className="relative flex items-start justify-between pt-2 pb-2 pl-2 pr-2.5">
@@ -856,6 +857,11 @@ function TemplateInner({ children }: AppTemplateProps) {
             onClick={() => {
               const params = new URLSearchParams(searchParams.toString());
               params.set('create', '1');
+              // When on a thread page, auto-set followUpTo for the latest poll
+              const threadLatestPollId = document.body.getAttribute('data-thread-latest-poll-id');
+              if (threadLatestPollId) {
+                params.set('followUpTo', threadLatestPollId);
+              }
               router.push(`${pathname}?${params.toString()}`);
             }}
             className="flex flex-col items-center gap-0.5 min-w-[64px] cursor-pointer"

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -1,64 +1,16 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo, Suspense } from "react";
-import { useRouter, useParams, usePathname } from "next/navigation";
+import { useEffect, useState, useRef, Suspense } from "react";
+import { useRouter, useParams } from "next/navigation";
 import { Poll } from "@/lib/types";
 import { getAccessiblePolls } from "@/lib/simplePollQueries";
 import { discoverRelatedPolls } from "@/lib/pollDiscovery";
 import { buildThreads, findThreadByPollId, Thread } from "@/lib/threadUtils";
 import { apiGetPollById, apiGetPollByShortId } from "@/lib/api";
-import { getUserName } from "@/lib/userProfile";
-import { buildPollSnapshot } from "@/lib/pollCreator";
+import { getCategoryIcon, relativeTime, isInSuggestionPhase, getResultBadge, BADGE_COLORS } from "@/lib/pollListUtils";
+import { loadVotedPolls } from "@/lib/votedPollsStorage";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
-import ModalPortal from "@/components/ModalPortal";
-import { getBuiltInType } from "@/components/TypeFieldInput";
-
-const POLL_TYPE_SYMBOLS: Record<string, string> = {
-  yes_no: '👍',
-  ranked_choice: '🗳️',
-  participation: '🙋',
-};
-
-function getPollSymbol(pollType: string, isClosed: boolean): string {
-  if (pollType === 'yes_no' && isClosed) return '🏆';
-  return POLL_TYPE_SYMBOLS[pollType] || '☰';
-}
-
-function getCategoryIcon(poll: Poll): string {
-  const category = poll.category;
-  if (category && category !== 'custom') {
-    const builtIn = getBuiltInType(category);
-    if (builtIn?.icon) return builtIn.icon;
-  }
-  return getPollSymbol(poll.poll_type, poll.is_closed ?? false);
-}
-
-function relativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const minutes = Math.floor(diffMs / 60000);
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return `${weeks}w ago`;
-  const months = Math.floor(days / 30);
-  if (months < 12) return `${months}mo ago`;
-  const years = Math.floor(days / 365);
-  return `${years}y ago`;
-}
-
-function isInSuggestionPhase(poll: Poll): boolean {
-  if (poll.poll_type !== 'ranked_choice') return false;
-  if (poll.suggestion_deadline && new Date(poll.suggestion_deadline) > new Date()) return true;
-  if (!poll.suggestion_deadline && poll.suggestion_deadline_minutes) return true;
-  return false;
-}
 
 const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:text-blue-400" }: { deadline: string; label: string; colorClass?: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -89,116 +41,12 @@ const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:tex
   return <>{label && `${label}: `}<span className={`font-mono font-semibold ${colorClass}`}>{timeLeft}</span></>;
 };
 
-interface ResultBadge {
-  text: string;
-  emoji: string;
-  color: 'green' | 'red' | 'yellow' | 'gray';
-}
-
-const BADGE_COLORS = {
-  green: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200',
-  red: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200',
-  yellow: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200',
-  gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
-};
-
-function getResultBadge(poll: Poll): ResultBadge {
-  const results = poll.results;
-  if (!results) return { text: 'No results', emoji: '🔇', color: 'gray' };
-  if (results.total_votes === 0) return { text: 'No voters', emoji: '🦗', color: 'gray' };
-
-  switch (poll.poll_type) {
-    case 'yes_no': {
-      if (results.winner === 'yes') return { text: 'Yes', emoji: '👑', color: 'green' };
-      if (results.winner === 'no') return { text: 'No', emoji: '👑', color: 'red' };
-      if (results.winner === 'tie') return { text: 'Tie', emoji: '🤝', color: 'yellow' };
-      return { text: 'No winner', emoji: '🤷', color: 'gray' };
-    }
-    case 'ranked_choice': {
-      if (results.winner) return { text: results.winner, emoji: '👑', color: 'green' };
-      return { text: 'No winner', emoji: '🤷', color: 'gray' };
-    }
-    case 'participation': {
-      const participatingCount = results.yes_count || 0;
-      let isHappening = participatingCount > 0;
-      if (results.min_participants != null && participatingCount < results.min_participants) isHappening = false;
-      if (results.max_participants != null && participatingCount > results.max_participants) isHappening = false;
-      if (isHappening) return { text: 'Happening', emoji: '🎉', color: 'green' };
-      return { text: 'Not happening', emoji: '✗', color: 'red' };
-    }
-    default:
-      return { text: 'Closed', emoji: '🔒', color: 'gray' };
-  }
-}
-
-/** Thread-aware modal: only Blank and Copy buttons */
-function ThreadFollowUpModal({ isOpen, poll, onClose }: { isOpen: boolean; poll: Poll; onClose: () => void }) {
-  const router = useRouter();
-  const pathname = usePathname();
-
-  if (!isOpen) return null;
-
-  const pollSnapshot = buildPollSnapshot(poll);
-
-  return (
-    <ModalPortal>
-      <div
-        className="fixed inset-0 bg-black/50 dark:bg-black/70 z-[100] animate-fade-in"
-        onClick={onClose}
-      />
-      <div className="fixed bottom-0 left-0 right-0 z-[110] animate-slide-up">
-        <div className="bg-white dark:bg-gray-800 rounded-t-2xl shadow-xl p-6 pb-8">
-          <div className="flex gap-3 mb-4">
-            <button
-              onClick={() => {
-                router.push(`${pathname}?create=1&followUpTo=${poll.id}`);
-                onClose();
-              }}
-              className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-green-600 hover:bg-green-700 active:bg-green-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <circle cx="12" cy="12" r="10"/>
-              </svg>
-              Blank
-            </button>
-
-            <button
-              onClick={() => {
-                localStorage.setItem(`duplicate-data-${poll.id}`, JSON.stringify(pollSnapshot));
-                router.push(`${pathname}?create=1&duplicate=${poll.id}`);
-                onClose();
-              }}
-              className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-              </svg>
-              Copy
-            </button>
-          </div>
-
-          <div className="mt-4">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center justify-center gap-2">
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-              </svg>
-              Follow up with the same recipients
-            </h3>
-          </div>
-        </div>
-      </div>
-    </ModalPortal>
-  );
-}
-
 function ThreadContent() {
   const router = useRouter();
   const params = useParams();
   const threadId = params.threadId as string;
 
   const [thread, setThread] = useState<Thread | null>(null);
-  const [allPolls, setAllPolls] = useState<Poll[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [votedPollIds, setVotedPollIds] = useState<Set<string>>(new Set());
@@ -225,19 +73,9 @@ function ThreadContent() {
   // Load voted/abstained
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    try {
-      const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
-      const voted = new Set<string>();
-      const abstained = new Set<string>();
-      Object.keys(votedPolls).forEach(id => {
-        if (votedPolls[id] === 'abstained') abstained.add(id);
-        else if (votedPolls[id] === true) voted.add(id);
-      });
-      setVotedPollIds(voted);
-      setAbstainedPollIds(abstained);
-    } catch (error) {
-      console.error('Error loading voted polls:', error);
-    }
+    const { votedPollIds: voted, abstainedPollIds: abstained } = loadVotedPolls();
+    setVotedPollIds(voted);
+    setAbstainedPollIds(abstained);
   }, []);
 
   // Fetch polls and find the thread
@@ -252,7 +90,6 @@ function ThreadContent() {
 
         const polls = await getAccessiblePolls();
         if (!polls) { setError(true); return; }
-        setAllPolls(polls);
 
         // Resolve the threadId to a poll ID (could be short_id or UUID)
         let rootPollId: string | null = null;
@@ -280,13 +117,7 @@ function ThreadContent() {
         }
 
         // Build threads from all polls
-        const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
-        const voted = new Set<string>();
-        const abstained = new Set<string>();
-        Object.keys(votedPolls).forEach(id => {
-          if (votedPolls[id] === 'abstained') abstained.add(id);
-          else if (votedPolls[id] === true) voted.add(id);
-        });
+        const { votedPollIds: voted, abstainedPollIds: abstained } = loadVotedPolls();
 
         const threads = buildThreads(polls, voted, abstained);
         const foundThread = findThreadByPollId(threads, rootPollId);
@@ -515,12 +346,13 @@ function ThreadContent() {
           })}
       </div>
 
-      {/* Thread-aware follow-up modal (Blank + Copy only) */}
+      {/* Thread-aware follow-up modal (Blank + Copy only, no Fork) */}
       {modalPoll && (
-        <ThreadFollowUpModal
+        <FollowUpModal
           isOpen={showModal}
           poll={modalPoll}
           onClose={() => setShowModal(false)}
+          showForkButton={false}
         />
       )}
     </div>

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -194,7 +194,6 @@ function ThreadFollowUpModal({ isOpen, poll, onClose }: { isOpen: boolean; poll:
 
 function ThreadContent() {
   const router = useRouter();
-  const pathname = usePathname();
   const params = useParams();
   const threadId = params.threadId as string;
 
@@ -342,10 +341,9 @@ function ThreadContent() {
 
   // Polls are already sorted oldest-first in thread.polls
   const threadPolls = thread.polls;
-  const latestPoll = thread.latestPoll;
 
   return (
-    <div className="flex flex-col h-full">
+    <div>
       {/* Thread header */}
       <div className="sticky top-0 z-10 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 py-3">
         <div className="flex items-center gap-3">
@@ -369,9 +367,8 @@ function ThreadContent() {
       </div>
 
       {/* Poll list (oldest first = messaging order) */}
-      <div className="flex-1 overflow-y-auto">
-        <div className="py-2">
-          {threadPolls.map((poll, index) => {
+      <div className="py-2">
+        {threadPolls.map((poll, index) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
             const now = new Date();
             const isOpen = poll.response_deadline
@@ -516,22 +513,6 @@ function ThreadContent() {
               </div>
             );
           })}
-        </div>
-
-        {/* New poll button at the bottom */}
-        <div className="px-4 py-4">
-          <button
-            onClick={() => {
-              router.push(`${pathname}?create=1&followUpTo=${latestPoll.id}`);
-            }}
-            className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-colors"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-            </svg>
-            New Poll in Thread
-          </button>
-        </div>
       </div>
 
       {/* Thread-aware follow-up modal (Blank + Copy only) */}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -1,0 +1,565 @@
+"use client";
+
+import { useEffect, useState, useRef, useMemo, Suspense } from "react";
+import { useRouter, useParams, usePathname } from "next/navigation";
+import { Poll } from "@/lib/types";
+import { getAccessiblePolls } from "@/lib/simplePollQueries";
+import { discoverRelatedPolls } from "@/lib/pollDiscovery";
+import { buildThreads, findThreadByPollId, Thread } from "@/lib/threadUtils";
+import { apiGetPollById, apiGetPollByShortId } from "@/lib/api";
+import { getUserName } from "@/lib/userProfile";
+import { buildPollSnapshot } from "@/lib/pollCreator";
+import ClientOnly from "@/components/ClientOnly";
+import FollowUpModal from "@/components/FollowUpModal";
+import ModalPortal from "@/components/ModalPortal";
+import { getBuiltInType } from "@/components/TypeFieldInput";
+
+const POLL_TYPE_SYMBOLS: Record<string, string> = {
+  yes_no: '👍',
+  ranked_choice: '🗳️',
+  participation: '🙋',
+};
+
+function getPollSymbol(pollType: string, isClosed: boolean): string {
+  if (pollType === 'yes_no' && isClosed) return '🏆';
+  return POLL_TYPE_SYMBOLS[pollType] || '☰';
+}
+
+function getCategoryIcon(poll: Poll): string {
+  const category = poll.category;
+  if (category && category !== 'custom') {
+    const builtIn = getBuiltInType(category);
+    if (builtIn?.icon) return builtIn.icon;
+  }
+  return getPollSymbol(poll.poll_type, poll.is_closed ?? false);
+}
+
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+function isInSuggestionPhase(poll: Poll): boolean {
+  if (poll.poll_type !== 'ranked_choice') return false;
+  if (poll.suggestion_deadline && new Date(poll.suggestion_deadline) > new Date()) return true;
+  if (!poll.suggestion_deadline && poll.suggestion_deadline_minutes) return true;
+  return false;
+}
+
+const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:text-blue-400" }: { deadline: string; label: string; colorClass?: string }) => {
+  const [timeLeft, setTimeLeft] = useState<string>("");
+  const [isClient, setIsClient] = useState(false);
+  useEffect(() => { setIsClient(true); }, []);
+  useEffect(() => {
+    if (!isClient) return;
+    const updateCountdown = () => {
+      const now = new Date().getTime();
+      const deadlineTime = new Date(deadline).getTime();
+      const difference = deadlineTime - now;
+      if (difference <= 0) { setTimeLeft("Expired"); return; }
+      const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+      let timeString = "";
+      if (days > 0) timeString = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+      else if (hours > 0) timeString = `${hours}h ${minutes}m ${seconds}s`;
+      else if (minutes > 0) timeString = `${minutes}m ${seconds}s`;
+      else timeString = `${seconds}s`;
+      setTimeLeft(timeString);
+    };
+    updateCountdown();
+    const interval = setInterval(updateCountdown, 1000);
+    return () => clearInterval(interval);
+  }, [deadline, isClient]);
+  return <>{label && `${label}: `}<span className={`font-mono font-semibold ${colorClass}`}>{timeLeft}</span></>;
+};
+
+interface ResultBadge {
+  text: string;
+  emoji: string;
+  color: 'green' | 'red' | 'yellow' | 'gray';
+}
+
+const BADGE_COLORS = {
+  green: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200',
+  red: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200',
+  yellow: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200',
+  gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+};
+
+function getResultBadge(poll: Poll): ResultBadge {
+  const results = poll.results;
+  if (!results) return { text: 'No results', emoji: '🔇', color: 'gray' };
+  if (results.total_votes === 0) return { text: 'No voters', emoji: '🦗', color: 'gray' };
+
+  switch (poll.poll_type) {
+    case 'yes_no': {
+      if (results.winner === 'yes') return { text: 'Yes', emoji: '👑', color: 'green' };
+      if (results.winner === 'no') return { text: 'No', emoji: '👑', color: 'red' };
+      if (results.winner === 'tie') return { text: 'Tie', emoji: '🤝', color: 'yellow' };
+      return { text: 'No winner', emoji: '🤷', color: 'gray' };
+    }
+    case 'ranked_choice': {
+      if (results.winner) return { text: results.winner, emoji: '👑', color: 'green' };
+      return { text: 'No winner', emoji: '🤷', color: 'gray' };
+    }
+    case 'participation': {
+      const participatingCount = results.yes_count || 0;
+      let isHappening = participatingCount > 0;
+      if (results.min_participants != null && participatingCount < results.min_participants) isHappening = false;
+      if (results.max_participants != null && participatingCount > results.max_participants) isHappening = false;
+      if (isHappening) return { text: 'Happening', emoji: '🎉', color: 'green' };
+      return { text: 'Not happening', emoji: '✗', color: 'red' };
+    }
+    default:
+      return { text: 'Closed', emoji: '🔒', color: 'gray' };
+  }
+}
+
+/** Thread-aware modal: only Blank and Copy buttons */
+function ThreadFollowUpModal({ isOpen, poll, onClose }: { isOpen: boolean; poll: Poll; onClose: () => void }) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  if (!isOpen) return null;
+
+  const pollSnapshot = buildPollSnapshot(poll);
+
+  return (
+    <ModalPortal>
+      <div
+        className="fixed inset-0 bg-black/50 dark:bg-black/70 z-[100] animate-fade-in"
+        onClick={onClose}
+      />
+      <div className="fixed bottom-0 left-0 right-0 z-[110] animate-slide-up">
+        <div className="bg-white dark:bg-gray-800 rounded-t-2xl shadow-xl p-6 pb-8">
+          <div className="flex gap-3 mb-4">
+            <button
+              onClick={() => {
+                router.push(`${pathname}?create=1&followUpTo=${poll.id}`);
+                onClose();
+              }}
+              className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-green-600 hover:bg-green-700 active:bg-green-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <circle cx="12" cy="12" r="10"/>
+              </svg>
+              Blank
+            </button>
+
+            <button
+              onClick={() => {
+                localStorage.setItem(`duplicate-data-${poll.id}`, JSON.stringify(pollSnapshot));
+                router.push(`${pathname}?create=1&duplicate=${poll.id}`);
+                onClose();
+              }}
+              className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+              Copy
+            </button>
+          </div>
+
+          <div className="mt-4">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center justify-center gap-2">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+              </svg>
+              Follow up with the same recipients
+            </h3>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}
+
+function ThreadContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useParams();
+  const threadId = params.threadId as string;
+
+  const [thread, setThread] = useState<Thread | null>(null);
+  const [allPolls, setAllPolls] = useState<Poll[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [votedPollIds, setVotedPollIds] = useState<Set<string>>(new Set());
+  const [abstainedPollIds, setAbstainedPollIds] = useState<Set<string>>(new Set());
+
+  // Set data attribute on body so the bottom bar "+" button can auto-follow-up
+  useEffect(() => {
+    if (thread) {
+      document.body.setAttribute('data-thread-latest-poll-id', thread.latestPoll.id);
+    }
+    return () => { document.body.removeAttribute('data-thread-latest-poll-id'); };
+  }, [thread]);
+
+  // Long press state
+  const [modalPoll, setModalPoll] = useState<Poll | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+  const isLongPress = useRef(false);
+  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+  const isScrolling = useRef(false);
+  const [pressedPollId, setPressedPollId] = useState<string | null>(null);
+  const [navigatingPollId, setNavigatingPollId] = useState<string | null>(null);
+
+  // Load voted/abstained
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
+      const voted = new Set<string>();
+      const abstained = new Set<string>();
+      Object.keys(votedPolls).forEach(id => {
+        if (votedPolls[id] === 'abstained') abstained.add(id);
+        else if (votedPolls[id] === true) voted.add(id);
+      });
+      setVotedPollIds(voted);
+      setAbstainedPollIds(abstained);
+    } catch (error) {
+      console.error('Error loading voted polls:', error);
+    }
+  }, []);
+
+  // Fetch polls and find the thread
+  useEffect(() => {
+    async function fetchThread() {
+      try {
+        setLoading(true);
+        setError(false);
+
+        // Discover related polls first
+        try { await discoverRelatedPolls(); } catch {}
+
+        const polls = await getAccessiblePolls();
+        if (!polls) { setError(true); return; }
+        setAllPolls(polls);
+
+        // Resolve the threadId to a poll ID (could be short_id or UUID)
+        let rootPollId: string | null = null;
+
+        // First try to find directly in the polls we have
+        const directMatch = polls.find(p =>
+          p.short_id === threadId || p.id === threadId
+        );
+        if (directMatch) {
+          rootPollId = directMatch.id;
+        } else {
+          // Try fetching the poll to resolve the ID
+          try {
+            let resolved: Poll;
+            if (threadId.length > 10 && threadId.includes('-')) {
+              resolved = await apiGetPollById(threadId);
+            } else {
+              resolved = await apiGetPollByShortId(threadId);
+            }
+            rootPollId = resolved.id;
+          } catch {
+            setError(true);
+            return;
+          }
+        }
+
+        // Build threads from all polls
+        const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
+        const voted = new Set<string>();
+        const abstained = new Set<string>();
+        Object.keys(votedPolls).forEach(id => {
+          if (votedPolls[id] === 'abstained') abstained.add(id);
+          else if (votedPolls[id] === true) voted.add(id);
+        });
+
+        const threads = buildThreads(polls, voted, abstained);
+        const foundThread = findThreadByPollId(threads, rootPollId);
+
+        if (!foundThread) {
+          setError(true);
+          return;
+        }
+
+        setThread(foundThread);
+      } catch (err) {
+        console.error('Error loading thread:', err);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchThread();
+  }, [threadId]);
+
+  if (loading) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center">
+          <svg className="animate-spin h-8 w-8 text-gray-500 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <p className="text-gray-600 dark:text-gray-400">Loading thread...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !thread) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Thread Not Found</h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">This thread may not exist or you don't have access.</p>
+          <button
+            onClick={() => router.push('/')}
+            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+          >
+            Go Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Polls are already sorted oldest-first in thread.polls
+  const threadPolls = thread.polls;
+  const latestPoll = thread.latestPoll;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Thread header */}
+      <div className="sticky top-0 z-10 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => router.push('/')}
+            className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 -ml-1"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <div className="flex-1 min-w-0">
+            <h1 className="font-semibold text-lg text-gray-900 dark:text-white truncate">
+              {thread.title}
+            </h1>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {thread.polls.length} {thread.polls.length === 1 ? 'poll' : 'polls'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Poll list (oldest first = messaging order) */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="py-2">
+          {threadPolls.map((poll, index) => {
+            const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
+            const now = new Date();
+            const isOpen = poll.response_deadline
+              ? new Date(poll.response_deadline) > now && !poll.is_closed
+              : !poll.is_closed;
+            const isClosed = !isOpen;
+
+            const handleTouchStart = (e: React.TouchEvent) => {
+              isLongPress.current = false;
+              isScrolling.current = false;
+              setPressedPollId(poll.id);
+              touchStartPos.current = {
+                x: e.touches[0].clientX,
+                y: e.touches[0].clientY,
+              };
+              longPressTimer.current = setTimeout(() => {
+                if (!isScrolling.current) {
+                  isLongPress.current = true;
+                  if ('vibrate' in navigator) {
+                    try { navigator.vibrate(50); } catch {}
+                  }
+                  setModalPoll(poll);
+                  setShowModal(true);
+                  setPressedPollId(null);
+                }
+              }, 500);
+            };
+
+            const handleTouchEnd = () => {
+              if (longPressTimer.current) {
+                clearTimeout(longPressTimer.current);
+                longPressTimer.current = null;
+              }
+              if (!isScrolling.current && !isLongPress.current) {
+                setNavigatingPollId(poll.id);
+                setPressedPollId(null);
+                router.push(`/p/${poll.short_id || poll.id}`);
+              } else {
+                setPressedPollId(null);
+              }
+              touchStartPos.current = null;
+              isScrolling.current = false;
+            };
+
+            const handleTouchMove = (e: React.TouchEvent) => {
+              if (!touchStartPos.current) return;
+              const deltaX = Math.abs(e.touches[0].clientX - touchStartPos.current.x);
+              const deltaY = Math.abs(e.touches[0].clientY - touchStartPos.current.y);
+              if (deltaX > 10 || deltaY > 10) {
+                isScrolling.current = true;
+                setPressedPollId(null);
+                if (longPressTimer.current) {
+                  clearTimeout(longPressTimer.current);
+                  longPressTimer.current = null;
+                }
+              }
+            };
+
+            return (
+              <div
+                key={poll.id}
+                className="border-b border-gray-200 dark:border-gray-700 mx-1.5"
+              >
+                <div
+                  onClick={() => {
+                    setNavigatingPollId(poll.id);
+                    router.push(`/p/${poll.short_id || poll.id}`);
+                  }}
+                  onTouchStart={handleTouchStart}
+                  onTouchEnd={handleTouchEnd}
+                  onTouchMove={handleTouchMove}
+                  className={`px-1 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                >
+                  {navigatingPollId === poll.id && (
+                    <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
+                      <svg className="animate-spin h-6 w-6 text-blue-600 dark:text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                    </div>
+                  )}
+
+                  {/* Status line */}
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm">{getCategoryIcon(poll)}</span>
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                      <ClientOnly fallback={<>Loading...</>}>
+                        {(() => {
+                          if (isClosed) {
+                            const badge = getResultBadge(poll);
+                            return (
+                              <div className="flex items-center gap-1">
+                                <span className="text-xs leading-none">{badge.emoji}</span>
+                                <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full truncate ${BADGE_COLORS[badge.color]}`}>
+                                  {badge.text}
+                                </span>
+                              </div>
+                            );
+                          }
+                          const inSuggestions = isInSuggestionPhase(poll);
+                          if (inSuggestions && poll.suggestion_deadline) {
+                            return <SimpleCountdown deadline={poll.suggestion_deadline} label="Suggestions" />;
+                          }
+                          if (inSuggestions && poll.suggestion_deadline_minutes) {
+                            return <span className="font-semibold text-blue-600 dark:text-blue-400">Taking Suggestions</span>;
+                          }
+                          if (poll.response_deadline) {
+                            return <SimpleCountdown deadline={poll.response_deadline} label="Voting" colorClass="text-green-600 dark:text-green-400" />;
+                          }
+                          return null;
+                        })()}
+                      </ClientOnly>
+                    </span>
+                  </div>
+
+                  {/* Title */}
+                  <h3 className="font-medium text-lg line-clamp-2 text-gray-900 dark:text-white">
+                    {poll.title}
+                  </h3>
+
+                  {/* Metadata */}
+                  <div className="flex items-center justify-between">
+                    <div className="text-xs text-gray-400 dark:text-gray-500">
+                      <ClientOnly fallback={null}>
+                        <>{poll.creator_name && <>{poll.creator_name} &middot; </>}{relativeTime(poll.created_at)}</>
+                      </ClientOnly>
+                    </div>
+                    {!isVoted && isOpen && (
+                      <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300">
+                        Not voted
+                      </span>
+                    )}
+                    {isOpen && (
+                      <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">
+                        {(poll.response_count ?? 0) > 0
+                          ? `${poll.response_count} ${poll.response_count === 1 ? 'response' : 'responses'}`
+                          : 'No responses yet'}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* New poll button at the bottom */}
+        <div className="px-4 py-4">
+          <button
+            onClick={() => {
+              router.push(`${pathname}?create=1&followUpTo=${latestPoll.id}`);
+            }}
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            New Poll in Thread
+          </button>
+        </div>
+      </div>
+
+      {/* Thread-aware follow-up modal (Blank + Copy only) */}
+      {modalPoll && (
+        <ThreadFollowUpModal
+          isOpen={showModal}
+          poll={modalPoll}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function ThreadPage() {
+  return (
+    <Suspense fallback={
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center">
+          <svg className="animate-spin h-8 w-8 text-gray-500 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <p className="text-gray-600 dark:text-gray-400">Loading thread...</p>
+        </div>
+      </div>
+    }>
+      <ThreadContent />
+    </Suspense>
+  );
+}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -176,25 +176,13 @@ function ThreadContent() {
   return (
     <div>
       {/* Thread header */}
-      <div className="sticky top-0 z-10 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 py-3">
-        <div className="flex items-center gap-3">
-          <button
-            onClick={() => router.push('/')}
-            className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 -ml-1"
-          >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-          </button>
-          <div className="flex-1 min-w-0">
-            <h1 className="font-semibold text-lg text-gray-900 dark:text-white truncate">
-              {thread.title}
-            </h1>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              {thread.polls.length} {thread.polls.length === 1 ? 'poll' : 'polls'}
-            </p>
-          </div>
-        </div>
+      <div className="border-b border-gray-200 dark:border-gray-700 px-4 py-3">
+        <h1 className="font-semibold text-lg text-gray-900 dark:text-white truncate">
+          {thread.title}
+        </h1>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {thread.polls.length} {thread.polls.length === 1 ? 'poll' : 'polls'}
+        </p>
       </div>
 
       {/* Poll list (oldest first = messaging order) */}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -158,7 +158,7 @@ function ThreadContent() {
       <div className="h-full flex items-center justify-center">
         <div className="text-center">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Thread Not Found</h2>
-          <p className="text-gray-600 dark:text-gray-400 mb-4">This thread may not exist or you don't have access.</p>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">This thread may not exist or you don&apos;t have access.</p>
           <button
             onClick={() => router.push('/')}
             className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -10,9 +10,10 @@ interface FollowUpModalProps {
   poll: Poll;
   onClose: () => void;
   totalVotes?: number;
+  showForkButton?: boolean;
 }
 
-export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: FollowUpModalProps) {
+export default function FollowUpModal({ isOpen, poll, onClose, totalVotes, showForkButton = true }: FollowUpModalProps) {
   const router = useRouter();
   const pathname = usePathname();
 
@@ -63,23 +64,25 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes }: Fol
               Copy
             </button>
 
-            <button
-              onClick={() => {
-                localStorage.setItem(`fork-data-${poll.id}`, JSON.stringify(pollSnapshot));
-                router.push(`${pathname}?create=1&fork=${poll.id}`);
-                onClose();
-              }}
-              className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-purple-600 hover:bg-purple-700 active:bg-purple-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <circle cx="6" cy="6" r="2"/>
-                <circle cx="18" cy="6" r="2"/>
-                <circle cx="12" cy="18" r="2"/>
-                <path d="M18 8v2a2 2 0 01-2 2H8a2 2 0 01-2-2V8"/>
-                <path d="M12 16V12"/>
-              </svg>
-              Fork
-            </button>
+            {showForkButton && (
+              <button
+                onClick={() => {
+                  localStorage.setItem(`fork-data-${poll.id}`, JSON.stringify(pollSnapshot));
+                  router.push(`${pathname}?create=1&fork=${poll.id}`);
+                  onClose();
+                }}
+                className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-3 bg-purple-600 hover:bg-purple-700 active:bg-purple-800 active:scale-95 text-white font-medium text-sm rounded-lg transition-all duration-200"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                  <circle cx="6" cy="6" r="2"/>
+                  <circle cx="18" cy="6" r="2"/>
+                  <circle cx="12" cy="18" r="2"/>
+                  <path d="M18 8v2a2 2 0 01-2 2H8a2 2 0 01-2-2V8"/>
+                  <path d="M12 16V12"/>
+                </svg>
+                Fork
+              </button>
+            )}
           </div>
 
           <div className="mt-4">

--- a/components/PollList.tsx
+++ b/components/PollList.tsx
@@ -6,30 +6,8 @@ import { Poll, PollResults } from "@/lib/types";
 import { getUserName } from "@/lib/userProfile";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
-import { getBuiltInType } from "@/components/TypeFieldInput";
-
-const POLL_TYPE_SYMBOLS: Record<string, string> = {
-  yes_no: '👍',
-  ranked_choice: '🗳️',
-  participation: '🙋',
-};
-
-const CLOSED_YES_NO_SYMBOL = '🏆';
-
-function getPollSymbol(pollType: string, isClosed: boolean): string {
-  if (pollType === 'yes_no' && isClosed) return CLOSED_YES_NO_SYMBOL;
-  return POLL_TYPE_SYMBOLS[pollType] || '☰';
-}
-
-function getCategoryIcon(poll: Poll): string {
-  const category = poll.category;
-  if (category && category !== 'custom') {
-    const builtIn = getBuiltInType(category);
-    if (builtIn?.icon) return builtIn.icon;
-  }
-  // Custom or no category — use poll type symbol
-  return getPollSymbol(poll.poll_type, poll.is_closed ?? false);
-}
+import { getCategoryIcon, relativeTime, isInSuggestionPhase, BADGE_COLORS, POLL_TYPE_SYMBOLS } from "@/lib/pollListUtils";
+import type { ResultBadge } from "@/lib/pollListUtils";
 
 /** Extract image URLs from poll options metadata (skip entries without images). */
 function getOptionIconUrls(poll: Poll): string[] {
@@ -85,25 +63,6 @@ function PollTitle({ poll, className }: { poll: Poll; className: string }) {
   );
 }
 
-function relativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const minutes = Math.floor(diffMs / 60000);
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return `${weeks}w ago`;
-  const months = Math.floor(days / 30);
-  if (months < 12) return `${months}mo ago`;
-  const years = Math.floor(days / 365);
-  return `${years}y ago`;
-}
-
 // Simple countdown component
 const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:text-blue-400" }: { deadline: string; label: string; colorClass?: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -157,31 +116,11 @@ const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:tex
   );
 };
 
-function isInSuggestionPhase(poll: Poll): boolean {
-  if (poll.poll_type !== 'ranked_choice') return false;
-  if (poll.suggestion_deadline && new Date(poll.suggestion_deadline) > new Date()) return true;
-  if (!poll.suggestion_deadline && poll.suggestion_deadline_minutes) return true;
-  return false;
-}
-
 function getOptionDisplayName(optionKey: string, poll: Poll): string {
   const meta = poll.options_metadata?.[optionKey];
   if (meta?.name) return meta.name;
   return optionKey;
 }
-
-interface ResultBadge {
-  text: string;
-  emoji: string;
-  color: 'green' | 'red' | 'yellow' | 'gray';
-}
-
-const BADGE_COLORS = {
-  green: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200',
-  red: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200',
-  yellow: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200',
-  gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
-};
 
 function getResultBadge(poll: Poll, results: PollResults | null | undefined, userVoteId?: string | null, userVoted?: boolean, userName?: string | null): ResultBadge {
   if (!results) {

--- a/components/ThreadList.tsx
+++ b/components/ThreadList.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Poll } from "@/lib/types";
+import { getUserName } from "@/lib/userProfile";
+import { buildThreads, getThreadRouteId, Thread } from "@/lib/threadUtils";
+import ClientOnly from "@/components/ClientOnly";
+
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+const SimpleCountdown = ({ deadline, colorClass = "text-green-600 dark:text-green-400" }: { deadline: string; colorClass?: string }) => {
+  const [timeLeft, setTimeLeft] = useState<string>("");
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => { setIsClient(true); }, []);
+
+  useEffect(() => {
+    if (!isClient) return;
+    const updateCountdown = () => {
+      const now = new Date().getTime();
+      const deadlineTime = new Date(deadline).getTime();
+      const difference = deadlineTime - now;
+      if (difference <= 0) { setTimeLeft("Expired"); return; }
+      const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+      let timeString = "";
+      if (days > 0) timeString = `${days}d ${hours}h ${minutes}m`;
+      else if (hours > 0) timeString = `${hours}h ${minutes}m ${seconds}s`;
+      else if (minutes > 0) timeString = `${minutes}m ${seconds}s`;
+      else timeString = `${seconds}s`;
+      setTimeLeft(timeString);
+    };
+    updateCountdown();
+    const interval = setInterval(updateCountdown, 1000);
+    return () => clearInterval(interval);
+  }, [deadline, isClient]);
+
+  return <span className={`font-mono font-semibold ${colorClass}`}>{timeLeft}</span>;
+};
+
+interface ThreadListProps {
+  polls: Poll[];
+}
+
+export default function ThreadList({ polls }: ThreadListProps) {
+  const router = useRouter();
+  const [votedPollIds, setVotedPollIds] = useState<Set<string>>(new Set());
+  const [abstainedPollIds, setAbstainedPollIds] = useState<Set<string>>(new Set());
+  const [pressedThreadId, setPressedThreadId] = useState<string | null>(null);
+  const [navigatingThreadId, setNavigatingThreadId] = useState<string | null>(null);
+  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+  const isScrolling = useRef(false);
+
+  // Load voted/abstained from localStorage
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
+      const voted = new Set<string>();
+      const abstained = new Set<string>();
+      Object.keys(votedPolls).forEach(id => {
+        if (votedPolls[id] === 'abstained') abstained.add(id);
+        else if (votedPolls[id] === true) voted.add(id);
+      });
+      setVotedPollIds(voted);
+      setAbstainedPollIds(abstained);
+    } catch (error) {
+      console.error('Error loading voted polls:', error);
+    }
+  }, []);
+
+  const threads = useMemo(() => {
+    return buildThreads(polls, votedPollIds, abstainedPollIds);
+  }, [polls, votedPollIds, abstainedPollIds]);
+
+  if (threads.length === 0) return null;
+
+  return (
+    <div>
+      {threads.map((thread, index) => {
+        const routeId = getThreadRouteId(thread);
+        const latestPoll = thread.latestPoll;
+        const hasUnvoted = thread.unvotedCount > 0;
+
+        const handleTouchStart = (e: React.TouchEvent) => {
+          isScrolling.current = false;
+          setPressedThreadId(thread.rootPollId);
+          touchStartPos.current = {
+            x: e.touches[0].clientX,
+            y: e.touches[0].clientY,
+          };
+        };
+
+        const handleTouchEnd = () => {
+          if (!isScrolling.current) {
+            setNavigatingThreadId(thread.rootPollId);
+            setPressedThreadId(null);
+            if (thread.polls.length === 1) {
+              // Single-poll thread: navigate directly to the poll
+              const poll = thread.polls[0];
+              router.push(`/p/${poll.short_id || poll.id}`);
+            } else {
+              router.push(`/thread/${routeId}`);
+            }
+          } else {
+            setPressedThreadId(null);
+          }
+          touchStartPos.current = null;
+          isScrolling.current = false;
+        };
+
+        const handleTouchMove = (e: React.TouchEvent) => {
+          if (!touchStartPos.current) return;
+          const deltaX = Math.abs(e.touches[0].clientX - touchStartPos.current.x);
+          const deltaY = Math.abs(e.touches[0].clientY - touchStartPos.current.y);
+          if (deltaX > 10 || deltaY > 10) {
+            isScrolling.current = true;
+            setPressedThreadId(null);
+          }
+        };
+
+        return (
+          <div
+            key={thread.rootPollId}
+            className={`border-b ${index === 0 ? 'border-t' : ''} border-gray-200 dark:border-gray-700 mx-1.5`}
+          >
+            <div
+              onClick={() => {
+                setNavigatingThreadId(thread.rootPollId);
+                if (thread.polls.length === 1) {
+                  const poll = thread.polls[0];
+                  router.push(`/p/${poll.short_id || poll.id}`);
+                } else {
+                  router.push(`/thread/${routeId}`);
+                }
+              }}
+              onTouchStart={handleTouchStart}
+              onTouchEnd={handleTouchEnd}
+              onTouchMove={handleTouchMove}
+              className={`px-3 py-3 ${pressedThreadId === thread.rootPollId ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+            >
+              {navigatingThreadId === thread.rootPollId && (
+                <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
+                  <svg className="animate-spin h-6 w-6 text-blue-600 dark:text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                </div>
+              )}
+
+              {/* Row 1: Thread title + unvoted badge */}
+              <div className="flex items-center justify-between gap-2">
+                <h3 className={`font-semibold text-base truncate flex-1 ${hasUnvoted ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>
+                  {thread.title}
+                </h3>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {hasUnvoted && (
+                    <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-red-500 text-white text-xs font-bold">
+                      {thread.unvotedCount}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Row 2: Latest poll title (preview) */}
+              <p className="text-sm text-gray-600 dark:text-gray-300 truncate mt-0.5">
+                {latestPoll.title}
+              </p>
+
+              {/* Row 3: Metadata row */}
+              <div className="flex items-center justify-between mt-1">
+                <div className="text-xs text-gray-400 dark:text-gray-500">
+                  <ClientOnly fallback={null}>
+                    <>
+                      {thread.polls.length > 1 && <>{thread.polls.length} polls &middot; </>}
+                      {relativeTime(latestPoll.created_at)}
+                    </>
+                  </ClientOnly>
+                </div>
+                {thread.soonestUnvotedDeadline && (
+                  <div className="text-xs">
+                    <ClientOnly fallback={null}>
+                      <SimpleCountdown deadline={thread.soonestUnvotedDeadline} />
+                    </ClientOnly>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ThreadList.tsx
+++ b/components/ThreadList.tsx
@@ -1,30 +1,12 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Poll } from "@/lib/types";
-import { getUserName } from "@/lib/userProfile";
 import { buildThreads, getThreadRouteId, Thread } from "@/lib/threadUtils";
+import { relativeTime } from "@/lib/pollListUtils";
+import { loadVotedPolls } from "@/lib/votedPollsStorage";
 import ClientOnly from "@/components/ClientOnly";
-
-function relativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const minutes = Math.floor(diffMs / 60000);
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return `${weeks}w ago`;
-  const months = Math.floor(days / 30);
-  if (months < 12) return `${months}mo ago`;
-  const years = Math.floor(days / 365);
-  return `${years}y ago`;
-}
 
 const SimpleCountdown = ({ deadline, colorClass = "text-green-600 dark:text-green-400" }: { deadline: string; colorClass?: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -74,19 +56,9 @@ export default function ThreadList({ polls }: ThreadListProps) {
   // Load voted/abstained from localStorage
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    try {
-      const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
-      const voted = new Set<string>();
-      const abstained = new Set<string>();
-      Object.keys(votedPolls).forEach(id => {
-        if (votedPolls[id] === 'abstained') abstained.add(id);
-        else if (votedPolls[id] === true) voted.add(id);
-      });
-      setVotedPollIds(voted);
-      setAbstainedPollIds(abstained);
-    } catch (error) {
-      console.error('Error loading voted polls:', error);
-    }
+    const { votedPollIds: voted, abstainedPollIds: abstained } = loadVotedPolls();
+    setVotedPollIds(voted);
+    setAbstainedPollIds(abstained);
   }, []);
 
   const threads = useMemo(() => {

--- a/components/ThreadList.tsx
+++ b/components/ThreadList.tsx
@@ -115,13 +115,7 @@ export default function ThreadList({ polls }: ThreadListProps) {
           if (!isScrolling.current) {
             setNavigatingThreadId(thread.rootPollId);
             setPressedThreadId(null);
-            if (thread.polls.length === 1) {
-              // Single-poll thread: navigate directly to the poll
-              const poll = thread.polls[0];
-              router.push(`/p/${poll.short_id || poll.id}`);
-            } else {
-              router.push(`/thread/${routeId}`);
-            }
+            router.push(`/thread/${routeId}`);
           } else {
             setPressedThreadId(null);
           }
@@ -147,12 +141,7 @@ export default function ThreadList({ polls }: ThreadListProps) {
             <div
               onClick={() => {
                 setNavigatingThreadId(thread.rootPollId);
-                if (thread.polls.length === 1) {
-                  const poll = thread.polls[0];
-                  router.push(`/p/${poll.short_id || poll.id}`);
-                } else {
-                  router.push(`/thread/${routeId}`);
-                }
+                router.push(`/thread/${routeId}`);
               }}
               onTouchStart={handleTouchStart}
               onTouchEnd={handleTouchEnd}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -137,6 +137,7 @@ function toPoll(data: any): Poll {
     show_preliminary_results: data.show_preliminary_results ?? true,
     response_count: data.response_count ?? undefined,
     availability_threshold: data.availability_threshold ?? undefined,
+    voter_names: data.voter_names ?? undefined,
   };
 }
 

--- a/lib/pollListUtils.ts
+++ b/lib/pollListUtils.ts
@@ -1,0 +1,94 @@
+import { Poll, PollResults } from "@/lib/types";
+import { getBuiltInType } from "@/components/TypeFieldInput";
+
+export const POLL_TYPE_SYMBOLS: Record<string, string> = {
+  yes_no: '👍',
+  ranked_choice: '🗳️',
+  participation: '🙋',
+};
+
+const CLOSED_YES_NO_SYMBOL = '🏆';
+
+export function getPollSymbol(pollType: string, isClosed: boolean): string {
+  if (pollType === 'yes_no' && isClosed) return CLOSED_YES_NO_SYMBOL;
+  return POLL_TYPE_SYMBOLS[pollType] || '☰';
+}
+
+export function getCategoryIcon(poll: Poll): string {
+  const category = poll.category;
+  if (category && category !== 'custom') {
+    const builtIn = getBuiltInType(category);
+    if (builtIn?.icon) return builtIn.icon;
+  }
+  // Custom or no category — use poll type symbol
+  return getPollSymbol(poll.poll_type, poll.is_closed ?? false);
+}
+
+export function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+export function isInSuggestionPhase(poll: Poll): boolean {
+  if (poll.poll_type !== 'ranked_choice') return false;
+  if (poll.suggestion_deadline && new Date(poll.suggestion_deadline) > new Date()) return true;
+  if (!poll.suggestion_deadline && poll.suggestion_deadline_minutes) return true;
+  return false;
+}
+
+export interface ResultBadge {
+  text: string;
+  emoji: string;
+  color: 'green' | 'red' | 'yellow' | 'gray';
+}
+
+export const BADGE_COLORS = {
+  green: 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200',
+  red: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200',
+  yellow: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200',
+  gray: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+};
+
+/** Simplified result badge — no user-specific logic, just poll + results. */
+export function getResultBadge(poll: Poll): ResultBadge {
+  const results = poll.results;
+  if (!results) return { text: 'No results', emoji: '🔇', color: 'gray' };
+  if (results.total_votes === 0) return { text: 'No voters', emoji: '🦗', color: 'gray' };
+
+  switch (poll.poll_type) {
+    case 'yes_no': {
+      if (results.winner === 'yes') return { text: 'Yes', emoji: '👑', color: 'green' };
+      if (results.winner === 'no') return { text: 'No', emoji: '👑', color: 'red' };
+      if (results.winner === 'tie') return { text: 'Tie', emoji: '🤝', color: 'yellow' };
+      return { text: 'No winner', emoji: '🤷', color: 'gray' };
+    }
+    case 'ranked_choice': {
+      if (results.winner) return { text: results.winner, emoji: '👑', color: 'green' };
+      return { text: 'No winner', emoji: '🤷', color: 'gray' };
+    }
+    case 'participation': {
+      const participatingCount = results.yes_count || 0;
+      let isHappening = participatingCount > 0;
+      if (results.min_participants != null && participatingCount < results.min_participants) isHappening = false;
+      if (results.max_participants != null && participatingCount > results.max_participants) isHappening = false;
+      if (isHappening) return { text: 'Happening', emoji: '🎉', color: 'green' };
+      return { text: 'Not happening', emoji: '✗', color: 'red' };
+    }
+    default:
+      return { text: 'Closed', emoji: '🔒', color: 'gray' };
+  }
+}

--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -20,6 +20,10 @@ export interface Thread {
   unvotedCount: number;
   /** Earliest deadline among unvoted open polls (undefined if none) */
   soonestUnvotedDeadline?: string;
+  /** Pre-computed ms timestamp of soonestUnvotedDeadline for sorting */
+  soonestUnvotedDeadlineMs?: number;
+  /** Pre-computed ms timestamp of latest poll created_at for sorting */
+  latestActivityMs: number;
   /** The latest poll in the thread (most recently created) */
   latestPoll: Poll;
 }
@@ -157,6 +161,8 @@ function buildThreadFromPolls(
     title,
     unvotedCount,
     soonestUnvotedDeadline,
+    soonestUnvotedDeadlineMs: soonestUnvotedDeadline ? new Date(soonestUnvotedDeadline).getTime() : undefined,
+    latestActivityMs: new Date(latestPoll.created_at).getTime(),
     latestPoll,
   };
 }
@@ -174,15 +180,13 @@ function sortThreads(threads: Thread[]): Thread[] {
 
     // Both have unvoted: sort by soonest deadline
     if (a.unvotedCount > 0 && b.unvotedCount > 0) {
-      const aDeadline = a.soonestUnvotedDeadline ? new Date(a.soonestUnvotedDeadline).getTime() : Infinity;
-      const bDeadline = b.soonestUnvotedDeadline ? new Date(b.soonestUnvotedDeadline).getTime() : Infinity;
+      const aDeadline = a.soonestUnvotedDeadlineMs ?? Infinity;
+      const bDeadline = b.soonestUnvotedDeadlineMs ?? Infinity;
       return aDeadline - bDeadline;
     }
 
     // Neither has unvoted: sort by most recent poll creation (newest first)
-    const aLatest = new Date(a.latestPoll.created_at).getTime();
-    const bLatest = new Date(b.latestPoll.created_at).getTime();
-    return bLatest - aLatest;
+    return b.latestActivityMs - a.latestActivityMs;
   });
 }
 

--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -1,0 +1,201 @@
+/**
+ * Thread grouping utilities for the messaging-style UI.
+ *
+ * A "thread" is a chain of polls linked by follow_up_to relationships.
+ * Standalone polls (no follow_up_to, nothing follows them) are single-poll threads.
+ */
+
+import type { Poll } from './types';
+
+export interface Thread {
+  /** ID of the root poll (topmost accessible poll in the chain) */
+  rootPollId: string;
+  /** Polls in the thread, sorted chronologically (oldest first) */
+  polls: Poll[];
+  /** Deduplicated participant names across all polls in the thread */
+  participantNames: string[];
+  /** Display title: comma-separated participant names */
+  title: string;
+  /** Number of unvoted polls in the thread */
+  unvotedCount: number;
+  /** Earliest deadline among unvoted open polls (undefined if none) */
+  soonestUnvotedDeadline?: string;
+  /** The latest poll in the thread (most recently created) */
+  latestPoll: Poll;
+}
+
+/**
+ * Build threads from a flat list of polls.
+ *
+ * Groups polls by follow_up_to chains. Only follow_up_to relationships form
+ * threads — fork_of relationships are ignored for threading purposes.
+ */
+export function buildThreads(
+  polls: Poll[],
+  votedPollIds: Set<string>,
+  abstainedPollIds: Set<string>,
+): Thread[] {
+  const pollById = new Map<string, Poll>();
+  for (const poll of polls) {
+    pollById.set(poll.id, poll);
+  }
+
+  // Build parent→children map (only follow_up_to, not fork_of)
+  const childrenOf = new Map<string, string[]>();
+  for (const poll of polls) {
+    if (poll.follow_up_to && pollById.has(poll.follow_up_to)) {
+      const existing = childrenOf.get(poll.follow_up_to) || [];
+      existing.push(poll.id);
+      childrenOf.set(poll.follow_up_to, existing);
+    }
+  }
+
+  // Find root polls: polls whose follow_up_to is null or points to a poll
+  // we don't have access to
+  const isChild = new Set<string>();
+  for (const poll of polls) {
+    if (poll.follow_up_to && pollById.has(poll.follow_up_to)) {
+      isChild.add(poll.id);
+    }
+  }
+
+  const roots = polls.filter(p => !isChild.has(p.id));
+
+  // For each root, collect all descendants via BFS
+  const visited = new Set<string>();
+  const threads: Thread[] = [];
+
+  for (const root of roots) {
+    if (visited.has(root.id)) continue;
+
+    const threadPolls: Poll[] = [];
+    const queue = [root.id];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const poll = pollById.get(current);
+      if (poll) {
+        threadPolls.push(poll);
+        const children = childrenOf.get(current) || [];
+        for (const childId of children) {
+          if (!visited.has(childId)) {
+            queue.push(childId);
+          }
+        }
+      }
+    }
+
+    // Sort chronologically (oldest first)
+    threadPolls.sort((a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    );
+
+    const thread = buildThreadFromPolls(threadPolls, votedPollIds, abstainedPollIds);
+    threads.push(thread);
+  }
+
+  // Also handle any orphaned polls not visited (shouldn't happen, but safety net)
+  for (const poll of polls) {
+    if (!visited.has(poll.id)) {
+      threads.push(buildThreadFromPolls([poll], votedPollIds, abstainedPollIds));
+    }
+  }
+
+  return sortThreads(threads);
+}
+
+function buildThreadFromPolls(
+  polls: Poll[],
+  votedPollIds: Set<string>,
+  abstainedPollIds: Set<string>,
+): Thread {
+  // Collect all unique participant names
+  const nameSet = new Set<string>();
+  for (const poll of polls) {
+    if (poll.creator_name) nameSet.add(poll.creator_name);
+    if (poll.voter_names) {
+      for (const name of poll.voter_names) {
+        nameSet.add(name);
+      }
+    }
+  }
+  const participantNames = Array.from(nameSet).sort();
+
+  // Build title from names
+  const title = participantNames.length > 0
+    ? participantNames.join(', ')
+    : polls[0]?.title || 'Untitled';
+
+  // Count unvoted polls and find soonest unvoted deadline
+  const now = new Date();
+  let unvotedCount = 0;
+  let soonestUnvotedDeadline: string | undefined;
+
+  for (const poll of polls) {
+    const hasVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
+    const isOpen = poll.response_deadline
+      ? new Date(poll.response_deadline) > now && !poll.is_closed
+      : !poll.is_closed;
+
+    if (!hasVoted && isOpen) {
+      unvotedCount++;
+      if (poll.response_deadline) {
+        if (!soonestUnvotedDeadline || poll.response_deadline < soonestUnvotedDeadline) {
+          soonestUnvotedDeadline = poll.response_deadline;
+        }
+      }
+    }
+  }
+
+  const latestPoll = polls[polls.length - 1];
+
+  return {
+    rootPollId: polls[0].id,
+    polls,
+    participantNames,
+    title,
+    unvotedCount,
+    soonestUnvotedDeadline,
+    latestPoll,
+  };
+}
+
+/**
+ * Sort threads:
+ * 1. Threads with unvoted open polls first, sorted by soonest unvoted deadline
+ * 2. Threads without unvoted open polls, sorted by most recent activity
+ */
+function sortThreads(threads: Thread[]): Thread[] {
+  return threads.sort((a, b) => {
+    // Threads with unvoted polls come first
+    if (a.unvotedCount > 0 && b.unvotedCount === 0) return -1;
+    if (a.unvotedCount === 0 && b.unvotedCount > 0) return 1;
+
+    // Both have unvoted: sort by soonest deadline
+    if (a.unvotedCount > 0 && b.unvotedCount > 0) {
+      const aDeadline = a.soonestUnvotedDeadline ? new Date(a.soonestUnvotedDeadline).getTime() : Infinity;
+      const bDeadline = b.soonestUnvotedDeadline ? new Date(b.soonestUnvotedDeadline).getTime() : Infinity;
+      return aDeadline - bDeadline;
+    }
+
+    // Neither has unvoted: sort by most recent poll creation (newest first)
+    const aLatest = new Date(a.latestPoll.created_at).getTime();
+    const bLatest = new Date(b.latestPoll.created_at).getTime();
+    return bLatest - aLatest;
+  });
+}
+
+/**
+ * Find the thread containing a specific poll ID.
+ */
+export function findThreadByPollId(threads: Thread[], pollId: string): Thread | undefined {
+  return threads.find(t => t.polls.some(p => p.id === pollId));
+}
+
+/**
+ * Get the root poll's short_id or id for URL routing.
+ */
+export function getThreadRouteId(thread: Thread): string {
+  return thread.polls[0].short_id || thread.polls[0].id;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -70,6 +70,7 @@ export interface Poll {
   response_count?: number | null;
   availability_threshold?: number | null;
   results?: PollResults | null;
+  voter_names?: string[] | null;
 }
 
 export interface TimeWindow {

--- a/lib/votedPollsStorage.ts
+++ b/lib/votedPollsStorage.ts
@@ -1,0 +1,15 @@
+/** Parse votedPolls from localStorage into voted and abstained sets. */
+export function loadVotedPolls(): { votedPollIds: Set<string>; abstainedPollIds: Set<string> } {
+  const voted = new Set<string>();
+  const abstained = new Set<string>();
+  try {
+    const votedPolls = JSON.parse(localStorage.getItem('votedPolls') || '{}');
+    Object.keys(votedPolls).forEach(id => {
+      if (votedPolls[id] === 'abstained') abstained.add(id);
+      else if (votedPolls[id] === true) voted.add(id);
+    });
+  } catch (error) {
+    console.error('Error loading voted polls:', error);
+  }
+  return { votedPollIds: voted, abstainedPollIds: abstained };
+}

--- a/server/models.py
+++ b/server/models.py
@@ -193,6 +193,7 @@ class PollResponse(BaseModel):
     response_count: int | None = None
     availability_threshold: int | None = None
     results: "PollResultsResponse | None" = None
+    voter_names: list[str] | None = None
 
 
 class VoteResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1420,6 +1420,20 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                     votes_by_poll[pid] = []
                 votes_by_poll[pid].append(v)
 
+        # Fetch unique voter names per poll for thread title generation
+        all_poll_ids = [str(r["id"]) for r in rows]
+        voter_names_by_poll: dict[str, list[str]] = {}
+        if all_poll_ids:
+            vn_rows = conn.execute(
+                """SELECT poll_id, array_agg(DISTINCT voter_name ORDER BY voter_name) as names
+                   FROM votes
+                   WHERE poll_id = ANY(%(poll_ids)s) AND voter_name IS NOT NULL AND voter_name != ''
+                   GROUP BY poll_id""",
+                {"poll_ids": all_poll_ids},
+            ).fetchall()
+            for vn in vn_rows:
+                voter_names_by_poll[str(vn["poll_id"])] = vn["names"]
+
     results = []
     for r in rows:
         poll_resp = _row_to_poll(r)
@@ -1431,6 +1445,8 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                 logger.warning("Failed to compute results for poll %s", pid, exc_info=True)
         if pid in response_counts:
             poll_resp.response_count = response_counts[pid]
+        if pid in voter_names_by_poll:
+            poll_resp.voter_names = voter_names_by_poll[pid]
         results.append(poll_resp)
     return results
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1420,16 +1420,28 @@ def get_accessible_polls(req: AccessiblePollsRequest):
                     votes_by_poll[pid] = []
                 votes_by_poll[pid].append(v)
 
-        # Fetch unique voter names per poll for thread title generation
-        all_poll_ids = [str(r["id"]) for r in rows]
+        # Fetch unique voter names per poll for thread title generation.
+        # First, extract names from votes already loaded in memory.
         voter_names_by_poll: dict[str, list[str]] = {}
-        if all_poll_ids:
+        for pid, votes in votes_by_poll.items():
+            names = sorted({
+                v["voter_name"] for v in votes
+                if v.get("voter_name") and v["voter_name"] != ""
+            })
+            if names:
+                voter_names_by_poll[pid] = names
+
+        # Only query DB for polls whose votes weren't already fetched.
+        remaining_poll_ids = [
+            str(r["id"]) for r in rows if str(r["id"]) not in votes_by_poll
+        ]
+        if remaining_poll_ids:
             vn_rows = conn.execute(
                 """SELECT poll_id, array_agg(DISTINCT voter_name ORDER BY voter_name) as names
                    FROM votes
                    WHERE poll_id = ANY(%(poll_ids)s) AND voter_name IS NOT NULL AND voter_name != ''
                    GROUP BY poll_id""",
-                {"poll_ids": all_poll_ids},
+                {"poll_ids": remaining_poll_ids},
             ).fetchall()
             for vn in vn_rows:
                 voter_names_by_poll[str(vn["poll_id"])] = vn["names"]


### PR DESCRIPTION
## Summary
- Reworks the main page to show **threads** (follow-up chains) instead of individual polls, resembling a messaging app
- Tapping a thread opens a thread view showing polls in chronological order (oldest first)
- Thread titles are auto-generated from deduplicated participant names (creator + voter names)
- Threads sorted by soonest unvoted deadline; red badge shows unvoted poll count
- Bottom bar "+" auto-creates follow-up to latest poll when on a thread page
- Long-press modal in thread view shows only Blank + Copy (no Fork) via new `showForkButton` prop on `FollowUpModal`
- Backend: `voter_names` field on accessible polls response, optimized to extract from already-fetched votes
- Extracted shared utilities: `lib/pollListUtils.ts`, `lib/votedPollsStorage.ts`

## Test plan
- [ ] Main page shows threads grouped by follow_up_to chains
- [ ] Tapping a thread navigates to /thread/[id] showing polls oldest-first
- [ ] Thread title shows deduplicated participant names
- [ ] Red unvoted badge count is accurate
- [ ] Bottom bar "+" on thread page creates follow-up to latest poll
- [ ] Long-press on poll in thread view shows Blank + Copy only (no Fork)
- [ ] Single-poll threads also navigate to thread view
- [ ] Back button in thread view returns to main page

https://claude.ai/code/session_01MtVg4bXB4romgXH6LvgN2Q