### PR TITLE
Phase B.2: use polls.thread_id for related-question discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,24 +748,37 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Poll System
 
-> **Phase B.1 of the thread-routing redesign shipped (this branch).** Migration
-> 099 introduces `threads(id, short_id, created_at)` and adds
-> `polls.thread_id uuid REFERENCES threads(id)`. Backfill: thread.id ==
-> root_poll.id (set deterministically via a recursive CTE on `follow_up_to`),
-> `threads.short_id` copied from the root poll's `short_id` (so the Phase A
-> route id continues to resolve once Phase B.4 starts using it). The column
-> is **nullable** in B.1 to avoid a deploy race; tightened to NOT NULL in B.2.
-> Server `_insert_poll` calls `_resolve_or_create_thread_id(parent_poll_id)`:
+> **Phase B.2 of the thread-routing redesign shipped (this branch).**
+> `algorithms/related_polls.py` no longer walks `polls.follow_up_to`
+> chains — it groups by `polls.thread_id`. The SQL in
+> `routers/questions.py:get_related_questions` is now a single indexed
+> `WHERE mp.thread_id IN (...)` lookup; the Python algorithm just dedupes
+> the result. `QuestionRelation` carries a single `thread_id` field
+> (replacing `poll_id` + `poll_follow_up_to`); `max_depth` is gone.
+> Migration `100_tighten_polls_thread_id_not_null` tightens
+> `polls.thread_id` to NOT NULL after a final backfill pass — any rows
+> still NULL at that point (orphans whose `follow_up_to` chain root was
+> deleted) get a freshly-minted `threads` row with `id = poll.id`.
+> `_resolve_parent_poll_id` is unchanged: it's a single `WHERE id = $1`
+> lookup translating a question_id (the public `follow_up_to` request
+> contract) into a poll_id, not a chain walk. No API contract changes —
+> see `docs/thread-routing-redesign.md`.
+>
+> **Phase B.1 (#261) is the previous step.** Migration 099 introduced
+> `threads(id, short_id, created_at)` and added `polls.thread_id uuid
+> REFERENCES threads(id)` (nullable). Backfill: thread.id == root_poll.id
+> set deterministically via a recursive CTE on `follow_up_to`;
+> `threads.short_id` copied from the root poll's `short_id` so the Phase A
+> route id continues to resolve once Phase B.4 starts using it. Server
+> `_insert_poll` calls `_resolve_or_create_thread_id(parent_poll_id)`:
 > follow-ups inherit `parent.thread_id`; root polls (no parent or missing
-> parent thread) get a fresh `threads` row via `INSERT INTO threads DEFAULT
-> VALUES RETURNING id`. New threads created post-migration have
-> `short_id = NULL` until Phase B.4 mints them. Nothing reads `polls.thread_id`
-> yet — Phase B.2 swaps server-side chain walking
-> (`_resolve_parent_poll_id`, `algorithms/related_polls.py`) for `WHERE
-> thread_id = $1` lookups. The integrity invariant "every poll's thread_id
-> matches its chain root" is enforced by application code in `_insert_poll`,
-> not by a CHECK constraint (subquery CHECKs aren't allowed; doable via a
-> trigger but skipped for B.1). See `docs/thread-routing-redesign.md`.
+> parent thread) get a fresh `threads` row via `INSERT INTO threads
+> DEFAULT VALUES RETURNING id`. New threads created post-migration have
+> `short_id = NULL` until Phase B.4 mints them. The integrity invariant
+> "every poll's thread_id matches its chain root" is enforced by application
+> code in `_insert_poll`, not by a CHECK constraint (subquery CHECKs aren't
+> allowed; doable via a trigger but skipped for B.1). See
+> `docs/thread-routing-redesign.md`.
 
 > **Phase 5 + 5b shipped.** Migration 096 dropped the wrapper-level columns
 > from `questions` (short_id, creator_secret, creator_name, response_deadline,

--- a/database/migrations/100_tighten_polls_thread_id_not_null_down.sql
+++ b/database/migrations/100_tighten_polls_thread_id_not_null_down.sql
@@ -1,0 +1,10 @@
+-- Down migration for 100_tighten_polls_thread_id_not_null.
+-- Loosens the NOT NULL constraint on polls.thread_id. The data backfilled
+-- by the up migration is left in place — that's a no-op for the schema and
+-- safe to keep.
+
+BEGIN;
+
+ALTER TABLE polls ALTER COLUMN thread_id DROP NOT NULL;
+
+COMMIT;

--- a/database/migrations/100_tighten_polls_thread_id_not_null_up.sql
+++ b/database/migrations/100_tighten_polls_thread_id_not_null_up.sql
@@ -1,0 +1,58 @@
+-- Phase B.2 of the thread routing redesign.
+-- Migration: 100_tighten_polls_thread_id_not_null
+--
+-- Phase B.1 (migration 099) added `polls.thread_id` as nullable to avoid a
+-- deploy race: the migration runs before the new code, so old code briefly
+-- inserts polls without setting thread_id. By the time this migration runs,
+-- the new code (which always sets thread_id on every insert via
+-- _resolve_or_create_thread_id) has fully rolled out, so any remaining NULLs
+-- are pre-deploy stragglers. Backfill them with a recursive CTE on
+-- follow_up_to (same approach as 099) and then tighten the column.
+--
+-- See docs/thread-routing-redesign.md for the full plan.
+
+BEGIN;
+
+-- Final backfill pass. Defensive: if 099 + the deploy already covered every
+-- row, this is a no-op. The recursive CTE finds chain roots (or stops at the
+-- first ancestor whose thread_id is set, even mid-chain).
+
+INSERT INTO threads (id, short_id, created_at)
+SELECT p.id, p.short_id, p.created_at
+  FROM polls p
+ WHERE p.follow_up_to IS NULL
+   AND p.thread_id IS NULL
+   AND NOT EXISTS (SELECT 1 FROM threads t WHERE t.id = p.id);
+
+WITH RECURSIVE chain AS (
+  SELECT id, follow_up_to, id AS root_id
+    FROM polls
+   WHERE follow_up_to IS NULL
+  UNION ALL
+  SELECT p.id, p.follow_up_to, c.root_id
+    FROM polls p
+    JOIN chain c ON p.follow_up_to = c.id
+)
+UPDATE polls p
+   SET thread_id = c.root_id
+  FROM chain c
+ WHERE p.id = c.id
+   AND p.thread_id IS NULL;
+
+-- Any poll still missing a thread_id at this point is orphaned (its
+-- follow_up_to references a deleted poll). Mint a fresh thread per orphan
+-- so the NOT NULL constraint can land cleanly.
+
+INSERT INTO threads (id, created_at)
+SELECT p.id, p.created_at
+  FROM polls p
+ WHERE p.thread_id IS NULL
+   AND NOT EXISTS (SELECT 1 FROM threads t WHERE t.id = p.id);
+
+UPDATE polls p
+   SET thread_id = p.id
+ WHERE p.thread_id IS NULL;
+
+ALTER TABLE polls ALTER COLUMN thread_id SET NOT NULL;
+
+COMMIT;

--- a/docs/thread-routing-redesign.md
+++ b/docs/thread-routing-redesign.md
@@ -1,7 +1,7 @@
 # Thread Routing Redesign
 
-> Status: Phase A shipped (#260). Phase B.1 in progress (this branch). Phases
-> B.2 / B.3 / B.4 / C are deferred.
+> Status: Phase A shipped (#260), Phase B.1 shipped (#261), Phase B.2 in
+> progress (this branch). Phases B.3 / B.4 / C are deferred.
 
 ## Vision
 
@@ -124,11 +124,22 @@ Broken into four sub-phases so each is independently shippable.
 Phase B.1 leaves `main` shippable: no API/FE changes, no behavior change. The
 schema is in place for Phases B.2 / B.4 to consume.
 
-#### Phase B.2 — Use `thread_id` server-side (deferred)
+#### Phase B.2 — Use `thread_id` server-side (this branch)
 
-- Replace server-side chain walking (e.g. `_resolve_parent_poll_id`,
-  `algorithms/related_polls.py`) with `WHERE thread_id = $1` lookups.
-- Tighten `polls.thread_id` to `NOT NULL` once the new code is fully rolled out.
+- `algorithms/related_polls.py` is reduced to a thread-id-grouped dedup
+  helper. The chain-walking logic is gone; the SQL in
+  `routers/questions.py:get_related_questions` does an indexed
+  `WHERE thread_id IN (...)` lookup in a single round-trip instead of
+  fetching every threaded question and walking in Python.
+- `_resolve_parent_poll_id` is unchanged — it's a single `WHERE id = $1`
+  lookup that translates a question_id (the public `follow_up_to`
+  contract on requests) into a poll_id, not a chain walk.
+- Migration `100_tighten_polls_thread_id_not_null` makes the column
+  NOT NULL after a final backfill pass. By the time this migration
+  runs, the Phase B.1 code has been writing thread_id on every insert
+  for at least one deploy cycle, so any remaining NULLs are
+  pre-deploy stragglers (handled by the same recursive CTE migration
+  099 used).
 - No API contract changes.
 
 #### Phase B.3 — `browser_id` cookie + new endpoints (deferred)

--- a/server/algorithms/related_polls.py
+++ b/server/algorithms/related_polls.py
@@ -1,12 +1,10 @@
-"""Discover all related question IDs via the poll-level follow_up chain.
+"""Discover all related question IDs by grouping on `thread_id`.
 
-Phase 3.5: thread chains live at the poll level. Two questions are related
-when their polls form a follow_up chain (in either direction) or when
-they share a poll wrapper (sibling questions).
-
-The original SQL discovery walked `questions.follow_up_to` per-row. Forks were
-removed in migration 095; sibling-question grouping was added when the
-poll system shipped.
+Phase B.2: thread membership is materialized as `polls.thread_id`. Two
+questions are related when their polls share a `thread_id`. The previous
+algorithm walked `polls.follow_up_to` chains in Python; that's now a single
+SQL `WHERE thread_id IN (...)` lookup, and this module just dedupes the
+result.
 """
 
 from __future__ import annotations
@@ -16,95 +14,43 @@ from dataclasses import dataclass
 
 @dataclass
 class QuestionRelation:
-    """A question's relationship fields used by the discovery algorithm.
+    """A question's thread membership.
 
-    `poll_id` groups sibling questions. `poll_follow_up_to` is the
-    question's wrapper's follow_up chain pointer (a poll_id, or None for
-    thread roots).
+    `thread_id` is `polls.thread_id` of the question's poll wrapper. Phase B.1
+    backfilled this for every existing poll and Phase B.2 tightens the column
+    to NOT NULL, so in practice it should always be set; we still tolerate
+    None on input rows so the caller doesn't have to filter.
     """
 
     id: str
-    poll_id: str | None = None
-    poll_follow_up_to: str | None = None
+    thread_id: str | None = None
 
 
 def get_all_related_question_ids(
     input_question_ids: list[str],
     all_questions: list[QuestionRelation],
-    max_depth: int = 10,
 ) -> list[str]:
-    """Find all question IDs related to the input set via poll-level
-    follow_up chains and poll-sibling grouping.
-
-    Searches bidirectionally at the poll level:
-    - Descendants: polls whose `follow_up_to` points to a known poll
-    - Ancestors: a known poll's `follow_up_to` target
-    - Siblings: every question of a visited poll
+    """Find every question sharing a thread with any input question.
 
     Args:
         input_question_ids: Starting set of question IDs.
-        all_questions: All questions with their poll-level relationship fields.
-        max_depth: Maximum traversal iterations (prevents infinite loops).
+        all_questions: Questions in the candidate pool, each with its
+            `thread_id`. Typically every question whose `thread_id` matches
+            an input's `thread_id`, fetched in one SQL hop by the caller.
 
     Returns:
-        Deduplicated list of all related question IDs (includes input IDs).
+        Deduplicated list of related question IDs (includes inputs even
+        when they're missing from `all_questions`).
     """
-    if not input_question_ids or not all_questions:
-        return list(set(input_question_ids)) if input_question_ids else []
+    if not input_question_ids:
+        return []
 
-    question_by_id: dict[str, QuestionRelation] = {p.id: p for p in all_questions}
-
-    # poll_id -> [question_id, ...] (every question of a wrapper).
-    questions_by_poll: dict[str, list[str]] = {}
-    # parent_poll_id -> [child_poll_id, ...] from mp.follow_up_to.
-    children_by_parent_poll: dict[str, list[str]] = {}
-    # poll_id -> parent_poll_id (mp.follow_up_to). Sub-questions of one
-    # wrapper share the same value; recorded once.
-    parent_of_poll: dict[str, str | None] = {}
-
-    for p in all_questions:
-        if not p.poll_id:
-            continue
-        questions_by_poll.setdefault(p.poll_id, []).append(p.id)
-        if p.poll_id not in parent_of_poll:
-            parent_of_poll[p.poll_id] = p.poll_follow_up_to
-        if p.poll_follow_up_to:
-            children_by_parent_poll.setdefault(p.poll_follow_up_to, []).append(
-                p.poll_id
-            )
-
-    # Dedupe child poll lists (one entry per child poll, not per
-    # sibling question of that child).
-    for parent_id, children in children_by_parent_poll.items():
-        children_by_parent_poll[parent_id] = list(dict.fromkeys(children))
-
-    discovered: set[str] = set(input_question_ids)
-    discovered_polls: set[str] = {
-        question_by_id[pid].poll_id
-        for pid in input_question_ids
-        if pid in question_by_id and question_by_id[pid].poll_id
+    input_set = set(input_question_ids)
+    input_threads = {
+        q.thread_id for q in all_questions if q.id in input_set and q.thread_id
     }
-    poll_frontier: set[str] = set(discovered_polls)
 
-    for _ in range(max_depth):
-        new_polls: set[str] = set()
-        for mid in poll_frontier:
-            # Descendants: child polls whose follow_up_to == mid.
-            for child_id in children_by_parent_poll.get(mid, []):
-                if child_id not in discovered_polls:
-                    new_polls.add(child_id)
-            # Ancestor: this poll's follow_up_to target.
-            parent_id = parent_of_poll.get(mid)
-            if parent_id and parent_id not in discovered_polls:
-                new_polls.add(parent_id)
-        if not new_polls:
-            break
-        discovered_polls |= new_polls
-        poll_frontier = new_polls
-
-    # Expand each discovered poll to its questions.
-    for mid in discovered_polls:
-        for pid in questions_by_poll.get(mid, []):
-            discovered.add(pid)
-
-    return list(discovered)
+    related = set(input_question_ids)
+    if input_threads:
+        related.update(q.id for q in all_questions if q.thread_id in input_threads)
+    return list(related)

--- a/server/routers/questions.py
+++ b/server/routers/questions.py
@@ -375,17 +375,20 @@ def get_related_questions(req: RelatedQuestionsRequest):
             all_related_ids=[], original_count=0, discovered_count=0
         )
     with get_db() as conn:
-        # Fetch every question plus its poll's follow_up_to (Phase 3.5 source
-        # of truth for thread chains). The discovery walks poll-level
-        # chains via mp.follow_up_to + poll-sibling grouping; per-question
-        # follow_up_to is no longer consulted for chain traversal.
+        # Phase B.2: thread membership is materialized as `polls.thread_id`.
+        # Fetch every question whose thread matches any input's thread —
+        # one indexed lookup, no chain walking.
         rows = conn.execute(
-            """SELECT p.id, p.poll_id,
-                      mp.follow_up_to AS poll_follow_up_to
+            """SELECT p.id, mp.thread_id
                  FROM questions p
-                 LEFT JOIN polls mp ON p.poll_id = mp.id
-                WHERE mp.follow_up_to IS NOT NULL
-                   OR p.poll_id IS NOT NULL
+                 JOIN polls mp ON p.poll_id = mp.id
+                WHERE mp.thread_id IN (
+                          SELECT mp2.thread_id
+                            FROM questions p2
+                            JOIN polls mp2 ON p2.poll_id = mp2.id
+                           WHERE p2.id = ANY(%(question_ids)s)
+                             AND mp2.thread_id IS NOT NULL
+                      )
                    OR p.id = ANY(%(question_ids)s)""",
             {"question_ids": req.question_ids},
         ).fetchall()
@@ -393,12 +396,7 @@ def get_related_questions(req: RelatedQuestionsRequest):
     all_questions = [
         QuestionRelation(
             id=str(r["id"]),
-            poll_id=str(r["poll_id"]) if r.get("poll_id") else None,
-            poll_follow_up_to=(
-                str(r["poll_follow_up_to"])
-                if r.get("poll_follow_up_to")
-                else None
-            ),
+            thread_id=str(r["thread_id"]) if r.get("thread_id") else None,
         )
         for r in rows
     ]

--- a/server/tests/test_related_polls.py
+++ b/server/tests/test_related_polls.py
@@ -1,9 +1,10 @@
 """Tests for related questions discovery algorithm.
 
-Phase 3.5: discovery walks poll-level chains. A `QuestionRelation` carries the
-question's `poll_id` and `poll_follow_up_to` (its wrapper's follow_up
-chain pointer). `_p()` wraps each test question in its own 1-question poll by
-default so the chain semantics mirror production after the Phase 4 backfill.
+Phase B.2: discovery groups by `polls.thread_id`. A `QuestionRelation` carries
+the question's `thread_id` (its poll wrapper's thread). The chain-walking
+that the algorithm used to do in Python now lives in SQL — the caller fetches
+every question whose poll shares a thread with any input, and the algorithm
+just dedupes.
 """
 
 import pytest
@@ -11,179 +12,93 @@ import pytest
 from algorithms.related_polls import QuestionRelation, get_all_related_question_ids
 
 
-def _p(
-    id: str,
-    *,
-    poll_id: str | None = None,
-    follow_up_to: str | None = None,
-) -> QuestionRelation:
-    """Build a QuestionRelation. By default each question lives in its own 1-question
-    poll whose id mirrors the question id (so single-question thread semantics are
-    expressed without test scaffolding noise). Pass `poll_id=...` to put
-    multiple questions in one wrapper. `follow_up_to` is a poll_id (the
-    wrapper's parent poll), matching `polls.follow_up_to` semantics.
+def _q(id: str, *, thread_id: str | None = None) -> QuestionRelation:
+    """Build a QuestionRelation. By default each question is in its own
+    single-question thread (thread_id mirrors id) — the trivial case.
+    Pass `thread_id=...` to put multiple questions in one thread.
     """
     return QuestionRelation(
         id=id,
-        poll_id=poll_id or id,
-        poll_follow_up_to=follow_up_to,
+        thread_id=thread_id or id,
     )
 
 
 class TestGetAllRelatedQuestionIds:
-    """Tests for bidirectional question relationship traversal at the poll level."""
+    """Tests for thread-grouped question discovery."""
 
     def test_empty_input(self):
         assert get_all_related_question_ids([], []) == []
 
     def test_single_question_no_relations(self):
-        questions = [_p("a")]
+        questions = [_q("a")]
         result = get_all_related_question_ids(["a"], questions)
         assert set(result) == {"a"}
 
-    def test_single_follow_up_descendant(self):
-        questions = [_p("a"), _p("b", follow_up_to="a")]
-        result = get_all_related_question_ids(["a"], questions)
-        assert set(result) == {"a", "b"}
+    def test_two_questions_in_one_thread(self):
+        """Two questions sharing a thread should both be returned, regardless
+        of which one is the input (membership is symmetric)."""
+        questions = [_q("a", thread_id="t1"), _q("b", thread_id="t1")]
+        assert set(get_all_related_question_ids(["a"], questions)) == {"a", "b"}
+        assert set(get_all_related_question_ids(["b"], questions)) == {"a", "b"}
 
-    def test_single_follow_up_ancestor(self):
-        """Starting from a follow-up should discover parent."""
-        questions = [_p("a"), _p("b", follow_up_to="a")]
-        result = get_all_related_question_ids(["b"], questions)
-        assert set(result) == {"a", "b"}
-
-    def test_chain_of_follow_ups(self):
-        """a -> b -> c -> d: starting from any should find all."""
+    def test_long_thread(self):
+        """All questions in one thread are discovered together."""
         questions = [
-            _p("a"),
-            _p("b", follow_up_to="a"),
-            _p("c", follow_up_to="b"),
-            _p("d", follow_up_to="c"),
+            _q("a", thread_id="t1"),
+            _q("b", thread_id="t1"),
+            _q("c", thread_id="t1"),
+            _q("d", thread_id="t1"),
         ]
         result = get_all_related_question_ids(["a"], questions)
         assert set(result) == {"a", "b", "c", "d"}
 
-    def test_chain_from_middle(self):
+    def test_multiple_input_questions_unrelated_threads(self):
+        """Two unrelated threads, querying from both."""
         questions = [
-            _p("a"),
-            _p("b", follow_up_to="a"),
-            _p("c", follow_up_to="b"),
-        ]
-        result = get_all_related_question_ids(["b"], questions)
-        assert set(result) == {"a", "b", "c"}
-
-    def test_branching_tree(self):
-        """a -> b, a -> c, b -> d"""
-        questions = [
-            _p("a"),
-            _p("b", follow_up_to="a"),
-            _p("c", follow_up_to="a"),
-            _p("d", follow_up_to="b"),
-        ]
-        result = get_all_related_question_ids(["a"], questions)
-        assert set(result) == {"a", "b", "c", "d"}
-
-    def test_branching_tree_from_leaf(self):
-        """Starting from d should find entire tree."""
-        questions = [
-            _p("a"),
-            _p("b", follow_up_to="a"),
-            _p("c", follow_up_to="a"),
-            _p("d", follow_up_to="b"),
-        ]
-        result = get_all_related_question_ids(["d"], questions)
-        assert set(result) == {"a", "b", "c", "d"}
-
-    def test_multiple_input_questions(self):
-        """Two unrelated trees, querying from both roots."""
-        questions = [
-            _p("a"),
-            _p("b", follow_up_to="a"),
-            _p("x"),
-            _p("y", follow_up_to="x"),
+            _q("a", thread_id="t1"),
+            _q("b", thread_id="t1"),
+            _q("x", thread_id="t2"),
+            _q("y", thread_id="t2"),
         ]
         result = get_all_related_question_ids(["a", "x"], questions)
         assert set(result) == {"a", "b", "x", "y"}
 
     def test_input_question_not_in_all_questions(self):
-        """Input question ID not in the all_questions list — still returned."""
-        questions = [_p("a")]
+        """Input ID missing from `all_questions` is still returned as-is."""
+        questions = [_q("a")]
         result = get_all_related_question_ids(["z"], questions)
         assert set(result) == {"z"}
 
-    def test_disconnected_questions_not_included(self):
-        """Questions not related to input should not appear."""
+    def test_disconnected_thread_not_included(self):
         questions = [
-            _p("a"),
-            _p("b", follow_up_to="a"),
-            _p("unrelated"),
+            _q("a", thread_id="t1"),
+            _q("b", thread_id="t1"),
+            _q("unrelated", thread_id="t2"),
         ]
         result = get_all_related_question_ids(["a"], questions)
         assert set(result) == {"a", "b"}
         assert "unrelated" not in result
 
-    def test_max_depth_limits_traversal(self):
-        """With max_depth=2, should only traverse 2 levels."""
-        questions = [
-            _p("a"),
-            _p("b", follow_up_to="a"),
-            _p("c", follow_up_to="b"),
-            _p("d", follow_up_to="c"),  # depth 3 from a
-        ]
-        result = get_all_related_question_ids(["a"], questions, max_depth=2)
-        assert set(result) == {"a", "b", "c"}
-        assert "d" not in result
-
     def test_duplicate_input_ids(self):
-        questions = [_p("a"), _p("b", follow_up_to="a")]
+        questions = [_q("a", thread_id="t1"), _q("b", thread_id="t1")]
         result = get_all_related_question_ids(["a", "a"], questions)
         assert set(result) == {"a", "b"}
-        # No duplicates in output
-        assert len(result) == len(set(result))
+        assert len(result) == len(set(result))  # no duplicates in output
 
     def test_empty_all_questions(self):
         result = get_all_related_question_ids(["a"], [])
         assert set(result) == {"a"}
 
-    # --- Poll-level semantics ---
-
-    def test_poll_siblings_grouped(self):
-        """Two questions in one wrapper are always discovered together."""
+    def test_mixed_threaded_and_unthreaded(self):
+        """An input with a thread_id discovers its thread mates; an input
+        without one still appears in the output as a no-op pass-through.
+        Post-migration 100, `thread_id` is NOT NULL — this test guards the
+        algorithm against a transient deploy state where a stale/unbackfilled
+        row sneaks through."""
         questions = [
-            _p("a", poll_id="m1"),
-            _p("b", poll_id="m1"),
+            _q("a", thread_id="t1"),
+            _q("b", thread_id="t1"),
+            QuestionRelation(id="c", thread_id=None),
         ]
-        result = get_all_related_question_ids(["a"], questions)
-        assert set(result) == {"a", "b"}
-
-    def test_followup_pulls_all_siblings_of_parent(self):
-        """A follow-up poll discovers every sibling question of its parent."""
-        questions = [
-            _p("a1", poll_id="m1"),
-            _p("a2", poll_id="m1"),
-            _p("b1", poll_id="m2", follow_up_to="m1"),
-        ]
-        result = get_all_related_question_ids(["b1"], questions)
-        assert set(result) == {"a1", "a2", "b1"}
-
-    def test_followup_pulls_all_siblings_of_child(self):
-        """Starting from a parent question discovers every sibling of the child."""
-        questions = [
-            _p("a1", poll_id="m1"),
-            _p("b1", poll_id="m2", follow_up_to="m1"),
-            _p("b2", poll_id="m2"),
-        ]
-        result = get_all_related_question_ids(["a1"], questions)
-        assert set(result) == {"a1", "b1", "b2"}
-
-    def test_chain_of_multi_question_wrappers(self):
-        """m1 -> m2 -> m3 with multiple questions in each: all discovered from any input."""
-        questions = [
-            _p("a1", poll_id="m1"),
-            _p("a2", poll_id="m1"),
-            _p("b1", poll_id="m2", follow_up_to="m1"),
-            _p("b2", poll_id="m2"),
-            _p("c1", poll_id="m3", follow_up_to="m2"),
-        ]
-        result = get_all_related_question_ids(["b2"], questions)
-        assert set(result) == {"a1", "a2", "b1", "b2", "c1"}
+        result = get_all_related_question_ids(["a", "c"], questions)
+        assert set(result) == {"a", "b", "c"}


### PR DESCRIPTION
## Summary

Phase B.2 of the [thread-routing redesign](../blob/main/docs/thread-routing-redesign.md). Phase B.1 (#261) materialized threads as a first-class table and added `polls.thread_id` (nullable, backfilled). This phase consumes it.

- `routers/questions.py:get_related_questions` swaps the old fetch-everything-and-walk-in-Python query for a single indexed `WHERE mp.thread_id IN (...)` lookup. The Python side just dedupes the result.
- `algorithms/related_polls.py` is reduced to a thread-id-grouped helper: `QuestionRelation` carries one field (`thread_id`) instead of two; `max_depth` is gone (no chain to walk).
- Migration `100_tighten_polls_thread_id_not_null` makes `polls.thread_id` NOT NULL after a final defensive backfill pass — any rows still NULL at that point (orphans whose `follow_up_to` chain root was deleted) get a freshly-minted `threads` row with `id = poll.id`.
- `_resolve_parent_poll_id` is unchanged — it's a single `WHERE id = $1` lookup translating a question_id (the public `follow_up_to` request contract) into a poll_id, not a chain walk.

No API contract changes. The FE keeps reading `Question.poll_follow_up_to` (computed from `polls.follow_up_to`, still written for FE chain walking — retired in a later phase).

## Test plan

- [x] `uv run pytest tests/` (160 passed) — algorithm + all server unit tests.
- [x] Migration 100 applied on dev (`dev_sam_at_samcarey_com`); `polls.thread_id` is NOT NULL.
- [x] Dev API smoke: created a root yes_no poll (`6c51fa3f...`) and a follow-up yes_no poll (`e74508c3...`); verified both share `thread_id=4c2fd54a...` in DB.
- [x] `/api/questions/related` resolves both questions when given either one as input (proves the new SQL groups by thread_id correctly).
- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq6iiFNASi9UoAZWs3FMJm)_