### PR TITLE
Strip inner card chrome around suggestion / ranking / yes-no ballots

### DIFF
--- a/components/QuestionBallot.tsx
+++ b/components/QuestionBallot.tsx
@@ -1228,7 +1228,7 @@ const QuestionBallot = forwardRef<QuestionBallotHandle, QuestionBallotProps>(fun
                 null
               ) : (
                 <>
-                  <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
+                  <div className="mb-2">
                     <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-3">
                       Select your preference
                     </h4>

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -169,7 +169,7 @@ export default function RankingSection({
         </div>
       )}
 
-      <div className="p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
+      <div className="mb-2">
         {showSummary && hasSubmittedRankings && (
           <>
             <div className="flex items-center justify-between mb-2">

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -267,7 +267,7 @@ export default function SuggestionVotingInterface({
 
   return (
     <>
-      <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg mb-2">
+      <div className="mt-4 mb-2">
         {/* Existing suggestions - all can be toggled in edit mode */}
         {filteredExistingSuggestions.length > 0 && (
           <div className="mb-3">


### PR DESCRIPTION
## Summary
- The poll card already provides a border + background; the inset gray-50 panel that wrapped `RankableOptions`, the suggestions input, and the yes/no buttons duplicated that chrome and made the ballot look nested-inside-a-card-inside-a-card.
- Strip the wrapper styling on three sites; keep the surrounding `mb-2` (and `mt-4` on the suggestions site) for spacing against neighboring blocks.

Affected:
- `components/RankingSection.tsx` — wrapper around the ranked-choice ballot / "Your ranking" summary.
- `components/SuggestionVotingInterface.tsx` — wrapper around the existing-suggestions list + new-suggestions input.
- `components/QuestionBallot.tsx` — wrapper around the yes/no buttons in the in-card branch (functionally dead today since the thread view's external Yes/No card takes over via `suppressYesNoHere`, but kept consistent for any future flow that re-mounts the in-card branch).

The visual change is most pronounced on the suggestions ballot, where the inset bordered panel was clearly visible. The ranked-choice change is subtler — the rows just extend slightly wider and the dividing line above "Your Name" disappears.

## Test plan
- [ ] Open a single-question ranked-choice poll and confirm the ranking ballot sits flush in the card (no inner border).
- [ ] Open a suggestion-phase ranked-choice poll and confirm the "Add new suggestions" input sits flush in the card.
- [ ] Open a multi-question poll (yes/no + ranked-choice) and confirm sections render without inner chrome.
- [ ] Submit a vote with an invalid state to surface `voteError` and confirm the red error banner still renders correctly inside each ballot.

Demo polls (dev): F1 (rc), F2 (suggestion), F3 (yn), F4 (yn+rc), F5 (3×yn), F6 (yn+rc+suggestion).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRd8tfZyqaXBYA3iJmcFes)_