### PR TITLE
Phase 1: multipoll schema and creation API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -785,7 +785,9 @@ The algorithm uses a **greedy selection with priority ordering**:
 
 ## Multipoll System (In Progress)
 
-**Status**: design locked, not yet implemented. Branch: `claude/multi-poll-creation-redesign-l0UOz`. Captures the decisions from the design conversation so future sessions can reference them without re-asking.
+**Status**: phasing plan in `docs/multipoll-phasing.md`. **Phase 1 (schema + new API) is implemented** on `claude/multipoll-implementation-2fXmI` — migration 092 creates the `multipolls` table and adds nullable `multipoll_id` + `sub_poll_index` to `polls`; new endpoints `POST /api/multipolls`, `GET /api/multipolls/{short_id}`, `GET /api/multipolls/by-id/{id}` create + read wrapper-and-sub-polls atomically. Validation rejects participation sub-polls, multiple `time` sub-polls, and same-kind sub-polls without distinct `context`. Auto-title is computed at read time from sub-poll categories + multipoll context (rules in `server/algorithms/multipoll_title.py`); explicit titles persist to `thread_title`. **No frontend changes yet** — single-poll codepaths and the existing `POST /api/polls` endpoint are untouched, and existing polls keep `multipoll_id IS NULL` indefinitely. Phases 2–5 are sketched in the doc.
+
+This section captures the design decisions from the original conversation so future sessions can reference them without re-asking.
 
 ### Core paradigm
 
@@ -1071,9 +1073,11 @@ SQL migration files live in `database/migrations/` (001-064, up + down). All 64 
 # Apply a new migration on the droplet
 bash scripts/remote.sh "docker exec -i whoeverwants-db-1 psql -U whoeverwants whoeverwants < /root/whoeverwants/database/migrations/065_description_up.sql" /root/whoeverwants
 
-# Verify migration applied
-bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c 'SELECT * FROM _migrations ORDER BY id DESC LIMIT 5;'"
+# Verify migration applied — query by FILENAME, not by `_migrations.id`
+bash scripts/remote.sh "docker exec whoeverwants-db-1 psql -U whoeverwants -c \"SELECT id, filename FROM _migrations WHERE filename LIKE '065_%'\""
 ```
+
+- **`_migrations.id` is a serial row counter, not the migration number.** `SELECT id FROM _migrations` returns sequence values like `1, 2, ..., 104` that have nothing to do with the `NNN_` prefix on the filename. Querying for "is migration 092 applied?" by `WHERE id = 92` is wrong (and will silently mislead — there *is* always an `id=92` once enough migrations have run). Always check `filename LIKE 'NNN_%'`. The only correct use of `_migrations.id` is `ORDER BY id DESC` to see recently-applied filenames.
 
 ### Writing New Migrations
 

--- a/database/migrations/092_create_multipolls_down.sql
+++ b/database/migrations/092_create_multipolls_down.sql
@@ -1,0 +1,11 @@
+-- Reverse migration 092.
+
+DROP INDEX IF EXISTS idx_polls_multipoll_id;
+ALTER TABLE polls DROP COLUMN IF EXISTS sub_poll_index;
+ALTER TABLE polls DROP COLUMN IF EXISTS multipoll_id;
+
+DROP TRIGGER IF EXISTS trigger_generate_multipoll_short_id ON multipolls;
+DROP TRIGGER IF EXISTS update_multipolls_updated_at ON multipolls;
+DROP FUNCTION IF EXISTS generate_multipoll_short_id();
+
+DROP TABLE IF EXISTS multipolls;

--- a/database/migrations/092_create_multipolls_up.sql
+++ b/database/migrations/092_create_multipolls_up.sql
@@ -1,0 +1,87 @@
+-- Create multipolls table (Phase 1 of multipoll redesign).
+-- Migration: 092_create_multipolls
+--
+-- Phase 1 stands up the wrapper table + new columns on `polls`. No data is
+-- migrated; existing polls keep multipoll_id IS NULL and continue to use the
+-- legacy single-poll codepath. Phase 4 will backfill.
+--
+-- See docs/multipoll-phasing.md for the full plan.
+
+-- ---------------------------------------------------------------------------
+-- multipolls: wrapper-level fields
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS multipolls (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  sequential_id SERIAL UNIQUE,
+  short_id TEXT UNIQUE,
+  creator_secret TEXT NOT NULL,
+  creator_name TEXT,
+  response_deadline TIMESTAMPTZ,
+  prephase_deadline TIMESTAMPTZ,
+  prephase_deadline_minutes INT,
+  is_closed BOOLEAN NOT NULL DEFAULT FALSE,
+  close_reason TEXT,
+  follow_up_to UUID REFERENCES multipolls(id) ON DELETE SET NULL,
+  fork_of UUID REFERENCES multipolls(id) ON DELETE SET NULL,
+  thread_title TEXT,
+  context TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Auto-update updated_at via the existing project-wide trigger function.
+DROP TRIGGER IF EXISTS update_multipolls_updated_at ON multipolls;
+CREATE TRIGGER update_multipolls_updated_at
+  BEFORE UPDATE ON multipolls
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Auto-generate base62 short_id from sequential_id, mirroring the polls table.
+CREATE OR REPLACE FUNCTION generate_multipoll_short_id()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.short_id IS NULL AND NEW.sequential_id IS NOT NULL THEN
+    NEW.short_id := encode_base62(NEW.sequential_id);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_generate_multipoll_short_id ON multipolls;
+CREATE TRIGGER trigger_generate_multipoll_short_id
+  BEFORE INSERT OR UPDATE ON multipolls
+  FOR EACH ROW
+  EXECUTE FUNCTION generate_multipoll_short_id();
+
+CREATE INDEX IF NOT EXISTS idx_multipolls_short_id ON multipolls(short_id);
+CREATE INDEX IF NOT EXISTS idx_multipolls_follow_up_to ON multipolls(follow_up_to);
+CREATE INDEX IF NOT EXISTS idx_multipolls_fork_of ON multipolls(fork_of);
+
+-- Match the existing polls RLS posture: anonymous read + write, with mutation
+-- gated at the application layer via creator_secret.
+ALTER TABLE multipolls ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow public read access on multipolls" ON multipolls;
+CREATE POLICY "Allow public read access on multipolls" ON multipolls
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Allow public insert access on multipolls" ON multipolls;
+CREATE POLICY "Allow public insert access on multipolls" ON multipolls
+  FOR INSERT WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Allow public update access on multipolls" ON multipolls;
+CREATE POLICY "Allow public update access on multipolls" ON multipolls
+  FOR UPDATE USING (true) WITH CHECK (true);
+
+-- ---------------------------------------------------------------------------
+-- polls: link sub-polls to their wrapper
+-- ---------------------------------------------------------------------------
+--
+-- Both columns are nullable in Phase 1: existing rows have no wrapper. Phase 4
+-- will backfill non-participation polls and the columns can be tightened then.
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS multipoll_id UUID
+  REFERENCES multipolls(id) ON DELETE CASCADE;
+ALTER TABLE polls ADD COLUMN IF NOT EXISTS sub_poll_index INT;
+
+CREATE INDEX IF NOT EXISTS idx_polls_multipoll_id ON polls(multipoll_id);

--- a/docs/multipoll-phasing.md
+++ b/docs/multipoll-phasing.md
@@ -1,0 +1,214 @@
+# Multipoll Redesign — Phasing Plan
+
+This document breaks the multipoll redesign (see CLAUDE.md → "Multipoll System (In Progress)") into discrete, shippable phases. Phase 1 is fully specified here; later phases are sketched and will be refined when their turn comes.
+
+The guiding principle: **every phase leaves `main` shippable**. Existing polls keep working through every step. The destructive cutover (migrating existing polls into multipoll wrappers) happens late, only after the new code paths have been exercised on freshly-created multipolls in production.
+
+---
+
+## Schema strategy (applies across phases)
+
+Rather than introduce a new `sub_polls` table that duplicates `polls`, we treat the existing `polls` table as **the sub-poll table** and add a new `multipolls` table for the wrapper-level fields. Each row in `polls` gains an `multipoll_id` FK pointing to its wrapper. A wrapper with one sub-poll renders identically to today's single-poll view (the wrapper is invisible).
+
+### Wrapper-level fields (move to `multipolls`)
+
+These currently live on `polls` and apply to the whole multipoll, not any one sub-poll:
+
+| Column | Notes |
+|---|---|
+| `id` (uuid, pk) | New uuid. Not the same as any poll id. |
+| `short_id` (text, unique) | Moves off `polls`. URL targets the multipoll, not a sub-poll. |
+| `creator_secret` (uuid) | One secret for the whole multipoll. |
+| `creator_name` (text, nullable) | |
+| `response_deadline` (timestamptz) | The voting cutoff. |
+| `prephase_deadline` (timestamptz, nullable) | Shared suggestion/availability cutoff. |
+| `prephase_deadline_minutes` (int, nullable) | For deferred prephase timing (mirrors current `suggestion_deadline_minutes`). |
+| `is_closed` (bool) | |
+| `close_reason` (text, nullable) | `'manual' \| 'deadline' \| 'max_capacity' \| 'uncontested'`. |
+| `follow_up_to` (uuid → multipolls.id, nullable) | Threads = chains of multipolls. |
+| `fork_of` (uuid → multipolls.id, nullable) | |
+| `thread_title` (text, nullable) | User override; inherited from `follow_up_to`'s `thread_title` via the same `COALESCE` insert pattern as today. |
+| `context` (text, nullable) | Optional whole-multipoll context (replaces today's `details` for the wrapper level). |
+| `created_at` / `updated_at` | |
+
+### Sub-poll-level fields (stay on `polls`)
+
+These are per-sub-poll and never need to be lifted to the wrapper:
+
+| Column | Notes |
+|---|---|
+| `id`, `poll_type`, `category`, `options`, `options_metadata` | |
+| `details` | Per-sub-poll context label (e.g. disambiguating two `Where` sub-polls). |
+| `multipoll_id` (uuid → multipolls.id) | New, NOT NULL after Phase 4. Nullable during the dual-mode phases so legacy single polls still work. |
+| `sub_poll_index` (int) | Display order within the multipoll. |
+| Type-specific fields | `suggestion_deadline_minutes`, `min_availability_percent`, time-poll fields, etc. The `suggestion_deadline` *value* moves to the multipoll level (shared); the *minutes* stay per-sub-poll only because different sub-poll types may compute it differently — but in practice all prephase-bearing sub-polls in a multipoll resolve to the same cutoff. **TBD in Phase 3:** whether `*_minutes` consolidates onto the multipoll. |
+
+### Fields that get retired (later)
+
+By Phase 5, the following can be dropped from `polls` because the multipoll owns them:
+`short_id`, `creator_secret`, `creator_name`, `response_deadline`, `is_closed`, `close_reason`, `follow_up_to`, `fork_of`, `thread_title`, `suggestion_deadline`. Don't drop them earlier — old code paths still read them.
+
+### Why participation polls are excluded
+
+Per CLAUDE.md → "Participation Polls (Deprecated)", participation polls don't get wrapped. They keep their own row in `polls` with `multipoll_id = NULL` forever. Phase 4's backfill explicitly skips `poll_type = 'participation'`.
+
+---
+
+## Phase 1 — Foundation (this phase)
+
+**Goal**: stand up the `multipolls` table and the new API endpoints. No frontend changes. No migration of existing data. Existing single-poll codepaths are untouched. The new API works end-to-end so Phase 2 can build a UI against it.
+
+### What's in scope
+
+1. **One up/down migration** (next number `092`):
+   - Create `multipolls` table with the columns above. All wrapper-level fields are NULLABLE except `id`, `short_id`, `creator_secret`, `created_at`, `updated_at` to allow flexible test-data shapes. RLS policies match those on `polls` (anon read, anon write; row-level access via `creator_secret` for mutations).
+   - Add `multipoll_id` (uuid, nullable, FK → multipolls.id ON DELETE CASCADE) and `sub_poll_index` (int, nullable) to `polls`. Both nullable in Phase 1 — existing polls have NULL.
+   - Backfill is **out of scope** for this migration. Existing polls keep `multipoll_id IS NULL`.
+   - Down migration: drop the FK and the new columns from `polls`, drop `multipolls`. Pure additive — fully reversible.
+2. **Pydantic models** (`server/models.py`):
+   - `CreateMultipollRequest` — wrapper fields + `sub_polls: list[CreateSubPollRequest]` (1+).
+   - `CreateSubPollRequest` — every per-sub-poll field from the existing `CreatePollRequest` *except* the wrapper-level ones, plus optional per-sub-poll `context`.
+   - `MultipollResponse` — wrapper fields + `sub_polls: list[PollResponse]`.
+3. **Endpoints** (`server/routers/polls.py` or a new `server/routers/multipolls.py`):
+   - `POST /api/multipolls` — creates one multipoll row + N poll rows in a single transaction. Returns the `MultipollResponse` plus the existing per-sub-poll `PollResponse` shape so the frontend can keep using the existing read paths.
+   - `GET /api/multipolls/{short_id}` — returns the multipoll wrapper + sub-polls, ordered by `sub_poll_index`.
+   - `GET /api/multipolls/by-id/{multipoll_id}` — same as above by uuid.
+   - **Auto-title**: `POST /api/multipolls` accepts an optional `title` and, when absent, computes one from `(sub_poll.category for sub_poll in sub_polls)` joined in title case (algorithm: see "Auto-title rules" below). Persisted to `multipolls.thread_title` only when explicitly provided; otherwise re-computed at read time so re-arranging sub-polls re-titles for free. **No new `multipolls.title` column.** The thread card already auto-titles from participants + thread_title; multipolls extend that with category-based titles.
+   - **Validation**:
+     - At least 1 sub-poll.
+     - At most one sub-poll of `poll_type = 'time'` (a single shared availability phase has only one time sub-poll).
+     - Multiple sub-polls of the same kind require distinct `context` strings.
+     - **Reject** `poll_type = 'participation'` sub-polls — multipoll system excludes them.
+     - `prephase_deadline < response_deadline` when both are set.
+4. **Tests** (`server/tests/`):
+   - Unit: title generator, sub-poll validators, transaction rollback on bad sub-poll input.
+   - Integration: create single-sub-poll multipoll → `GET` returns it; create 3-sub-poll multipoll (e.g. one What, one When, one Where) → `GET` returns all 3 in order; create-with-bad-input rolls back atomically (no orphan polls).
+   - **No coverage of voting, results, or thread aggregation in Phase 1.** Each sub-poll inherits the existing single-poll vote/results endpoints unchanged.
+5. **No frontend changes.** `lib/api.ts` may add `apiCreateMultipoll` / `apiGetMultipoll` helpers if convenient, but no component or page uses them yet.
+
+### Auto-title rules
+
+Pure function `generate_multipoll_title(sub_polls, multipoll_context) -> str`. Lives in `server/algorithms/multipoll_title.py` so it can be unit-tested.
+
+- Input: ordered list of sub-poll category strings (e.g. `["restaurant", "time"]`) + optional multipoll-level context (e.g. `"Birthday"`).
+- Output rules (deterministic, locked here so frontend Phase 2 can mirror them):
+  - 1 sub-poll, no context → use the sub-poll's existing single-poll auto-title (`"Restaurant?"`, `"Time?"`, etc.).
+  - 1 sub-poll + context → `"<Category> for <Context>"` (e.g. `"Restaurant for Birthday"`).
+  - 2+ sub-polls, no context → `"<A> and <B>"` (2) or `"<A>, <B>, and <C>"` (3+), title-cased.
+  - 2+ sub-polls + context → above + ` for <Context>` (e.g. `"Restaurant and Time for Birthday"`).
+- Categories are mapped to titlecase display labels via the same lookup the frontend already uses (TBD: extract `BUILT_IN_TYPES` labels from `components/TypeFieldInput.tsx` into a backend-shared JSON or duplicate). For Phase 1, hardcode the eight common labels (`yes/no`, `restaurant`, `location`, `time`, `movie`, `videogame`, `petname`, `custom`) and fall back to title-cased `category` string for unknowns.
+
+### Out of scope for Phase 1
+
+- Frontend What/When/Where buttons.
+- Dual-modal create flow.
+- Multi-sub-poll voting (single Submit, per-sub-poll abstain).
+- Thread card aggregation (one card per multipoll instead of per poll).
+- Migration of existing polls.
+- Moving `follow_up_to` / `fork_of` to multipolls.
+- Any change to how votes, results, close/reopen, or threading work for legacy single polls.
+
+### Risk / rollback
+
+- All schema changes are additive. The down migration cleanly removes them.
+- New endpoints are net-new; no existing route changes behavior.
+- The whole phase can be reverted by `git revert` + running the down migration.
+
+### Done criteria
+
+- Migration `092` applied on dev + production droplets.
+- `POST /api/multipolls` + `GET /api/multipolls/{short_id}` + `GET /api/multipolls/by-id/{id}` all green in `server/tests/`.
+- A `curl` against the dev API can create a 3-sub-poll multipoll and read it back. Demo this in the PR description.
+- Existing E2E suite still passes.
+
+---
+
+## Phase 2 — Frontend creation flow
+
+**Goal**: users start creating multipolls via the new What/When/Where bubbles. New polls go through `POST /api/multipolls`. Old polls continue to render via the existing single-poll codepath.
+
+### Scope sketch
+
+- Replace single `+` FAB on home + thread pages with **What / When / Where** bubble buttons (equally spaced along the bottom).
+- Each bubble opens the dual-modal sheet (top: sub-poll category + options + per-sub-poll context; bottom: shared multipoll context + voting cutoff + optional prephase cutoff).
+- Top modal's checkmark commits the sub-poll into a draft slot. The What/When/Where buttons reappear so the user can add more.
+- localStorage draft persistence (per-tab, per-device).
+- Submit calls `POST /api/multipolls`; on success, navigate to `/p/<multipoll_short_id>/`.
+- **The thread/poll page reads via `GET /api/multipolls/by-id/{...}`** when the multipoll wrapper exists; otherwise falls through to the existing single-poll path. This means voting/results/close/reopen still flow through the per-sub-poll endpoints — Phase 2 doesn't unify those yet.
+- 1-sub-poll multipolls render identically to today's polls (the wrapper is invisible).
+- Backwards-compat: every existing `+`-button entry point (Follow-Up, Fork, Duplicate, "Vote on it", thread-page FAB) is replaced with the new bubble UI.
+
+### Open questions for Phase 2
+
+- How do Follow-Up / Fork / Duplicate compose with the new What/When/Where flow? Likely: each of those auto-fills a single What sub-poll matching the source poll's category, and the user can add more sub-polls before submitting.
+- Does the bottom modal "shared prephase cutoff" only show when at least one of the staged sub-polls has a prephase? (Probably yes — if the only sub-poll is a yes/no, no prephase cutoff is needed.)
+- Pre-existing pollCache / accessiblePollsCache invalidation when the new endpoint is the source of truth.
+
+---
+
+## Phase 3 — Voting + multipoll-level operations unified
+
+**Goal**: voting, results, close/reopen, follow-up/fork all operate at the multipoll level.
+
+### Scope sketch
+
+- Single `POST /api/multipolls/{id}/votes` accepts an array of `{sub_poll_id, ...vote payload}` plus a single `voter_name` and per-sub-poll `is_abstain`.
+- The thread card displays one card per multipoll. Each sub-poll renders inside the card with its `context` label. There's one Submit at the bottom.
+- Compact previews stack one per sub-poll inside the card footer row.
+- `multipolls.is_closed` becomes the source of truth for "is this poll open"; existing per-poll `is_closed` continues to be written to keep legacy code working until Phase 5.
+- Long-press modal (Forget / Reopen / Close / End Pre-Phase) targets the multipoll, not any single sub-poll.
+- Multipoll-level `follow_up_to` and `fork_of` are introduced — the new bubble FAB on a thread page sets them.
+- Cache layer updates: `pollCache.ts` adds a `multipollCache` keyed by short_id; getAccessiblePolls returns multipolls.
+
+### Migration concern
+
+By the end of Phase 3, two write paths exist for any given user action:
+1. New polls (created in Phase 2+) live as multipolls; voting/closing operates at the multipoll level.
+2. Old polls (created before Phase 2) live as standalone `polls` rows with no multipoll wrapper; voting/closing still uses the per-poll endpoints.
+
+The frontend needs to handle both. A simple way: if `poll.multipoll_id` is set, use multipoll-level endpoints; else use legacy endpoints. The thread list and poll page already deal with mixed state via `lib/threadUtils.ts`.
+
+---
+
+## Phase 4 — Backfill existing polls
+
+**Goal**: every non-participation poll has a multipoll wrapper. The legacy single-poll codepath can be deleted.
+
+### Scope sketch
+
+- One-shot data migration (next available migration number, `093` or higher):
+  - For every poll with `multipoll_id IS NULL` and `poll_type != 'participation'`:
+    - Insert a multipoll row, copying wrapper-level fields from the poll.
+    - Set the poll's `multipoll_id` to the new multipoll id, `sub_poll_index = 0`.
+    - The multipoll's `short_id` adopts the poll's `short_id`. The poll's `short_id` is left in place but is no longer the URL target.
+  - For every poll with `follow_up_to` or `fork_of` set, look up the target poll's new `multipoll_id` and write that into the new multipoll's `follow_up_to` / `fork_of`.
+  - Wrap in a single transaction.
+- `/p/<shortId>/` route resolves shortId → multipoll first, then falls back to poll for the brief window before the migration runs in production.
+- After successful production run, the frontend can drop the legacy fallback path.
+- **Participation polls are deliberately untouched.** Their URL routing keeps working via the legacy single-poll path; they remain `multipoll_id IS NULL` forever.
+
+---
+
+## Phase 5 — Cleanup
+
+**Goal**: remove the columns and code paths the multipoll system no longer needs.
+
+### Scope sketch
+
+- Drop wrapper-level columns from `polls`: `short_id`, `creator_secret`, `creator_name`, `response_deadline`, `is_closed`, `close_reason`, `follow_up_to`, `fork_of`, `thread_title`. (Keep them on participation polls if those still exist — likely a partial drop with a `WHERE poll_type != 'participation'` data clear before the column drop.)
+- Delete legacy single-poll API endpoints (`POST /api/polls`, `POST /api/polls/{id}/votes` per-poll variants, etc.). Or keep them as thin shims for participation polls only.
+- Delete frontend dual-codepath branches.
+- Begin participation poll phase-out as a separate sub-track (out of scope for this plan).
+
+---
+
+## How to start Phase 1
+
+1. Create a new branch from `main` (e.g. `claude/multi-poll-phase-1-schema-and-api`).
+2. Write `database/migrations/092_create_multipolls_up.sql` and `_down.sql`.
+3. Apply on the dev droplet via the standard migration command in CLAUDE.md.
+4. Add Pydantic models + endpoints + tests in `server/`.
+5. Push, wait for the dev server to come up, demo with a `curl` that creates a 3-sub-poll multipoll and reads it back. Share the dev URL in the PR.
+6. PR title: `Phase 1: multipoll schema and creation API`.
+
+The frontend is **deliberately untouched** — Phase 1 ends here.

--- a/server/algorithms/multipoll_title.py
+++ b/server/algorithms/multipoll_title.py
@@ -1,0 +1,86 @@
+"""Auto-title generator for multipolls.
+
+Pure function so it can be unit-tested independently. Mirrors the rules
+documented in docs/multipoll-phasing.md "Auto-title rules".
+"""
+
+from __future__ import annotations
+
+
+# Display labels for built-in categories. Mirrors the labels exposed by
+# components/TypeFieldInput.tsx on the frontend; unknown categories fall back
+# to a title-cased version of the raw category string.
+_CATEGORY_LABELS: dict[str, str] = {
+    "yes_no": "Yes/No",
+    "yes/no": "Yes/No",
+    "restaurant": "Restaurant",
+    "location": "Location",
+    "time": "Time",
+    "movie": "Movie",
+    "videogame": "Video Game",
+    "petname": "Pet Name",
+    "custom": "Custom",
+}
+
+
+def _label_for(category: str) -> str:
+    if not category:
+        return ""
+    key = category.strip().lower()
+    if key in _CATEGORY_LABELS:
+        return _CATEGORY_LABELS[key]
+    # Title-case fallback for unknown categories. Preserves embedded spaces.
+    return " ".join(word.capitalize() for word in category.strip().split())
+
+
+def _join_categories(labels: list[str]) -> str:
+    if len(labels) == 1:
+        return labels[0]
+    if len(labels) == 2:
+        return f"{labels[0]} and {labels[1]}"
+    return ", ".join(labels[:-1]) + f", and {labels[-1]}"
+
+
+def _single_subpoll_default_title(category: str) -> str:
+    """Match the existing single-poll auto-titles for 1-sub-poll multipolls.
+
+    Mirrors generateTitle() in app/create-poll/page.tsx. Time and yes/no get
+    short prompts; everything else uses "<Category>?".
+    """
+    key = (category or "").strip().lower()
+    if key in ("yes_no", "yes/no"):
+        return "Yes/No?"
+    if key == "time":
+        return "Time?"
+    label = _label_for(category)
+    return f"{label}?" if label else "Poll?"
+
+
+def generate_multipoll_title(
+    sub_poll_categories: list[str],
+    multipoll_context: str | None,
+) -> str:
+    """Compute a default title for a multipoll.
+
+    Args:
+        sub_poll_categories: ordered list of category strings (one per sub-poll).
+        multipoll_context: optional whole-multipoll context string.
+
+    Returns:
+        A title-cased string suitable for display.
+    """
+    context = (multipoll_context or "").strip() or None
+    cats = [c for c in (sub_poll_categories or []) if c and c.strip()]
+
+    if not cats:
+        return context or "Poll?"
+
+    if len(cats) == 1:
+        if context:
+            return f"{_label_for(cats[0])} for {context}"
+        return _single_subpoll_default_title(cats[0])
+
+    joined = _join_categories([_label_for(c) for c in cats])
+    if context:
+        return f"{joined} for {context}"
+    return joined

--- a/server/algorithms/multipoll_title.py
+++ b/server/algorithms/multipoll_title.py
@@ -1,15 +1,10 @@
-"""Auto-title generator for multipolls.
-
-Pure function so it can be unit-tested independently. Mirrors the rules
-documented in docs/multipoll-phasing.md "Auto-title rules".
-"""
+"""Auto-title generator for multipolls. See docs/multipoll-phasing.md."""
 
 from __future__ import annotations
 
 
-# Display labels for built-in categories. Mirrors the labels exposed by
-# components/TypeFieldInput.tsx on the frontend; unknown categories fall back
-# to a title-cased version of the raw category string.
+# Mirrors the labels exposed by components/TypeFieldInput.tsx on the frontend;
+# unknown categories fall back to a title-cased version of the raw string.
 _CATEGORY_LABELS: dict[str, str] = {
     "yes_no": "Yes/No",
     "yes/no": "Yes/No",
@@ -29,7 +24,6 @@ def _label_for(category: str) -> str:
     key = category.strip().lower()
     if key in _CATEGORY_LABELS:
         return _CATEGORY_LABELS[key]
-    # Title-case fallback for unknown categories. Preserves embedded spaces.
     return " ".join(word.capitalize() for word in category.strip().split())
 
 
@@ -42,11 +36,7 @@ def _join_categories(labels: list[str]) -> str:
 
 
 def _single_subpoll_default_title(category: str) -> str:
-    """Match the existing single-poll auto-titles for 1-sub-poll multipolls.
-
-    Mirrors generateTitle() in app/create-poll/page.tsx. Time and yes/no get
-    short prompts; everything else uses "<Category>?".
-    """
+    # Mirrors generateTitle() in app/create-poll/page.tsx for 1-sub-poll cases.
     key = (category or "").strip().lower()
     if key in ("yes_no", "yes/no"):
         return "Yes/No?"
@@ -60,15 +50,6 @@ def generate_multipoll_title(
     sub_poll_categories: list[str],
     multipoll_context: str | None,
 ) -> str:
-    """Compute a default title for a multipoll.
-
-    Args:
-        sub_poll_categories: ordered list of category strings (one per sub-poll).
-        multipoll_context: optional whole-multipoll context string.
-
-    Returns:
-        A title-cased string suitable for display.
-    """
     context = (multipoll_context or "").strip() or None
     cats = [c for c in (sub_poll_categories or []) if c and c.strip()]
 

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import psycopg
 
 from middleware import RateLimitMiddleware
+from routers.multipolls import router as multipolls_router
 from routers.polls import router as polls_router
 from routers.search import router as search_router
 from routers.client_logs import router as client_logs_router
@@ -26,6 +27,7 @@ app.add_middleware(
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
 
 app.include_router(polls_router)
+app.include_router(multipolls_router)
 app.include_router(search_router)
 app.include_router(client_logs_router)
 

--- a/server/models.py
+++ b/server/models.py
@@ -288,5 +288,79 @@ class RankedChoiceRoundResponse(BaseModel):
     tie_broken_by_borda: bool = False
 
 
+# -- Multipoll models (Phase 1 of multipoll redesign) --
+#
+# A multipoll wraps one or more sub-polls. Sub-poll rows live in the existing
+# `polls` table; wrapper-level fields (response_deadline, creator_secret, etc.)
+# live in `multipolls`. See docs/multipoll-phasing.md.
+
+
+class CreateSubPollRequest(BaseModel):
+    """A sub-poll within a multipoll create request.
+
+    Excludes wrapper-level fields (response_deadline, creator_secret,
+    follow_up_to, fork_of, thread_title, etc.) — those live on the multipoll.
+    Per-sub-poll `context` disambiguates multiple sub-polls of the same kind.
+    """
+
+    poll_type: PollType = PollType.yes_no
+    category: str | None = None
+    options: list[str] | None = None
+    options_metadata: dict | None = None
+    # Per-sub-poll context label (e.g. disambiguating two `Where` sub-polls).
+    # Stored on polls.details.
+    context: str | None = None
+    # Type-specific fields. The wrapper owns the `*_deadline` *value*; the
+    # *_minutes lives per-sub-poll because it's still type-specific (e.g. only
+    # ranked_choice + suggestion polls use suggestion_deadline_minutes).
+    suggestion_deadline_minutes: int | None = None
+    allow_pre_ranking: bool = True
+    min_responses: int | None = None
+    show_preliminary_results: bool = True
+    min_availability_percent: int = 95
+    day_time_windows: list[dict] | None = None
+    duration_window: dict | None = None
+    reference_latitude: float | None = None
+    reference_longitude: float | None = None
+    reference_location_label: str | None = None
+
+
+class CreateMultipollRequest(BaseModel):
+    creator_secret: str
+    creator_name: str | None = None
+    response_deadline: str | None = None
+    prephase_deadline: str | None = None
+    prephase_deadline_minutes: int | None = None
+    follow_up_to: str | None = None
+    fork_of: str | None = None
+    thread_title: str | None = None
+    context: str | None = None
+    # Optional explicit title; when absent, derived from sub-poll categories
+    # and `context` via algorithms.multipoll_title.generate_multipoll_title.
+    title: str | None = None
+    sub_polls: list[CreateSubPollRequest] = Field(..., min_length=1)
+
+
+class MultipollResponse(BaseModel):
+    id: str
+    short_id: str | None = None
+    creator_secret: str | None = None
+    creator_name: str | None = None
+    response_deadline: str | None = None
+    prephase_deadline: str | None = None
+    prephase_deadline_minutes: int | None = None
+    is_closed: bool = False
+    close_reason: str | None = None
+    follow_up_to: str | None = None
+    fork_of: str | None = None
+    thread_title: str | None = None
+    context: str | None = None
+    title: str
+    created_at: str
+    updated_at: str
+    sub_polls: list[PollResponse]
+
+
 # Resolve forward references (PollResponse.results -> PollResultsResponse)
 PollResponse.model_rebuild()
+MultipollResponse.model_rebuild()

--- a/server/models.py
+++ b/server/models.py
@@ -288,31 +288,20 @@ class RankedChoiceRoundResponse(BaseModel):
     tie_broken_by_borda: bool = False
 
 
-# -- Multipoll models (Phase 1 of multipoll redesign) --
-#
-# A multipoll wraps one or more sub-polls. Sub-poll rows live in the existing
-# `polls` table; wrapper-level fields (response_deadline, creator_secret, etc.)
-# live in `multipolls`. See docs/multipoll-phasing.md.
+# -- Multipoll models. See docs/multipoll-phasing.md. --
 
 
 class CreateSubPollRequest(BaseModel):
-    """A sub-poll within a multipoll create request.
-
-    Excludes wrapper-level fields (response_deadline, creator_secret,
-    follow_up_to, fork_of, thread_title, etc.) — those live on the multipoll.
-    Per-sub-poll `context` disambiguates multiple sub-polls of the same kind.
-    """
+    """A sub-poll inside a multipoll create request. Wrapper-level fields
+    (response_deadline, creator_secret, follow_up_to, etc.) live on the
+    multipoll, not here. `context` disambiguates same-kind sub-polls and is
+    stored on polls.details."""
 
     poll_type: PollType = PollType.yes_no
     category: str | None = None
     options: list[str] | None = None
     options_metadata: dict | None = None
-    # Per-sub-poll context label (e.g. disambiguating two `Where` sub-polls).
-    # Stored on polls.details.
     context: str | None = None
-    # Type-specific fields. The wrapper owns the `*_deadline` *value*; the
-    # *_minutes lives per-sub-poll because it's still type-specific (e.g. only
-    # ranked_choice + suggestion polls use suggestion_deadline_minutes).
     suggestion_deadline_minutes: int | None = None
     allow_pre_ranking: bool = True
     min_responses: int | None = None

--- a/server/routers/multipolls.py
+++ b/server/routers/multipolls.py
@@ -1,17 +1,7 @@
-"""Multipoll API endpoints (Phase 1 of multipoll redesign).
-
-POST /api/multipolls
-GET  /api/multipolls/{short_id}
-GET  /api/multipolls/by-id/{multipoll_id}
-
-Phase 1 only covers wrapper creation + read. Voting, results, and close/reopen
-still flow through the existing per-sub-poll endpoints (see routers/polls.py).
-See docs/multipoll-phasing.md.
-"""
+"""Multipoll API endpoints. See docs/multipoll-phasing.md."""
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException
@@ -24,24 +14,27 @@ from models import (
     MultipollResponse,
     PollType,
 )
-from routers.polls import _row_to_poll
+from routers.polls import _json_or_none, _row_to_poll
 
 router = APIRouter(prefix="/api/multipolls", tags=["multipolls"])
 
 
-# Categories used to derive the auto-title. A sub-poll's `category` (when set)
-# is preferred over its raw `poll_type` so e.g. a `yes_no` sub-poll with
-# category="movie" becomes "Movie", not "Yes/No".
 def _categories_for_title(sub_polls: list[CreateSubPollRequest]) -> list[str]:
     return [sp.category or sp.poll_type.value for sp in sub_polls]
 
 
+def _iso_or_none(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
 def _validate_request(req: CreateMultipollRequest) -> None:
-    """Reject requests that violate Phase 1 invariants. Raises HTTPException."""
     if not req.sub_polls:
         raise HTTPException(status_code=400, detail="At least one sub-poll is required")
 
-    # Phase 1: participation polls are explicitly excluded from multipolls.
     for sp in req.sub_polls:
         if sp.poll_type == PollType.participation:
             raise HTTPException(
@@ -49,7 +42,6 @@ def _validate_request(req: CreateMultipollRequest) -> None:
                 detail="Participation polls cannot be sub-polls of a multipoll",
             )
 
-    # At most one time sub-poll: a multipoll has a single shared availability phase.
     time_count = sum(1 for sp in req.sub_polls if sp.poll_type == PollType.time)
     if time_count > 1:
         raise HTTPException(
@@ -57,12 +49,11 @@ def _validate_request(req: CreateMultipollRequest) -> None:
             detail="A multipoll can contain at most one time sub-poll",
         )
 
-    # Multiple sub-polls of the same (poll_type, category) require distinct context.
     seen: dict[tuple[str, str | None], list[str | None]] = {}
     for sp in req.sub_polls:
         key = (sp.poll_type.value, (sp.category or "").strip().lower() or None)
         seen.setdefault(key, []).append((sp.context or "").strip() or None)
-    for key, contexts in seen.items():
+    for contexts in seen.values():
         if len(contexts) <= 1:
             continue
         normalized = [c.lower() if c else None for c in contexts]
@@ -75,7 +66,6 @@ def _validate_request(req: CreateMultipollRequest) -> None:
                 ),
             )
 
-    # Deadline ordering. Both are optional; only enforce when both are set.
     if req.response_deadline and req.prephase_deadline:
         try:
             response_dt = datetime.fromisoformat(
@@ -94,14 +84,9 @@ def _validate_request(req: CreateMultipollRequest) -> None:
 
 
 def _insert_multipoll(conn, req: CreateMultipollRequest, now: datetime) -> dict:
-    """Insert the multipoll wrapper row.
-
-    `req.title` (when provided) is stored in `thread_title` per the plan:
-    explicit titles are persisted; absent titles are computed at read time
-    from sub-poll categories. The COALESCE subquery inherits the parent
-    multipoll's thread_title for follow-ups when neither `req.title` nor
-    `req.thread_title` is set.
-    """
+    # Explicit titles are persisted to thread_title; absent titles are
+    # computed at read time so re-arranging sub-polls re-titles for free.
+    # The COALESCE inherits the parent multipoll's thread_title on follow-ups.
     explicit_title = req.title if req.title is not None else req.thread_title
     return conn.execute(
         """
@@ -128,9 +113,9 @@ def _insert_multipoll(conn, req: CreateMultipollRequest, now: datetime) -> dict:
             "creator_secret": req.creator_secret,
             "creator_name": req.creator_name,
             "response_deadline": req.response_deadline,
-            # If prephase_deadline_minutes is set, defer the absolute deadline
-            # (mirrors the suggestion_deadline / suggestion_deadline_minutes
-            # split on polls — see CLAUDE.md "Deferred Suggestion Deadline").
+            # Defer the absolute deadline when *_minutes is set — mirrors the
+            # suggestion_deadline split on polls (see CLAUDE.md "Deferred
+            # Suggestion Deadline").
             "prephase_deadline": (
                 None if req.prephase_deadline_minutes else req.prephase_deadline
             ),
@@ -147,24 +132,17 @@ def _insert_multipoll(conn, req: CreateMultipollRequest, now: datetime) -> dict:
 def _insert_sub_poll(
     conn,
     multipoll_row: dict,
+    req: CreateMultipollRequest,
     sub: CreateSubPollRequest,
     sub_poll_index: int,
     title: str,
-    creator_secret: str,
-    creator_name: str | None,
-    response_deadline: str | None,
-    suggestion_deadline: str | None,
     now: datetime,
 ) -> dict:
-    """Insert one sub-poll row into `polls` linked to the parent multipoll.
-
-    Wrapper-level fields (creator_secret, creator_name, response_deadline) are
-    written on the polls row too — Phase 1 keeps the legacy single-poll columns
-    populated so existing per-sub-poll endpoints (vote/results/close) keep
-    working without modification. Phase 5 will retire those.
-    """
+    # Wrapper-level fields are duplicated onto the polls row so the existing
+    # per-sub-poll endpoints (vote/results/close) keep working without
+    # modification. Phase 5 retires the duplicated columns.
     suggestion_deadline_value = (
-        None if sub.suggestion_deadline_minutes else suggestion_deadline
+        None if sub.suggestion_deadline_minutes else req.prephase_deadline
     )
     return conn.execute(
         """
@@ -203,24 +181,18 @@ def _insert_sub_poll(
         {
             "title": title,
             "poll_type": sub.poll_type.value,
-            "options": json.dumps(sub.options) if sub.options else None,
-            "response_deadline": response_deadline,
-            "creator_secret": creator_secret,
-            "creator_name": creator_name,
+            "options": _json_or_none(sub.options),
+            "response_deadline": req.response_deadline,
+            "creator_secret": req.creator_secret,
+            "creator_name": req.creator_name,
             "suggestion_deadline": suggestion_deadline_value,
             "suggestion_deadline_minutes": sub.suggestion_deadline_minutes,
             "allow_pre_ranking": sub.allow_pre_ranking,
             "details": sub.context,
-            "day_time_windows": (
-                json.dumps(sub.day_time_windows) if sub.day_time_windows else None
-            ),
-            "duration_window": (
-                json.dumps(sub.duration_window) if sub.duration_window else None
-            ),
+            "day_time_windows": _json_or_none(sub.day_time_windows),
+            "duration_window": _json_or_none(sub.duration_window),
             "category": sub.category or "custom",
-            "options_metadata": (
-                json.dumps(sub.options_metadata) if sub.options_metadata else None
-            ),
+            "options_metadata": _json_or_none(sub.options_metadata),
             "reference_latitude": sub.reference_latitude,
             "reference_longitude": sub.reference_longitude,
             "reference_location_label": sub.reference_location_label,
@@ -237,7 +209,6 @@ def _insert_sub_poll(
 
 
 def _compute_display_title(row: dict, sub_poll_rows: list[dict]) -> str:
-    """Effective display title: thread_title override OR auto-generated."""
     override = row.get("thread_title")
     if override:
         return override
@@ -251,12 +222,8 @@ def _row_to_multipoll(row: dict, sub_poll_rows: list[dict]) -> MultipollResponse
         short_id=row.get("short_id"),
         creator_secret=row.get("creator_secret"),
         creator_name=row.get("creator_name"),
-        response_deadline=(
-            row["response_deadline"].isoformat() if row.get("response_deadline") else None
-        ),
-        prephase_deadline=(
-            row["prephase_deadline"].isoformat() if row.get("prephase_deadline") else None
-        ),
+        response_deadline=_iso_or_none(row.get("response_deadline")),
+        prephase_deadline=_iso_or_none(row.get("prephase_deadline")),
         prephase_deadline_minutes=row.get("prephase_deadline_minutes"),
         is_closed=row.get("is_closed", False),
         close_reason=row.get("close_reason"),
@@ -265,16 +232,8 @@ def _row_to_multipoll(row: dict, sub_poll_rows: list[dict]) -> MultipollResponse
         thread_title=row.get("thread_title"),
         context=row.get("context"),
         title=_compute_display_title(row, sub_poll_rows),
-        created_at=(
-            row["created_at"].isoformat()
-            if isinstance(row["created_at"], datetime)
-            else str(row["created_at"])
-        ),
-        updated_at=(
-            row["updated_at"].isoformat()
-            if isinstance(row["updated_at"], datetime)
-            else str(row["updated_at"])
-        ),
+        created_at=_iso_or_none(row["created_at"]) or "",
+        updated_at=_iso_or_none(row["updated_at"]) or "",
         sub_polls=[_row_to_poll(sp) for sp in sub_poll_rows],
     )
 
@@ -294,9 +253,8 @@ def _fetch_sub_polls(conn, multipoll_id: str) -> list[dict]:
 def create_multipoll(req: CreateMultipollRequest):
     _validate_request(req)
 
-    # Sub-poll title: use thread_title override (if any) or the auto-computed
-    # title. polls.title is NOT NULL, so each sub-poll needs *some* title even
-    # though Phase 2+ will display the multipoll's computed title instead.
+    # polls.title is NOT NULL, so each sub-poll row needs a value even though
+    # display goes through the multipoll's computed title.
     sub_poll_title = (
         req.title
         or req.thread_title
@@ -307,23 +265,10 @@ def create_multipoll(req: CreateMultipollRequest):
 
     with get_db() as conn:
         multipoll_row = _insert_multipoll(conn, req, now)
-
-        sub_poll_rows: list[dict] = []
-        for index, sub in enumerate(req.sub_polls):
-            sub_poll_rows.append(
-                _insert_sub_poll(
-                    conn,
-                    multipoll_row,
-                    sub,
-                    index,
-                    sub_poll_title,
-                    req.creator_secret,
-                    req.creator_name,
-                    req.response_deadline,
-                    req.prephase_deadline,
-                    now,
-                )
-            )
+        sub_poll_rows = [
+            _insert_sub_poll(conn, multipoll_row, req, sub, index, sub_poll_title, now)
+            for index, sub in enumerate(req.sub_polls)
+        ]
 
     return _row_to_multipoll(multipoll_row, sub_poll_rows)
 

--- a/server/routers/multipolls.py
+++ b/server/routers/multipolls.py
@@ -1,0 +1,354 @@
+"""Multipoll API endpoints (Phase 1 of multipoll redesign).
+
+POST /api/multipolls
+GET  /api/multipolls/{short_id}
+GET  /api/multipolls/by-id/{multipoll_id}
+
+Phase 1 only covers wrapper creation + read. Voting, results, and close/reopen
+still flow through the existing per-sub-poll endpoints (see routers/polls.py).
+See docs/multipoll-phasing.md.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException
+
+from algorithms.multipoll_title import generate_multipoll_title
+from database import get_db
+from models import (
+    CreateMultipollRequest,
+    CreateSubPollRequest,
+    MultipollResponse,
+    PollType,
+)
+from routers.polls import _row_to_poll
+
+router = APIRouter(prefix="/api/multipolls", tags=["multipolls"])
+
+
+# Categories used to derive the auto-title. A sub-poll's `category` (when set)
+# is preferred over its raw `poll_type` so e.g. a `yes_no` sub-poll with
+# category="movie" becomes "Movie", not "Yes/No".
+def _categories_for_title(sub_polls: list[CreateSubPollRequest]) -> list[str]:
+    return [sp.category or sp.poll_type.value for sp in sub_polls]
+
+
+def _validate_request(req: CreateMultipollRequest) -> None:
+    """Reject requests that violate Phase 1 invariants. Raises HTTPException."""
+    if not req.sub_polls:
+        raise HTTPException(status_code=400, detail="At least one sub-poll is required")
+
+    # Phase 1: participation polls are explicitly excluded from multipolls.
+    for sp in req.sub_polls:
+        if sp.poll_type == PollType.participation:
+            raise HTTPException(
+                status_code=400,
+                detail="Participation polls cannot be sub-polls of a multipoll",
+            )
+
+    # At most one time sub-poll: a multipoll has a single shared availability phase.
+    time_count = sum(1 for sp in req.sub_polls if sp.poll_type == PollType.time)
+    if time_count > 1:
+        raise HTTPException(
+            status_code=400,
+            detail="A multipoll can contain at most one time sub-poll",
+        )
+
+    # Multiple sub-polls of the same (poll_type, category) require distinct context.
+    seen: dict[tuple[str, str | None], list[str | None]] = {}
+    for sp in req.sub_polls:
+        key = (sp.poll_type.value, (sp.category or "").strip().lower() or None)
+        seen.setdefault(key, []).append((sp.context or "").strip() or None)
+    for key, contexts in seen.items():
+        if len(contexts) <= 1:
+            continue
+        normalized = [c.lower() if c else None for c in contexts]
+        if len(set(normalized)) != len(normalized):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Sub-polls of the same kind must each have a distinct "
+                    "context to disambiguate them"
+                ),
+            )
+
+    # Deadline ordering. Both are optional; only enforce when both are set.
+    if req.response_deadline and req.prephase_deadline:
+        try:
+            response_dt = datetime.fromisoformat(
+                req.response_deadline.replace("Z", "+00:00")
+            )
+            prephase_dt = datetime.fromisoformat(
+                req.prephase_deadline.replace("Z", "+00:00")
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid deadline format: {exc}") from exc
+        if prephase_dt >= response_dt:
+            raise HTTPException(
+                status_code=400,
+                detail="Prephase deadline must be before the voting deadline",
+            )
+
+
+def _insert_multipoll(conn, req: CreateMultipollRequest, now: datetime) -> dict:
+    """Insert the multipoll wrapper row.
+
+    `req.title` (when provided) is stored in `thread_title` per the plan:
+    explicit titles are persisted; absent titles are computed at read time
+    from sub-poll categories. The COALESCE subquery inherits the parent
+    multipoll's thread_title for follow-ups when neither `req.title` nor
+    `req.thread_title` is set.
+    """
+    explicit_title = req.title if req.title is not None else req.thread_title
+    return conn.execute(
+        """
+        INSERT INTO multipolls (
+            creator_secret, creator_name, response_deadline,
+            prephase_deadline, prephase_deadline_minutes,
+            follow_up_to, fork_of, context,
+            thread_title,
+            created_at, updated_at
+        )
+        VALUES (
+            %(creator_secret)s, %(creator_name)s, %(response_deadline)s,
+            %(prephase_deadline)s, %(prephase_deadline_minutes)s,
+            %(follow_up_to)s, %(fork_of)s, %(context)s,
+            COALESCE(
+                %(explicit_title)s,
+                (SELECT thread_title FROM multipolls WHERE id = %(follow_up_to)s)
+            ),
+            %(now)s, %(now)s
+        )
+        RETURNING *
+        """,
+        {
+            "creator_secret": req.creator_secret,
+            "creator_name": req.creator_name,
+            "response_deadline": req.response_deadline,
+            # If prephase_deadline_minutes is set, defer the absolute deadline
+            # (mirrors the suggestion_deadline / suggestion_deadline_minutes
+            # split on polls — see CLAUDE.md "Deferred Suggestion Deadline").
+            "prephase_deadline": (
+                None if req.prephase_deadline_minutes else req.prephase_deadline
+            ),
+            "prephase_deadline_minutes": req.prephase_deadline_minutes,
+            "follow_up_to": req.follow_up_to,
+            "fork_of": req.fork_of,
+            "context": req.context,
+            "explicit_title": explicit_title,
+            "now": now,
+        },
+    ).fetchone()
+
+
+def _insert_sub_poll(
+    conn,
+    multipoll_row: dict,
+    sub: CreateSubPollRequest,
+    sub_poll_index: int,
+    title: str,
+    creator_secret: str,
+    creator_name: str | None,
+    response_deadline: str | None,
+    suggestion_deadline: str | None,
+    now: datetime,
+) -> dict:
+    """Insert one sub-poll row into `polls` linked to the parent multipoll.
+
+    Wrapper-level fields (creator_secret, creator_name, response_deadline) are
+    written on the polls row too — Phase 1 keeps the legacy single-poll columns
+    populated so existing per-sub-poll endpoints (vote/results/close) keep
+    working without modification. Phase 5 will retire those.
+    """
+    suggestion_deadline_value = (
+        None if sub.suggestion_deadline_minutes else suggestion_deadline
+    )
+    return conn.execute(
+        """
+        INSERT INTO polls (
+            title, poll_type, options, response_deadline,
+            creator_secret, creator_name,
+            suggestion_deadline, suggestion_deadline_minutes,
+            allow_pre_ranking,
+            details,
+            day_time_windows, duration_window,
+            category, options_metadata,
+            reference_latitude, reference_longitude,
+            reference_location_label,
+            min_responses, show_preliminary_results,
+            min_availability_percent,
+            multipoll_id, sub_poll_index,
+            created_at, updated_at
+        )
+        VALUES (
+            %(title)s, %(poll_type)s, %(options)s::jsonb, %(response_deadline)s,
+            %(creator_secret)s, %(creator_name)s,
+            %(suggestion_deadline)s, %(suggestion_deadline_minutes)s,
+            %(allow_pre_ranking)s,
+            %(details)s,
+            %(day_time_windows)s::jsonb, %(duration_window)s::jsonb,
+            %(category)s, %(options_metadata)s::jsonb,
+            %(reference_latitude)s, %(reference_longitude)s,
+            %(reference_location_label)s,
+            %(min_responses)s, %(show_preliminary_results)s,
+            %(min_availability_percent)s,
+            %(multipoll_id)s, %(sub_poll_index)s,
+            %(now)s, %(now)s
+        )
+        RETURNING *
+        """,
+        {
+            "title": title,
+            "poll_type": sub.poll_type.value,
+            "options": json.dumps(sub.options) if sub.options else None,
+            "response_deadline": response_deadline,
+            "creator_secret": creator_secret,
+            "creator_name": creator_name,
+            "suggestion_deadline": suggestion_deadline_value,
+            "suggestion_deadline_minutes": sub.suggestion_deadline_minutes,
+            "allow_pre_ranking": sub.allow_pre_ranking,
+            "details": sub.context,
+            "day_time_windows": (
+                json.dumps(sub.day_time_windows) if sub.day_time_windows else None
+            ),
+            "duration_window": (
+                json.dumps(sub.duration_window) if sub.duration_window else None
+            ),
+            "category": sub.category or "custom",
+            "options_metadata": (
+                json.dumps(sub.options_metadata) if sub.options_metadata else None
+            ),
+            "reference_latitude": sub.reference_latitude,
+            "reference_longitude": sub.reference_longitude,
+            "reference_location_label": sub.reference_location_label,
+            "min_responses": sub.min_responses,
+            "show_preliminary_results": sub.show_preliminary_results,
+            "min_availability_percent": (
+                sub.min_availability_percent if sub.poll_type == PollType.time else None
+            ),
+            "multipoll_id": str(multipoll_row["id"]),
+            "sub_poll_index": sub_poll_index,
+            "now": now,
+        },
+    ).fetchone()
+
+
+def _compute_display_title(row: dict, sub_poll_rows: list[dict]) -> str:
+    """Effective display title: thread_title override OR auto-generated."""
+    override = row.get("thread_title")
+    if override:
+        return override
+    categories = [sp.get("category") or sp.get("poll_type") or "" for sp in sub_poll_rows]
+    return generate_multipoll_title(categories, row.get("context"))
+
+
+def _row_to_multipoll(row: dict, sub_poll_rows: list[dict]) -> MultipollResponse:
+    return MultipollResponse(
+        id=str(row["id"]),
+        short_id=row.get("short_id"),
+        creator_secret=row.get("creator_secret"),
+        creator_name=row.get("creator_name"),
+        response_deadline=(
+            row["response_deadline"].isoformat() if row.get("response_deadline") else None
+        ),
+        prephase_deadline=(
+            row["prephase_deadline"].isoformat() if row.get("prephase_deadline") else None
+        ),
+        prephase_deadline_minutes=row.get("prephase_deadline_minutes"),
+        is_closed=row.get("is_closed", False),
+        close_reason=row.get("close_reason"),
+        follow_up_to=str(row["follow_up_to"]) if row.get("follow_up_to") else None,
+        fork_of=str(row["fork_of"]) if row.get("fork_of") else None,
+        thread_title=row.get("thread_title"),
+        context=row.get("context"),
+        title=_compute_display_title(row, sub_poll_rows),
+        created_at=(
+            row["created_at"].isoformat()
+            if isinstance(row["created_at"], datetime)
+            else str(row["created_at"])
+        ),
+        updated_at=(
+            row["updated_at"].isoformat()
+            if isinstance(row["updated_at"], datetime)
+            else str(row["updated_at"])
+        ),
+        sub_polls=[_row_to_poll(sp) for sp in sub_poll_rows],
+    )
+
+
+def _fetch_sub_polls(conn, multipoll_id: str) -> list[dict]:
+    return conn.execute(
+        """
+        SELECT * FROM polls
+        WHERE multipoll_id = %(multipoll_id)s
+        ORDER BY sub_poll_index NULLS LAST, created_at
+        """,
+        {"multipoll_id": multipoll_id},
+    ).fetchall()
+
+
+@router.post("", response_model=MultipollResponse, status_code=201)
+def create_multipoll(req: CreateMultipollRequest):
+    _validate_request(req)
+
+    # Sub-poll title: use thread_title override (if any) or the auto-computed
+    # title. polls.title is NOT NULL, so each sub-poll needs *some* title even
+    # though Phase 2+ will display the multipoll's computed title instead.
+    sub_poll_title = (
+        req.title
+        or req.thread_title
+        or generate_multipoll_title(_categories_for_title(req.sub_polls), req.context)
+    )
+
+    now = datetime.now(timezone.utc)
+
+    with get_db() as conn:
+        multipoll_row = _insert_multipoll(conn, req, now)
+
+        sub_poll_rows: list[dict] = []
+        for index, sub in enumerate(req.sub_polls):
+            sub_poll_rows.append(
+                _insert_sub_poll(
+                    conn,
+                    multipoll_row,
+                    sub,
+                    index,
+                    sub_poll_title,
+                    req.creator_secret,
+                    req.creator_name,
+                    req.response_deadline,
+                    req.prephase_deadline,
+                    now,
+                )
+            )
+
+    return _row_to_multipoll(multipoll_row, sub_poll_rows)
+
+
+@router.get("/by-id/{multipoll_id}", response_model=MultipollResponse)
+def get_multipoll_by_id(multipoll_id: str):
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT * FROM multipolls WHERE id = %(id)s",
+            {"id": multipoll_id},
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Multipoll not found")
+        sub_poll_rows = _fetch_sub_polls(conn, str(row["id"]))
+    return _row_to_multipoll(row, sub_poll_rows)
+
+
+@router.get("/{short_id}", response_model=MultipollResponse)
+def get_multipoll(short_id: str):
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT * FROM multipolls WHERE short_id = %(short_id)s",
+            {"short_id": short_id},
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Multipoll not found")
+        sub_poll_rows = _fetch_sub_polls(conn, str(row["id"]))
+    return _row_to_multipoll(row, sub_poll_rows)

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1540,8 +1540,8 @@ def get_related_polls(req: RelatedPollsRequest):
 # --- Helpers ---
 
 
-def _json_or_none(val: list[str] | None) -> str | None:
-    """Convert a list to a JSON string for JSONB column, or None."""
+def _json_or_none(val) -> str | None:
+    """Serialize a JSON-compatible value for a JSONB column, or None."""
     if val is None:
         return None
     import json

--- a/server/tests/test_multipoll_title.py
+++ b/server/tests/test_multipoll_title.py
@@ -1,0 +1,90 @@
+"""Tests for the multipoll auto-title generator."""
+
+from algorithms.multipoll_title import generate_multipoll_title
+
+
+class TestSingleSubPoll:
+    def test_yes_no_no_context(self):
+        assert generate_multipoll_title(["yes_no"], None) == "Yes/No?"
+
+    def test_time_no_context(self):
+        assert generate_multipoll_title(["time"], None) == "Time?"
+
+    def test_restaurant_no_context(self):
+        assert generate_multipoll_title(["restaurant"], None) == "Restaurant?"
+
+    def test_unknown_category_no_context(self):
+        # Unknown category falls back to title-cased raw string + "?"
+        assert generate_multipoll_title(["dessert"], None) == "Dessert?"
+
+    def test_single_with_context(self):
+        assert (
+            generate_multipoll_title(["restaurant"], "Birthday")
+            == "Restaurant for Birthday"
+        )
+
+    def test_single_with_context_strips_whitespace(self):
+        assert (
+            generate_multipoll_title(["movie"], "  Friday Night  ")
+            == "Movie for Friday Night"
+        )
+
+
+class TestMultipleSubPolls:
+    def test_two_no_context(self):
+        assert (
+            generate_multipoll_title(["restaurant", "time"], None)
+            == "Restaurant and Time"
+        )
+
+    def test_three_no_context(self):
+        assert (
+            generate_multipoll_title(["restaurant", "time", "movie"], None)
+            == "Restaurant, Time, and Movie"
+        )
+
+    def test_two_with_context(self):
+        assert (
+            generate_multipoll_title(["restaurant", "time"], "Birthday")
+            == "Restaurant and Time for Birthday"
+        )
+
+    def test_three_with_context(self):
+        assert (
+            generate_multipoll_title(
+                ["restaurant", "time", "movie"], "Friday"
+            )
+            == "Restaurant, Time, and Movie for Friday"
+        )
+
+    def test_videogame_label(self):
+        assert (
+            generate_multipoll_title(["videogame", "time"], None)
+            == "Video Game and Time"
+        )
+
+    def test_petname_label(self):
+        assert (
+            generate_multipoll_title(["petname"], "Cat")
+            == "Pet Name for Cat"
+        )
+
+
+class TestEdgeCases:
+    def test_empty_list_no_context(self):
+        assert generate_multipoll_title([], None) == "Poll?"
+
+    def test_empty_list_with_context(self):
+        assert generate_multipoll_title([], "Birthday") == "Birthday"
+
+    def test_blank_categories_filtered(self):
+        assert (
+            generate_multipoll_title(["", "  ", "restaurant"], None)
+            == "Restaurant?"
+        )
+
+    def test_blank_context_treated_as_none(self):
+        assert generate_multipoll_title(["restaurant"], "   ") == "Restaurant?"
+
+    def test_yes_slash_no_alias(self):
+        assert generate_multipoll_title(["yes/no"], None) == "Yes/No?"

--- a/server/tests/test_multipolls_api.py
+++ b/server/tests/test_multipolls_api.py
@@ -1,0 +1,283 @@
+"""Integration tests for the multipolls API.
+
+Mirrors test_polls_api.py: requires a real Postgres reachable via DATABASE_URL,
+either the local Docker Compose db or the test database on the dev droplet.
+"""
+
+import os
+import uuid
+
+import pytest
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def creator_secret():
+    return f"test-secret-{uuid.uuid4().hex[:8]}"
+
+
+def _yes_no_sub_poll(**overrides) -> dict:
+    base = {"poll_type": "yes_no", "category": "yes_no"}
+    base.update(overrides)
+    return base
+
+
+def _restaurant_sub_poll(**overrides) -> dict:
+    base = {
+        "poll_type": "ranked_choice",
+        "category": "restaurant",
+        "options": ["Pizza Hut", "Chipotle"],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCreateMultipoll:
+    def test_create_single_sub_poll(self, client, creator_secret):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [_yes_no_sub_poll()],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["id"]
+        assert data["short_id"]
+        assert data["title"] == "Yes/No?"  # computed at read time
+        assert len(data["sub_polls"]) == 1
+        assert data["sub_polls"][0]["poll_type"] == "yes_no"
+        assert data["sub_polls"][0]["category"] == "yes_no"
+
+    def test_create_three_sub_polls_what_when_where(self, client, creator_secret):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "context": "Birthday",
+                "sub_polls": [
+                    _restaurant_sub_poll(),
+                    {
+                        "poll_type": "time",
+                        "category": "time",
+                    },
+                    {
+                        "poll_type": "ranked_choice",
+                        "category": "movie",
+                        "options": ["Dune", "Oppenheimer"],
+                    },
+                ],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["context"] == "Birthday"
+        assert data["title"] == "Restaurant, Time, and Movie for Birthday"
+        assert len(data["sub_polls"]) == 3
+        # Sub-polls preserve insertion order
+        assert [sp["category"] for sp in data["sub_polls"]] == [
+            "restaurant",
+            "time",
+            "movie",
+        ]
+
+    def test_explicit_title_persisted_in_thread_title(self, client, creator_secret):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "title": "What should we do tonight?",
+                "sub_polls": [_yes_no_sub_poll()],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["title"] == "What should we do tonight?"
+        assert data["thread_title"] == "What should we do tonight?"
+
+    def test_rejects_zero_sub_polls(self, client, creator_secret):
+        resp = client.post(
+            "/api/multipolls",
+            json={"creator_secret": creator_secret, "sub_polls": []},
+        )
+        assert resp.status_code == 422  # pydantic min_length
+
+    def test_rejects_participation_sub_poll(self, client, creator_secret):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [{"poll_type": "participation"}],
+            },
+        )
+        assert resp.status_code == 400
+        assert "participation" in resp.json()["detail"].lower()
+
+    def test_rejects_two_time_sub_polls(self, client, creator_secret):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [
+                    {"poll_type": "time", "category": "time"},
+                    {"poll_type": "time", "category": "time"},
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert "time" in resp.json()["detail"].lower()
+
+    def test_rejects_duplicate_kind_without_distinct_context(
+        self, client, creator_secret
+    ):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [
+                    _restaurant_sub_poll(),
+                    _restaurant_sub_poll(),
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert "distinct context" in resp.json()["detail"].lower()
+
+    def test_accepts_duplicate_kind_with_distinct_context(
+        self, client, creator_secret
+    ):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [
+                    _restaurant_sub_poll(context="Lunch"),
+                    _restaurant_sub_poll(context="Dinner"),
+                ],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        # Each sub-poll preserves its per-sub-poll context in `details`.
+        assert [sp["details"] for sp in data["sub_polls"]] == ["Lunch", "Dinner"]
+
+    def test_rejects_prephase_after_response_deadline(self, client, creator_secret):
+        resp = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "response_deadline": "2030-01-01T12:00:00Z",
+                "prephase_deadline": "2030-01-02T12:00:00Z",
+                "sub_polls": [_yes_no_sub_poll()],
+            },
+        )
+        assert resp.status_code == 400
+        assert "before" in resp.json()["detail"].lower()
+
+
+class TestReadMultipoll:
+    def test_get_by_short_id(self, client, creator_secret):
+        create = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [_yes_no_sub_poll()],
+            },
+        )
+        short_id = create.json()["short_id"]
+        resp = client.get(f"/api/multipolls/{short_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["short_id"] == short_id
+        assert len(data["sub_polls"]) == 1
+
+    def test_get_by_uuid(self, client, creator_secret):
+        create = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [_restaurant_sub_poll()],
+            },
+        )
+        multipoll_id = create.json()["id"]
+        resp = client.get(f"/api/multipolls/by-id/{multipoll_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == multipoll_id
+
+    def test_get_missing_short_id_returns_404(self, client):
+        resp = client.get("/api/multipolls/zzzzzz-not-real")
+        assert resp.status_code == 404
+
+    def test_get_missing_uuid_returns_404(self, client):
+        resp = client.get(f"/api/multipolls/by-id/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+
+class TestSubPollLinkage:
+    def test_existing_polls_keep_null_multipoll_id(self, client, creator_secret):
+        """Legacy single-poll create path should not link to any multipoll."""
+        resp = client.post(
+            "/api/polls",
+            json={
+                "title": "Legacy poll",
+                "poll_type": "yes_no",
+                "creator_secret": creator_secret,
+            },
+        )
+        assert resp.status_code == 201
+        # The PollResponse doesn't currently expose multipoll_id; verify by
+        # querying the DB directly via psycopg.
+        import psycopg
+
+        poll_id = resp.json()["id"]
+        with psycopg.connect(TEST_DB_URL) as conn:
+            row = conn.execute(
+                "SELECT multipoll_id, sub_poll_index FROM polls WHERE id = %s",
+                (poll_id,),
+            ).fetchone()
+            assert row is not None
+            assert row[0] is None
+            assert row[1] is None
+
+    def test_multipoll_subpoll_has_index(self, client, creator_secret):
+        create = client.post(
+            "/api/multipolls",
+            json={
+                "creator_secret": creator_secret,
+                "sub_polls": [
+                    _yes_no_sub_poll(),
+                    _restaurant_sub_poll(),
+                ],
+            },
+        )
+        assert create.status_code == 201, create.text
+        sub_polls = create.json()["sub_polls"]
+        multipoll_id = create.json()["id"]
+
+        import psycopg
+
+        with psycopg.connect(TEST_DB_URL) as conn:
+            for index, sp in enumerate(sub_polls):
+                row = conn.execute(
+                    "SELECT multipoll_id, sub_poll_index FROM polls WHERE id = %s",
+                    (sp["id"],),
+                ).fetchone()
+                assert row is not None
+                assert str(row[0]) == multipoll_id
+                assert row[1] == index


### PR DESCRIPTION
## Summary

Phase 1 of the multipoll redesign (see `docs/multipoll-phasing.md`). Stands up the `multipolls` wrapper table + new POST/GET endpoints. **No frontend changes** — existing single-poll codepaths and the existing `POST /api/polls` endpoint are untouched.

- **Migration 092**: new `multipolls` table (creator_secret, deadlines, follow_up_to/fork_of pointing at multipolls, thread_title, context). Adds nullable `multipoll_id` + `sub_poll_index` to `polls` so existing rows stay `multipoll_id IS NULL` indefinitely. Pure additive — fully reversible via `_down.sql`.
- **`POST /api/multipolls`** — transactional create of wrapper + N sub-polls. Validation: ≥1 sub-poll, no participation type, ≤1 time sub-poll, same-kind requires distinct context, prephase < voting deadline.
- **`GET /api/multipolls/{short_id}`** and **`GET /api/multipolls/by-id/{id}`** — return wrapper + sub-polls in `sub_poll_index` order.
- **Auto-title** computed at read time from sub-poll categories + multipoll context (rules + 17 unit tests in `server/algorithms/multipoll_title.py`); explicit titles persist to `thread_title` and re-arranging sub-polls re-titles for free.
- **Sub-poll rows duplicate wrapper-level fields** (creator_secret, creator_name, response_deadline) onto the polls row so the existing per-sub-poll vote/results/close endpoints keep working unchanged. Phase 5 retires the duplicated columns.
- **Integration tests** (`server/tests/test_multipolls_api.py`) cover create / read / validation paths and verify legacy single polls keep `multipoll_id IS NULL`.
- **Phasing plan** documented in `docs/multipoll-phasing.md` (Phases 1–5, this PR is Phase 1).

Includes a follow-up simplify pass (reuse `_json_or_none` from `routers/polls.py`, add local `_iso_or_none` helper, trim phase-narrative comments and oversized docstrings) and a `CLAUDE.md` update marking Phase 1 as implemented + a pitfall note about `_migrations.id` (serial row counter, not the filename number).

## Done-criteria demo (against the dev API)

```bash
$ curl -X POST .../api/multipolls -d '{
    "creator_secret": "...",
    "creator_name": "Sam",
    "context": "Birthday",
    "response_deadline": "2026-05-10T23:00:00Z",
    "sub_polls": [
      {"poll_type": "ranked_choice", "category": "restaurant",
       "options": ["Liguria", "Sushi Den", "El Farolito"]},
      {"poll_type": "time", "category": "time", ...},
      {"poll_type": "yes_no", "category": "yes_no", "context": "Bring partner?"}
    ]
  }'
# 201 Created
# {
#   "short_id": "3",
#   "title": "Restaurant, Time, and Yes/No for Birthday",
#   "context": "Birthday",
#   "sub_polls": [<3 entries with poll_types ranked_choice/time/yes_no>]
# }

$ curl .../api/multipolls/3              # → 200, returns the multipoll
$ curl .../api/multipolls/by-id/<uuid>   # → 200, same payload

# Validation:
$ curl ... -d '{"sub_polls":[{"poll_type":"participation"}]}'
# 400 {"detail":"Participation polls cannot be sub-polls of a multipoll"}

$ curl ... -d '{"sub_polls":[{"poll_type":"time"...},{"poll_type":"time"...}]}'
# 400 {"detail":"A multipoll can contain at most one time sub-poll"}

# Legacy polls untouched: 32 existing rows still have multipoll_id IS NULL.
```

Migration 092 has been applied to my dev DB; the dev API at `sam-at-samcarey-com.dev.whoeverwants.com` exercises all three endpoints. Production gets it on merge via the auto-deploy webhook.

## Test plan

- [x] `pytest server/tests/test_multipoll_title.py` — 17/17 passed
- [x] App loads with all three multipoll routes registered
- [x] Live demo against dev API: 3-sub-poll create + GET by short_id + GET by uuid
- [x] Validation: rejects participation, rejects two time sub-polls, rejects same-kind without distinct context
- [x] Existing 32 legacy polls keep `multipoll_id IS NULL` — confirmed against dev DB
- [ ] CI passes (Vercel + GitHub Actions)

https://claude.ai/code/session_011yfbYrk3e6fk1Y8kpdtWEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2ipKDnMY3XCDbQvopc7Mu)_