### PR TITLE
Move &quot;Expired on &lt;date&gt;&quot; text from expanded card to long-press modal

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -35,7 +35,7 @@ import PollDetails from "@/components/PollDetails";
 import SubPollField from "@/components/SubPollField";
 import SearchRadiusBubble from "@/components/SearchRadiusBubble";
 import { loadBallotDraft, saveBallotDraft, clearBallotDraft, BallotDraft } from "@/lib/ballotDraft";
-import { windowDurationMinutes, formatDurationLabel, formatTimeSlot, isVoterAvailableForSlot } from "@/lib/timeUtils";
+import { windowDurationMinutes, formatDurationLabel, formatTimeSlot, isVoterAvailableForSlot, formatShortDateTime } from "@/lib/timeUtils";
 import { isLocationLikeCategory } from "@/components/TypeFieldInput";
 
 interface PollPageClientProps {
@@ -1568,36 +1568,14 @@ export default function PollPageClient({ poll, createdDate, pollId }: PollPageCl
             return (
               <div className="mb-3 text-center">
                 <span className="text-sm font-bold text-red-700 dark:text-red-300">
-                  Closed manually on {closedDate.toLocaleString("en-US", {
-                    month: "numeric",
-                    day: "numeric",
-                    year: "2-digit",
-                    hour: "numeric",
-                    minute: "2-digit",
-                    hour12: true
-                  })}
+                  Closed manually on {formatShortDateTime(closedDate)}
                 </span>
               </div>
             );
           }
-          
-          // Case 3: Poll expired and is closed
-          if (isPollClosed && isExpired) {
-            return (
-              <div className="mb-3 text-center">
-                <span className="text-sm font-bold text-red-700 dark:text-red-300">
-                  Expired on {deadline.toLocaleString("en-US", {
-                    month: "numeric",
-                    day: "numeric",
-                    year: "2-digit",
-                    hour: "numeric",
-                    minute: "2-digit",
-                    hour12: true
-                  })}
-                </span>
-              </div>
-            );
-          }
+
+          // Case 3 (expired + closed) renders nothing here — the
+          // "Expired on <date>" label is surfaced in the long-press modal.
 
           // Case 4: Poll open, not expired. Live countdown is rendered
           // above the card in the thread view; only deferred-deadline

--- a/components/FollowUpModal.tsx
+++ b/components/FollowUpModal.tsx
@@ -6,6 +6,7 @@ import ModalPortal from "@/components/ModalPortal";
 import FollowUpHeader from "@/components/FollowUpHeader";
 import { Poll } from "@/lib/types";
 import { buildPollSnapshot } from "@/lib/pollCreator";
+import { formatShortDateTime } from "@/lib/timeUtils";
 
 interface FollowUpModalProps {
   isOpen: boolean;
@@ -45,6 +46,11 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes, showF
     total_votes: totalVotes,
   };
 
+  const deadline = poll.response_deadline ? new Date(poll.response_deadline) : null;
+  const expiredText = deadline && deadline <= new Date()
+    ? `Expired on ${formatShortDateTime(deadline)}`
+    : null;
+
   return (
     <ModalPortal>
       {/* Backdrop */}
@@ -56,6 +62,13 @@ export default function FollowUpModal({ isOpen, poll, onClose, totalVotes, showF
       {/* Modal */}
       <div className="fixed bottom-0 left-0 right-0 z-[110] animate-slide-up">
         <div className="bg-white dark:bg-gray-800 rounded-t-2xl shadow-xl p-6 pb-8">
+          {expiredText && (
+            <div className="mb-4 text-center">
+              <span className="text-sm font-bold text-red-700 dark:text-red-300">
+                {expiredText}
+              </span>
+            </div>
+          )}
           <div className="flex gap-3">
             <button
               onClick={() => {

--- a/lib/timeUtils.ts
+++ b/lib/timeUtils.ts
@@ -49,6 +49,18 @@ export function formatCreationTimestamp(iso: string): string {
   return `@ ${t} ${d}`;
 }
 
+/** Compact date-time for poll close/expire messages — e.g. "4/18/26, 12:30 AM". */
+export function formatShortDateTime(date: Date): string {
+  return date.toLocaleString("en-US", {
+    month: "numeric",
+    day: "numeric",
+    year: "2-digit",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
 // --- Time slot helpers (slot format: "YYYY-MM-DD HH:MM-HH:MM") ---
 
 /** Parse slot start time → {h, m} */


### PR DESCRIPTION
## Summary
- Removed the `Expired on <date>` label that rendered at the top of an expanded poll card (Case 3 of the status block in `PollPageClient`) and surfaced it in the `FollowUpModal` (long-press) instead.
- Extracted the shared short date-time format used for close/expire messages into `formatShortDateTime` in `lib/timeUtils.ts`; both the "Closed manually on" case in `PollPageClient` and the new modal text use it.

## Test plan
- [ ] Open a thread containing an expired closed poll; expanded card no longer shows the "Expired on …" line.
- [ ] Long-press the same card; the modal shows "Expired on &lt;date&gt;" above the Copy/Fork/Forget row.
- [ ] Manually closed (non-expired) polls still show "Closed manually on &lt;date&gt;" inside the card.
- [ ] Open polls continue to show countdowns/deferred-deadline notices where expected.