### PR TITLE
Thread back button falls back to home on deep link

### DIFF
--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -181,7 +181,14 @@ function ThreadContent() {
       {/* Fixed thread header with back button — not scrollable */}
       <div className="shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden touch-none">
         <button
-          onClick={() => window.history.back()}
+          onClick={() => {
+            const navCount = parseInt(sessionStorage.getItem('app_nav_count') || '0', 10);
+            if (navCount > 1) {
+              window.history.back();
+            } else {
+              router.push('/');
+            }
+          }}
           className="w-10 h-10 flex items-center justify-center shrink-0"
           aria-label="Go back"
         >


### PR DESCRIPTION
## Summary
- Thread page back button now checks `sessionStorage` nav count (same mechanism as the template's back button)
- If the user navigated within the app (count > 1), goes back normally
- If the user deep-linked directly to the thread (count <= 1), navigates to home instead of leaving the site

## Test plan
- [ ] Open a thread from the home page, tap back — should go back to home
- [ ] Deep-link directly to a thread URL, tap back — should go to home (not leave the app)
- [ ] Back button still shows the `<` chevron in both cases

https://claude.ai/code/session_015TPnoMbBwr98VSJowjwKgW