### PR TITLE
Thread card expand polish: bottom scroll gap + remove divider

### DIFF
--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -301,9 +301,6 @@ export function ThreadContent({ threadId, initialExpandedPollId = null }: Thread
       !hasHandledInitialExpandRef.current &&
       expandedPollId === initialExpandedPollId;
 
-    // Extra gap below the card so its bottom isn't flush with the viewport edge.
-    // Capped by the available slack (same logic as the overshoot itself), so we
-    // never push the compact header above the top bar to add the gap.
     const BOTTOM_GAP = 12;
 
     let targetDelta = 0;

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -301,14 +301,19 @@ export function ThreadContent({ threadId, initialExpandedPollId = null }: Thread
       !hasHandledInitialExpandRef.current &&
       expandedPollId === initialExpandedPollId;
 
+    // Extra gap below the card so its bottom isn't flush with the viewport edge.
+    // Capped by the available slack (same logic as the overshoot itself), so we
+    // never push the compact header above the top bar to add the gap.
+    const BOTTOM_GAP = 12;
+
     let targetDelta = 0;
     if (isInitialExpand) {
       targetDelta = cardTopY - visibleTopY;
       hasHandledInitialExpandRef.current = true;
     } else if (cardTopY < visibleTopY) {
       targetDelta = cardTopY - visibleTopY;
-    } else if (finalCardBottomY > visibleBottomY) {
-      const overshoot = finalCardBottomY - visibleBottomY;
+    } else if (finalCardBottomY + BOTTOM_GAP > visibleBottomY) {
+      const overshoot = finalCardBottomY + BOTTOM_GAP - visibleBottomY;
       const slack = cardTopY - visibleTopY;
       targetDelta = Math.min(overshoot, slack);
     }

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -704,7 +704,7 @@ export function ThreadContent({ threadId, initialExpandedPollId = null }: Thread
                           else expandedWrapperRefs.current.delete(poll.id);
                         }}
                       >
-                        <div className="mt-3 pt-3 border-t border-gray-300 dark:border-gray-600">
+                        <div className="mt-3">
                           <PollPageClient
                             poll={poll}
                             createdDate={formatCreationTimestamp(poll.created_at)}


### PR DESCRIPTION
## Summary
- Leave a 12px gap below an expanded poll card when scrolling into view, so its bottom isn't flush with the viewport edge. Capped by the existing slack above so the compact header still never goes behind the fixed top bar.
- Drop the horizontal divider (`border-t` + `pt-3`) between the compact card header and the expanded `PollPageClient` body. The `mt-3` gap alone is enough to delineate the two regions.

## Test plan
- [ ] Tap a card near the viewport bottom — card expands and page scrolls so there's a small gap below the card, not flush against the bottom edge.
- [ ] Tap a card with no room below — it still expands without pushing the compact header above the top bar.
- [ ] Tap a card near the top — it expands in place without extraneous scrolling.
- [ ] Expanded card no longer shows a horizontal divider line between the compact header and the expanded content.

https://claude.ai/code/session_01X8u6bzhNveeLCA68g2cn9W