### PR TITLE
Fix thread page layout shrinking to content width

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,7 @@ whoeverwants/
 - **Bottom bar "+" auto-follows-up** when on a thread page via `document.body.getAttribute('data-thread-latest-poll-id')` — the thread page sets this attribute on mount.
 - **Shared utilities**: `lib/pollListUtils.ts` (relativeTime, getCategoryIcon, badges), `lib/votedPollsStorage.ts` (loadVotedPolls). PollList keeps its own full-featured `getResultBadge` with user-specific participation messages.
 - **Backend**: `voter_names` field on accessible polls response — extracted from already-fetched votes when possible, DB query only for remaining open polls.
+- **Thread page layout requires `w-full` on flex-col wrappers in `template.tsx`.** The thread page uses `flex-col` layouts through `pwa-safe-top` and the `max-w-4xl mx-auto` content wrapper. In flex-column layout, `mx-auto` (margin-left/right: auto) overrides the default `align-items: stretch`, causing the element to shrink to intrinsic content width instead of filling the parent. Without `w-full`, the thread header bar and poll list widths become coupled to the longest content text. Always pair `mx-auto` with `w-full` in flex-col children.
 
 ### Data Flow
 

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -709,7 +709,7 @@ function TemplateInner({ children }: AppTemplateProps) {
           paddingLeft: 'max(0.35rem, env(safe-area-inset-left))',
           paddingRight: 'max(0.35rem, env(safe-area-inset-right))',
         }}>
-        <div className={`pwa-safe-top relative ${isThreadPage ? 'flex-1 flex flex-col overflow-hidden' : ''}`}>
+        <div className={`pwa-safe-top relative ${isThreadPage ? 'w-full flex-1 flex flex-col overflow-hidden' : ''}`}>
           {/* Commit age badge - absolutely positioned so it never pushes content down when it loads.
                Uses pwa-badge-top class to sit below the safe area inset in PWA standalone mode.
                Only rendered after mount to avoid hydration mismatch — CommitInfo (in layout)
@@ -760,7 +760,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             </div>
           )}
           
-          <div className={`max-w-4xl mx-auto ${(pathname === '/' || isThreadPage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${isThreadPage ? '' : (isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'flex-1 flex flex-col overflow-hidden' : ''}`}>
+          <div className={`max-w-4xl mx-auto ${(pathname === '/' || isThreadPage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${isThreadPage ? '' : (isPollPage || isProfilePage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'} ${isThreadPage ? 'w-full flex-1 flex flex-col overflow-hidden' : ''}`}>
             {children}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Thread page header bar and poll list widths were coupled to the longest content text — short titles caused both to be narrow and centered
- Root cause: in flex-column layout, `mx-auto` (margin-left/right: auto) overrides the default `align-items: stretch`, causing wrapper elements to shrink to intrinsic content width
- Fix: added `w-full` to both the `pwa-safe-top` wrapper and the `max-w-4xl` content wrapper for thread pages, so width is always 100% of the parent

## Test plan
- [x] Created thread with short titles ("Tea?", "Cake?", "3pm?") — header and poll list both span full width
- [x] Screenshot verified on mobile viewport (430x932)
- [ ] Verify no regression on home page layout
- [ ] Verify no regression on poll page layout

https://claude.ai/code/session_01G7zQdB7kzhQLojtHwqHFkX