### PR TITLE
Phase B.3: thread endpoints + browser_id header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,7 +748,46 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Poll System
 
-> **Phase B.2 of the thread-routing redesign shipped (this branch).**
+> **Phase B.3 of the thread-routing redesign shipped (this branch).**
+> Two new endpoints — `POST /api/threads/mine` and
+> `GET /api/threads/by-route-id/{routeId}` — collapse the legacy three-step
+> bootstrap (`discoverRelatedQuestions` + `apiGetAccessibleQuestions` +
+> client-side `buildThreads`) into one server round-trip driven by
+> `polls.thread_id`. Both return `list[PollResponse]` — the same shape as
+> `/api/questions/accessible` — so the FE consumer is a drop-in. The
+> aggregation body of `/api/questions/accessible` was extracted to
+> `services/threads.py: polls_for_poll_ids(conn, poll_ids, *, include_results)`
+> and is shared by both routers.
+>
+> A new `BrowserIdMiddleware` mints a uuid4 on first visit and echoes it
+> via the `X-Browser-Id` response header. `lib/browserIdentity.ts` captures
+> the value and persists to localStorage so subsequent requests carry the
+> same id via the matching request header. **Header, not cookie** — the
+> FE talks to the API same-origin in prod (Next.js rewrite) and direct in
+> dev/CI; cookies require credentialed CORS which doesn't compose with
+> `allow_origins=["*"]`. The header avoids that minefield while giving
+> Phase C the same identity guarantee. Phase B.3 captures the id on
+> `request.state.browser_id` but doesn't gate visibility on it yet — that's
+> Phase C's job.
+>
+> FE rewiring: `lib/api/threads.ts` adds `apiGetMyThreads` /
+> `apiGetThreadByRouteId` (both warm `cachePoll` + the per-question
+> results cache); `lib/simpleQuestionQueries.ts: getMyThreads()` is the
+> drop-in replacement for `getAccessiblePolls() + discoverRelatedQuestions()`
+> that home/thread/`useThread` all consume. Newly-discovered question_ids
+> are persisted to localStorage (subject to the forgotten-list filter)
+> and the accessible cache is invalidated when the set grows so subsequent
+> freshness checks pick up the expanded list.
+> `discoverRelatedQuestions` is no longer called from any navigation path;
+> the function still exists for `triggerDiscoveryIfNeeded` callers but is
+> dead code in production. `next.config.ts` adds the `/api/threads`
+> rewrites alongside the existing `/api/questions` and `/api/polls` ones.
+>
+> Phase B.3 leaves `main` shippable: no schema changes, no contract changes
+> for existing endpoints. The legacy endpoints stay in place so any client
+> running the previous JS bundle keeps working through the rollout window.
+>
+> **Phase B.2 (#262) is the previous step.**
 > `algorithms/related_polls.py` no longer walks `polls.follow_up_to`
 > chains — it groups by `polls.thread_id`. The SQL in
 > `routers/questions.py:get_related_questions` is now a single indexed
@@ -1564,6 +1603,10 @@ Submitting a draft used to navigate to `/p/<newPollShortId>`. The user described
 ### API Development Pitfalls
 
 - **`server/services/questions.py` is the home for non-route helpers.** Anything that's a free function operating on a DB connection (`_fetch_question_full`, `_finalize_*`, `_submit_vote_to_question`, `_edit_vote_on_question`, `_row_to_question`, `_compute_results`, etc.) lives in `services/questions.py` and is imported by both `routers/questions.py` and `routers/polls.py`. Don't reach across routers (`from routers.questions import _foo` from a sibling router) — that pattern was retired when `services/` was introduced. Underscore-prefixed names are kept as a "low-stability internal API during poll Phase X churn" signal; OK to drop the underscore once the surface stabilizes.
+- **`server/services/threads.py` is the equivalent home for thread-aggregation helpers (Phase B.3).** `polls_for_poll_ids(conn, poll_ids, *, include_results)` builds the `PollResponse[]` payload (with inline results, voter aggregates, response counts) from a list of poll_ids. Both `/api/questions/accessible` and `/api/threads/*` use it. `thread_ids_for_question_ids` and `poll_ids_for_thread_ids` are thin SQL wrappers; `resolve_thread_id_from_route_id(conn, route_id)` does the four-form lookup (threads.short_id → threads.id → polls.short_id → polls.id) — extend it when Phase B.4 starts minting fresh `threads.short_id`s.
+- **`BrowserIdMiddleware` reads/mints a `X-Browser-Id` header per request (Phase B.3).** A header (not cookie) because the FE talks same-origin to the API in prod (Next.js rewrite) and direct in dev/CI; cookies would require credentialed CORS which doesn't compose with `allow_origins=["*"]`. The id is always echoed on the response (even on 4xx/5xx) so the FE can adopt server-issued ids on the very first request. `request.state.browser_id` is populated for every request; **Phase B.3 only captures, doesn't enforce** — Phase C will add `thread_members` and start gating visibility on this id. Reading/setting from a router: `getattr(request.state, "browser_id", None)`.
+- **FE `lib/browserIdentity.ts` is the canonical browser-id storage.** `getBrowserId()` returns the localStorage value or null. `adoptServerBrowserId(value)` is called by `_internal.ts: fetchWithBase` after every fetch — it's a first-write-wins merger so a compromised middlebox can't rewrite the id mid-session (mismatch logs a warning and keeps the existing id). Don't roll your own UUID — let the server mint and adopt the response.
+- **`apiGetMyThreads(accessibleQuestionIds)` and `apiGetThreadByRouteId(routeId)` (in `lib/api/threads.ts`) replace the legacy `discoverRelatedQuestions + apiGetAccessibleQuestions` pair.** Both warm `cachePoll` and the per-question results cache so subsequent `apiGetQuestionById`/`apiGetQuestionResults` calls hit warm cache. Use these for any new "give me this thread" flow; don't reach for `apiGetAccessibleQuestions` in new code (it's preserved for the legacy compatibility layer). The drop-in `getMyThreads()` wrapper in `lib/simpleQuestionQueries.ts` is what `app/page.tsx`, `app/t/[threadShortId]/page.tsx`, and `lib/useThread.ts` consume — it adds in-flight coalescing (StrictMode-safe), accessible-id persistence (the server-discovered question_ids get added to localStorage subject to the forgotten-list filter), and accessible-cache invalidation when the set grew.
 - **Catch-all fallthrough in `_compute_results()`**: When adding new question types, `server/services/questions.py: _compute_results()` has a catch-all return at the bottom returning `yes_count=None`. Any question type without an explicit handler silently falls through and the frontend interprets `None` as `0`. Always add an explicit handler for each question type.
 - **Frontend TODO stubs cause silent failures**: If the backend adds a new endpoint, check whether the frontend has TODO stubs (e.g., `setParticipants([])`) that need to be connected. Stubs cause incorrect UI without errors.
 - **`toQuestionResults()` in `lib/api.ts` is a manual field mapper** — when adding new fields to `QuestionResultsResponse` on the backend, you MUST also add them to `toQuestionResults()` or they'll be silently dropped. The function explicitly maps each field; unmapped fields from the API response are discarded.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import type { Poll } from "@/lib/types";
-import { getAccessiblePolls } from "@/lib/simpleQuestionQueries";
-import { discoverRelatedQuestions } from "@/lib/questionDiscovery";
+import { getMyThreads } from "@/lib/simpleQuestionQueries";
 import { apiGetAllQuestionIds } from "@/lib/api";
 import { addAccessibleQuestionId } from "@/lib/browserQuestionAccess";
 import { getCachedAccessiblePolls } from "@/lib/questionCache";
@@ -152,18 +151,13 @@ export default function Home() {
           }
         }
 
-        // First, discover any new follow-up questions
-        try {
-          const discoveryResult = await discoverRelatedQuestions();
-          if (discoveryResult.newQuestionIds.length > 0) {
-          }
-        } catch (discoveryError) {
-        }
-
-        // Get polls this browser has access to
-        const data = await getAccessiblePolls();
+        // Phase B.3: one round-trip — server walks polls.thread_id and
+        // returns every poll in any thread containing one of our
+        // accessible questions, with results inline. Replaces the legacy
+        // discoverRelatedQuestions + getAccessiblePolls pair.
+        const data = await getMyThreads();
         if (!data) {
-          console.error("Error fetching accessible questions");
+          console.error("Error fetching threads");
           setError("Failed to load polls");
           return;
         }
@@ -188,7 +182,7 @@ export default function Home() {
   useEffect(() => {
     const handler = async () => {
       try {
-        const data = await getAccessiblePolls();
+        const data = await getMyThreads();
         if (!data) return;
         setPolls((prev) =>
           prev.length === data.length && prev.every((p, i) => p.id === data[i].id)
@@ -206,19 +200,13 @@ export default function Home() {
     try {
       setLoading(true);
       setError(null);
-      
-      // First, discover any new follow-up questions
-      try {
-        const discoveryResult = await discoverRelatedQuestions();
-        if (discoveryResult.newQuestionIds.length > 0) {
-        }
-      } catch (discoveryError) {
-      }
 
-      // Get polls this browser has access to
-      const data = await getAccessiblePolls();
+      // Phase B.3: server walks polls.thread_id and returns every poll
+      // in any thread containing one of our accessible questions —
+      // discovery + accessibility are one round-trip now.
+      const data = await getMyThreads();
       if (!data) {
-        console.error("Error fetching accessible questions");
+        console.error("Error fetching threads");
         setError("Failed to load polls");
         return;
       }

--- a/app/t/[threadShortId]/page.tsx
+++ b/app/t/[threadShortId]/page.tsx
@@ -4,14 +4,13 @@ import { useCallback, useEffect, useLayoutEffect, useState, useRef, useMemo, Sus
 import { flushSync, createPortal } from "react-dom";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { Question } from "@/lib/types";
-import { getAccessiblePolls } from "@/lib/simpleQuestionQueries";
-import { discoverRelatedQuestions } from "@/lib/questionDiscovery";
+import { getMyThreads } from "@/lib/simpleQuestionQueries";
 import { buildThreadFromPollDown, buildThreadSyncFromCache, buildPollMap, isPendingPollId, POLL_QUERY_PARAM } from "@/lib/threadUtils";
-import { apiGetQuestionById, apiGetQuestionByShortId, apiGetQuestionResults, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiGetPollById, apiGetPollByShortId, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
+import { apiGetQuestionById, apiGetQuestionByShortId, apiGetQuestionResults, apiGetThreadByRouteId, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiGetPollById, apiGetPollByShortId, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
 import type { Poll } from "@/lib/types";
 import { useThreadVoting } from "@/lib/useThreadVoting";
 import type { QuestionResults } from "@/lib/types";
-import { addAccessibleQuestionId, getAccessibleQuestionIds, getCreatorSecret } from "@/lib/browserQuestionAccess";
+import { addAccessibleQuestionId, getCreatorSecret } from "@/lib/browserQuestionAccess";
 import { getCachedQuestionById, getCachedQuestionByShortId, getCachedAccessiblePolls, getCachedPollById, getCachedPollByShortId } from "@/lib/questionCache";
 import {
   POLL_PENDING_EVENT,
@@ -410,17 +409,32 @@ export function ThreadContent({ threadId, initialExpandedQuestionId = null }: Th
           return;
         }
 
-        // Discover children (may add new question IDs), then fetch the updated set.
-        // Votes prefetch fires in parallel with getAccessibleQuestions so the votes
-        // cache is warm by the time VoterList mounts — bubbles render alongside
-        // the cards instead of ~100ms after. apiGetVotes is cache + in-flight
+        // Phase B.3: one round-trip — apiGetThreadByRouteId resolves the
+        // route id to a thread_id and returns every poll in that thread,
+        // with full inline-results / voter aggregates. The legacy
+        // discoverRelatedQuestions + getAccessiblePolls pair walked the
+        // follow_up_to chain client-side; the server walks polls.thread_id
+        // directly now.
+        //
+        // Votes prefetch fires in parallel so the votes cache is warm by
+        // the time VoterList mounts — bubbles render alongside the cards
+        // instead of ~100ms after. apiGetVotes is cache + in-flight
         // coalesced, so the later per-card fetch hits the warm cache.
-        try { await discoverRelatedQuestions(); } catch {}
-        for (const id of getAccessibleQuestionIds()) {
-          void apiGetVotes(id).catch(() => null);
+        let polls: Poll[];
+        try {
+          polls = await apiGetThreadByRouteId(threadId);
+        } catch (err) {
+          if (err instanceof ApiError && err.status === 404) { setError(true); return; }
+          throw err;
         }
-        const polls = await getAccessiblePolls();
-        if (!polls) { setError(true); return; }
+        // Persist any newly-discovered question_ids to localStorage so a
+        // forget-and-re-discover cycle still works on direct navigation.
+        for (const mp of polls) {
+          for (const sp of mp.questions) addAccessibleQuestionId(sp.id);
+        }
+        for (const mp of polls) {
+          for (const sp of mp.questions) void apiGetVotes(sp.id).catch(() => null);
+        }
 
         // Re-read voted state — discovery or the user voting elsewhere may have changed it.
         const { votedQuestionIds: voted, abstainedQuestionIds: abstained } = loadVotedQuestions();
@@ -607,7 +621,7 @@ export function ThreadContent({ threadId, initialExpandedQuestionId = null }: Th
       if (optimisticWillAdd) return;
       void (async () => {
         try {
-          await getAccessiblePolls();
+          await getMyThreads();
           setThread((prev) => prev ? rebuildThreadFromCacheOrPrev(prev, { add: realPoll, remove: placeholderId }) : prev);
         } catch {
           // Optimistic rebuild has already fired; nothing else to do.
@@ -1886,10 +1900,16 @@ function ThreadPageInner() {
         }
         const firstQ = poll.questions[0]?.id;
         if (firstQ) addAccessibleQuestionId(firstQ);
-        try { await discoverRelatedQuestions(); } catch {}
-        // Warm the accessible-polls cache so ThreadContent's thread builder
-        // sees the full chain (ancestors + siblings) on first paint.
-        await getAccessiblePolls().catch(() => null);
+        // Phase B.3: one round-trip warms every poll in the thread so
+        // ThreadContent's buildThreadFromPollDown sees the full chain
+        // (ancestors + siblings) on first paint. Replaces the legacy
+        // discoverRelatedQuestions + getAccessiblePolls pair.
+        try {
+          const polls = await apiGetThreadByRouteId(threadShortId);
+          for (const mp of polls) {
+            for (const sp of mp.questions) addAccessibleQuestionId(sp.id);
+          }
+        } catch {}
         if (!cancelled) setRootPoll(poll);
       } catch {
         if (!cancelled) setError(true);

--- a/docs/thread-routing-redesign.md
+++ b/docs/thread-routing-redesign.md
@@ -1,7 +1,8 @@
 # Thread Routing Redesign
 
-> Status: Phase A shipped (#260), Phase B.1 shipped (#261), Phase B.2 in
-> progress (this branch). Phases B.3 / B.4 / C are deferred.
+> Status: Phase A shipped (#260), Phase B.1 shipped (#261), Phase B.2
+> shipped (#262), Phase B.3 in progress (this branch). Phase B.4 / C are
+> deferred.
 
 ## Vision
 
@@ -142,12 +143,62 @@ schema is in place for Phases B.2 / B.4 to consume.
   099 used).
 - No API contract changes.
 
-#### Phase B.3 — `browser_id` cookie + new endpoints (deferred)
+#### Phase B.3 — `browser_id` header + thread endpoints (this branch)
 
-- Introduce `browser_id` cookie. Server hands one out on first visit; client mirrors
-  into localStorage. New endpoints `getMyThreads()` and `getThread(id)` use it.
-- Replace `getAccessiblePolls()` + client-side `buildThreads()` + `discoverRelatedQuestions`
-  with the new server endpoints.
+- `BrowserIdMiddleware` mints a uuid4 on first visit and echoes it via the
+  `X-Browser-Id` response header. The FE captures the value
+  (`lib/browserIdentity.ts`) and persists to localStorage; subsequent
+  requests carry the same id via the matching request header.
+  - **Header, not cookie.** The FE talks to the API same-origin via
+    Next.js rewrites in prod and direct host in dev/CI; cookies under
+    either setup would require flipping CORS to credentialed mode which
+    doesn't compose with `allow_origins=["*"]`. The header avoids the
+    CORS minefield while giving Phase C the same identity guarantee.
+  - **Captured but not enforced yet.** `request.state.browser_id` is
+    populated for every request; the new endpoints don't gate on it.
+    Phase C will add the membership table and start filtering visibility.
+- New endpoints — `routers/threads.py`:
+  - `POST /api/threads/mine` — body
+    `{accessible_question_ids: list[str], include_results?: bool}`,
+    returns `list[PollResponse]` (every poll in any thread containing one of
+    the requested questions). Collapses the legacy
+    `discoverRelatedQuestions + apiGetAccessibleQuestions` pair into one
+    server round-trip — the server walks `polls.thread_id` once instead of
+    the FE walking `follow_up_to` chains across two calls.
+  - `GET /api/threads/by-route-id/{routeId}?include_results=...` — same
+    shape for one thread, resolved by `routeId`. The resolver checks
+    `threads.short_id` → `threads.id` → `polls.short_id` → `polls.id`
+    in order. Phase B.4 will start writing fresh `threads.short_id`s
+    that take priority over the root-poll-short_id fallback.
+- The aggregation body of `POST /api/questions/accessible` was extracted to
+  `services/threads.py: polls_for_poll_ids(conn, poll_ids, *, include_results)`
+  so both the legacy endpoint and the new threads router build identical
+  payloads from a list of poll_ids. The legacy endpoint is now a thin
+  question_id → poll_id resolver wrapping the same helper.
+- FE rewiring:
+  - `lib/api/threads.ts`: `apiGetMyThreads(ids)`, `apiGetThreadByRouteId(routeId)`.
+    Both return `Poll[]` and warm `cachePoll` + the per-question results
+    cache like `apiGetAccessibleQuestions` does.
+  - `lib/simpleQuestionQueries.ts: getMyThreads()` — drop-in replacement
+    for `getAccessiblePolls() + discoverRelatedQuestions()`. Reads the
+    accessible_question_ids from localStorage, calls `apiGetMyThreads`,
+    persists newly-discovered question_ids back to localStorage (subject
+    to the forgotten-list filter), invalidates the accessible cache when
+    the set grew, and caches the result.
+  - `app/page.tsx`, `app/t/[threadShortId]/page.tsx`, `lib/useThread.ts`:
+    home page + thread page + cache-first hook all switched to the new
+    endpoints. `discoverRelatedQuestions` is no longer called from any of
+    them; the function still exists for the test stub but is dead code on
+    the navigation path.
+- `next.config.ts` rewrites `/api/threads`, `/api/threads/`, and
+  `/api/threads/:path*` to the backend so client-side requests stay
+  same-origin.
+
+Phase B.3 leaves `main` shippable as well: no schema changes, no API
+contract changes for existing endpoints, just new endpoints + a request
+header. The legacy endpoints (`/api/questions/accessible`, `/api/questions/related`)
+remain in place so any client running the previous JS bundle keeps working
+through the rollout window.
 
 #### Phase B.4 — Decouple `threads.short_id` keyspace (deferred)
 

--- a/lib/api/_internal.ts
+++ b/lib/api/_internal.ts
@@ -8,6 +8,7 @@
 
 import type { Poll, Question, QuestionResults } from "@/lib/types";
 import { branchToSlug } from "@/lib/slug";
+import { adoptServerBrowserId, getBrowserId } from "@/lib/browserIdentity";
 
 // API URL resolution:
 // - NEXT_PUBLIC_API_URL overrides everything
@@ -34,7 +35,10 @@ export function getApiEndpoint(endpoint: string): string {
 
 export const API_BASE = getApiEndpoint('questions');
 export const POLL_BASE = getApiEndpoint('polls');
+export const THREAD_BASE = getApiEndpoint('threads');
 export const SEARCH_BASE = getApiEndpoint('search');
+
+const BROWSER_ID_HEADER = 'X-Browser-Id';
 
 export class ApiError extends Error {
   constructor(public status: number, message: string) {
@@ -45,13 +49,25 @@ export class ApiError extends Error {
 
 async function fetchWithBase<T>(base: string, path: string, options?: RequestInit): Promise<T> {
   const url = `${base}${path}`;
+  // Phase B.3: attach the browser_id (if known) on the way out, and adopt
+  // whatever value the server returns. The header round-trip is the FE↔BE
+  // identity handshake that Phase C will hang membership off of.
+  const browserId = getBrowserId();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options?.headers as Record<string, string> | undefined),
+  };
+  if (browserId) headers[BROWSER_ID_HEADER] = browserId;
+
   const res = await fetch(url, {
     ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
+    headers,
   });
+
+  // Adopt the server-issued id BEFORE error-throwing — even 4xx/5xx
+  // responses carry the header, and capturing it on the very first request
+  // means subsequent retries already have an id.
+  adoptServerBrowserId(res.headers.get(BROWSER_ID_HEADER));
 
   if (!res.ok) {
     let detail = res.statusText;
@@ -73,6 +89,10 @@ export function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
 
 export function pollFetch<T>(path: string, options?: RequestInit): Promise<T> {
   return fetchWithBase<T>(POLL_BASE, path, options);
+}
+
+export function threadFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  return fetchWithBase<T>(THREAD_BASE, path, options);
 }
 
 /**

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -39,6 +39,11 @@ export type { ApiVote, PollVoteItem } from "./votes";
 export { apiGetQuestionResults } from "./results";
 
 export {
+  apiGetMyThreads,
+  apiGetThreadByRouteId,
+} from "./threads";
+
+export {
   apiSearchLocations,
   apiSearchRestaurants,
   apiGeocode,

--- a/lib/api/threads.ts
+++ b/lib/api/threads.ts
@@ -1,0 +1,70 @@
+/**
+ * Phase B.3: thread-level API helpers.
+ *
+ * `apiGetMyThreads(accessibleQuestionIds)` collapses the legacy
+ * `discoverRelatedQuestions + apiGetAccessibleQuestions` pair into one
+ * server round-trip. The server resolves the question_ids to their threads
+ * (via `polls.thread_id`) and returns every poll in those threads with the
+ * full inline-results / voter aggregates that the home page expects.
+ *
+ * `apiGetThreadByRouteId(routeId)` returns the same shape for one thread,
+ * resolved by `routeId` (today: root poll's short_id; Phase B.4 will mint
+ * dedicated `threads.short_id`s).
+ *
+ * Both helpers piggyback on the existing per-poll cache: `cachePoll` is
+ * called for each returned poll so subsequent `apiGetPollById` calls hit
+ * warm cache.
+ */
+
+import type { Poll } from "@/lib/types";
+import { cachePoll, cacheQuestionResults } from "@/lib/questionCache";
+import { threadFetch, toPoll, toQuestionResults } from "./_internal";
+
+function hydrateAndCache(data: any[]): Poll[] {
+  return data.map((d) => {
+    const poll = toPoll(d);
+    cachePoll(poll);
+    // Mirror inline per-question results so apiGetQuestionResults hits
+    // the per-question results cache without a late re-fetch (matching
+    // apiGetAccessibleQuestions's behavior).
+    const sub = Array.isArray(d.questions) ? d.questions : [];
+    for (let i = 0; i < sub.length; i++) {
+      const subData = sub[i];
+      if (subData?.results) {
+        const results = toQuestionResults(subData.results);
+        cacheQuestionResults(subData.id, results);
+        if (poll.questions[i]) {
+          poll.questions[i].results = results;
+        }
+      }
+    }
+    return poll;
+  });
+}
+
+export async function apiGetMyThreads(
+  accessibleQuestionIds: string[],
+  options: { include_results?: boolean } = {},
+): Promise<Poll[]> {
+  if (accessibleQuestionIds.length === 0) return [];
+  const data: any[] = await threadFetch('/mine', {
+    method: 'POST',
+    body: JSON.stringify({
+      accessible_question_ids: accessibleQuestionIds,
+      include_results: options.include_results ?? true,
+    }),
+  });
+  return hydrateAndCache(data);
+}
+
+export async function apiGetThreadByRouteId(
+  routeId: string,
+  options: { include_results?: boolean } = {},
+): Promise<Poll[]> {
+  const params = new URLSearchParams();
+  if (options.include_results === false) params.set('include_results', 'false');
+  const qs = params.toString();
+  const path = `/by-route-id/${encodeURIComponent(routeId)}${qs ? `?${qs}` : ''}`;
+  const data: any[] = await threadFetch(path);
+  return hydrateAndCache(data);
+}

--- a/lib/browserIdentity.ts
+++ b/lib/browserIdentity.ts
@@ -1,0 +1,78 @@
+/**
+ * Phase B.3: per-browser identity that bridges to Phase C (membership).
+ *
+ * The server's `BrowserIdMiddleware` mints a uuid4 on first visit and echoes
+ * it via the `X-Browser-Id` response header. The FE captures the value and
+ * persists it to localStorage so subsequent requests carry the same id via
+ * the matching request header.
+ *
+ * `getBrowserId()` returns the stored id or `null` until the first response
+ * arrives. `adoptServerBrowserId(value)` is called from the API fetch wrapper
+ * whenever the server header is present — first-write wins; later writes
+ * (same value) are no-ops; conflicting values are logged and ignored so a
+ * compromised middlebox can't rewrite the id mid-session.
+ *
+ * Phase C will switch reads on the server to drive visibility off this id
+ * (via a `thread_members` table). For Phase B.3 it's pure scaffolding.
+ */
+
+const STORAGE_KEY = 'browser_id';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+let cached: string | null | undefined; // undefined = not yet read from storage
+
+function readFromStorage(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return v && UUID_RE.test(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeToStorage(value: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // Quota / privacy mode — accept the in-memory value and move on.
+  }
+}
+
+/** Current browser id, or null if the server hasn't issued one yet. */
+export function getBrowserId(): string | null {
+  if (cached === undefined) cached = readFromStorage();
+  return cached;
+}
+
+/** Adopt the value the server returned via `X-Browser-Id`. Idempotent
+ *  when the value matches what's stored; logs and skips on conflict. */
+export function adoptServerBrowserId(value: string | null | undefined): void {
+  if (!value || !UUID_RE.test(value)) return;
+  if (cached === undefined) cached = readFromStorage();
+  if (cached === value) return;
+  if (cached) {
+    // Persist the existing one and ignore the new value — first-write wins.
+    // Logging the divergence helps catch proxy / middlebox shenanigans.
+    if (typeof console !== 'undefined') {
+      console.warn(
+        '[browser_id] server returned different id; keeping existing',
+        cached.slice(0, 8) + '...',
+        'vs',
+        value.slice(0, 8) + '...',
+      );
+    }
+    return;
+  }
+  cached = value;
+  writeToStorage(value);
+}
+
+/** Reset for tests. Not for production use. */
+export function _resetBrowserIdForTests(): void {
+  cached = undefined;
+  if (typeof window !== 'undefined') {
+    try { localStorage.removeItem(STORAGE_KEY); } catch {}
+  }
+}

--- a/lib/simpleQuestionQueries.ts
+++ b/lib/simpleQuestionQueries.ts
@@ -2,16 +2,27 @@
 // No fingerprinting, no complex RLS - just localStorage question lists
 
 import type { Poll, Question } from '@/lib/types';
-import { apiGetAccessibleQuestions, apiGetQuestionById } from '@/lib/api';
-import { getAccessibleQuestionIds, addAccessibleQuestionId } from '@/lib/browserQuestionAccess';
+import {
+  apiGetAccessibleQuestions,
+  apiGetMyThreads,
+  apiGetQuestionById,
+} from '@/lib/api';
+import {
+  addAccessibleQuestionId,
+  getAccessibleQuestionIds,
+  getForgottenQuestionIds,
+} from '@/lib/browserQuestionAccess';
 import {
   cacheAccessiblePolls,
   getCachedAccessiblePolls,
   cacheQuestion,
+  invalidateAccessibleQuestions,
 } from '@/lib/questionCache';
 
-// Coalesce concurrent getAccessiblePolls calls (e.g., StrictMode double-mount)
+// Coalesce concurrent getAccessiblePolls / getMyThreads calls
+// (e.g., StrictMode double-mount).
 let inFlight: Promise<Poll[]> | null = null;
+let myThreadsInFlight: Promise<Poll[]> | null = null;
 
 /** Get the poll wrappers this browser has access to. Phase 5b: returns
  *  Poll[] (the wrappers covering the user's accessible questions).
@@ -65,6 +76,69 @@ export async function getAccessibleQuestions(): Promise<Question[]> {
   const questions: Question[] = [];
   for (const mp of polls) for (const sp of mp.questions) questions.push(sp);
   return questions;
+}
+
+/** Phase B.3: drop-in replacement for `getAccessiblePolls() +
+ *  discoverRelatedQuestions()`. Returns every poll in any thread that
+ *  contains one of this browser's accessible questions — the server walks
+ *  `polls.thread_id` once instead of the FE doing follow_up_to chain
+ *  expansion across two round-trips.
+ *
+ *  Side-effect: any newly-discovered question_ids are added to the browser's
+ *  accessible list (subject to the forgotten-list filter) so they survive a
+ *  cache flush. The cache is then cleared so the next call sees the
+ *  expanded set in subsequent freshness checks.
+ */
+export async function getMyThreads(): Promise<Poll[]> {
+  if (typeof window === 'undefined') return [];
+  try {
+    const accessibleIds = getAccessibleQuestionIds();
+    if (accessibleIds.length === 0) {
+      cacheAccessiblePolls([]);
+      return [];
+    }
+
+    const cached = getCachedAccessiblePolls();
+    if (cached) {
+      const cachedQuestionIds = new Set<string>();
+      for (const mp of cached) for (const sp of mp.questions) cachedQuestionIds.add(sp.id);
+      const allPresent = accessibleIds.every(id => cachedQuestionIds.has(id));
+      if (allPresent) return cached;
+    }
+
+    if (myThreadsInFlight) return myThreadsInFlight;
+
+    myThreadsInFlight = (async () => {
+      try {
+        const polls = await apiGetMyThreads(accessibleIds);
+        const forgotten = new Set(getForgottenQuestionIds());
+        const knownIds = new Set(accessibleIds);
+        let discovered = 0;
+        for (const mp of polls) {
+          for (const sp of mp.questions) {
+            if (!knownIds.has(sp.id) && !forgotten.has(sp.id)) {
+              addAccessibleQuestionId(sp.id);
+              discovered++;
+            }
+          }
+        }
+        if (discovered > 0) {
+          // The accessible list grew — invalidate so subsequent freshness
+          // checks see the expanded set.
+          invalidateAccessibleQuestions();
+        }
+        cacheAccessiblePolls(polls);
+        return polls;
+      } finally {
+        myThreadsInFlight = null;
+      }
+    })();
+
+    return myThreadsInFlight;
+  } catch (error) {
+    console.error('Error in getMyThreads:', error);
+    return [];
+  }
 }
 
 // Get a specific question by ID and grant access if found

--- a/lib/useThread.ts
+++ b/lib/useThread.ts
@@ -12,9 +12,7 @@
 import { useEffect, useState } from "react";
 import type { Question } from "./types";
 import { buildThreadFromPollDown, buildThreadSyncFromCache, type Thread } from "./threadUtils";
-import { getAccessiblePolls } from "./simpleQuestionQueries";
-import { discoverRelatedQuestions } from "./questionDiscovery";
-import { apiGetQuestionById, apiGetQuestionByShortId } from "./api";
+import { apiGetQuestionById, apiGetQuestionByShortId, apiGetThreadByRouteId } from "./api";
 import { addAccessibleQuestionId } from "./browserQuestionAccess";
 import { getCachedQuestionById, getCachedQuestionByShortId } from "./questionCache";
 import { isUuidLike } from "./questionId";
@@ -71,9 +69,12 @@ export function useThread(threadId: string): UseThreadResult {
           return;
         }
 
-        try { await discoverRelatedQuestions(); } catch {}
-        const polls = await getAccessiblePolls();
-        if (!polls) { if (!cancelled) setError(true); return; }
+        // Phase B.3: one round-trip — server walks polls.thread_id and
+        // returns every poll in this thread.
+        const polls = await apiGetThreadByRouteId(threadId);
+        for (const mp of polls) {
+          for (const sp of mp.questions) addAccessibleQuestionId(sp.id);
+        }
 
         const { votedQuestionIds, abstainedQuestionIds } = loadVotedQuestions();
         const anchorPollId = anchorQuestion.poll_id;

--- a/next.config.ts
+++ b/next.config.ts
@@ -71,6 +71,18 @@ if (process.env.NEXT_OUTPUT === 'standalone') {
         destination: `${apiDest}/api/polls/:path*`,
       },
       {
+        source: '/api/threads',
+        destination: `${apiDest}/api/threads`,
+      },
+      {
+        source: '/api/threads/',
+        destination: `${apiDest}/api/threads`,
+      },
+      {
+        source: '/api/threads/:path*',
+        destination: `${apiDest}/api/threads/:path*`,
+      },
+      {
         source: '/api/search/:path*',
         destination: `${apiDest}/api/search/:path*`,
       },

--- a/server/main.py
+++ b/server/main.py
@@ -4,30 +4,39 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import psycopg
 
-from middleware import RateLimitMiddleware
+from middleware import BrowserIdMiddleware, RateLimitMiddleware
 from routers.polls import router as polls_router
 from routers.questions import router as questions_router
 from routers.search import router as search_router
 from routers.client_logs import router as client_logs_router
+from routers.threads import router as threads_router
 
 app = FastAPI(title="WhoeverWants API", redirect_slashes=False)
 
 # Rate limiting (must be added before CORS so it runs first)
 app.add_middleware(RateLimitMiddleware, read_rpm=120, write_rpm=30)
 
-# CORS: allow any origin (anonymous API, no credentials needed)
+# Phase B.3: capture (or mint) browser_id per request. CORS exposes the
+# response header so the FE can read it cross-origin (same-origin in prod
+# via Next.js rewrite, but dev/CI sometimes hits the API directly).
+app.add_middleware(BrowserIdMiddleware)
+
+# CORS: allow any origin (anonymous API, no credentials needed). Expose the
+# X-Browser-Id response header so the FE can adopt server-assigned ids.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-Browser-Id"],
 )
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
 
 app.include_router(questions_router)
 app.include_router(polls_router)
+app.include_router(threads_router)
 app.include_router(search_router)
 app.include_router(client_logs_router)
 

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -1,7 +1,9 @@
-"""Rate limiting middleware for FastAPI."""
+"""Middleware for FastAPI: rate limiting + Phase B.3 browser_id capture."""
 
 import os
+import re
 import time
+import uuid
 from collections import defaultdict
 from threading import Lock
 
@@ -76,3 +78,55 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             )
 
         return await call_next(request)
+
+
+# uuid4 form, lowercase hex; rejects anything else so a hostile client can't
+# inject a free-form value through the header.
+_BROWSER_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+class BrowserIdMiddleware(BaseHTTPMiddleware):
+    """Phase B.3: capture or mint a `browser_id` for the request.
+
+    Reads the `X-Browser-Id` header (which the FE attaches from
+    `lib/browserIdentity.ts`). When absent or malformed, the server mints a
+    fresh uuid and returns it in the `X-Browser-Id` response header — first
+    visit, the FE captures the response value and persists it to localStorage
+    so future requests carry the same id.
+
+    A header (rather than a cookie) is used because the FE talks to the API
+    same-origin via Next.js rewrites in prod and via direct host in dev/CI;
+    cookies under either setup would require flipping CORS to credentialed
+    mode which doesn't compose with `allow_origins=["*"]`. The header avoids
+    the entire CORS minefield while giving Phase C the same identity
+    guarantee.
+
+    Phase B.3 only captures; nothing on the read path enforces yet. Phase C
+    will add the membership table and start gating visibility on this id.
+    """
+
+    def __init__(self, app, header_name: str = "X-Browser-Id"):
+        super().__init__(app)
+        self._header = header_name
+
+    @staticmethod
+    def _normalize(value: str | None) -> str | None:
+        if not value:
+            return None
+        v = value.strip().lower()
+        return v if _BROWSER_ID_RE.match(v) else None
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        incoming = self._normalize(request.headers.get(self._header))
+        browser_id = incoming or str(uuid.uuid4())
+        request.state.browser_id = browser_id
+
+        response = await call_next(request)
+        # Always echo the (possibly newly-minted) browser_id so the FE can
+        # adopt server-assigned ids on first visit. A subsequent request
+        # already carrying the id sees the same value echoed back, which is
+        # cheap and keeps the response shape stable.
+        response.headers[self._header] = browser_id
+        return response

--- a/server/routers/questions.py
+++ b/server/routers/questions.py
@@ -28,6 +28,7 @@ from services.questions import (
     _row_to_question,
     _row_to_vote,
 )
+from services.threads import polls_for_poll_ids
 
 router = APIRouter(prefix="/api/questions", tags=["questions"])
 
@@ -206,19 +207,14 @@ def get_accessible_questions(req: AccessibleQuestionsRequest):
     populated on each question using the same gating as the per-question /results
     endpoint (closed questions always; open questions when show_preliminary_results
     is true and min_responses is unset-or-met).
-    """
-    # Local import keeps this file from growing a circular dep with polls.py.
-    from routers.polls import (
-        _compute_poll_voter_data,
-        _row_to_poll,
-    )
 
+    Phase B.3: aggregation logic moved to `services.threads.polls_for_poll_ids`
+    so `/api/threads/*` can build identical payloads from a thread-id-driven
+    poll set. This endpoint stays as a same-shape compatibility surface.
+    """
     if not req.question_ids:
         return []
-    now = datetime.now(timezone.utc)
     with get_db() as conn:
-        # Resolve requested question_ids → unique poll_ids. Questions without a
-        # poll_id are skipped (post-Phase-4 there shouldn't be any).
         mp_id_rows = conn.execute(
             """SELECT DISTINCT poll_id
                  FROM questions
@@ -226,145 +222,7 @@ def get_accessible_questions(req: AccessibleQuestionsRequest):
             {"ids": req.question_ids},
         ).fetchall()
         poll_ids = [str(r["poll_id"]) for r in mp_id_rows]
-        if not poll_ids:
-            return []
-
-        # Fetch every poll wrapper.
-        poll_rows = conn.execute(
-            """SELECT * FROM polls
-                WHERE id = ANY(%(ids)s)
-                ORDER BY created_at DESC""",
-            {"ids": poll_ids},
-        ).fetchall()
-
-        # Fetch every question of these polls in one query, preserving
-        # creator-intended order.
-        question_rows = conn.execute(
-            """SELECT * FROM questions
-                WHERE poll_id = ANY(%(ids)s)
-                ORDER BY poll_id, question_index NULLS LAST, created_at""",
-            {"ids": poll_ids},
-        ).fetchall()
-        questions_by_mp: dict[str, list] = {}
-        for sp in question_rows:
-            questions_by_mp.setdefault(str(sp["poll_id"]), []).append(sp)
-        all_question_ids = [str(sp["id"]) for sp in question_rows]
-
-        # Inline-results gating mirrors the previous per-question behavior. A
-        # question's `is_closed` / `response_deadline` come from its wrapper.
-        wrappers_by_id = {str(mp["id"]): mp for mp in poll_rows}
-        closed_question_ids: list[str] = []
-        open_question_ids: list[str] = []
-        for sp in question_rows:
-            mp = wrappers_by_id.get(str(sp["poll_id"]))
-            is_closed = bool(mp and mp.get("is_closed"))
-            deadline = mp.get("response_deadline") if mp else None
-            deadline_passed = bool(deadline and deadline <= now)
-            (closed_question_ids if (is_closed or deadline_passed) else open_question_ids).append(str(sp["id"]))
-
-        votes_by_question: dict[str, list] = {pid: [] for pid in closed_question_ids}
-        if closed_question_ids:
-            vote_rows = conn.execute(
-                "SELECT * FROM votes WHERE question_id = ANY(%(question_ids)s)",
-                {"question_ids": closed_question_ids},
-            ).fetchall()
-            for v in vote_rows:
-                pid = str(v["question_id"])
-                if pid in votes_by_question:
-                    votes_by_question[pid].append(v)
-
-        response_counts: dict[str, int] = {}
-        if open_question_ids:
-            count_rows = conn.execute(
-                "SELECT question_id, COUNT(*) as cnt FROM votes WHERE question_id = ANY(%(question_ids)s) GROUP BY question_id",
-                {"question_ids": open_question_ids},
-            ).fetchall()
-            for cr in count_rows:
-                response_counts[str(cr["question_id"])] = cr["cnt"]
-
-        question_rows_by_id = {str(sp["id"]): sp for sp in question_rows}
-        preliminary_question_ids: list[str] = []
-        for pid in open_question_ids:
-            sp = question_rows_by_id[pid]
-            mp = wrappers_by_id.get(str(sp["poll_id"]))
-            # Migration 098: these settings live on the poll wrapper now.
-            min_resp = mp.get("min_responses") if mp else None
-            show_prelim = mp.get("show_preliminary_results", True) if mp else True
-            if show_prelim and (min_resp is None or response_counts.get(pid, 0) >= min_resp):
-                preliminary_question_ids.append(pid)
-        if preliminary_question_ids:
-            prelim_vote_rows = conn.execute(
-                "SELECT * FROM votes WHERE question_id = ANY(%(question_ids)s)",
-                {"question_ids": preliminary_question_ids},
-            ).fetchall()
-            for v in prelim_vote_rows:
-                pid = str(v["question_id"])
-                votes_by_question.setdefault(pid, []).append(v)
-
-        # Per-question voter_names (kept on QuestionResponse for per-card respondent
-        # rows). Reuse vote rows we already fetched to avoid a second pass.
-        voter_names_by_question: dict[str, list[str]] = {}
-        for pid, votes in votes_by_question.items():
-            names = sorted({
-                v["voter_name"] for v in votes
-                if v.get("voter_name") and v["voter_name"] != ""
-            })
-            if names:
-                voter_names_by_question[pid] = names
-        remaining_question_ids = [pid for pid in all_question_ids if pid not in votes_by_question]
-        if remaining_question_ids:
-            vn_rows = conn.execute(
-                """SELECT question_id, array_agg(DISTINCT voter_name ORDER BY voter_name) as names
-                     FROM votes
-                    WHERE question_id = ANY(%(question_ids)s)
-                      AND voter_name IS NOT NULL AND voter_name != ''
-                    GROUP BY question_id""",
-                {"question_ids": remaining_question_ids},
-            ).fetchall()
-            for vn in vn_rows:
-                voter_names_by_question[str(vn["question_id"])] = vn["names"]
-
-        # Poll-level voter aggregates. _compute_poll_voter_data
-        # issues one query per poll; for the typical user with <100
-        # accessible polls this is fine, and matching the existing
-        # /api/polls/by-id/{id} behavior keeps the aggregation logic
-        # in one place.
-        voter_data_by_mp: dict[str, tuple[list[str], int]] = {}
-        for mp_id in poll_ids:
-            voter_data_by_mp[mp_id] = _compute_poll_voter_data(conn, mp_id)
-
-    # Build the response. Inline results / response_count / per-question
-    # voter_names are attached to each QuestionResponse after _row_to_poll
-    # builds it.
-    responses: list[PollResponse] = []
-    for mp_row in poll_rows:
-        mp_id = str(mp_row["id"])
-        sp_rows = questions_by_mp.get(mp_id, [])
-        voter_names, anon_count = voter_data_by_mp.get(mp_id, ([], 0))
-        mp_resp = _row_to_poll(mp_row, sp_rows, voter_names, anon_count)
-        if req.include_results:
-            for sp_resp in mp_resp.questions:
-                pid = sp_resp.id
-                if pid in votes_by_question:
-                    sp_row = question_rows_by_id[pid]
-                    # _compute_results reads wrapper-level fields off the row
-                    # (response_deadline, close_reason, suggestion_deadline)
-                    # so splice them in from the wrapper.
-                    enriched = dict(sp_row)
-                    enriched["response_deadline"] = mp_row.get("response_deadline")
-                    enriched["close_reason"] = mp_row.get("close_reason")
-                    enriched["is_closed"] = mp_row.get("is_closed", False)
-                    enriched["suggestion_deadline"] = mp_row.get("prephase_deadline")
-                    try:
-                        sp_resp.results = _compute_results(enriched, votes_by_question[pid])
-                    except Exception:
-                        logger.warning("Failed to compute results for question %s", pid, exc_info=True)
-                if pid in response_counts:
-                    sp_resp.response_count = response_counts[pid]
-                if pid in voter_names_by_question:
-                    sp_resp.voter_names = voter_names_by_question[pid]
-        responses.append(mp_resp)
-    return responses
+        return polls_for_poll_ids(conn, poll_ids, include_results=req.include_results)
 
 
 @router.post("/related", response_model=RelatedQuestionsResponse)

--- a/server/routers/threads.py
+++ b/server/routers/threads.py
@@ -1,0 +1,104 @@
+"""Thread API endpoints (Phase B.3 of the thread routing redesign).
+
+Two endpoints — `POST /api/threads/mine` and
+`GET /api/threads/by-route-id/{route_id}` — collapse the legacy three-step
+home / thread page bootstrap (discoverRelatedQuestions + getAccessiblePolls
++ client-side `buildThreads`) into a single server round-trip driven by
+`polls.thread_id`.
+
+Both return `list[PollResponse]` — same shape as
+`POST /api/questions/accessible` — so the FE consumer is a drop-in for
+the existing flow. The thread set is computed server-side using the
+indexed `polls.thread_id` column rather than walking
+`polls.follow_up_to` chains in Python.
+
+Phase B.3 deliberately stops short of cookie-driven membership (Phase C):
+`POST /api/threads/mine` still accepts `{accessible_question_ids: list[str]}`
+as the access signal. The browser_id captured by `BrowserIdMiddleware` is
+read for telemetry/forward-compat but never gates results yet.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from database import get_db
+from models import PollResponse
+from services.threads import (
+    poll_ids_for_thread_ids,
+    polls_for_poll_ids,
+    resolve_thread_id_from_route_id,
+    thread_ids_for_question_ids,
+)
+
+router = APIRouter(prefix="/api/threads", tags=["threads"])
+
+
+class MyThreadsRequest(BaseModel):
+    """Request body for `POST /api/threads/mine`.
+
+    Phase B.3: the FE passes its localStorage `accessible_question_ids` list;
+    the server resolves to thread_ids and returns every poll in those threads.
+    Phase C will switch to cookie-driven membership and this list becomes
+    optional/legacy.
+    """
+
+    accessible_question_ids: list[str] = Field(default_factory=list)
+    include_results: bool = True
+
+
+@router.post("/mine", response_model=list[PollResponse])
+def get_my_threads(req: MyThreadsRequest, request: Request):
+    """Return every poll in any thread that contains one of the user's
+    accessible questions.
+
+    Replaces the legacy `discoverRelatedQuestions + getAccessiblePolls`
+    pair: the server walks `polls.thread_id` once to fan out from the
+    requested question_ids to every poll in their threads, then hydrates
+    each poll the same way `POST /api/questions/accessible` does.
+
+    The browser_id (set by BrowserIdMiddleware) is captured on
+    `request.state.browser_id` but not used for filtering yet — Phase C
+    will add `thread_members` and start enforcing visibility here.
+    """
+    # Touch attribute so static checkers don't flag unused state. Phase C
+    # will read this for membership lookup.
+    _ = getattr(request.state, "browser_id", None)
+
+    if not req.accessible_question_ids:
+        return []
+    with get_db() as conn:
+        thread_ids = thread_ids_for_question_ids(conn, req.accessible_question_ids)
+        if not thread_ids:
+            return []
+        poll_ids = poll_ids_for_thread_ids(conn, thread_ids)
+        return polls_for_poll_ids(conn, poll_ids, include_results=req.include_results)
+
+
+@router.get("/by-route-id/{route_id}", response_model=list[PollResponse])
+def get_thread_by_route_id(
+    route_id: str,
+    request: Request,
+    include_results: bool = True,
+):
+    """Return every poll in one thread, resolved by route id.
+
+    `route_id` accepts (in order):
+      - `threads.short_id`
+      - `threads.id` (uuid)
+      - `polls.short_id` (Phase A → Phase B.3 fallback: today's
+        `threadShortId` is the root poll's short_id; Phase B.4 will mint
+        dedicated thread short_ids)
+      - `polls.id` (uuid fallback)
+
+    404 when no thread can be resolved.
+    """
+    _ = getattr(request.state, "browser_id", None)
+
+    with get_db() as conn:
+        thread_id = resolve_thread_id_from_route_id(conn, route_id)
+        if not thread_id:
+            raise HTTPException(status_code=404, detail="Thread not found")
+        poll_ids = poll_ids_for_thread_ids(conn, [thread_id])
+        return polls_for_poll_ids(conn, poll_ids, include_results=include_results)

--- a/server/services/threads.py
+++ b/server/services/threads.py
@@ -1,0 +1,247 @@
+"""Shared helpers for poll/thread aggregation queries.
+
+Phase B.3 extracted the heavy aggregation body of
+`POST /api/questions/accessible` here so both the legacy endpoint and the
+new `/api/threads/*` endpoints can build identical PollResponse[] payloads
+from a list of poll_ids — without each router re-implementing the
+inline-results / per-question voter_names / poll-level voter aggregation
+logic.
+
+`polls_for_poll_ids(conn, poll_ids, include_results)` is the canonical entry:
+caller resolves which poll_ids to surface (via question_ids → poll_id
+lookup, thread_id-grouped fanout, or any other path) and the helper does the
+rest.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from models import PollResponse
+from services.questions import _compute_results
+
+logger = logging.getLogger(__name__)
+
+
+def polls_for_poll_ids(
+    conn,
+    poll_ids: list[str],
+    *,
+    include_results: bool,
+) -> list[PollResponse]:
+    """Build PollResponse[] (with inline results / voter aggregates) for the
+    given poll_ids. Order: most recently created first. Empty list in →
+    empty list out (no DB roundtrip)."""
+    # Local import keeps services/* free of router cycles.
+    from routers.polls import _compute_poll_voter_data, _row_to_poll
+
+    if not poll_ids:
+        return []
+
+    now = datetime.now(timezone.utc)
+
+    poll_rows = conn.execute(
+        """SELECT * FROM polls
+            WHERE id = ANY(%(ids)s)
+            ORDER BY created_at DESC""",
+        {"ids": poll_ids},
+    ).fetchall()
+    if not poll_rows:
+        return []
+
+    poll_ids_present = [str(r["id"]) for r in poll_rows]
+
+    question_rows = conn.execute(
+        """SELECT * FROM questions
+            WHERE poll_id = ANY(%(ids)s)
+            ORDER BY poll_id, question_index NULLS LAST, created_at""",
+        {"ids": poll_ids_present},
+    ).fetchall()
+    questions_by_mp: dict[str, list] = {}
+    for sp in question_rows:
+        questions_by_mp.setdefault(str(sp["poll_id"]), []).append(sp)
+    all_question_ids = [str(sp["id"]) for sp in question_rows]
+
+    wrappers_by_id = {str(mp["id"]): mp for mp in poll_rows}
+    closed_question_ids: list[str] = []
+    open_question_ids: list[str] = []
+    for sp in question_rows:
+        mp = wrappers_by_id.get(str(sp["poll_id"]))
+        is_closed = bool(mp and mp.get("is_closed"))
+        deadline = mp.get("response_deadline") if mp else None
+        deadline_passed = bool(deadline and deadline <= now)
+        target = closed_question_ids if (is_closed or deadline_passed) else open_question_ids
+        target.append(str(sp["id"]))
+
+    votes_by_question: dict[str, list] = {pid: [] for pid in closed_question_ids}
+    if closed_question_ids:
+        vote_rows = conn.execute(
+            "SELECT * FROM votes WHERE question_id = ANY(%(question_ids)s)",
+            {"question_ids": closed_question_ids},
+        ).fetchall()
+        for v in vote_rows:
+            pid = str(v["question_id"])
+            if pid in votes_by_question:
+                votes_by_question[pid].append(v)
+
+    response_counts: dict[str, int] = {}
+    if open_question_ids:
+        count_rows = conn.execute(
+            "SELECT question_id, COUNT(*) as cnt FROM votes WHERE question_id = ANY(%(question_ids)s) GROUP BY question_id",
+            {"question_ids": open_question_ids},
+        ).fetchall()
+        for cr in count_rows:
+            response_counts[str(cr["question_id"])] = cr["cnt"]
+
+    question_rows_by_id = {str(sp["id"]): sp for sp in question_rows}
+    preliminary_question_ids: list[str] = []
+    for pid in open_question_ids:
+        sp = question_rows_by_id[pid]
+        mp = wrappers_by_id.get(str(sp["poll_id"]))
+        min_resp = mp.get("min_responses") if mp else None
+        show_prelim = mp.get("show_preliminary_results", True) if mp else True
+        if show_prelim and (min_resp is None or response_counts.get(pid, 0) >= min_resp):
+            preliminary_question_ids.append(pid)
+    if preliminary_question_ids:
+        prelim_vote_rows = conn.execute(
+            "SELECT * FROM votes WHERE question_id = ANY(%(question_ids)s)",
+            {"question_ids": preliminary_question_ids},
+        ).fetchall()
+        for v in prelim_vote_rows:
+            pid = str(v["question_id"])
+            votes_by_question.setdefault(pid, []).append(v)
+
+    voter_names_by_question: dict[str, list[str]] = {}
+    for pid, votes in votes_by_question.items():
+        names = sorted({
+            v["voter_name"] for v in votes
+            if v.get("voter_name") and v["voter_name"] != ""
+        })
+        if names:
+            voter_names_by_question[pid] = names
+    remaining_question_ids = [pid for pid in all_question_ids if pid not in votes_by_question]
+    if remaining_question_ids:
+        vn_rows = conn.execute(
+            """SELECT question_id, array_agg(DISTINCT voter_name ORDER BY voter_name) as names
+                 FROM votes
+                WHERE question_id = ANY(%(question_ids)s)
+                  AND voter_name IS NOT NULL AND voter_name != ''
+                GROUP BY question_id""",
+            {"question_ids": remaining_question_ids},
+        ).fetchall()
+        for vn in vn_rows:
+            voter_names_by_question[str(vn["question_id"])] = vn["names"]
+
+    voter_data_by_mp: dict[str, tuple[list[str], int]] = {}
+    for mp_id in poll_ids_present:
+        voter_data_by_mp[mp_id] = _compute_poll_voter_data(conn, mp_id)
+
+    responses: list[PollResponse] = []
+    for mp_row in poll_rows:
+        mp_id = str(mp_row["id"])
+        sp_rows = questions_by_mp.get(mp_id, [])
+        voter_names, anon_count = voter_data_by_mp.get(mp_id, ([], 0))
+        mp_resp = _row_to_poll(mp_row, sp_rows, voter_names, anon_count)
+        if include_results:
+            for sp_resp in mp_resp.questions:
+                pid = sp_resp.id
+                if pid in votes_by_question:
+                    sp_row = question_rows_by_id[pid]
+                    enriched = dict(sp_row)
+                    enriched["response_deadline"] = mp_row.get("response_deadline")
+                    enriched["close_reason"] = mp_row.get("close_reason")
+                    enriched["is_closed"] = mp_row.get("is_closed", False)
+                    enriched["suggestion_deadline"] = mp_row.get("prephase_deadline")
+                    try:
+                        sp_resp.results = _compute_results(enriched, votes_by_question[pid])
+                    except Exception:
+                        logger.warning(
+                            "Failed to compute results for question %s", pid, exc_info=True,
+                        )
+                if pid in response_counts:
+                    sp_resp.response_count = response_counts[pid]
+                if pid in voter_names_by_question:
+                    sp_resp.voter_names = voter_names_by_question[pid]
+        responses.append(mp_resp)
+    return responses
+
+
+def thread_ids_for_question_ids(conn, question_ids: list[str]) -> list[str]:
+    """Resolve a list of question_ids to the set of thread_ids that own them.
+    Skips question_ids without a poll_id (post-Phase-4 there shouldn't be any)
+    and polls without a thread_id (post-migration-100 there aren't any). Order
+    is unstable — the caller deduplicates."""
+    if not question_ids:
+        return []
+    rows = conn.execute(
+        """SELECT DISTINCT mp.thread_id
+             FROM questions p
+             JOIN polls mp ON p.poll_id = mp.id
+            WHERE p.id = ANY(%(ids)s)
+              AND mp.thread_id IS NOT NULL""",
+        {"ids": question_ids},
+    ).fetchall()
+    return [str(r["thread_id"]) for r in rows]
+
+
+def poll_ids_for_thread_ids(conn, thread_ids: list[str]) -> list[str]:
+    """Resolve a list of thread_ids to every poll_id that belongs to those
+    threads. Used by the threads endpoints to fan out from the user's
+    'these threads matter' set to every poll the user should see."""
+    if not thread_ids:
+        return []
+    rows = conn.execute(
+        """SELECT id FROM polls WHERE thread_id = ANY(%(ids)s)""",
+        {"ids": thread_ids},
+    ).fetchall()
+    return [str(r["id"]) for r in rows]
+
+
+def resolve_thread_id_from_route_id(conn, route_id: str) -> str | None:
+    """Resolve a route id (path param of `/t/<routeId>`) to a `threads.id`.
+
+    Phase B.3 supports four forms:
+      - threads.short_id (preferred when present)
+      - threads.id (uuid, e.g. fresh threads with NULL short_id)
+      - polls.short_id (Phase A → Phase B.3 fallback: threadShortId today
+        is the root poll's short_id)
+      - polls.id (uuid fallback for unkeyed routing)
+
+    Returns None if no thread can be resolved.
+    """
+    if not route_id:
+        return None
+
+    row = conn.execute(
+        "SELECT id FROM threads WHERE short_id = %(rid)s",
+        {"rid": route_id},
+    ).fetchone()
+    if row:
+        return str(row["id"])
+
+    is_uuid_like = (len(route_id) == 36 and route_id.count("-") == 4)
+    if is_uuid_like:
+        row = conn.execute(
+            "SELECT id FROM threads WHERE id = %(rid)s::uuid",
+            {"rid": route_id},
+        ).fetchone()
+        if row:
+            return str(row["id"])
+
+    row = conn.execute(
+        "SELECT thread_id FROM polls WHERE short_id = %(rid)s AND thread_id IS NOT NULL",
+        {"rid": route_id},
+    ).fetchone()
+    if row:
+        return str(row["thread_id"])
+
+    if is_uuid_like:
+        row = conn.execute(
+            "SELECT thread_id FROM polls WHERE id = %(rid)s::uuid AND thread_id IS NOT NULL",
+            {"rid": route_id},
+        ).fetchone()
+        if row:
+            return str(row["thread_id"])
+
+    return None

--- a/server/tests/test_middleware.py
+++ b/server/tests/test_middleware.py
@@ -1,11 +1,13 @@
-"""Tests for rate limiting middleware."""
+"""Tests for rate-limiting and browser-id middleware."""
 
+import asyncio
+import re
 import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from middleware import RateLimitMiddleware
+from middleware import BrowserIdMiddleware, RateLimitMiddleware
 
 
 class FakeRequest:
@@ -83,3 +85,70 @@ class TestRateLimitMiddleware:
         assert self.middleware._is_write("PATCH") is True
         assert self.middleware._is_write("GET") is False
         assert self.middleware._is_write("HEAD") is False
+
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def _run_browser_id(headers: dict | None) -> tuple[str, "MagicMock"]:
+    """Run BrowserIdMiddleware.dispatch with fake request/response and return
+    `(echoed_id, response_mock)`. Uses asyncio.run to drive the async path."""
+    mw = BrowserIdMiddleware(MagicMock())
+    request = MagicMock()
+    request.headers = headers or {}
+    request.state = MagicMock()
+    response = MagicMock()
+    response.headers = {}
+
+    async def call_next(_req):
+        return response
+
+    out = asyncio.run(mw.dispatch(request, call_next))
+    assert out is response
+    return response.headers.get("X-Browser-Id"), response
+
+
+class TestBrowserIdMiddleware:
+    def test_normalize_accepts_valid_uuid(self):
+        v = "0123abcd-89ef-4567-89ab-cdef01234567"
+        assert BrowserIdMiddleware._normalize(v) == v
+
+    def test_normalize_rejects_invalid(self):
+        for bad in (None, "", "not-a-uuid", "0123abcd-89ef-4567-89ab-cdef0123456"):
+            assert BrowserIdMiddleware._normalize(bad) is None
+
+    def test_normalize_lowercases(self):
+        v = "0123ABCD-89EF-4567-89AB-CDEF01234567"
+        assert BrowserIdMiddleware._normalize(v) == v.lower()
+
+    def test_dispatch_mints_when_header_missing(self):
+        echoed, _ = _run_browser_id(headers=None)
+        assert echoed and UUID_RE.match(echoed)
+
+    def test_dispatch_echoes_supplied_header(self):
+        my_id = "11111111-2222-4333-8444-555555555555"
+        echoed, _ = _run_browser_id(headers={"X-Browser-Id": my_id})
+        assert echoed == my_id
+
+    def test_dispatch_replaces_malformed_header(self):
+        echoed, _ = _run_browser_id(headers={"X-Browser-Id": "garbage"})
+        assert echoed and UUID_RE.match(echoed)
+        assert echoed != "garbage"
+
+    def test_dispatch_sets_request_state(self):
+        my_id = "11111111-2222-4333-8444-555555555555"
+        request = MagicMock()
+        request.headers = {"X-Browser-Id": my_id}
+        request.state = MagicMock()
+        response = MagicMock()
+        response.headers = {}
+        mw = BrowserIdMiddleware(MagicMock())
+
+        async def call_next(_req):
+            assert request.state.browser_id == my_id
+            return response
+
+        out = asyncio.run(mw.dispatch(request, call_next))
+        assert out is response

--- a/server/tests/test_threads_api.py
+++ b/server/tests/test_threads_api.py
@@ -1,0 +1,241 @@
+"""Integration tests for the threads API (Phase B.3).
+
+Covers:
+  - POST /api/threads/mine  — discovery + accessibility in one call
+  - GET  /api/threads/by-route-id/{route_id} — by short_id and uuid
+  - BrowserIdMiddleware — header echo + auto-mint
+
+Like test_polls_api.py these need a real Postgres reachable via DATABASE_URL.
+"""
+
+import os
+import re
+import uuid
+
+import pytest
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def creator_secret():
+    return f"test-secret-{uuid.uuid4().hex[:8]}"
+
+
+def _yes_no_question(**overrides) -> dict:
+    base = {"question_type": "yes_no", "category": "yes_no"}
+    base.update(overrides)
+    return base
+
+
+def _create_poll(client, creator_secret: str, **kwargs) -> dict:
+    payload = {
+        "creator_secret": creator_secret,
+        "questions": [_yes_no_question()],
+    }
+    payload.update(kwargs)
+    resp = client.post("/api/polls", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _create_followup(client, creator_secret: str, parent_question_id: str) -> dict:
+    """Create a poll wrapped in a follow-up to `parent_question_id`."""
+    return _create_poll(
+        client,
+        creator_secret,
+        follow_up_to=parent_question_id,
+    )
+
+
+class TestMyThreads:
+    def test_empty_input_returns_empty(self, client):
+        resp = client.post("/api/threads/mine", json={"accessible_question_ids": []})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_single_question_returns_its_poll(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        question_id = poll["questions"][0]["id"]
+
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": [question_id]},
+        )
+        assert resp.status_code == 200
+        polls = resp.json()
+        assert len(polls) == 1
+        assert polls[0]["id"] == poll["id"]
+
+    def test_followup_chain_returns_every_poll_in_thread(self, client, creator_secret):
+        """Asking for ONE question in a multi-poll thread should return EVERY
+        poll in that thread — that's the discovery + accessibility merge."""
+        root = _create_poll(client, creator_secret)
+        child1 = _create_followup(client, creator_secret, root["questions"][0]["id"])
+        child2 = _create_followup(client, creator_secret, child1["questions"][0]["id"])
+
+        # Pass only the deepest question; discovery walks via thread_id back to
+        # the root and returns every poll.
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": [child2["questions"][0]["id"]]},
+        )
+        assert resp.status_code == 200
+        polls = resp.json()
+        ids = {p["id"] for p in polls}
+        assert ids == {root["id"], child1["id"], child2["id"]}
+
+    def test_two_unrelated_threads_both_returned(self, client, creator_secret):
+        a = _create_poll(client, creator_secret)
+        b = _create_poll(client, creator_secret)
+        resp = client.post(
+            "/api/threads/mine",
+            json={
+                "accessible_question_ids": [
+                    a["questions"][0]["id"],
+                    b["questions"][0]["id"],
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert ids == {a["id"], b["id"]}
+
+    def test_unknown_question_id_returns_empty(self, client):
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": [str(uuid.uuid4())]},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_inline_results_default_on(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        question_id = poll["questions"][0]["id"]
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": [question_id]},
+        )
+        polls = resp.json()
+        # Open question with no votes still has the `results` field on the
+        # question (since show_preliminary_results defaults to True and the
+        # question has no min_responses gate).
+        assert polls[0]["questions"][0].get("results") is not None
+
+    def test_inline_results_off_when_requested(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        question_id = poll["questions"][0]["id"]
+        resp = client.post(
+            "/api/threads/mine",
+            json={
+                "accessible_question_ids": [question_id],
+                "include_results": False,
+            },
+        )
+        polls = resp.json()
+        assert polls[0]["questions"][0].get("results") is None
+
+
+class TestThreadByRouteId:
+    def test_resolves_by_root_poll_short_id(self, client, creator_secret):
+        root = _create_poll(client, creator_secret)
+        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+
+        # threadShortId is the root poll's short_id today.
+        resp = client.get(f"/api/threads/by-route-id/{root['short_id']}")
+        assert resp.status_code == 200
+        polls = resp.json()
+        ids = {p["id"] for p in polls}
+        assert ids == {root["id"], child["id"]}
+
+    def test_resolves_by_root_poll_uuid(self, client, creator_secret):
+        root = _create_poll(client, creator_secret)
+        _create_followup(client, creator_secret, root["questions"][0]["id"])
+
+        resp = client.get(f"/api/threads/by-route-id/{root['id']}")
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert root["id"] in ids
+
+    def test_resolves_by_child_poll_short_id(self, client, creator_secret):
+        """Even if the user types a child poll's short_id into the route id
+        slot, we still return the WHOLE thread — that's the only sensible
+        definition of `/t/<routeId>`."""
+        root = _create_poll(client, creator_secret)
+        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+
+        resp = client.get(f"/api/threads/by-route-id/{child['short_id']}")
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert ids == {root["id"], child["id"]}
+
+    def test_unknown_route_id_returns_404(self, client):
+        resp = client.get(f"/api/threads/by-route-id/zzznotreal")
+        assert resp.status_code == 404
+
+    def test_include_results_query_param(self, client, creator_secret):
+        root = _create_poll(client, creator_secret)
+        resp = client.get(
+            f"/api/threads/by-route-id/{root['short_id']}?include_results=false",
+        )
+        assert resp.status_code == 200
+        polls = resp.json()
+        assert polls[0]["questions"][0].get("results") is None
+
+
+class TestBrowserIdMiddleware:
+    def test_response_carries_browser_id_header(self, client, creator_secret):
+        """First-visit case: client sends no header; server mints + echoes one."""
+        resp = client.post("/api/threads/mine", json={"accessible_question_ids": []})
+        assert resp.status_code == 200
+        bid = resp.headers.get("X-Browser-Id") or resp.headers.get("x-browser-id")
+        assert bid is not None
+        assert UUID_RE.match(bid)
+
+    def test_supplied_browser_id_is_echoed(self, client):
+        my_id = str(uuid.uuid4())
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": my_id},
+        )
+        assert resp.status_code == 200
+        echoed = resp.headers.get("X-Browser-Id") or resp.headers.get("x-browser-id")
+        assert echoed == my_id
+
+    def test_malformed_browser_id_is_replaced(self, client):
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": "not-a-uuid"},
+        )
+        assert resp.status_code == 200
+        echoed = resp.headers.get("X-Browser-Id") or resp.headers.get("x-browser-id")
+        assert echoed and UUID_RE.match(echoed)
+        assert echoed != "not-a-uuid"
+
+    def test_browser_id_set_even_on_404(self, client):
+        """Adoption MUST work on error responses too — first-visit failed
+        request should still leave the FE with a server-issued id."""
+        resp = client.get("/api/threads/by-route-id/zzznotreal")
+        assert resp.status_code == 404
+        echoed = resp.headers.get("X-Browser-Id") or resp.headers.get("x-browser-id")
+        assert echoed and UUID_RE.match(echoed)


### PR DESCRIPTION
## Summary
- Two new endpoints — `POST /api/threads/mine` and `GET /api/threads/by-route-id/{routeId}` — collapse the legacy `discoverRelatedQuestions + apiGetAccessibleQuestions` pair into one server round-trip driven by `polls.thread_id`. Both return `list[PollResponse]` (same shape as `/api/questions/accessible`). Aggregation body extracted to `services/threads.py: polls_for_poll_ids` and shared by both routers.
- New `BrowserIdMiddleware` mints a uuid4 on first visit and echoes it via `X-Browser-Id` (header rather than cookie — avoids credentialed-CORS minefield with `allow_origins=["*"]`). Captured on `request.state.browser_id` for every request but **not used for filtering yet** — Phase C will add `thread_members` and start gating visibility.
- FE: `lib/browserIdentity.ts` persists the id to localStorage with a first-write-wins adopter; `lib/api/threads.ts` adds `apiGetMyThreads` / `apiGetThreadByRouteId`; `lib/simpleQuestionQueries.ts: getMyThreads()` is the drop-in for `getAccessiblePolls() + discoverRelatedQuestions()` that home page, thread page, and `useThread` hook all consume now.
- `next.config.ts` adds `/api/threads*` rewrites alongside the existing `/api/questions` and `/api/polls` ones.

Phase B.3 leaves `main` shippable: no schema changes, no contract changes for existing endpoints, just new endpoints + a request header. Legacy endpoints stay in place so any client running the previous JS bundle keeps working through the rollout window. See `docs/thread-routing-redesign.md`.

## Test plan
- [x] Middleware unit tests pass (`tests/test_middleware.py` — 15 tests, including 7 new BrowserIdMiddleware tests for normalization, mint, echo, malformed-replace, and request.state plumbing)
- [x] DB-free server tests pass (`tests/test_related_polls.py`, `test_poll_title.py`, `test_yes_no.py`, `test_ranked_choice.py`, `test_suggestion.py`, `test_time_poll.py`, `test_vote_validation.py` — 150 tests)
- [x] Server imports cleanly (`uv run python -c "import main"`)
- [ ] DB-backed integration tests (`tests/test_threads_api.py`) — need a Postgres reachable via `DATABASE_URL`; covers thread fanout, route-id resolution (short_id + uuid + child-poll forms), 404 path, include_results toggle, and BrowserIdMiddleware end-to-end
- [ ] Manual: home page loads, opens thread, follow-up creation appears in both pages without refresh
- [ ] CI green

https://claude.ai/code/session_01BazKzgcdLsXSBm9tv7sDUe

---
_Generated by [Claude Code](https://claude.ai/code/session_01BazKzgcdLsXSBm9tv7sDUe)_