### PR TITLE
Fix thread poll layout: bottom-aligned, sticky header, direct access

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -67,6 +67,7 @@ function TemplateInner({ children }: AppTemplateProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const bounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isInBounceRef = useRef(false);
+  const isThreadPageRef = useRef(false);
 
   // Pull-to-refresh state — uses refs + direct DOM manipulation for 60fps during drag,
   // React state only for mount/unmount of indicator and final actions (refresh/snap-back).
@@ -174,6 +175,8 @@ function TemplateInner({ children }: AppTemplateProps) {
     // Track current visibility to avoid no-op setState calls during scroll
     let isVisible = true;
     const setVisible = (visible: boolean) => {
+      // Never hide bottom bar on thread pages
+      if (isThreadPageRef.current) visible = true;
       if (visible !== isVisible) {
         isVisible = visible;
         setShowBottomBar(visible);
@@ -404,6 +407,7 @@ function TemplateInner({ children }: AppTemplateProps) {
 
   const isPollPage = pathname.startsWith('/p/');
   const isThreadPage = pathname.startsWith('/thread/');
+  isThreadPageRef.current = isThreadPage;
   const isCreateModalOpen = searchParams.has('create');
   const isProfilePage = pathname === '/profile' || pathname === '/profile/';
   const [modalClosing, setModalClosing] = useState(false);
@@ -701,7 +705,7 @@ function TemplateInner({ children }: AppTemplateProps) {
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
         }}>
-        <div className="pwa-safe-top relative">
+        <div className={`pwa-safe-top relative ${isThreadPage ? 'min-h-full' : ''}`}>
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode.
                Only rendered after mount to avoid hydration mismatch — CommitInfo (in layout)
@@ -752,7 +756,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'min-h-full flex flex-col' : ''}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -911,7 +911,7 @@ function TemplateInner({ children }: AppTemplateProps) {
       <HeaderPortal>
         {/* Back arrow in upper left — only shown when user has navigated within the app.
              The bottom bar Home button handles navigation to home. */}
-        {(isPollPage || isProfilePage || isThreadPage) && hasAppHistory && (
+        {(isPollPage || isProfilePage) && hasAppHistory && (
           <div className="fixed left-0 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
             <button
               onClick={() => window.history.back()}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -756,7 +756,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col' : ''}`}>
+          <div className={`max-w-4xl mx-auto ${(pathname === '/' || isThreadPage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col' : ''}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -84,6 +84,11 @@ function TemplateInner({ children }: AppTemplateProps) {
     setHasAppHistory(count > 1);
   }, [pathname]);
 
+  // Keep thread page ref in sync for the scroll handler (which runs in a [] effect).
+  useEffect(() => {
+    isThreadPageRef.current = pathname.startsWith('/thread/');
+  }, [pathname]);
+
   // Detect PWA standalone mode once — these are device constants that never change mid-session.
   useEffect(() => {
     setIsStandalone(isStandalonePWA());
@@ -407,7 +412,6 @@ function TemplateInner({ children }: AppTemplateProps) {
 
   const isPollPage = pathname.startsWith('/p/');
   const isThreadPage = pathname.startsWith('/thread/');
-  isThreadPageRef.current = isThreadPage;
   const isCreateModalOpen = searchParams.has('create');
   const isProfilePage = pathname === '/profile' || pathname === '/profile/';
   const [modalClosing, setModalClosing] = useState(false);

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -756,7 +756,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${(pathname === '/' || isThreadPage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${isThreadPage ? 'pt-0 pb-0' : (isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col overflow-hidden' : ''}`}>
+          <div className={`max-w-4xl mx-auto ${(pathname === '/' || isThreadPage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${isThreadPage ? '' : (isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col overflow-hidden' : ''}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -699,13 +699,13 @@ function TemplateInner({ children }: AppTemplateProps) {
       {/* Scrollable Content Area - consistent across all pages */}
       <div
         ref={scrollContainerRef}
-        className="flex-1 overflow-auto safari-scroll-container mb-14"
+        className={`flex-1 overflow-auto safari-scroll-container mb-14 ${isThreadPage ? 'flex flex-col' : ''}`}
         style={{
           paddingTop: '0',
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
         }}>
-        <div className={`pwa-safe-top relative ${isThreadPage ? 'min-h-full' : ''}`}>
+        <div className={`pwa-safe-top relative ${isThreadPage ? 'flex-1 flex flex-col' : ''}`}>
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode.
                Only rendered after mount to avoid hydration mismatch — CommitInfo (in layout)
@@ -756,7 +756,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'min-h-full flex flex-col' : ''}`}>
+          <div className={`max-w-4xl mx-auto ${pathname === '/' ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col' : ''}`}>
             {children}
           </div>
         </div>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -699,7 +699,7 @@ function TemplateInner({ children }: AppTemplateProps) {
       {/* Scrollable Content Area - consistent across all pages */}
       <div
         ref={scrollContainerRef}
-        className={`flex-1 overflow-auto safari-scroll-container mb-14 ${isThreadPage ? 'flex flex-col' : ''}`}
+        className={`flex-1 safari-scroll-container mb-14 ${isThreadPage ? 'overflow-hidden flex flex-col' : 'overflow-auto'}`}
         style={{
           paddingTop: '0',
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -705,7 +705,7 @@ function TemplateInner({ children }: AppTemplateProps) {
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
         }}>
-        <div className={`pwa-safe-top relative ${isThreadPage ? 'flex-1 flex flex-col' : ''}`}>
+        <div className={`pwa-safe-top relative ${isThreadPage ? 'flex-1 flex flex-col overflow-hidden' : ''}`}>
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode.
                Only rendered after mount to avoid hydration mismatch — CommitInfo (in layout)
@@ -756,7 +756,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${(pathname === '/' || isThreadPage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${(isPollPage || isProfilePage || isThreadPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col' : ''}`}>
+          <div className={`max-w-4xl mx-auto ${(pathname === '/' || isThreadPage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${isThreadPage ? 'pt-0 pb-0' : (isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col overflow-hidden' : ''}`}>
             {children}
           </div>
         </div>

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -175,9 +175,9 @@ function ThreadContent() {
   const threadPolls = thread.polls;
 
   return (
-    <div className="flex-1 flex flex-col">
+    <div className="flex-1 flex flex-col overflow-x-hidden">
       {/* Sticky thread header with back button */}
-      <div className="sticky top-0 z-20 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2">
+      <div className="sticky top-0 z-20 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden">
         <button
           onClick={() => window.history.back()}
           className="w-10 h-10 flex items-center justify-center shrink-0"

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -140,6 +140,17 @@ function ThreadContent() {
     fetchThread();
   }, [threadId]);
 
+  // Auto-scroll to the bottom on load so newest polls are visible
+  const bottomRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (thread && !loading) {
+      // Wait a frame for the DOM to settle after render
+      requestAnimationFrame(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
+      });
+    }
+  }, [thread, loading]);
+
   if (loading) {
     return (
       <div className="h-full flex items-center justify-center">
@@ -170,17 +181,6 @@ function ThreadContent() {
       </div>
     );
   }
-
-  // Auto-scroll to the bottom on load so newest polls are visible
-  const bottomRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (thread && !loading) {
-      // Wait a frame for the DOM to settle after render
-      requestAnimationFrame(() => {
-        bottomRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
-      });
-    }
-  }, [thread, loading]);
 
   // Polls are already sorted oldest-first in thread.polls
   const threadPolls = thread.polls;

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -171,11 +171,22 @@ function ThreadContent() {
     );
   }
 
+  // Auto-scroll to the bottom on load so newest polls are visible
+  const bottomRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (thread && !loading) {
+      // Wait a frame for the DOM to settle after render
+      requestAnimationFrame(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
+      });
+    }
+  }, [thread, loading]);
+
   // Polls are already sorted oldest-first in thread.polls
   const threadPolls = thread.polls;
 
   return (
-    <div>
+    <div className="mt-auto">
       {/* Thread header */}
       <div className="border-b border-gray-200 dark:border-gray-700 pl-6 pr-4 py-2 flex items-center gap-3">
         <RespondentCircles
@@ -340,6 +351,9 @@ function ThreadContent() {
             );
           })}
       </div>
+
+      {/* Scroll anchor for auto-scroll-to-bottom */}
+      <div ref={bottomRef} />
 
       {/* Thread-aware follow-up modal (Blank + Copy only, no Fork) */}
       {modalPoll && (

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -186,8 +186,8 @@ function ThreadContent() {
   const threadPolls = thread.polls;
 
   return (
-    <div className="mt-auto">
-      {/* Thread header */}
+    <div className="flex-1 flex flex-col">
+      {/* Thread header — stays at top */}
       <div className="border-b border-gray-200 dark:border-gray-700 pl-6 pr-4 py-2 flex items-center gap-3">
         <RespondentCircles
           names={thread.participantNames}
@@ -203,8 +203,9 @@ function ThreadContent() {
         </div>
       </div>
 
-      {/* Poll list (oldest first = messaging order) */}
-      <div className="py-2">
+      {/* Poll list — bottom-aligned within remaining space */}
+      <div className="flex-1 flex flex-col justify-end">
+        <div className="py-2">
         {threadPolls.map((poll, index) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
             const now = new Date();
@@ -350,10 +351,11 @@ function ThreadContent() {
               </div>
             );
           })}
-      </div>
+        </div>
 
-      {/* Scroll anchor for auto-scroll-to-bottom */}
-      <div ref={bottomRef} />
+        {/* Scroll anchor for auto-scroll-to-bottom */}
+        <div ref={bottomRef} />
+      </div>
 
       {/* Thread-aware follow-up modal (Blank + Copy only, no Fork) */}
       {modalPoll && (

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -175,9 +175,9 @@ function ThreadContent() {
   const threadPolls = thread.polls;
 
   return (
-    <div className="flex-1 flex flex-col overflow-x-hidden">
-      {/* Sticky thread header with back button */}
-      <div className="sticky top-0 z-20 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden">
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Fixed thread header with back button — not scrollable */}
+      <div className="shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden">
         <button
           onClick={() => window.history.back()}
           className="w-10 h-10 flex items-center justify-center shrink-0"
@@ -201,8 +201,8 @@ function ThreadContent() {
         </div>
       </div>
 
-      {/* Poll list — bottom-aligned within remaining space */}
-      <div className="flex-1 flex flex-col justify-end">
+      {/* Scrollable poll list — bottom-aligned, vertical only */}
+      <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col justify-end">
         <div className="py-2">
         {threadPolls.map((poll) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -104,10 +104,8 @@ function ThreadContent() {
           return;
         }
 
-        // Step 2: Discover related polls (children via follow_up_to chain)
+        // Step 2: Discover children, then fetch all accessible polls
         try { await discoverRelatedPolls(); } catch {}
-
-        // Step 3: Fetch all accessible polls and build thread from anchor down
         const polls = await getAccessiblePolls();
         if (!polls) { setError(true); return; }
 

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -5,13 +5,16 @@ import { useRouter, useParams } from "next/navigation";
 import { Poll } from "@/lib/types";
 import { getAccessiblePolls } from "@/lib/simplePollQueries";
 import { discoverRelatedPolls } from "@/lib/pollDiscovery";
-import { buildThreads, findThreadByPollId, Thread } from "@/lib/threadUtils";
+import { buildThreadFromPollDown } from "@/lib/threadUtils";
 import { apiGetPollById, apiGetPollByShortId } from "@/lib/api";
+import { addAccessiblePollId } from "@/lib/browserPollAccess";
 import { getCategoryIcon, relativeTime, isInSuggestionPhase, getResultBadge, BADGE_COLORS } from "@/lib/pollListUtils";
 import { loadVotedPolls } from "@/lib/votedPollsStorage";
 import ClientOnly from "@/components/ClientOnly";
 import FollowUpModal from "@/components/FollowUpModal";
 import RespondentCircles from "@/components/RespondentCircles";
+
+import type { Thread } from "@/lib/threadUtils";
 
 const SimpleCountdown = ({ deadline, label, colorClass = "text-blue-600 dark:text-blue-400" }: { deadline: string; label: string; colorClass?: string }) => {
   const [timeLeft, setTimeLeft] = useState<string>("");
@@ -79,49 +82,37 @@ function ThreadContent() {
     setAbstainedPollIds(abstained);
   }, []);
 
-  // Fetch polls and find the thread
+  // Fetch the referenced poll, register access, discover children, build thread
   useEffect(() => {
     async function fetchThread() {
       try {
         setLoading(true);
         setError(false);
 
-        // Discover related polls first
+        // Step 1: Fetch the poll referenced in the URL and register access
+        let anchorPoll: Poll;
+        try {
+          if (threadId.length > 10 && threadId.includes('-')) {
+            anchorPoll = await apiGetPollById(threadId);
+          } else {
+            anchorPoll = await apiGetPollByShortId(threadId);
+          }
+          // Register access (like visiting /p/[id] does)
+          addAccessiblePollId(anchorPoll.id);
+        } catch {
+          setError(true);
+          return;
+        }
+
+        // Step 2: Discover related polls (children via follow_up_to chain)
         try { await discoverRelatedPolls(); } catch {}
 
+        // Step 3: Fetch all accessible polls and build thread from anchor down
         const polls = await getAccessiblePolls();
         if (!polls) { setError(true); return; }
 
-        // Resolve the threadId to a poll ID (could be short_id or UUID)
-        let rootPollId: string | null = null;
-
-        // First try to find directly in the polls we have
-        const directMatch = polls.find(p =>
-          p.short_id === threadId || p.id === threadId
-        );
-        if (directMatch) {
-          rootPollId = directMatch.id;
-        } else {
-          // Try fetching the poll to resolve the ID
-          try {
-            let resolved: Poll;
-            if (threadId.length > 10 && threadId.includes('-')) {
-              resolved = await apiGetPollById(threadId);
-            } else {
-              resolved = await apiGetPollByShortId(threadId);
-            }
-            rootPollId = resolved.id;
-          } catch {
-            setError(true);
-            return;
-          }
-        }
-
-        // Build threads from all polls
         const { votedPollIds: voted, abstainedPollIds: abstained } = loadVotedPolls();
-
-        const threads = buildThreads(polls, voted, abstained);
-        const foundThread = findThreadByPollId(threads, rootPollId);
+        const foundThread = buildThreadFromPollDown(anchorPoll.id, polls, voted, abstained);
 
         if (!foundThread) {
           setError(true);
@@ -144,7 +135,6 @@ function ThreadContent() {
   const bottomRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (thread && !loading) {
-      // Wait a frame for the DOM to settle after render
       requestAnimationFrame(() => {
         bottomRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
       });
@@ -182,13 +172,21 @@ function ThreadContent() {
     );
   }
 
-  // Polls are already sorted oldest-first in thread.polls
   const threadPolls = thread.polls;
 
   return (
     <div className="flex-1 flex flex-col">
-      {/* Thread header — stays at top */}
-      <div className="border-b border-gray-200 dark:border-gray-700 pl-6 pr-4 py-2 flex items-center gap-3">
+      {/* Sticky thread header with back button */}
+      <div className="sticky top-0 z-20 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2">
+        <button
+          onClick={() => window.history.back()}
+          className="w-10 h-10 flex items-center justify-center shrink-0"
+          aria-label="Go back"
+        >
+          <svg className="w-6 h-6 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
         <RespondentCircles
           names={thread.participantNames}
           anonymousCount={thread.anonymousRespondentCount}
@@ -206,7 +204,7 @@ function ThreadContent() {
       {/* Poll list — bottom-aligned within remaining space */}
       <div className="flex-1 flex flex-col justify-end">
         <div className="py-2">
-        {threadPolls.map((poll, index) => {
+        {threadPolls.map((poll) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
             const now = new Date();
             const isOpen = poll.response_deadline

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -202,7 +202,7 @@ function ThreadContent() {
       </div>
 
       {/* Scrollable poll list — bottom-aligned, vertical only */}
-      <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col justify-end">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain flex flex-col justify-end">
         <div className="py-2">
         {threadPolls.map((poll) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);

--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -31,6 +31,59 @@ export interface Thread {
 }
 
 /**
+ * Build index maps and collect descendants via BFS from a set of start IDs.
+ * Shared by buildThreads (multiple roots) and buildThreadFromPollDown (single anchor).
+ */
+function collectDescendants(
+  startIds: string[],
+  pollById: Map<string, Poll>,
+  childrenOf: Map<string, string[]>,
+  visited: Set<string>,
+): Poll[] {
+  const collected: Poll[] = [];
+  const queue = [...startIds];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    const poll = pollById.get(current);
+    if (poll) {
+      collected.push(poll);
+      const children = childrenOf.get(current) || [];
+      for (const childId of children) {
+        if (!visited.has(childId)) {
+          queue.push(childId);
+        }
+      }
+    }
+  }
+  collected.sort((a, b) =>
+    new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+  return collected;
+}
+
+/** Build pollById and childrenOf maps from a flat list of polls. */
+function buildPollMaps(polls: Poll[]): {
+  pollById: Map<string, Poll>;
+  childrenOf: Map<string, string[]>;
+} {
+  const pollById = new Map<string, Poll>();
+  for (const poll of polls) {
+    pollById.set(poll.id, poll);
+  }
+  const childrenOf = new Map<string, string[]>();
+  for (const poll of polls) {
+    if (poll.follow_up_to && pollById.has(poll.follow_up_to)) {
+      const existing = childrenOf.get(poll.follow_up_to) || [];
+      existing.push(poll.id);
+      childrenOf.set(poll.follow_up_to, existing);
+    }
+  }
+  return { pollById, childrenOf };
+}
+
+/**
  * Build threads from a flat list of polls.
  *
  * Groups polls by follow_up_to chains. Only follow_up_to relationships form
@@ -41,20 +94,7 @@ export function buildThreads(
   votedPollIds: Set<string>,
   abstainedPollIds: Set<string>,
 ): Thread[] {
-  const pollById = new Map<string, Poll>();
-  for (const poll of polls) {
-    pollById.set(poll.id, poll);
-  }
-
-  // Build parent→children map (only follow_up_to, not fork_of)
-  const childrenOf = new Map<string, string[]>();
-  for (const poll of polls) {
-    if (poll.follow_up_to && pollById.has(poll.follow_up_to)) {
-      const existing = childrenOf.get(poll.follow_up_to) || [];
-      existing.push(poll.id);
-      childrenOf.set(poll.follow_up_to, existing);
-    }
-  }
+  const { pollById, childrenOf } = buildPollMaps(polls);
 
   // Find root polls: polls whose follow_up_to is null or points to a poll
   // we don't have access to
@@ -67,41 +107,16 @@ export function buildThreads(
 
   const roots = polls.filter(p => !isChild.has(p.id));
 
-  // For each root, collect all descendants via BFS
   const visited = new Set<string>();
   const threads: Thread[] = [];
 
   for (const root of roots) {
     if (visited.has(root.id)) continue;
-
-    const threadPolls: Poll[] = [];
-    const queue = [root.id];
-    while (queue.length > 0) {
-      const current = queue.shift()!;
-      if (visited.has(current)) continue;
-      visited.add(current);
-      const poll = pollById.get(current);
-      if (poll) {
-        threadPolls.push(poll);
-        const children = childrenOf.get(current) || [];
-        for (const childId of children) {
-          if (!visited.has(childId)) {
-            queue.push(childId);
-          }
-        }
-      }
-    }
-
-    // Sort chronologically (oldest first)
-    threadPolls.sort((a, b) =>
-      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-    );
-
-    const thread = buildThreadFromPolls(threadPolls, votedPollIds, abstainedPollIds);
-    threads.push(thread);
+    const threadPolls = collectDescendants([root.id], pollById, childrenOf, visited);
+    threads.push(buildThreadFromPolls(threadPolls, votedPollIds, abstainedPollIds));
   }
 
-  // Also handle any orphaned polls not visited (shouldn't happen, but safety net)
+  // Safety net for orphaned polls
   for (const poll of polls) {
     if (!visited.has(poll.id)) {
       threads.push(buildThreadFromPolls([poll], votedPollIds, abstainedPollIds));
@@ -227,48 +242,9 @@ export function buildThreadFromPollDown(
   votedPollIds: Set<string>,
   abstainedPollIds: Set<string>,
 ): Thread | null {
-  const pollById = new Map<string, Poll>();
-  for (const poll of allPolls) {
-    pollById.set(poll.id, poll);
-  }
+  const { pollById, childrenOf } = buildPollMaps(allPolls);
+  if (!pollById.has(anchorPollId)) return null;
 
-  const anchor = pollById.get(anchorPollId);
-  if (!anchor) return null;
-
-  // Build parent→children map
-  const childrenOf = new Map<string, string[]>();
-  for (const poll of allPolls) {
-    if (poll.follow_up_to && pollById.has(poll.follow_up_to)) {
-      const existing = childrenOf.get(poll.follow_up_to) || [];
-      existing.push(poll.id);
-      childrenOf.set(poll.follow_up_to, existing);
-    }
-  }
-
-  // BFS from anchor to collect all descendants
-  const threadPolls: Poll[] = [];
-  const visited = new Set<string>();
-  const queue = [anchorPollId];
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    if (visited.has(current)) continue;
-    visited.add(current);
-    const poll = pollById.get(current);
-    if (poll) {
-      threadPolls.push(poll);
-      const children = childrenOf.get(current) || [];
-      for (const childId of children) {
-        if (!visited.has(childId)) {
-          queue.push(childId);
-        }
-      }
-    }
-  }
-
-  // Sort chronologically (oldest first)
-  threadPolls.sort((a, b) =>
-    new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-  );
-
+  const threadPolls = collectDescendants([anchorPollId], pollById, childrenOf, new Set());
   return buildThreadFromPolls(threadPolls, votedPollIds, abstainedPollIds);
 }

--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -215,3 +215,60 @@ export function findThreadByPollId(threads: Thread[], pollId: string): Thread | 
 export function getThreadRouteId(thread: Thread): string {
   return thread.polls[0].short_id || thread.polls[0].id;
 }
+
+/**
+ * Build a thread starting from a specific poll and collecting all its descendants.
+ * Used by the thread page to show "this poll + its children" rather than the
+ * full ancestor chain.
+ */
+export function buildThreadFromPollDown(
+  anchorPollId: string,
+  allPolls: Poll[],
+  votedPollIds: Set<string>,
+  abstainedPollIds: Set<string>,
+): Thread | null {
+  const pollById = new Map<string, Poll>();
+  for (const poll of allPolls) {
+    pollById.set(poll.id, poll);
+  }
+
+  const anchor = pollById.get(anchorPollId);
+  if (!anchor) return null;
+
+  // Build parent→children map
+  const childrenOf = new Map<string, string[]>();
+  for (const poll of allPolls) {
+    if (poll.follow_up_to && pollById.has(poll.follow_up_to)) {
+      const existing = childrenOf.get(poll.follow_up_to) || [];
+      existing.push(poll.id);
+      childrenOf.set(poll.follow_up_to, existing);
+    }
+  }
+
+  // BFS from anchor to collect all descendants
+  const threadPolls: Poll[] = [];
+  const visited = new Set<string>();
+  const queue = [anchorPollId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    const poll = pollById.get(current);
+    if (poll) {
+      threadPolls.push(poll);
+      const children = childrenOf.get(current) || [];
+      for (const childId of children) {
+        if (!visited.has(childId)) {
+          queue.push(childId);
+        }
+      }
+    }
+  }
+
+  // Sort chronologically (oldest first)
+  threadPolls.sort((a, b) =>
+    new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+
+  return buildThreadFromPolls(threadPolls, votedPollIds, abstainedPollIds);
+}


### PR DESCRIPTION
## Summary
- **Bottom-aligned poll list**: Thread view now shows polls anchored to the bottom of the screen (messaging style), with oldest at top and newest near the bottom bar
- **Fixed sticky header**: Thread header (back button, respondent circles, title) stays locked at the top — no scroll-away, no bounce, no horizontal drift
- **Direct thread access**: Visiting `/thread/[pollId]` registers access to the anchor poll and discovers children via follow_up_to chain — no need to pre-visit individual polls
- **Poll + descendants model**: Thread view shows the referenced poll and its follow-up children only (not ancestors), matching the intended mental model
- **Bottom bar always visible**: Scroll-to-hide behavior disabled on thread pages
- **Full-width layout**: Thread page uses same edge-to-edge margins as the home page thread list
- **Code cleanup**: Extracted shared BFS helpers (`buildPollMaps`, `collectDescendants`) in threadUtils.ts to eliminate duplication between `buildThreads` and `buildThreadFromPollDown`

## Test plan
- [ ] Open a thread URL directly (without visiting individual polls first) — should load and show polls
- [ ] Verify header stays fixed when scrolling the poll list
- [ ] Verify no horizontal scroll on the thread page
- [ ] Verify bottom bar stays visible and doesn't hide on scroll
- [ ] Verify polls are bottom-aligned (short threads show gap above, newest poll near bottom bar)
- [ ] Verify overscroll bounce only affects the poll list, not the header
- [ ] Verify home page thread list still works correctly (no regression from threadUtils refactor)

https://claude.ai/code/session_01SSte5oTxK4Uwo8kGnZjm5V