### PR TITLE
Add respondent circle avatars to thread list

### DIFF
--- a/components/RespondentCircles.tsx
+++ b/components/RespondentCircles.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+
+// Circle packing layouts for N=1..7 circles in an SVG viewBox (0-100)
+// Visually balanced arrangements with consistent margins between circles
+const LAYOUTS: { centers: [number, number][]; diameter: number }[] = [
+  /* 0 */ { centers: [], diameter: 0 },
+  /* 1 */ { centers: [[50, 50]], diameter: 76 },
+  /* 2 */ { centers: [[28, 50], [72, 50]], diameter: 42 },
+  /* 3 */ { centers: [[50, 27], [28, 73], [72, 73]], diameter: 38 },
+  /* 4 */ { centers: [[27, 27], [73, 27], [27, 73], [73, 73]], diameter: 38 },
+  /* 5 */ { centers: [[23, 23], [77, 23], [50, 50], [23, 77], [77, 77]], diameter: 32 },
+  /* 6 */ { centers: [[19, 35], [50, 35], [81, 35], [19, 65], [50, 65], [81, 65]], diameter: 26 },
+  /* 7 -- 2-3-2 honeycomb */ {
+    centers: [[33, 22], [67, 22], [17, 50], [50, 50], [83, 50], [33, 78], [67, 78]],
+    diameter: 24,
+  },
+];
+
+const COLORS = [
+  '#4F46E5', // indigo
+  '#2563EB', // blue
+  '#0891B2', // cyan
+  '#0D9488', // teal
+  '#059669', // emerald
+  '#EA580C', // orange
+  '#DC2626', // red
+  '#DB2777', // pink
+  '#9333EA', // purple
+  '#7C3AED', // violet
+];
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function nameToColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash) + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+}
+
+interface RespondentCirclesProps {
+  names: string[];
+  anonymousCount: number;
+}
+
+export default function RespondentCircles({ names, anonymousCount }: RespondentCirclesProps) {
+  const validNames = names.filter(n => n.trim().length > 0);
+  const shownNames = validNames.slice(0, 6);
+  const overflow = Math.max(0, validNames.length - 6) + anonymousCount;
+
+  const circles: { label: string; fill: string }[] = shownNames.map(name => ({
+    label: getInitials(name),
+    fill: nameToColor(name),
+  }));
+
+  if (overflow > 0) {
+    circles.push({ label: `+${overflow}`, fill: '#6B7280' });
+  }
+
+  if (circles.length === 0) {
+    circles.push({ label: '?', fill: '#9CA3AF' });
+  }
+
+  const n = Math.min(circles.length, 7);
+  const layout = LAYOUTS[n];
+
+  return (
+    <div className="self-stretch flex-shrink-0" style={{ aspectRatio: '1 / 1' }}>
+      <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden="true">
+        {circles.map((circle, i) => {
+          const [cx, cy] = layout.centers[i];
+          const r = layout.diameter / 2;
+          const fontSize = circle.label.length <= 2 ? r * 1.0 : r * 0.8;
+          return (
+            <g key={i}>
+              <circle cx={cx} cy={cy} r={r} fill={circle.fill} />
+              <text
+                x={cx}
+                y={cy}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill="white"
+                fontSize={fontSize}
+                fontWeight="700"
+                fontFamily="system-ui, -apple-system, sans-serif"
+              >
+                {circle.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/components/RespondentCircles.tsx
+++ b/components/RespondentCircles.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { getUserInitials } from '@/lib/userProfile';
 
-// Circle packing layouts for N=1..7 circles in an SVG viewBox (0-100)
-// Visually balanced arrangements with consistent margins between circles
+// Pre-computed circle packing layouts in SVG viewBox units (0-100)
 const LAYOUTS: { centers: [number, number][]; diameter: number }[] = [
   /* 0 */ { centers: [], diameter: 0 },
   /* 1 */ { centers: [[50, 50]], diameter: 76 },
@@ -10,31 +10,18 @@ const LAYOUTS: { centers: [number, number][]; diameter: number }[] = [
   /* 4 */ { centers: [[27, 27], [73, 27], [27, 73], [73, 73]], diameter: 38 },
   /* 5 */ { centers: [[23, 23], [77, 23], [50, 50], [23, 77], [77, 77]], diameter: 32 },
   /* 6 */ { centers: [[19, 35], [50, 35], [81, 35], [19, 65], [50, 65], [81, 65]], diameter: 26 },
-  /* 7 -- 2-3-2 honeycomb */ {
+  /* 7 */ {
     centers: [[33, 22], [67, 22], [17, 50], [50, 50], [83, 50], [33, 78], [67, 78]],
     diameter: 24,
   },
 ];
 
-const COLORS = [
-  '#4F46E5', // indigo
-  '#2563EB', // blue
-  '#0891B2', // cyan
-  '#0D9488', // teal
-  '#059669', // emerald
-  '#EA580C', // orange
-  '#DC2626', // red
-  '#DB2777', // pink
-  '#9333EA', // purple
-  '#7C3AED', // violet
-];
+const MAX_NAMED = 6;
 
-function getInitials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '?';
-  if (parts.length === 1) return parts[0][0].toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-}
+const COLORS = [
+  '#4F46E5', '#2563EB', '#0891B2', '#0D9488', '#059669',
+  '#EA580C', '#DC2626', '#DB2777', '#9333EA', '#7C3AED',
+];
 
 function nameToColor(name: string): string {
   let hash = 0;
@@ -42,7 +29,7 @@ function nameToColor(name: string): string {
     hash = ((hash << 5) - hash) + name.charCodeAt(i);
     hash |= 0;
   }
-  return COLORS[Math.abs(hash) % COLORS.length];
+  return COLORS[(hash >>> 0) % COLORS.length];
 }
 
 interface RespondentCirclesProps {
@@ -52,11 +39,11 @@ interface RespondentCirclesProps {
 
 export default function RespondentCircles({ names, anonymousCount }: RespondentCirclesProps) {
   const validNames = names.filter(n => n.trim().length > 0);
-  const shownNames = validNames.slice(0, 6);
-  const overflow = Math.max(0, validNames.length - 6) + anonymousCount;
+  const shownNames = validNames.slice(0, MAX_NAMED);
+  const overflow = Math.max(0, validNames.length - MAX_NAMED) + anonymousCount;
 
   const circles: { label: string; fill: string }[] = shownNames.map(name => ({
-    label: getInitials(name),
+    label: getUserInitials(name),
     fill: nameToColor(name),
   }));
 
@@ -68,7 +55,7 @@ export default function RespondentCircles({ names, anonymousCount }: RespondentC
     circles.push({ label: '?', fill: '#9CA3AF' });
   }
 
-  const n = Math.min(circles.length, 7);
+  const n = Math.min(circles.length, LAYOUTS.length - 1);
   const layout = LAYOUTS[n];
 
   return (
@@ -77,7 +64,7 @@ export default function RespondentCircles({ names, anonymousCount }: RespondentC
         {circles.map((circle, i) => {
           const [cx, cy] = layout.centers[i];
           const r = layout.diameter / 2;
-          const fontSize = circle.label.length <= 2 ? r * 1.0 : r * 0.8;
+          const fontSize = circle.label.length <= 2 ? r : r * 0.8;
           return (
             <g key={i}>
               <circle cx={cx} cy={cy} r={r} fill={circle.fill} />

--- a/components/RespondentCircles.tsx
+++ b/components/RespondentCircles.tsx
@@ -72,7 +72,7 @@ export default function RespondentCircles({ names, anonymousCount }: RespondentC
   const layout = LAYOUTS[n];
 
   return (
-    <div className="self-stretch flex-shrink-0" style={{ aspectRatio: '1 / 1' }}>
+    <div className="w-16 aspect-square flex-shrink-0 self-center">
       <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden="true">
         {circles.map((circle, i) => {
           const [cx, cy] = layout.centers[i];

--- a/components/ThreadList.tsx
+++ b/components/ThreadList.tsx
@@ -7,6 +7,7 @@ import { buildThreads, getThreadRouteId, Thread } from "@/lib/threadUtils";
 import { relativeTime } from "@/lib/pollListUtils";
 import { loadVotedPolls } from "@/lib/votedPollsStorage";
 import ClientOnly from "@/components/ClientOnly";
+import RespondentCircles from "@/components/RespondentCircles";
 
 const SimpleCountdown = ({ deadline, colorClass = "text-green-600 dark:text-green-400" }: { deadline: string; colorClass?: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -118,10 +119,10 @@ export default function ThreadList({ polls }: ThreadListProps) {
               onTouchStart={handleTouchStart}
               onTouchEnd={handleTouchEnd}
               onTouchMove={handleTouchMove}
-              className={`px-3 py-3 ${pressedThreadId === thread.rootPollId ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+              className={`flex gap-3 px-3 py-3 ${pressedThreadId === thread.rootPollId ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
             >
               {navigatingThreadId === thread.rootPollId && (
-                <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center">
+                <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center z-10">
                   <svg className="animate-spin h-6 w-6 text-blue-600 dark:text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
@@ -129,42 +130,51 @@ export default function ThreadList({ polls }: ThreadListProps) {
                 </div>
               )}
 
-              {/* Row 1: Thread title + unvoted badge */}
-              <div className="flex items-center justify-between gap-2">
-                <h3 className={`font-semibold text-base truncate flex-1 ${hasUnvoted ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>
-                  {thread.title}
-                </h3>
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  {hasUnvoted && (
-                    <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-red-500 text-white text-xs font-bold">
-                      {thread.unvotedCount}
-                    </span>
-                  )}
-                </div>
-              </div>
+              {/* Respondent circles */}
+              <RespondentCircles
+                names={thread.participantNames}
+                anonymousCount={thread.anonymousRespondentCount}
+              />
 
-              {/* Row 2: Latest poll title (preview) */}
-              <p className="text-sm text-gray-600 dark:text-gray-300 truncate mt-0.5">
-                {latestPoll.title}
-              </p>
-
-              {/* Row 3: Metadata row */}
-              <div className="flex items-center justify-between mt-1">
-                <div className="text-xs text-gray-400 dark:text-gray-500">
-                  <ClientOnly fallback={null}>
-                    <>
-                      {thread.polls.length > 1 && <>{thread.polls.length} polls &middot; </>}
-                      {relativeTime(latestPoll.created_at)}
-                    </>
-                  </ClientOnly>
+              {/* Text content */}
+              <div className="flex-1 min-w-0">
+                {/* Row 1: Thread title + unvoted badge */}
+                <div className="flex items-center justify-between gap-2">
+                  <h3 className={`font-semibold text-base truncate flex-1 ${hasUnvoted ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400'}`}>
+                    {thread.title}
+                  </h3>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {hasUnvoted && (
+                      <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-red-500 text-white text-xs font-bold">
+                        {thread.unvotedCount}
+                      </span>
+                    )}
+                  </div>
                 </div>
-                {thread.soonestUnvotedDeadline && (
-                  <div className="text-xs">
+
+                {/* Row 2: Latest poll title (preview) */}
+                <p className="text-sm text-gray-600 dark:text-gray-300 truncate mt-0.5">
+                  {latestPoll.title}
+                </p>
+
+                {/* Row 3: Metadata row */}
+                <div className="flex items-center justify-between mt-1">
+                  <div className="text-xs text-gray-400 dark:text-gray-500">
                     <ClientOnly fallback={null}>
-                      <SimpleCountdown deadline={thread.soonestUnvotedDeadline} />
+                      <>
+                        {thread.polls.length > 1 && <>{thread.polls.length} polls &middot; </>}
+                        {relativeTime(latestPoll.created_at)}
+                      </>
                     </ClientOnly>
                   </div>
-                )}
+                  {thread.soonestUnvotedDeadline && (
+                    <div className="text-xs">
+                      <ClientOnly fallback={null}>
+                        <SimpleCountdown deadline={thread.soonestUnvotedDeadline} />
+                      </ClientOnly>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -26,6 +26,8 @@ export interface Thread {
   latestActivityMs: number;
   /** The latest poll in the thread (most recently created) */
   latestPoll: Poll;
+  /** Estimated count of anonymous respondents (max across any single poll) */
+  anonymousRespondentCount: number;
 }
 
 /**
@@ -154,6 +156,15 @@ function buildThreadFromPolls(
 
   const latestPoll = polls[polls.length - 1];
 
+  // Estimate anonymous respondent count (max across any single poll)
+  let anonymousRespondentCount = 0;
+  for (const poll of polls) {
+    const totalVotes = poll.response_count ?? 0;
+    const namedVoters = poll.voter_names?.length ?? 0;
+    const anonymous = Math.max(0, totalVotes - namedVoters);
+    anonymousRespondentCount = Math.max(anonymousRespondentCount, anonymous);
+  }
+
   return {
     rootPollId: polls[0].id,
     polls,
@@ -164,6 +175,7 @@ function buildThreadFromPolls(
     soonestUnvotedDeadlineMs: soonestUnvotedDeadline ? new Date(soonestUnvotedDeadline).getTime() : undefined,
     latestActivityMs: new Date(latestPoll.created_at).getTime(),
     latestPoll,
+    anonymousRespondentCount,
   };
 }
 


### PR DESCRIPTION
## Summary
- Each thread in the main list now shows a square region on the left with colored initial circles for each named respondent
- Uses SVG-based circle packing with 7 pre-computed layouts: single centered, side-by-side, inverted triangle, 2×2 grid, quincunx, 3×2 grid, and 2-3-2 honeycomb
- Up to 6 named circles with initials + optional gray "+N" overflow circle for excess named + anonymous respondents
- Deterministic color assignment via name hash (10-color palette), reuses existing `getUserInitials()` from `lib/userProfile.ts`
- Adds `anonymousRespondentCount` to Thread interface (estimated as max anonymous voters across any single poll)

## Test plan
- [ ] Verify circle layouts render correctly for 1–7 respondents
- [ ] Verify overflow "+N" circle appears when >6 named respondents or anonymous voters exist
- [ ] Verify thread title text still truncates properly with the new flex layout
- [ ] Verify loading spinner overlay still covers the full thread row
- [ ] Check dark mode appearance of colored circles
- [ ] Verify no layout shifts on mobile viewport (430px width)