### PR TITLE
Fix thread page safe area and disable dev rate limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -994,8 +994,14 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **Don't use `document.referrer` or `window.history.length` for navigation decisions.** `document.referrer` is unreliable (privacy settings, cross-origin, browser variations). `history.length` is cumulative across the tab's lifetime, not app-specific. Use `sessionStorage` to track in-app navigation count instead (per-tab, auto-cleared on close).
 - **In PWA standalone mode**: show back arrow if user has navigated within the app (`sessionStorage` nav count > 1), home icon if this is the entry point (deep link / first page).
 
+### scrollIntoView Pitfalls
+
+- **Never use `scrollIntoView` in nested `overflow-hidden` layouts.** `scrollIntoView` traverses ALL scrollable ancestors — including `overflow-hidden` elements, which can be scrolled programmatically even though users can't scroll them manually. In the thread page, `scrollIntoView` on a bottom anchor pushed the `pwa-safe-top` container's `scrollTop` to a non-zero value, hiding the safe area padding behind the notch. Fix: use direct `scrollTop = scrollHeight` on the specific inner scroll container ref.
+- **Non-scrollable headers in iOS PWA need `touch-action: none`** to prevent elastic rubber-banding. Even with `overflow-hidden` on all parent containers, iOS WebKit allows bounce/elastic behavior from touch gestures. Adding `touch-none` (Tailwind) to fixed header bars prevents touches on them from initiating any scroll behavior. Taps (`onClick`) still work — `touch-action` only controls default browser behaviors.
+
 ### Dev Server Pitfalls
 
+- **Dev server rate limiting is disabled** via `DISABLE_RATE_LIMIT=1` in `dev-server-manager.sh`. Dev servers are single-user, so production rate limits (120 GET/30 POST per minute) just cause friction during development.
 - **`npm run dev` spawns a process chain** (`npm` -> `next` -> `node`). Killing the parent PID doesn't reliably kill child processes holding the TCP port. After PID-based kill, always `fuser -k <port>/tcp` to clean up orphaned children — otherwise the next start gets `EADDRINUSE`.
 - **Dev server shows stale commit info** when the restart fails silently. The old process keeps serving pages. Always check `dev-server-manager.sh list` for `[STOPPED]` status after a push if the commit info doesn't update.
 

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -179,7 +179,7 @@ function ThreadContent() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Fixed thread header with back button — not scrollable */}
-      <div className="shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 pt-4 pb-2 flex items-center gap-2 overflow-hidden">
+      <div className="shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden touch-none">
         <button
           onClick={() => window.history.back()}
           className="w-10 h-10 flex items-center justify-center shrink-0"

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -129,12 +129,16 @@ function ThreadContent() {
     fetchThread();
   }, [threadId]);
 
-  // Auto-scroll to the bottom on load so newest polls are visible
-  const bottomRef = useRef<HTMLDivElement>(null);
+  // Auto-scroll to the bottom on load so newest polls are visible.
+  // Uses direct scrollTop instead of scrollIntoView — scrollIntoView traverses
+  // all ancestors (including overflow-hidden parents like pwa-safe-top) and
+  // pushes the safe area padding above the viewport on iOS PWA.
+  const scrollListRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (thread && !loading) {
       requestAnimationFrame(() => {
-        bottomRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
+        const el = scrollListRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
       });
     }
   }, [thread, loading]);
@@ -200,7 +204,7 @@ function ThreadContent() {
       </div>
 
       {/* Scrollable poll list — auto-scrolls to bottom on load */}
-      <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
+      <div ref={scrollListRef} className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
         <div className="py-2">
         {threadPolls.map((poll) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
@@ -349,8 +353,6 @@ function ThreadContent() {
           })}
         </div>
 
-        {/* Scroll anchor for auto-scroll-to-bottom */}
-        <div ref={bottomRef} />
       </div>
 
       {/* Thread-aware follow-up modal (Blank + Copy only, no Fork) */}

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -175,7 +175,7 @@ function ThreadContent() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Fixed thread header with back button — not scrollable */}
-      <div className="shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden">
+      <div className="shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 pt-4 pb-2 flex items-center gap-2 overflow-hidden">
         <button
           onClick={() => window.history.back()}
           className="w-10 h-10 flex items-center justify-center shrink-0"

--- a/scripts/dev-server-manager.sh
+++ b/scripts/dev-server-manager.sh
@@ -263,6 +263,7 @@ start_api() {
     set -a; source "$api_env_file"; set +a
   fi
 
+  DISABLE_RATE_LIMIT=1 \
   DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${db_name}" \
     "$UV_BIN" run uvicorn main:app --host 0.0.0.0 --port "$api_port" --workers 1 \
     >> "${dir}/api.log" 2>&1 200>&- &


### PR DESCRIPTION
## Summary
- **Fix thread header behind notch in PWA**: `scrollIntoView` was traversing `overflow-hidden` ancestors and pushing the `pwa-safe-top` padding above the viewport. Replaced with direct `scrollTop` on the inner scroll container.
- **Fix thread header bounce**: Added `touch-none` to the header bar so iOS doesn't initiate elastic rubber-banding from touches on it.
- **Disable rate limiting on dev servers**: Dev servers are single-user — the production rate limits (120 GET/30 POST per minute) just cause friction during development.

## Test plan
- [ ] Open a thread page in iOS PWA — header should sit below the notch, not behind it
- [ ] Drag up/down on the thread header — it should not bounce or move
- [ ] Thread page in non-PWA browser — no excess space above the header
- [ ] Thread with many polls auto-scrolls to the bottom on load
- [ ] Back button on thread header still works (touch-none doesn't block taps)
- [ ] Dev server no longer returns 429 rate limit errors during normal use

https://claude.ai/code/session_015TPnoMbBwr98VSJowjwKgW