### PR TITLE
Refine participant squares and back button layout

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -909,24 +909,24 @@ function TemplateInner({ children }: AppTemplateProps) {
              In regular browser tabs, the browser's own back button handles navigation.
              Shows back arrow if user has navigated within the app, home icon otherwise. */}
         {(isPollPage || isProfilePage || isThreadPage) && (
-          <div className="fixed left-1 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
+          <div className="fixed left-0 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
             {hasAppHistory ? (
               <button
                 onClick={() => window.history.back()}
-                className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+                className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go back"
               >
-                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
             ) : (
               <button
                 onClick={() => window.location.href = '/'}
-                className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+                className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go to home"
               >
-                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                 </svg>
               </button>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -905,32 +905,19 @@ function TemplateInner({ children }: AppTemplateProps) {
 
       {/* Header elements rendered outside scaling container */}
       <HeaderPortal>
-        {/* Back/home button in upper left — PWA standalone mode only.
-             In regular browser tabs, the browser's own back button handles navigation.
-             Shows back arrow if user has navigated within the app, home icon otherwise. */}
-        {(isPollPage || isProfilePage || isThreadPage) && (
+        {/* Back arrow in upper left — only shown when user has navigated within the app.
+             The bottom bar Home button handles navigation to home. */}
+        {(isPollPage || isProfilePage || isThreadPage) && hasAppHistory && (
           <div className="fixed left-0 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
-            {hasAppHistory ? (
-              <button
-                onClick={() => window.history.back()}
-                className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-                aria-label="Go back"
-              >
-                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                </svg>
-              </button>
-            ) : (
-              <button
-                onClick={() => window.location.href = '/'}
-                className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-                aria-label="Go to home"
-              >
-                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                </svg>
-              </button>
-            )}
+            <button
+              onClick={() => window.history.back()}
+              className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+              aria-label="Go back"
+            >
+              <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
           </div>
         )}
         

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -909,14 +909,14 @@ function TemplateInner({ children }: AppTemplateProps) {
              In regular browser tabs, the browser's own back button handles navigation.
              Shows back arrow if user has navigated within the app, home icon otherwise. */}
         {(isPollPage || isProfilePage || isThreadPage) && (
-          <div className="fixed left-1.5 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
+          <div className="fixed left-1 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
             {hasAppHistory ? (
               <button
                 onClick={() => window.history.back()}
                 className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go back"
               >
-                <svg className="w-8 h-8 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
@@ -926,7 +926,7 @@ function TemplateInner({ children }: AppTemplateProps) {
                 className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go to home"
               >
-                <svg className="w-8 h-8 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                 </svg>
               </button>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -909,24 +909,24 @@ function TemplateInner({ children }: AppTemplateProps) {
              In regular browser tabs, the browser's own back button handles navigation.
              Shows back arrow if user has navigated within the app, home icon otherwise. */}
         {(isPollPage || isProfilePage || isThreadPage) && (
-          <div className="fixed left-4 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}>
+          <div className="fixed left-2 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
             {hasAppHistory ? (
               <button
                 onClick={() => window.history.back()}
-                className="w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+                className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go back"
               >
-                <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-10 h-10 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
             ) : (
               <button
                 onClick={() => window.location.href = '/'}
-                className="w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+                className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go to home"
               >
-                <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-10 h-10 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                 </svg>
               </button>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -916,7 +916,7 @@ function TemplateInner({ children }: AppTemplateProps) {
                 className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go back"
               >
-                <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
@@ -926,7 +926,7 @@ function TemplateInner({ children }: AppTemplateProps) {
                 className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go to home"
               >
-                <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                 </svg>
               </button>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -909,14 +909,14 @@ function TemplateInner({ children }: AppTemplateProps) {
              In regular browser tabs, the browser's own back button handles navigation.
              Shows back arrow if user has navigated within the app, home icon otherwise. */}
         {(isPollPage || isProfilePage || isThreadPage) && (
-          <div className="fixed left-2 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
+          <div className="fixed left-1.5 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
             {hasAppHistory ? (
               <button
                 onClick={() => window.history.back()}
                 className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go back"
               >
-                <svg className="w-10 h-10 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-8 h-8 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
@@ -926,7 +926,7 @@ function TemplateInner({ children }: AppTemplateProps) {
                 className="w-16 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Go to home"
               >
-                <svg className="w-10 h-10 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-8 h-8 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                 </svg>
               </button>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -752,7 +752,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
             {children}
           </div>
         </div>

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -177,7 +177,7 @@ function ThreadContent() {
   return (
     <div>
       {/* Thread header */}
-      <div className="border-b border-gray-200 dark:border-gray-700 pl-10 pr-4 py-2 flex items-center gap-3">
+      <div className="border-b border-gray-200 dark:border-gray-700 pl-[64px] pr-4 py-2 flex items-center gap-3">
         <RespondentCircles
           names={thread.participantNames}
           anonymousCount={thread.anonymousRespondentCount}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -11,6 +11,7 @@ import { getCategoryIcon, relativeTime, isInSuggestionPhase, getResultBadge, BAD
 import { loadVotedPolls } from "@/lib/votedPollsStorage";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
+import RespondentCircles from "@/components/RespondentCircles";
 
 const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:text-blue-400" }: { deadline: string; label: string; colorClass?: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -176,13 +177,19 @@ function ThreadContent() {
   return (
     <div>
       {/* Thread header */}
-      <div className="border-b border-gray-200 dark:border-gray-700 px-4 py-3">
-        <h1 className="font-semibold text-lg text-gray-900 dark:text-white truncate">
-          {thread.title}
-        </h1>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
-          {thread.polls.length} {thread.polls.length === 1 ? 'poll' : 'polls'}
-        </p>
+      <div className="border-b border-gray-200 dark:border-gray-700 pl-10 pr-4 py-2 flex items-center gap-3">
+        <RespondentCircles
+          names={thread.participantNames}
+          anonymousCount={thread.anonymousRespondentCount}
+        />
+        <div className="min-w-0">
+          <h1 className="font-semibold text-lg text-gray-900 dark:text-white truncate">
+            {thread.title}
+          </h1>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {thread.polls.length} {thread.polls.length === 1 ? 'poll' : 'polls'}
+          </p>
+        </div>
       </div>
 
       {/* Poll list (oldest first = messaging order) */}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -177,7 +177,7 @@ function ThreadContent() {
   return (
     <div>
       {/* Thread header */}
-      <div className="border-b border-gray-200 dark:border-gray-700 pl-[42px] pr-4 py-2 flex items-center gap-3">
+      <div className="border-b border-gray-200 dark:border-gray-700 pl-8 pr-4 py-2 flex items-center gap-3">
         <RespondentCircles
           names={thread.participantNames}
           anonymousCount={thread.anonymousRespondentCount}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -177,7 +177,7 @@ function ThreadContent() {
   return (
     <div>
       {/* Thread header */}
-      <div className="border-b border-gray-200 dark:border-gray-700 pl-12 pr-4 py-2 flex items-center gap-3">
+      <div className="border-b border-gray-200 dark:border-gray-700 pl-[42px] pr-4 py-2 flex items-center gap-3">
         <RespondentCircles
           names={thread.participantNames}
           anonymousCount={thread.anonymousRespondentCount}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -177,7 +177,7 @@ function ThreadContent() {
   return (
     <div>
       {/* Thread header */}
-      <div className="border-b border-gray-200 dark:border-gray-700 pl-8 pr-4 py-2 flex items-center gap-3">
+      <div className="border-b border-gray-200 dark:border-gray-700 pl-6 pr-4 py-2 flex items-center gap-3">
         <RespondentCircles
           names={thread.participantNames}
           anonymousCount={thread.anonymousRespondentCount}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -177,7 +177,7 @@ function ThreadContent() {
   return (
     <div>
       {/* Thread header */}
-      <div className="border-b border-gray-200 dark:border-gray-700 pl-[64px] pr-4 py-2 flex items-center gap-3">
+      <div className="border-b border-gray-200 dark:border-gray-700 pl-12 pr-4 py-2 flex items-center gap-3">
         <RespondentCircles
           names={thread.participantNames}
           anonymousCount={thread.anonymousRespondentCount}

--- a/components/RespondentCircles.tsx
+++ b/components/RespondentCircles.tsx
@@ -4,15 +4,15 @@ import { getUserInitials } from '@/lib/userProfile';
 // Pre-computed circle packing layouts in SVG viewBox units (0-100)
 const LAYOUTS: { centers: [number, number][]; diameter: number }[] = [
   /* 0 */ { centers: [], diameter: 0 },
-  /* 1 */ { centers: [[50, 50]], diameter: 76 },
-  /* 2 */ { centers: [[28, 50], [72, 50]], diameter: 42 },
-  /* 3 */ { centers: [[50, 27], [28, 73], [72, 73]], diameter: 38 },
-  /* 4 */ { centers: [[27, 27], [73, 27], [27, 73], [73, 73]], diameter: 38 },
-  /* 5 */ { centers: [[23, 23], [77, 23], [50, 50], [23, 77], [77, 77]], diameter: 32 },
-  /* 6 */ { centers: [[19, 35], [50, 35], [81, 35], [19, 65], [50, 65], [81, 65]], diameter: 26 },
+  /* 1 */ { centers: [[50, 50]], diameter: 83 },
+  /* 2 */ { centers: [[27, 50], [73, 50]], diameter: 44 },
+  /* 3 */ { centers: [[50, 26], [27, 74], [73, 74]], diameter: 42 },
+  /* 4 */ { centers: [[26, 26], [74, 26], [26, 74], [74, 74]], diameter: 42 },
+  /* 5 */ { centers: [[22, 22], [78, 22], [50, 50], [22, 78], [78, 78]], diameter: 35 },
+  /* 6 */ { centers: [[18, 34], [50, 34], [82, 34], [18, 66], [50, 66], [82, 66]], diameter: 29 },
   /* 7 */ {
-    centers: [[33, 22], [67, 22], [17, 50], [50, 50], [83, 50], [33, 78], [67, 78]],
-    diameter: 24,
+    centers: [[32, 21], [68, 21], [16, 50], [50, 50], [84, 50], [32, 79], [68, 79]],
+    diameter: 26,
   },
 ];
 
@@ -64,7 +64,7 @@ export default function RespondentCircles({ names, anonymousCount }: RespondentC
         {circles.map((circle, i) => {
           const [cx, cy] = layout.centers[i];
           const r = layout.diameter / 2;
-          const fontSize = circle.label.length <= 2 ? r : r * 0.8;
+          const fontSize = circle.label.length <= 1 ? r * 1.25 : circle.label.length <= 2 ? r : r * 0.8;
           return (
             <g key={i}>
               <circle cx={cx} cy={cy} r={r} fill={circle.fill} />

--- a/components/ThreadList.tsx
+++ b/components/ThreadList.tsx
@@ -119,7 +119,7 @@ export default function ThreadList({ polls }: ThreadListProps) {
               onTouchStart={handleTouchStart}
               onTouchEnd={handleTouchEnd}
               onTouchMove={handleTouchMove}
-              className={`flex gap-3 px-3 py-3 ${pressedThreadId === thread.rootPollId ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+              className={`flex gap-3 pl-2 pr-3 py-3 ${pressedThreadId === thread.rootPollId ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
             >
               {navigatingThreadId === thread.rootPollId && (
                 <div className="absolute inset-0 bg-white/80 dark:bg-gray-900/80 flex items-center justify-center z-10">


### PR DESCRIPTION
## Summary
- Tighter circle packing in respondent squares (~30% less whitespace), larger single-initial font (+25%)
- Add respondent circles to thread view header, next to back arrow and title
- Enlarge back button tap target, position flush-left with zero gap to circle square
- Remove home icon fallback from back button — bottom bar Home suffices
- Reduce left padding on thread list items

## Test plan
- [ ] Thread list: circles are larger/tighter, left-aligned closer to edge
- [ ] Thread view: header shows back arrow + respondent circle + title in a row
- [ ] Poll page: back arrow in same position, no home icon when no history
- [ ] Deep-linked pages (no app history): no back button shown, bottom bar navigates home

https://claude.ai/code/session_01VZv4yePdbsAX96F5jbsZ92