### PR TITLE
Equalize spacing above modal header buttons with side spacing

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1820,12 +1820,12 @@ export function CreateQuestionContent() {
                   centered title gives the user a hint of what the modal is
                   for; we don't repeat the category here (the form body's
                   CategoryForLine already shows it). */}
-              <div className="relative flex items-center justify-center px-4 pt-3 pb-2">
+              <div className="relative flex items-center justify-center px-4 py-2 min-h-[3.25rem]">
                 <button
                   type="button"
                   onClick={dismissModal}
                   aria-label="Discard"
-                  className="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 flex items-center justify-center rounded-full text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  className="absolute left-2 top-2 w-9 h-9 flex items-center justify-center rounded-full text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
                 >
                   <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2.2} viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -1839,7 +1839,7 @@ export function CreateQuestionContent() {
                   onClick={() => confirmModal()}
                   disabled={isLoading || !inlineFormHasDraftableContent}
                   aria-label={editingDraftIndex !== null ? 'Save question edits' : 'Save question'}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 flex items-center justify-center rounded-full bg-blue-500 text-white cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="absolute right-2 top-2 w-9 h-9 flex items-center justify-center rounded-full bg-blue-500 text-white cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />


### PR DESCRIPTION
## Summary
- The X and check buttons in the New/Edit Question modal header used `left-2`/`right-2` (8px from sides) but were vertically centered, so the gap above them didn't match the side gap.
- Pin them to `top-2` and bump the header to `min-h-[3.25rem]` (52px) so the buttons sit 8px from the top with 8px below, while the title stays vertically centered with them.

## Test plan
- [ ] Open the New Question modal from a thread page; verify the X and check buttons are equally inset 8px from the top, left, and right of the modal.
- [ ] Open the Edit Question modal (pencil icon on a staged draft); same check.
- [ ] Confirm the "New Question" / "Edit Question" title remains vertically centered with the buttons.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B1udC5rgPBrRCgZFiAz9Ug)_