### PR TITLE
Fix thread page top bar bg and sort unvoted polls to bottom

### DIFF
--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -179,7 +179,7 @@ function ThreadContent() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Fixed thread header with back button — not scrollable */}
-      <div className="shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden touch-none">
+      <div className="shrink-0 bg-background border-b border-gray-200 dark:border-gray-700 pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden touch-none">
         <button
           onClick={() => {
             const navCount = parseInt(sessionStorage.getItem('app_nav_count') || '0', 10);

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -174,15 +174,14 @@ function ThreadContent() {
     );
   }
 
-  // Sort: voted/abstained/closed polls first (chronological), then unvoted open polls at the bottom
+  const now = new Date();
+  const isPollOpen = (poll: Poll) =>
+    poll.response_deadline ? new Date(poll.response_deadline) > now && !poll.is_closed : !poll.is_closed;
+
+  // Unvoted open polls sort to bottom so they're visible on auto-scroll
   const threadPolls = [...thread.polls].sort((a, b) => {
-    const now = new Date();
-    const aIsOpen = a.response_deadline ? new Date(a.response_deadline) > now && !a.is_closed : !a.is_closed;
-    const bIsOpen = b.response_deadline ? new Date(b.response_deadline) > now && !b.is_closed : !b.is_closed;
-    const aVoted = votedPollIds.has(a.id) || abstainedPollIds.has(a.id);
-    const bVoted = votedPollIds.has(b.id) || abstainedPollIds.has(b.id);
-    const aNeedsAction = aIsOpen && !aVoted;
-    const bNeedsAction = bIsOpen && !bVoted;
+    const aNeedsAction = isPollOpen(a) && !votedPollIds.has(a.id) && !abstainedPollIds.has(a.id);
+    const bNeedsAction = isPollOpen(b) && !votedPollIds.has(b.id) && !abstainedPollIds.has(b.id);
     if (aNeedsAction !== bNeedsAction) return aNeedsAction ? 1 : -1;
     return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
   });
@@ -226,10 +225,7 @@ function ThreadContent() {
         <div className="py-2">
         {threadPolls.map((poll) => {
             const isVoted = votedPollIds.has(poll.id) || abstainedPollIds.has(poll.id);
-            const now = new Date();
-            const isOpen = poll.response_deadline
-              ? new Date(poll.response_deadline) > now && !poll.is_closed
-              : !poll.is_closed;
+            const isOpen = isPollOpen(poll);
             const isClosed = !isOpen;
 
             const handleTouchStart = (e: React.TouchEvent) => {

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -189,7 +189,7 @@ function ThreadContent() {
               router.push('/');
             }
           }}
-          className="w-10 h-10 flex items-center justify-center shrink-0"
+          className="w-10 h-10 -mr-1.5 flex items-center justify-center shrink-0"
           aria-label="Go back"
         >
           <svg className="w-6 h-6 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -174,7 +174,18 @@ function ThreadContent() {
     );
   }
 
-  const threadPolls = thread.polls;
+  // Sort: voted/abstained/closed polls first (chronological), then unvoted open polls at the bottom
+  const threadPolls = [...thread.polls].sort((a, b) => {
+    const now = new Date();
+    const aIsOpen = a.response_deadline ? new Date(a.response_deadline) > now && !a.is_closed : !a.is_closed;
+    const bIsOpen = b.response_deadline ? new Date(b.response_deadline) > now && !b.is_closed : !b.is_closed;
+    const aVoted = votedPollIds.has(a.id) || abstainedPollIds.has(a.id);
+    const bVoted = votedPollIds.has(b.id) || abstainedPollIds.has(b.id);
+    const aNeedsAction = aIsOpen && !aVoted;
+    const bNeedsAction = bIsOpen && !bVoted;
+    if (aNeedsAction !== bNeedsAction) return aNeedsAction ? 1 : -1;
+    return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+  });
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">


### PR DESCRIPTION
## Summary
- **Top bar background**: Changed from `bg-white dark:bg-gray-900` to `bg-background` so the thread header matches the app's `--background` CSS variable in both light and dark themes
- **Back arrow spacing**: Added `-mr-1.5` to reduce horizontal gap between the back arrow and respondent circle by ~30%
- **Unvoted poll sorting**: Open polls the user hasn't voted/abstained in are sorted to the bottom of the thread list, making them immediately visible since the thread auto-scrolls to the bottom on load

## Test plan
- [ ] Open a thread page in light mode — top bar background matches page background
- [ ] Open in dark mode — same, no visible color difference between header and content area
- [ ] Back arrow and respondent circle have tighter spacing
- [ ] In a thread with a mix of voted and unvoted polls, unvoted open polls appear at the bottom
- [ ] Closed/voted polls maintain chronological order among themselves

https://claude.ai/code/session_01WXZsXJAyZ7ZMdQRbD6xcmJ