### PR TITLE
Show "New Thread" for threads with no named participants

### DIFF
--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -143,18 +143,10 @@ function buildThreadFromPolls(
   }
   const participantNames = Array.from(nameSet).sort();
 
-  // Check if any poll in the thread has received votes
-  const hasAnyVotes = polls.some(poll =>
-    (poll.response_count != null && poll.response_count > 0) ||
-    (poll.voter_names != null && poll.voter_names.length > 0)
-  );
-
-  // Build title from names, or "New Thread" if no votes yet
-  const title = !hasAnyVotes
-    ? 'New Thread'
-    : participantNames.length > 0
-      ? participantNames.join(', ')
-      : polls[0]?.title || 'Untitled';
+  // Build title from participant names, or "New Thread" if none yet
+  const title = participantNames.length > 0
+    ? participantNames.join(', ')
+    : 'New Thread';
 
   // Count unvoted polls and find soonest unvoted deadline
   const now = new Date();

--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -143,10 +143,18 @@ function buildThreadFromPolls(
   }
   const participantNames = Array.from(nameSet).sort();
 
-  // Build title from names
-  const title = participantNames.length > 0
-    ? participantNames.join(', ')
-    : polls[0]?.title || 'Untitled';
+  // Check if any poll in the thread has received votes
+  const hasAnyVotes = polls.some(poll =>
+    (poll.response_count != null && poll.response_count > 0) ||
+    (poll.voter_names != null && poll.voter_names.length > 0)
+  );
+
+  // Build title from names, or "New Thread" if no votes yet
+  const title = !hasAnyVotes
+    ? 'New Thread'
+    : participantNames.length > 0
+      ? participantNames.join(', ')
+      : polls[0]?.title || 'Untitled';
 
   // Count unvoted polls and find soonest unvoted deadline
   const now = new Date();


### PR DESCRIPTION
## Summary
- When no participants (creator or voters) have names, the thread title now shows "New Thread" instead of the first poll's title
- Previously, freshly created polls would display the poll title as the thread title, which was confusing in the threaded messaging UI

## Test plan
- [ ] Create a new poll without setting a name — home page should show "New Thread"
- [ ] Create a poll with a creator name — home page should show the creator's name
- [ ] Vote on a poll with a voter name — thread title should update to show participant names
- [ ] Verify older threads with named participants still show their names correctly