### PR TITLE
Cancel ballot edit when thread card collapses

### DIFF
--- a/app/p/[shortId]/PollPageClient.tsx
+++ b/app/p/[shortId]/PollPageClient.tsx
@@ -42,9 +42,13 @@ interface PollPageClientProps {
   // caller (thread view) is rendering them in a stable DOM position above
   // the expand clip to avoid winner-card flicker across expand/collapse.
   externalYesNoResults?: boolean;
+  // Thread-view cards pre-mount PollPageClient in a collapsed grid clip.
+  // When the card collapses while the ballot is being edited, we cancel
+  // the edit so it doesn't persist for the next expansion.
+  isExpanded?: boolean;
 }
 
-export default function PollPageClient({ poll, createdDate, pollId, externalYesNoResults }: PollPageClientProps) {
+export default function PollPageClient({ poll, createdDate, pollId, externalYesNoResults, isExpanded = true }: PollPageClientProps) {
   // Set the page title in the template header
   usePageTitle(poll.title);
 
@@ -102,6 +106,13 @@ export default function PollPageClient({ poll, createdDate, pollId, externalYesN
   const [isLoadingVoteData, setIsLoadingVoteData] = useState(false);
   const [isEditingVote, setIsEditingVote] = useState(false); // For suggestion editing
   const [isEditingRanking, setIsEditingRanking] = useState(false); // For ranking editing (independent)
+
+  useEffect(() => {
+    if (!isExpanded) {
+      setIsEditingVote(false);
+      setIsEditingRanking(false);
+    }
+  }, [isExpanded]);
   const [hasPollDataState, setHasPollDataState] = useState(false);
   const [currentTime, setCurrentTime] = useState<Date | null>(null);
   // Options the user saw when they last voted — used to detect newly added suggestions

--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -1044,6 +1044,7 @@ export function ThreadContent({ threadId, initialExpandedPollId = null }: Thread
                               createdDate={formatCreationTimestamp(poll.created_at)}
                               pollId={poll.id}
                               externalYesNoResults={poll.poll_type === 'yes_no'}
+                              isExpanded={isExpanded}
                             />
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- Collapsing an expanded thread card while the ballot is being edited now drops edit mode, so the next expansion opens in view mode.
- Wired via a new `isExpanded` prop on `PollPageClient`; a `useEffect` clears `isEditingVote` / `isEditingRanking` when it flips false.

## Test plan
- [ ] Expand a ranked_choice card, tap "Your Ballot" to enter edit mode, collapse the card, re-expand — should open in view mode with "Your Ballot" button.
- [ ] Repeat for a suggestion-phase poll (edit suggestions).
- [ ] Submitting an edit still collapses edit mode normally (no regression).
- [ ] Non-thread usage unaffected (`isExpanded` defaults to `true`).

https://claude.ai/code/session_012qokE95VcUb3mxXwM8D4Bw

---
_Generated by [Claude Code](https://claude.ai/code/session_012qokE95VcUb3mxXwM8D4Bw)_