### PR TITLE
Thread page: drop top-bar border, render polls as flat cards

### DIFF
--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -380,7 +380,7 @@ function ThreadContent() {
                   onTouchStart={handleTouchStart}
                   onTouchEnd={handleTouchEnd}
                   onTouchMove={handleTouchMove}
-                  className={`px-2 py-2 rounded-lg ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-200 dark:bg-gray-700'} hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
+                  className={`px-2 py-2 rounded-2xl ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-300 dark:bg-gray-600'} hover:bg-gray-400 dark:hover:bg-gray-500 active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
                 >
                   {/* Status line */}
                   <div className="flex items-center justify-between">

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -373,14 +373,14 @@ function ThreadContent() {
             return (
               <div
                 key={poll.id}
-                className="border-b border-gray-200 dark:border-gray-700 mx-1.5"
+                className="mx-1.5 mb-1.5"
               >
                 <div
                   onClick={goToPoll}
                   onTouchStart={handleTouchStart}
                   onTouchEnd={handleTouchEnd}
                   onTouchMove={handleTouchMove}
-                  className={`px-1 py-2.5 ${pressedPollId === poll.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''} hover:bg-gray-50 dark:hover:bg-gray-800/50 active:bg-blue-50 dark:active:bg-blue-900/30 transition-colors cursor-pointer select-none relative`}
+                  className={`px-2 py-2 rounded-lg ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-100 dark:bg-gray-800'} hover:bg-gray-200 dark:hover:bg-gray-700 active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
                 >
                   {/* Status line */}
                   <div className="flex items-center justify-between">

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -268,7 +268,7 @@ function ThreadContent() {
           no transform on mobile. */}
       <div
         ref={headerRef}
-        className="fixed left-0 right-0 z-20 bg-background border-b border-gray-200 dark:border-gray-700 touch-none"
+        className="fixed left-0 right-0 z-20 bg-background touch-none"
         style={{ top: 'env(safe-area-inset-top, 0px)' }}
       >
         <div className="max-w-4xl mx-auto pl-2 pr-4 py-2 flex items-center gap-2 overflow-hidden">

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -380,7 +380,7 @@ function ThreadContent() {
                   onTouchStart={handleTouchStart}
                   onTouchEnd={handleTouchEnd}
                   onTouchMove={handleTouchMove}
-                  className={`px-2 py-2 rounded-lg ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-100 dark:bg-gray-800'} hover:bg-gray-200 dark:hover:bg-gray-700 active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
+                  className={`px-2 py-2 rounded-lg ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-200 dark:bg-gray-700'} hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
                 >
                   {/* Status line */}
                   <div className="flex items-center justify-between">

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -380,7 +380,7 @@ function ThreadContent() {
                   onTouchStart={handleTouchStart}
                   onTouchEnd={handleTouchEnd}
                   onTouchMove={handleTouchMove}
-                  className={`px-2 py-2 rounded-2xl ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-300 dark:bg-gray-600'} hover:bg-gray-400 dark:hover:bg-gray-500 active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
+                  className={`px-2 py-2 rounded-2xl ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-[#dbdee3] dark:bg-[#414b5a]'} hover:bg-[#b7bcc5] dark:hover:bg-[#5b6472] active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
                 >
                   {/* Status line */}
                   <div className="flex items-center justify-between">

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -380,7 +380,7 @@ function ThreadContent() {
                   onTouchStart={handleTouchStart}
                   onTouchEnd={handleTouchEnd}
                   onTouchMove={handleTouchMove}
-                  className={`px-2 py-2 rounded-2xl ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-[#dbdee3] dark:bg-[#414b5a]'} hover:bg-[#b7bcc5] dark:hover:bg-[#5b6472] active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
+                  className={`px-2 py-2 rounded-2xl ${pressedPollId === poll.id ? 'bg-blue-100 dark:bg-blue-900/40' : 'bg-gray-200 dark:bg-gray-700'} hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-blue-100 dark:active:bg-blue-900/40 transition-colors cursor-pointer select-none relative`}
                 >
                   {/* Status line */}
                   <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Remove the bottom border under the fixed thread-page top bar
- Render each poll in the thread list as a flat, off-background card: `rounded-2xl`, narrow `mx-1.5 mb-1.5 / px-2 py-2`, `bg-gray-200 dark:bg-gray-700` with `hover:bg-gray-300 dark:hover:bg-gray-600` and the existing pressed-blue state

## Test plan
- [ ] Thread page: top bar has no bottom divider
- [ ] Each poll in the thread list appears as a rounded off-bg card in both light and dark mode
- [ ] Hover and press (tap) states still show darker/blue feedback
- [ ] Long-press still opens the follow-up modal; tap still navigates to the poll

https://claude.ai/code/session_01UfMNUTk3dgDZdHiMEwHJBu