### PR TITLE
Fix thread view scroll: top-align polls like messaging apps

### DIFF
--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -200,7 +200,7 @@ function ThreadContent() {
       </div>
 
       {/* Scrollable poll list — bottom-aligned, vertical only */}
-      <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain flex flex-col justify-end">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
         <div className="py-2">
         {threadPolls.map((poll) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -199,7 +199,7 @@ function ThreadContent() {
         </div>
       </div>
 
-      {/* Scrollable poll list — bottom-aligned, vertical only */}
+      {/* Scrollable poll list — auto-scrolls to bottom on load */}
       <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
         <div className="py-2">
         {threadPolls.map((poll) => {


### PR DESCRIPTION
## Summary
- Remove `flex flex-col justify-end` from thread view scroll container so polls start at the top when there aren't enough to fill the screen (standard messaging app behavior)
- The existing `scrollIntoView` logic still handles auto-scrolling to the bottom when content overflows

## Test plan
- [ ] Open a thread with only 1-2 polls — polls should appear at the top with empty space below
- [ ] Open a thread with many polls — view should auto-scroll to the bottom, with older polls scrollable above

https://claude.ai/code/session_01TAeBefmn7auJEn72T5NNXF