### PR TITLE
Simplify yes/no compact summary: leader count only, tighter spacing

### DIFF
--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -141,7 +141,7 @@ function YesNoResults({ results, isPollClosed, userVoteData, onFollowUpClick, hi
       return null;
     }
     return (
-      <div className="flex items-center justify-end gap-2">
+      <div className="flex items-center justify-end gap-[0.3rem]">
         <span className={`inline-block px-3 py-0.5 rounded-full border text-sm font-bold ${winnerPillColors}`}>
           {winnerLabel}
         </span>

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -141,7 +141,7 @@ function YesNoResults({ results, isPollClosed, userVoteData, onFollowUpClick, hi
       return null;
     }
     return (
-      <div className="flex items-center justify-end gap-[0.3rem]">
+      <div className="flex items-center justify-end gap-[0.2rem]">
         <span className={`inline-block px-3 py-0.5 rounded-full border text-sm font-bold ${winnerPillColors}`}>
           {winnerLabel}
         </span>

--- a/components/PollResults.tsx
+++ b/components/PollResults.tsx
@@ -149,7 +149,7 @@ function YesNoResults({ results, isPollClosed, userVoteData, onFollowUpClick, hi
           {winnerPct}%
         </span>
         <span className="text-xs tabular-nums text-gray-500 dark:text-gray-400">
-          {winnerCount} / {totalVotes} votes
+          ({winnerCount})
         </span>
       </div>
     );


### PR DESCRIPTION
## Summary
- Yes/no compact pill in thread cards now shows just the leader's vote count in parentheses instead of `X / Y votes`.
- Reduced the flex gap around the percent from `0.5rem` to `0.2rem` so the winner pill, percent, and count sit closer together.

## Test plan
- [ ] Open a thread with a yes/no poll that has votes and confirm the collapsed card shows `Yes  85%  (17)` (pill / percent / count) with tight spacing.
- [ ] Expand the card and confirm the fuller results view still shows the `(count)` / `%` pair per side unchanged.
- [ ] Poll with no votes still renders nothing in the compact slot (no regression on the empty-state guard).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuN3EWZSG4Vhat2QzGExsZ)_