### PR TITLE
Hide name field on poll draft form when name is set

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1728,11 +1728,13 @@ export function CreateQuestionContent() {
                     )}
                   </div>
 
-                  <CompactNameField
-                    name={creatorName}
-                    setName={setCreatorName}
-                    disabled={isLoading}
-                  />
+                  {!creatorName.trim() && (
+                    <CompactNameField
+                      name={creatorName}
+                      setName={setCreatorName}
+                      disabled={isLoading}
+                    />
+                  )}
                 </form>
 
                 {(error || (validationError && drafts.length > 0)) && (


### PR DESCRIPTION
## Summary
- Once a name has been entered (from settings or a previous submission), the "Your Name" field on the poll draft form is hidden — it just adds noise. The name is still submitted implicitly via the existing `creatorName` state.
- To change a saved name, users now go to /settings (the canonical store anyway).
- One-line conditional gate around `<CompactNameField>` in `app/create-poll/page.tsx`.

## Test plan
- [ ] First-time visitor with no saved name sees the "Your Name (optional)" field and can fill it in.
- [ ] Returning user with a saved name sees the field hidden; submitting a poll still attaches their name.
- [ ] Clearing the name on the settings page makes the field reappear on the draft form.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WmHUUDAwRDKjv2xeGnMTdf)_