### PR TITLE
Style suggested poll options as rich chips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1046,6 +1046,13 @@ bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"
 - **`line-clamp-2` breaks flex layouts**: Don't apply `line-clamp-*` to containers with flex children (like `OptionLabel`). The CSS treats flex items as flowing text and truncates unexpectedly. Use `overflow-hidden` instead and let inner components handle their own truncation.
 - **Voting Cutoff field is a shared component**: `components/VotingCutoffField.tsx` renders the inline colored-value dropdown + conditional custom date/time inputs used by every poll category in `app/create-poll/page.tsx`. Reuse it when adding new categories — don't copy-paste the JSX. The custom date/time inputs inside use ids `customDate` and `customTime`; the component assumes only one instance is rendered at a time (enforced by the mutually exclusive `category === 'time'` vs `category !== 'time'` branches).
 
+### Rich Selection Styling (Autocomplete Options)
+
+- **Options selected from autocomplete are styled as "chips"**: underlined text (Tailwind `underline decoration-blue-500/50 underline-offset-2`) and a favicon/image on the left edge (`pl-8` + absolutely positioned `<img>`). Plain-typed options have no special styling.
+- **Chip-like clear behavior**: on focus, all text is selected (`input.select()`), so backspace or any keystroke replaces the entire value. After `selectSuggestion`, `requestAnimationFrame(() => input.select())` auto-selects; on re-focus when `isRichSelection`, text is selected again.
+- **Metadata lifecycle**: `isRichSelection` is derived from `!!optionsMetadata?.[option]`. When the user edits a rich selection (any keystroke), `onRichValueCleared` fires and the parent calls `clearMetadataForOption()` to remove the metadata entry. The underline/icon disappear and the field reverts to plain text. Deleting an option via the trash button also cleans up its metadata.
+- **`clearMetadataForOption()`** in `OptionsInput.tsx` is the single helper for metadata cleanup — used by both `removeOption` and `onRichValueCleared`. Don't duplicate this pattern.
+
 ### Trim-on-Blur Policy (App-Wide)
 
 - **All text inputs trim leading/trailing whitespace on blur.** This is applied globally across the app: create-poll form fields (title, options, category, context, details), profile page (name, location), `CompactNameField`, `AutocompleteInput`, `LocationTimeFieldConfig`, and `ReferenceLocationInput`. When adding new text inputs, add `onBlur` trim handling.

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -100,10 +100,8 @@ export default function AutocompleteInput({
   }, [category, referenceLatitude, referenceLongitude, searchRadius]);
 
   const handleChange = (newValue: string) => {
-    // If the user edits a rich selection, clear its metadata
-    if (isRichSelection) {
-      onRichValueCleared?.();
-    }
+    if (isRichSelection) onRichValueCleared?.();
+
     onChange(newValue);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => doSearch(newValue), 300);
@@ -202,12 +200,8 @@ export default function AutocompleteInput({
           onKeyDown={handleKeyDown}
           disabled={disabled}
           maxLength={maxLength}
-          className={className}
+          className={`${className}${showIcon ? ' pl-8' : ''}${isRichSelection ? ' underline decoration-blue-500/50 underline-offset-2' : ''}`}
           placeholder={placeholder}
-          style={{
-            ...(showIcon ? { paddingLeft: '2rem' } : {}),
-            ...(isRichSelection ? { textDecoration: 'underline', textDecorationColor: 'rgba(59, 130, 246, 0.5)', textUnderlineOffset: '2px' } : {}),
-          }}
         />
       </div>
       {showSuggestions && suggestions.length > 0 && (

--- a/components/AutocompleteInput.tsx
+++ b/components/AutocompleteInput.tsx
@@ -18,6 +18,12 @@ interface AutocompleteInputProps {
   referenceLatitude?: number;
   referenceLongitude?: number;
   searchRadius?: number;
+  /** When the current value has associated metadata from a search selection */
+  richImageUrl?: string;
+  /** Whether the current value was selected from autocomplete (has metadata) */
+  isRichSelection?: boolean;
+  /** Called when the user edits/clears a rich selection, so parent can clean up metadata */
+  onRichValueCleared?: () => void;
 }
 
 export default function AutocompleteInput({
@@ -33,6 +39,9 @@ export default function AutocompleteInput({
   referenceLatitude,
   referenceLongitude,
   searchRadius,
+  richImageUrl,
+  isRichSelection = false,
+  onRichValueCleared,
 }: AutocompleteInputProps) {
   const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
@@ -91,6 +100,10 @@ export default function AutocompleteInput({
   }, [category, referenceLatitude, referenceLongitude, searchRadius]);
 
   const handleChange = (newValue: string) => {
+    // If the user edits a rich selection, clear its metadata
+    if (isRichSelection) {
+      onRichValueCleared?.();
+    }
     onChange(newValue);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => doSearch(newValue), 300);
@@ -101,6 +114,10 @@ export default function AutocompleteInput({
     onSelect?.(result);
     setSuggestions([]);
     setShowSuggestions(false);
+    // Select all text so backspace or any keystroke replaces the whole value
+    requestAnimationFrame(() => {
+      localInputRef.current?.select();
+    });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -152,27 +169,47 @@ export default function AutocompleteInput({
     };
   }, [showSuggestions, suggestions.length]);
 
+  const showIcon = isRichSelection && !!richImageUrl;
+
   return (
     <div ref={containerRef} className="relative">
-      <input
-        ref={(el) => {
-          localInputRef.current = el;
-          if (inputRef) inputRef(el);
-        }}
-        type="text"
-        value={value}
-        onChange={(e) => handleChange(e.target.value)}
-        onBlur={(e) => {
-          const trimmed = e.target.value.trim();
-          if (trimmed !== value) onChange(trimmed);
-        }}
-        onFocus={() => { if (suggestions.length > 0) setShowSuggestions(true); }}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        maxLength={maxLength}
-        className={className}
-        placeholder={placeholder}
-      />
+      <div className="relative">
+        {showIcon && (
+          <img
+            src={richImageUrl}
+            alt=""
+            draggable={false}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 w-5 h-5 rounded object-cover pointer-events-none z-10"
+          />
+        )}
+        <input
+          ref={(el) => {
+            localInputRef.current = el;
+            if (inputRef) inputRef(el);
+          }}
+          type="text"
+          value={value}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={(e) => {
+            const trimmed = e.target.value.trim();
+            if (trimmed !== value) onChange(trimmed);
+          }}
+          onFocus={() => {
+            if (suggestions.length > 0) setShowSuggestions(true);
+            // Select all text on focus so backspace/typing replaces the whole chip
+            if (isRichSelection) localInputRef.current?.select();
+          }}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          maxLength={maxLength}
+          className={className}
+          placeholder={placeholder}
+          style={{
+            ...(showIcon ? { paddingLeft: '2rem' } : {}),
+            ...(isRichSelection ? { textDecoration: 'underline', textDecorationColor: 'rgba(59, 130, 246, 0.5)', textUnderlineOffset: '2px' } : {}),
+          }}
+        />
+      </div>
       {showSuggestions && suggestions.length > 0 && (
         <ul ref={dropdownRef} className="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto">
           {suggestions.map((result, index) => (

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -99,6 +99,14 @@ export default function OptionsInput({
   };
 
   const removeOption = (index: number) => {
+    // Clean up metadata for the removed option
+    const removedOption = options[index];
+    if (removedOption && onMetadataChange && optionsMetadata?.[removedOption]) {
+      const newMeta = { ...optionsMetadata };
+      delete newMeta[removedOption];
+      onMetadataChange(newMeta);
+    }
+
     const newOptions = options.filter((_, i) => i !== index);
 
     // Ensure we always have at least 1 field
@@ -189,6 +197,15 @@ export default function OptionsInput({
                     referenceLatitude={referenceLatitude}
                     referenceLongitude={referenceLongitude}
                     searchRadius={searchRadius}
+                    isRichSelection={!!option && !!optionsMetadata?.[option]}
+                    richImageUrl={optionsMetadata?.[option]?.imageUrl}
+                    onRichValueCleared={() => {
+                      if (onMetadataChange && optionsMetadata?.[option]) {
+                        const newMeta = { ...optionsMetadata };
+                        delete newMeta[option];
+                        onMetadataChange(newMeta);
+                      }
+                    }}
                   />
                 </div>
               ) : (

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -98,14 +98,17 @@ export default function OptionsInput({
     onMetadataChange({ ...optionsMetadata, [result.label]: entry });
   };
 
-  const removeOption = (index: number) => {
-    // Clean up metadata for the removed option
-    const removedOption = options[index];
-    if (removedOption && onMetadataChange && optionsMetadata?.[removedOption]) {
+  const clearMetadataForOption = (optionLabel: string) => {
+    if (onMetadataChange && optionsMetadata?.[optionLabel]) {
       const newMeta = { ...optionsMetadata };
-      delete newMeta[removedOption];
+      delete newMeta[optionLabel];
       onMetadataChange(newMeta);
     }
+  };
+
+  const removeOption = (index: number) => {
+    const removedOption = options[index];
+    if (removedOption) clearMetadataForOption(removedOption);
 
     const newOptions = options.filter((_, i) => i !== index);
 
@@ -179,6 +182,7 @@ export default function OptionsInput({
           const isDuplicate = isDuplicateOption(index);
           const isLastField = index === options.length - 1;
           const canDelete = filledCount >= 1;
+          const optionMeta = optionsMetadata?.[option];
 
           return (
             <div key={index} className="flex items-start gap-2">
@@ -197,15 +201,9 @@ export default function OptionsInput({
                     referenceLatitude={referenceLatitude}
                     referenceLongitude={referenceLongitude}
                     searchRadius={searchRadius}
-                    isRichSelection={!!option && !!optionsMetadata?.[option]}
-                    richImageUrl={optionsMetadata?.[option]?.imageUrl}
-                    onRichValueCleared={() => {
-                      if (onMetadataChange && optionsMetadata?.[option]) {
-                        const newMeta = { ...optionsMetadata };
-                        delete newMeta[option];
-                        onMetadataChange(newMeta);
-                      }
-                    }}
+                    isRichSelection={!!option && !!optionMeta}
+                    richImageUrl={optionMeta?.imageUrl}
+                    onRichValueCleared={() => clearMetadataForOption(option)}
                   />
                 </div>
               ) : (


### PR DESCRIPTION
## Summary
- When a poll option is selected from autocomplete (restaurant, movie, location, etc.), the input field now shows **underlined text** and a **favicon/image on the left edge** to visually distinguish it from manually typed options
- On focus, all text is auto-selected — **backspace or any keystroke replaces the entire value** (chip-like behavior)
- Editing a rich selection clears its metadata and reverts to plain text mode
- Metadata is properly cleaned up on option delete (no orphaned entries)
- Extracted `clearMetadataForOption()` helper to deduplicate cleanup logic

## Test plan
- [ ] Create a restaurant poll → search and select a restaurant → verify underline + favicon appear in the input field
- [ ] Tap into the field after selection → verify all text is selected
- [ ] Press backspace → verify entire field clears instantly
- [ ] Type a character → verify it replaces the entire value
- [ ] After editing, verify underline/icon disappear (plain text mode)
- [ ] Delete an option via trash button → verify metadata is cleaned up
- [ ] Test with movie/location/video game categories (same behavior)
- [ ] Test selections without images (e.g., some locations) → underline appears, no icon

https://claude.ai/code/session_017zFhaaFYW7nmMT2XJjzmhk