### PR TITLE
Phase B.4: decouple threads.short_id keyspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,7 +748,49 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Poll System
 
-> **Phase B.3 of the thread-routing redesign shipped (this branch).**
+> **Phase B.4 of the thread-routing redesign shipped (this branch).**
+> Every `PollResponse` now carries `thread_id` (uuid) and `thread_short_id`
+> so the FE builds `/t/<thread.short_id>?p=<poll.short_id>` URLs in a
+> single field read — no follow_up_to chain walking, no extra round-trips.
+> Migration 101 mints fresh `threads.short_id`s from a separate
+> `~`-prefixed keyspace via the `generate_thread_short_id` trigger; the
+> `~` is URL-safe (RFC 3986 unreserved) and not in the base62 alphabet,
+> so it's collision-free with every existing `polls.short_id` (including
+> the values B.1 backfilled into `threads.short_id` for legacy chain
+> roots). Threads created in the B.1→B.4 window with `short_id = NULL`
+> are backfilled with `~`-prefixed values by the same migration.
+>
+> FE rewiring: `lib/types.ts: Poll` gains `thread_id` + `thread_short_id`
+> (both `string | null` for resilience against synthesized placeholder
+> polls and pre-B.4 cached polls left in memory across a deploy);
+> `lib/threadUtils.ts` (`getThreadRouteId`, `resolveThreadRootRouteId`,
+> `findThreadRootRouteId`, `buildThreadSyncFromCache`) all prefer
+> `thread_short_id` and fall through to the legacy walk when it's
+> absent. `lib/useThread.ts` and `app/t/[threadShortId]/page.tsx:
+> ThreadPageInner` skip the per-question and per-poll resolution paths
+> entirely — they call `apiGetThreadByRouteId(threadId)` (which the
+> server resolves against `threads.short_id` first), find the chain root
+> in the returned poll list, and warm the accessible-questions cache
+> from there. The per-poll `apiGetPollByShortId` fallback in the thread
+> page remains as a last-ditch safety net for very old URL forms during
+> a partial rollout.
+>
+> Server side: `_SELECT_POLLS_WITH_THREAD` in `routers/polls.py` and the
+> mirrored JOIN in `services/threads.py: polls_for_poll_ids` are the
+> single source of truth for "every polls SELECT must surface
+> `thread_short_id`". `_attach_thread_short_id(conn, row)` enriches
+> `RETURNING *` rows from INSERT/UPDATE paths with the same field.
+> Adding another threads-table field to `PollResponse` requires
+> extending only those two SELECT-prefix strings + the helper — every
+> read path picks it up automatically.
+>
+> Pitfall: `BIGSERIAL` populates existing rows on `ALTER TABLE ADD
+> COLUMN` (Postgres 10+) so the migration's backfill UPDATE works. If
+> the threads table is renamed/dropped/recreated in a future migration,
+> manually preserve `sequential_id` so the `~`-encoded short_ids stay
+> stable — the URL is the public ID for an entire thread.
+>
+> **Phase B.3 (#263) is the previous step.**
 > Two new endpoints — `POST /api/threads/mine` and
 > `GET /api/threads/by-route-id/{routeId}` — collapse the legacy three-step
 > bootstrap (`discoverRelatedQuestions` + `apiGetAccessibleQuestions` +
@@ -1603,7 +1645,7 @@ Submitting a draft used to navigate to `/p/<newPollShortId>`. The user described
 ### API Development Pitfalls
 
 - **`server/services/questions.py` is the home for non-route helpers.** Anything that's a free function operating on a DB connection (`_fetch_question_full`, `_finalize_*`, `_submit_vote_to_question`, `_edit_vote_on_question`, `_row_to_question`, `_compute_results`, etc.) lives in `services/questions.py` and is imported by both `routers/questions.py` and `routers/polls.py`. Don't reach across routers (`from routers.questions import _foo` from a sibling router) — that pattern was retired when `services/` was introduced. Underscore-prefixed names are kept as a "low-stability internal API during poll Phase X churn" signal; OK to drop the underscore once the surface stabilizes.
-- **`server/services/threads.py` is the equivalent home for thread-aggregation helpers (Phase B.3).** `polls_for_poll_ids(conn, poll_ids, *, include_results)` builds the `PollResponse[]` payload (with inline results, voter aggregates, response counts) from a list of poll_ids. Both `/api/questions/accessible` and `/api/threads/*` use it. `thread_ids_for_question_ids` and `poll_ids_for_thread_ids` are thin SQL wrappers; `resolve_thread_id_from_route_id(conn, route_id)` does the four-form lookup (threads.short_id → threads.id → polls.short_id → polls.id) — extend it when Phase B.4 starts minting fresh `threads.short_id`s.
+- **`server/services/threads.py` is the equivalent home for thread-aggregation helpers (Phase B.3).** `polls_for_poll_ids(conn, poll_ids, *, include_results)` builds the `PollResponse[]` payload (with inline results, voter aggregates, response counts) from a list of poll_ids. Both `/api/questions/accessible` and `/api/threads/*` use it. `thread_ids_for_question_ids` and `poll_ids_for_thread_ids` are thin SQL wrappers; `resolve_thread_id_from_route_id(conn, route_id)` does the four-form lookup (threads.short_id → threads.id → polls.short_id → polls.id). Phase B.4 introduced `~`-prefixed thread short_ids that resolve via the first lookup; the legacy `/t/<root-poll-short-id>` form still resolves via the same first lookup because B.1 backfilled `threads.short_id` from the root poll's short_id. The polls.short_id / polls.id fallbacks remain only for redirects from legacy URL paths.
 - **`BrowserIdMiddleware` reads/mints a `X-Browser-Id` header per request (Phase B.3).** A header (not cookie) because the FE talks same-origin to the API in prod (Next.js rewrite) and direct in dev/CI; cookies would require credentialed CORS which doesn't compose with `allow_origins=["*"]`. The id is always echoed on the response (even on 4xx/5xx) so the FE can adopt server-issued ids on the very first request. `request.state.browser_id` is populated for every request; **Phase B.3 only captures, doesn't enforce** — Phase C will add `thread_members` and start gating visibility on this id. Reading/setting from a router: `getattr(request.state, "browser_id", None)`.
 - **FE `lib/browserIdentity.ts` is the canonical browser-id storage.** `getBrowserId()` returns the localStorage value or null. `adoptServerBrowserId(value)` is called by `_internal.ts: fetchWithBase` after every fetch — it's a first-write-wins merger so a compromised middlebox can't rewrite the id mid-session (mismatch logs a warning and keeps the existing id). Don't roll your own UUID — let the server mint and adopt the response.
 - **`apiGetMyThreads(accessibleQuestionIds)` and `apiGetThreadByRouteId(routeId)` (in `lib/api/threads.ts`) replace the legacy `discoverRelatedQuestions + apiGetAccessibleQuestions` pair.** Both warm `cachePoll` and the per-question results cache so subsequent `apiGetQuestionById`/`apiGetQuestionResults` calls hit warm cache. Use these for any new "give me this thread" flow; don't reach for `apiGetAccessibleQuestions` in new code (it's preserved for the legacy compatibility layer). The drop-in `getMyThreads()` wrapper in `lib/simpleQuestionQueries.ts` is what `app/page.tsx`, `app/t/[threadShortId]/page.tsx`, and `lib/useThread.ts` consume — it adds in-flight coalescing (StrictMode-safe), accessible-id persistence (the server-discovered question_ids get added to localStorage subject to the forgotten-list filter), and accessible-cache invalidation when the set grew.

--- a/app/t/[threadShortId]/page.tsx
+++ b/app/t/[threadShortId]/page.tsx
@@ -1864,9 +1864,16 @@ function ThreadPageInner() {
 
   const rootInitial = useMemo<Poll | null>(() => {
     if (typeof window === "undefined" || !threadShortId) return null;
-    return isUuidLike(threadShortId)
-      ? getCachedPollById(threadShortId)
-      : getCachedPollByShortId(threadShortId);
+    if (isUuidLike(threadShortId)) return getCachedPollById(threadShortId);
+    // Phase B.4: thread route id can be `threads.short_id` (preferred) OR
+    // `polls.short_id` (legacy /t/<root-poll-short-id> fallback). Look up
+    // both forms before falling back to the async fetch.
+    const accessible = getCachedAccessiblePolls() ?? [];
+    const matches = accessible.filter(mp => mp.thread_short_id === threadShortId);
+    if (matches.length > 0) {
+      return matches.find(mp => !mp.follow_up_to) ?? matches[0];
+    }
+    return getCachedPollByShortId(threadShortId);
   }, [threadShortId]);
 
   const [rootPoll, setRootPoll] = useState<Poll | null>(rootInitial);
@@ -1886,6 +1893,25 @@ function ThreadPageInner() {
     let cancelled = false;
     (async () => {
       try {
+        // Phase B.4: prefer the thread endpoint which resolves any route id
+        // form (threads.short_id, threads.id, polls.short_id, polls.id) in
+        // one call. Fall back to the per-poll endpoint when the thread
+        // endpoint 404s (older deploys, network glitches) so we don't lose
+        // resolution on partially-rolled-out backends.
+        const polls = await apiGetThreadByRouteId(threadShortId).catch((err: unknown) => {
+          if (err instanceof ApiError && err.status === 404) return null;
+          throw err;
+        });
+        if (polls && polls.length > 0) {
+          const root = polls.find(mp => !mp.follow_up_to) ?? polls[0];
+          for (const mp of polls) {
+            for (const sp of mp.questions) addAccessibleQuestionId(sp.id);
+          }
+          if (!cancelled) setRootPoll(root);
+          return;
+        }
+        // Last-ditch fallback: per-poll lookup for very old URL forms whose
+        // resolution path didn't survive the threads-endpoint cutover.
         const isUuid = isUuidLike(threadShortId);
         const poll = await (isUuid
           ? apiGetPollById(threadShortId)
@@ -1900,16 +1926,6 @@ function ThreadPageInner() {
         }
         const firstQ = poll.questions[0]?.id;
         if (firstQ) addAccessibleQuestionId(firstQ);
-        // Phase B.3: one round-trip warms every poll in the thread so
-        // ThreadContent's buildThreadFromPollDown sees the full chain
-        // (ancestors + siblings) on first paint. Replaces the legacy
-        // discoverRelatedQuestions + getAccessiblePolls pair.
-        try {
-          const polls = await apiGetThreadByRouteId(threadShortId);
-          for (const mp of polls) {
-            for (const sp of mp.questions) addAccessibleQuestionId(sp.id);
-          }
-        } catch {}
         if (!cancelled) setRootPoll(poll);
       } catch {
         if (!cancelled) setError(true);
@@ -1959,7 +1975,11 @@ function ThreadPageInner() {
     );
   }
 
-  const threadRouteId = rootPoll.short_id || threadShortId;
+  // Phase B.4: prefer threads.short_id (the canonical /t/<id> form) so any
+  // FE-built URL based on the resolved Poll matches the route id the user
+  // landed with. Falls back to the URL's threadShortId for placeholder
+  // polls and pre-B.4 cached polls without thread_short_id.
+  const threadRouteId = rootPoll.thread_short_id || rootPoll.short_id || threadShortId;
 
   return (
     <ThreadContent

--- a/database/migrations/101_mint_threads_short_id_down.sql
+++ b/database/migrations/101_mint_threads_short_id_down.sql
@@ -1,0 +1,20 @@
+-- Down migration for 101_mint_threads_short_id.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trigger_generate_thread_short_id ON threads;
+DROP FUNCTION IF EXISTS generate_thread_short_id();
+
+-- Best-effort: restore short_id NULL for rows whose short_id has the `~`
+-- prefix this migration introduces. Backfilled (B.1-era) short_ids without
+-- the prefix are preserved so legacy /t/<root-poll-short-id> URLs keep
+-- resolving on rollback.
+UPDATE threads
+   SET short_id = NULL
+ WHERE short_id LIKE '~%';
+
+ALTER TABLE threads DROP CONSTRAINT IF EXISTS threads_sequential_id_key;
+ALTER TABLE threads DROP COLUMN IF EXISTS sequential_id;
+DROP SEQUENCE IF EXISTS threads_sequential_id_seq;
+
+COMMIT;

--- a/database/migrations/101_mint_threads_short_id_up.sql
+++ b/database/migrations/101_mint_threads_short_id_up.sql
@@ -1,0 +1,76 @@
+-- Phase B.4 of the thread routing redesign.
+-- Migration: 101_mint_threads_short_id
+--
+-- Phase B.1 created `threads` with a nullable `short_id`, backfilled from
+-- the chain-root poll's short_id. New threads created post-B.1 had
+-- `short_id = NULL` (the FE was still using the root poll's short_id as the
+-- thread route id, so threads.short_id was unused).
+--
+-- Phase B.4 starts using `threads.short_id` as the URL keyspace on the
+-- server resolver and the FE URL builders. We need:
+--   1. A separate keyspace so fresh thread short_ids never collide with the
+--      backfilled root-poll-short-id values (or with any future poll
+--      short_ids — `polls.sequential_id` and `threads.sequential_id` are
+--      independent SERIALs whose base62 encodings would otherwise overlap).
+--   2. Trigger-driven minting on every thread INSERT so the application
+--      code stays simple (`INSERT INTO threads DEFAULT VALUES` keeps working).
+--
+-- Approach: prefix every freshly-minted thread short_id with `~`. The
+-- character is URL-safe (RFC 3986 unreserved) and not in the base62
+-- alphabet (`0-9 A-Z a-z`), guaranteeing zero overlap with poll short_ids.
+-- Backfilled thread short_ids from B.1 are left untouched so existing
+-- `/t/<root-poll-short-id>` URLs continue to resolve via the same
+-- `threads.short_id` lookup the new URLs use — no fallback path needed
+-- for the legacy form.
+--
+-- See docs/thread-routing-redesign.md for the full plan.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. threads.sequential_id
+-- ---------------------------------------------------------------------------
+--
+-- BIGSERIAL on ALTER ADD COLUMN populates existing rows with sequential
+-- values from the new sequence at add time (Postgres 10+), and the column's
+-- DEFAULT keeps the sequence in play for new inserts. UNIQUE backstops the
+-- short_id uniqueness invariant.
+
+ALTER TABLE threads ADD COLUMN IF NOT EXISTS sequential_id BIGSERIAL UNIQUE;
+
+-- ---------------------------------------------------------------------------
+-- 2. Trigger to mint short_id from sequential_id on insert (or update where
+--    short_id is NULL, mirroring polls' generate_short_id pattern).
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION generate_thread_short_id()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.short_id IS NULL AND NEW.sequential_id IS NOT NULL THEN
+    NEW.short_id := '~' || encode_base62(NEW.sequential_id);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_generate_thread_short_id ON threads;
+CREATE TRIGGER trigger_generate_thread_short_id
+  BEFORE INSERT OR UPDATE ON threads
+  FOR EACH ROW
+  EXECUTE FUNCTION generate_thread_short_id();
+
+-- ---------------------------------------------------------------------------
+-- 3. Backfill: mint short_ids for any threads that don't have one yet.
+-- ---------------------------------------------------------------------------
+--
+-- B.1's backfill set `threads.short_id = root_poll.short_id` for every chain
+-- root present at migration time. New threads created in the window between
+-- B.1 and B.4 were inserted with `INSERT INTO threads DEFAULT VALUES`,
+-- leaving short_id NULL. Mint those now using the same `~`-prefix scheme
+-- the trigger uses.
+
+UPDATE threads
+   SET short_id = '~' || encode_base62(sequential_id)
+ WHERE short_id IS NULL;
+
+COMMIT;

--- a/docs/thread-routing-redesign.md
+++ b/docs/thread-routing-redesign.md
@@ -1,8 +1,8 @@
 # Thread Routing Redesign
 
 > Status: Phase A shipped (#260), Phase B.1 shipped (#261), Phase B.2
-> shipped (#262), Phase B.3 in progress (this branch). Phase B.4 / C are
-> deferred.
+> shipped (#262), Phase B.3 shipped (#263), Phase B.4 in progress (this
+> branch). Phase C is deferred.
 
 ## Vision
 
@@ -200,14 +200,44 @@ header. The legacy endpoints (`/api/questions/accessible`, `/api/questions/relat
 remain in place so any client running the previous JS bundle keeps working
 through the rollout window.
 
-#### Phase B.4 — Decouple `threads.short_id` keyspace (deferred)
+#### Phase B.4 — Decouple `threads.short_id` keyspace (this branch)
 
-- `threadShortId` becomes `threads.short_id` rather than the root poll's short_id.
-- Mint fresh `threads.short_id`s from a separate sequence (avoiding collision with
-  the existing root-poll-short-id values copied during B.1 backfill).
-- Old `/p/<shortId>` redirects continue to work via server-side resolution; old
-  `/t/<root-poll-short-id>` URLs continue to work because B.1 backfilled
-  `threads.short_id` to match.
+- `threadShortId` is now `threads.short_id` rather than the root poll's
+  short_id. Every `PollResponse` carries `thread_id` (uuid) and
+  `thread_short_id` so the FE can build `/t/<thread.short_id>?p=<poll.short_id>`
+  URLs in a single field read — no follow-up-chain walking, no extra
+  round-trips.
+- Fresh `threads.short_id`s are minted from a separate `~`-prefixed
+  keyspace via the trigger `generate_thread_short_id` introduced by
+  migration 101. The `~` is URL-safe (RFC 3986 unreserved) and not in the
+  base62 alphabet, so it guarantees zero collision with existing
+  `polls.short_id` values — including the values B.1 backfilled into
+  `threads.short_id` for legacy chain roots.
+- Migration 101 also adds `threads.sequential_id BIGSERIAL UNIQUE` (the
+  number-space the trigger encodes) and backfills `~`-prefixed short_ids
+  for any threads created in the B.1→B.4 window that left
+  `threads.short_id = NULL`.
+- Old `/p/<shortId>` redirects continue to work via server-side resolution
+  (`resolve_thread_id_from_route_id` in `services/threads.py`); old
+  `/t/<root-poll-short-id>` URLs continue to work because the same
+  resolver looks up `threads.short_id` first, and B.1 backfilled exactly
+  those values into the column.
+- FE rewiring:
+  - `lib/types.ts: Poll` gains `thread_id` + `thread_short_id` (both
+    `string | null` for resilience against synthesized placeholder polls
+    and pre-B.4 cached polls).
+  - `lib/threadUtils.ts: getThreadRouteId`, `resolveThreadRootRouteId`,
+    `findThreadRootRouteId`, `buildThreadSyncFromCache` all prefer
+    `thread_short_id` and fall back to the legacy walk.
+  - `lib/useThread.ts` skips the question-anchor lookup entirely — it
+    just calls `apiGetThreadByRouteId(threadId)` (which handles every
+    route id form server-side) and finds the chain root in the returned
+    list.
+  - `app/t/[threadShortId]/page.tsx: ThreadPageInner` does the same:
+    one thread-endpoint call resolves the route, finds the root poll,
+    and warms the accessible-questions list — replacing the prior
+    per-poll `apiGetPollByShortId` call which couldn't resolve
+    `~`-prefixed thread route ids.
 
 ### Phase C — Membership with join-time visibility (deferred)
 

--- a/lib/api/_internal.ts
+++ b/lib/api/_internal.ts
@@ -194,6 +194,12 @@ export function toPoll(data: any): Poll {
   return {
     id: data.id,
     short_id: data.short_id ?? null,
+    // Phase B.4: every poll carries its thread's id + short_id so the FE can
+    // build /t/<thread.short_id>?p=<poll.short_id> URLs without walking
+    // follow_up_to chains. Tolerates absence (synthesized placeholder polls
+    // and pre-Phase-B.4 cached polls don't have these fields).
+    thread_id: data.thread_id ?? null,
+    thread_short_id: data.thread_short_id ?? null,
     creator_secret: data.creator_secret ?? null,
     creator_name: data.creator_name ?? null,
     response_deadline: data.response_deadline ?? null,

--- a/lib/threadUtils.ts
+++ b/lib/threadUtils.ts
@@ -360,20 +360,24 @@ export function findThreadByQuestionId(threads: Thread[], questionId: string): T
   return threads.find(t => t.questions.some(p => p.id === questionId));
 }
 
-/** Route id for a thread — the root poll's short_id (or the root question id
- *  when the root poll has no short_id). Used as the path param in
- *  `/t/<threadRouteId>`. Phase A: thread short_id is derived from the root
- *  poll; Phase B will mint a real `threads.short_id`. */
+/** Route id for a thread — preferred form is `threads.short_id` (Phase B.4),
+ *  with fallbacks to the root poll's short_id (legacy /t/<root-poll-short-id>
+ *  URLs) and finally the root question id (synthesized placeholder polls
+ *  before the API responds). Used as the path param in `/t/<threadRouteId>`. */
 export function getThreadRouteId(thread: Thread): string {
   const rootPoll = thread.polls.find(p => p.id === thread.rootPollId) ?? thread.polls[0];
-  return rootPoll?.short_id || thread.rootQuestionId;
+  return rootPoll?.thread_short_id || rootPoll?.short_id || thread.rootQuestionId;
 }
 
-/** Walk up `poll.follow_up_to` via the in-memory accessible-polls cache to
- *  find the thread root and return its route id. Falls back to `poll` itself
- *  when no ancestors are cached — degraded but always returns a usable id.
- *  Short-circuits the cache walk when `poll` already IS the root. */
+/** Resolve a poll's thread route id (the path param of `/t/<routeId>`).
+ *
+ *  Phase B.4: every poll returned by the API carries `thread_short_id`, so the
+ *  preferred path is a single field read with no cache traversal. The legacy
+ *  walk-up-via-`follow_up_to` fallback exists only for synthesized placeholder
+ *  polls (created optimistically on submit, pre-API-roundtrip) and any
+ *  pre-Phase-B.4 cached poll left in memory across a deploy. */
 export function resolveThreadRootRouteId(poll: Poll): string {
+  if (poll.thread_short_id) return poll.thread_short_id;
   if (!poll.follow_up_to) return poll.short_id || poll.questions[0]?.id || poll.id;
   const accessible = getCachedAccessiblePolls() ?? [];
   const byPoll = buildPollMap([poll, ...accessible]);
@@ -408,9 +412,13 @@ export function getThreadHref(thread: Thread): string {
 
 /**
  * Walk up the poll-level follow_up chain starting from `poll` and
- * return the route ID (short_id or id) of the furthest ancestor reachable.
- * The chain is poll-to-poll — at each step we follow `follow_up_to`
- * to a parent poll.
+ * return the route ID of the furthest ancestor reachable. The chain is
+ * poll-to-poll — at each step we follow `follow_up_to` to a parent poll.
+ *
+ * Phase B.4: a poll's `thread_short_id` (when present) short-circuits the
+ * walk entirely — every poll in a thread shares the same thread_short_id,
+ * so we don't need to find the root to construct a URL. The walk is kept
+ * for placeholder/legacy polls without `thread_short_id`.
  *
  * `pollById` defaults to scanning `getCachedAccessiblePolls()`.
  * Pass a custom resolver when you have a faster lookup at hand.
@@ -419,6 +427,7 @@ export function findThreadRootRouteId(
   poll: Poll,
   pollById?: (id: string) => Poll | null | undefined,
 ): string {
+  if (poll.thread_short_id) return poll.thread_short_id;
   const resolve = pollById ?? defaultPollById;
   let root: Poll = poll;
   while (root.follow_up_to) {
@@ -426,7 +435,7 @@ export function findThreadRootRouteId(
     if (!parent) break;
     root = parent;
   }
-  return root.short_id || root.questions[0]?.id || root.id;
+  return root.thread_short_id || root.short_id || root.questions[0]?.id || root.id;
 }
 
 function defaultPollById(id: string): Poll | null {
@@ -459,19 +468,28 @@ export function buildThreadFromPollDown(
   return buildThreadFromPolls(collected, votedQuestionIds, abstainedQuestionIds);
 }
 
-/** Build the thread for a route id (UUID or short_id) synchronously from
- *  in-memory caches. Returns null if any required piece is missing — callers
- *  fall through to their async fetch path. */
+/** Build the thread for a route id synchronously from in-memory caches.
+ *  Returns null if any required piece is missing — callers fall through to
+ *  their async fetch path.
+ *
+ *  Phase B.4: routeId can be a `threads.short_id` (preferred form, prefixed
+ *  with `~` for fresh threads, or a backfilled root-poll-short-id for
+ *  pre-B.4 threads), a polls.short_id (legacy /t/<root-poll-short-id>
+ *  fallback), or a UUID (poll/question). The accessible polls cache is
+ *  walked once for thread_short_id matches before falling back to the
+ *  short-id-keyed cache.
+ */
 export function buildThreadSyncFromCache(
   threadId: string,
   voted: Set<string>,
   abstained: Set<string>,
 ): Thread | null {
   if (typeof window === 'undefined') return null;
+  const polls = getCachedAccessiblePolls();
+  if (!polls) return null;
   let anchorPollId: string | null = null;
   if (isUuidLike(threadId)) {
     // threadId may be a question uuid OR a poll uuid. Try both.
-    const polls = getCachedAccessiblePolls() ?? [];
     const direct = polls.find(mp => mp.id === threadId);
     if (direct) {
       anchorPollId = direct.id;
@@ -480,11 +498,19 @@ export function buildThreadSyncFromCache(
       anchorPollId = question?.poll_id ?? null;
     }
   } else {
-    const mp = getCachedPollByShortId(threadId);
-    anchorPollId = mp?.id ?? null;
+    // Phase B.4 preferred path: routeId is a threads.short_id. Threads can
+    // contain multiple polls all sharing the same thread_short_id; the
+    // chain root is the one with `follow_up_to == null`. Find it directly
+    // so buildThreadFromPollDown collects every descendant.
+    const matches = polls.filter(mp => mp.thread_short_id === threadId);
+    const root = matches.find(mp => !mp.follow_up_to) ?? matches[0];
+    if (root) {
+      anchorPollId = root.id;
+    } else {
+      const mp = getCachedPollByShortId(threadId);
+      anchorPollId = mp?.id ?? null;
+    }
   }
   if (!anchorPollId) return null;
-  const polls = getCachedAccessiblePolls();
-  if (!polls) return null;
   return buildThreadFromPollDown(anchorPollId, polls, voted, abstained);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -128,6 +128,15 @@ export interface RankedChoiceRound {
 export interface Poll {
   id: string;
   short_id?: string | null;
+  // Phase B.4: every poll carries its thread's id + short_id so the FE can
+  // build /t/<thread.short_id>?p=<poll.short_id> URLs without walking
+  // follow_up_to chains. Both are nullable for resilience: synthesized
+  // placeholder polls don't have them, and pre-Phase-B.4 cached polls
+  // (still in-memory across a deploy) won't either. Use them when present
+  // and fall through to the legacy walk otherwise — see
+  // resolveThreadRootRouteId in lib/threadUtils.ts.
+  thread_id?: string | null;
+  thread_short_id?: string | null;
   creator_secret?: string | null;
   creator_name?: string | null;
   response_deadline?: string | null;

--- a/lib/useThread.ts
+++ b/lib/useThread.ts
@@ -10,12 +10,9 @@
  */
 
 import { useEffect, useState } from "react";
-import type { Question } from "./types";
 import { buildThreadFromPollDown, buildThreadSyncFromCache, type Thread } from "./threadUtils";
-import { apiGetQuestionById, apiGetQuestionByShortId, apiGetThreadByRouteId } from "./api";
+import { apiGetThreadByRouteId } from "./api";
 import { addAccessibleQuestionId } from "./browserQuestionAccess";
-import { getCachedQuestionById, getCachedQuestionByShortId } from "./questionCache";
-import { isUuidLike } from "./questionId";
 import { loadVotedQuestions } from "./votedQuestionsStorage";
 import { usePageReady } from "./usePageReady";
 
@@ -51,35 +48,20 @@ export function useThread(threadId: string): UseThreadResult {
         setLoading(true);
         setError(false);
 
-        let anchorQuestion: Question;
-        try {
-          const cached = isUuidLike(threadId)
-            ? getCachedQuestionById(threadId)
-            : getCachedQuestionByShortId(threadId);
-          if (cached) {
-            anchorQuestion = cached;
-          } else if (isUuidLike(threadId)) {
-            anchorQuestion = await apiGetQuestionById(threadId);
-          } else {
-            anchorQuestion = await apiGetQuestionByShortId(threadId);
-          }
-          addAccessibleQuestionId(anchorQuestion.id);
-        } catch {
-          if (!cancelled) setError(true);
-          return;
-        }
-
-        // Phase B.3: one round-trip — server walks polls.thread_id and
-        // returns every poll in this thread.
+        // Phase B.3+: a single thread endpoint resolves any route id form
+        // (threads.short_id, threads.id, polls.short_id, polls.id) to the
+        // full poll list. The chain root is the poll with `follow_up_to ==
+        // null`. No separate anchor-question lookup needed.
         const polls = await apiGetThreadByRouteId(threadId);
+        if (cancelled) return;
+        if (polls.length === 0) { setError(true); return; }
         for (const mp of polls) {
           for (const sp of mp.questions) addAccessibleQuestionId(sp.id);
         }
 
+        const root = polls.find(mp => !mp.follow_up_to) ?? polls[0];
         const { votedQuestionIds, abstainedQuestionIds } = loadVotedQuestions();
-        const anchorPollId = anchorQuestion.poll_id;
-        if (!anchorPollId) { if (!cancelled) setError(true); return; }
-        const found = buildThreadFromPollDown(anchorPollId, polls, votedQuestionIds, abstainedQuestionIds);
+        const found = buildThreadFromPollDown(root.id, polls, votedQuestionIds, abstainedQuestionIds);
         if (cancelled) return;
         if (!found) { setError(true); return; }
         setThread(found);

--- a/server/models.py
+++ b/server/models.py
@@ -308,6 +308,14 @@ class PollResponse(BaseModel):
     title: str
     created_at: str
     updated_at: str
+    # Phase B.4: every poll exposes its thread's id and short_id so the FE
+    # can build /t/<thread.short_id>?p=<poll.short_id> URLs without walking
+    # follow_up_to chains client-side. `thread_id` is NOT NULL post-migration
+    # 100; `thread_short_id` is NOT NULL post-migration 101 (trigger mints
+    # one on every insert) but typed as Optional for resilience against
+    # mid-deploy races where a thread row briefly exists without a short_id.
+    thread_id: str | None = None
+    thread_short_id: str | None = None
     # Poll-level results-display + ranked-choice settings (migration 098).
     min_responses: int | None = None
     show_preliminary_results: bool = True

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -36,6 +36,18 @@ from services.questions import (
 router = APIRouter(prefix="/api/polls", tags=["polls"])
 
 
+# Phase B.4: every SELECT that feeds `_row_to_poll` must surface
+# `threads.short_id` as `thread_short_id` so the FE can build
+# `/t/<thread.short_id>` URLs without a second round-trip. Centralizing the
+# JOIN here keeps the SELECTs in routers/polls.py and services/threads.py
+# in lockstep — adding another field from the threads table only requires
+# extending this string.
+_SELECT_POLLS_WITH_THREAD = (
+    "SELECT polls.*, t.short_id AS thread_short_id "
+    "FROM polls LEFT JOIN threads t ON polls.thread_id = t.id"
+)
+
+
 def _categories_for_title(questions: list[CreateQuestionRequest]) -> list[str]:
     return [sp.category or sp.question_type.value for sp in questions]
 
@@ -131,6 +143,25 @@ def _resolve_or_create_thread_id(conn, parent_poll_id: str | None) -> str:
     return str(row["id"])
 
 
+def _attach_thread_short_id(conn, row) -> dict:
+    """Enrich a polls row dict with `thread_short_id` (Phase B.4).
+
+    INSERT/UPDATE `RETURNING *` paths only see polls.* columns, not the
+    joined threads.short_id surfaced by `_SELECT_POLLS_WITH_THREAD`. After a
+    write, look up threads.short_id by thread_id so the resulting row dict
+    matches the SELECT shape `_row_to_poll` expects.
+    """
+    out = dict(row)
+    if out.get("thread_id") and not out.get("thread_short_id"):
+        t = conn.execute(
+            "SELECT short_id FROM threads WHERE id = %(id)s",
+            {"id": out["thread_id"]},
+        ).fetchone()
+        if t:
+            out["thread_short_id"] = t.get("short_id")
+    return out
+
+
 def _insert_poll(conn, req: CreatePollRequest, now: datetime) -> dict:
     # follow_up_to in the request is a *question id* (matching the legacy
     # single-question create API). Resolve to the parent's poll_id for the
@@ -140,7 +171,7 @@ def _insert_poll(conn, req: CreatePollRequest, now: datetime) -> dict:
     parent_followup_poll_id = _resolve_parent_poll_id(conn, req.follow_up_to)
     thread_id = _resolve_or_create_thread_id(conn, parent_followup_poll_id)
     explicit_title = req.title if req.title is not None else req.thread_title
-    return conn.execute(
+    row = conn.execute(
         """
         INSERT INTO polls (
             creator_secret, creator_name, response_deadline,
@@ -187,6 +218,7 @@ def _insert_poll(conn, req: CreatePollRequest, now: datetime) -> dict:
             "now": now,
         },
     ).fetchone()
+    return _attach_thread_short_id(conn, row)
 
 
 def _insert_question(
@@ -289,6 +321,8 @@ def _row_to_poll(
     return PollResponse(
         id=str(row["id"]),
         short_id=row.get("short_id"),
+        thread_id=str(row["thread_id"]) if row.get("thread_id") else None,
+        thread_short_id=row.get("thread_short_id"),
         creator_secret=row.get("creator_secret"),
         creator_name=row.get("creator_name"),
         response_deadline=_iso_or_none(row.get("response_deadline")),
@@ -391,7 +425,7 @@ def create_poll(req: CreatePollRequest):
 def get_poll_by_id(poll_id: str):
     with get_db() as conn:
         row = conn.execute(
-            "SELECT * FROM polls WHERE id = %(id)s",
+            f"{_SELECT_POLLS_WITH_THREAD} WHERE polls.id = %(id)s",
             {"id": poll_id},
         ).fetchone()
         if not row:
@@ -405,7 +439,7 @@ def get_poll_by_id(poll_id: str):
 def get_poll(short_id: str):
     with get_db() as conn:
         row = conn.execute(
-            "SELECT * FROM polls WHERE short_id = %(short_id)s",
+            f"{_SELECT_POLLS_WITH_THREAD} WHERE polls.short_id = %(short_id)s",
             {"short_id": short_id},
         ).fetchone()
         if not row:
@@ -477,7 +511,7 @@ def close_poll(poll_id: str, req: CloseQuestionRequest):
                 _finalize_suggestion_options(conn, str(sp["id"]), now)
 
         poll_row = conn.execute(
-            "SELECT * FROM polls WHERE id = %(id)s",
+            f"{_SELECT_POLLS_WITH_THREAD} WHERE polls.id = %(id)s",
             {"id": poll_id},
         ).fetchone()
         question_rows = _fetch_questions(conn, poll_id)
@@ -504,7 +538,7 @@ def reopen_poll(poll_id: str, req: ReopenQuestionRequest):
             {"poll_id": poll_id, "now": now},
         )
         poll_row = conn.execute(
-            "SELECT * FROM polls WHERE id = %(id)s",
+            f"{_SELECT_POLLS_WITH_THREAD} WHERE polls.id = %(id)s",
             {"id": poll_id},
         ).fetchone()
         question_rows = _fetch_questions(conn, poll_id)
@@ -560,7 +594,7 @@ def cutoff_poll_suggestions(poll_id: str, req: CutoffSuggestionsRequest):
             _finalize_suggestion_options(conn, str(row["id"]), now)
 
         poll_row = conn.execute(
-            "SELECT * FROM polls WHERE id = %(id)s",
+            f"{_SELECT_POLLS_WITH_THREAD} WHERE polls.id = %(id)s",
             {"id": poll_id},
         ).fetchone()
         question_rows = _fetch_questions(conn, poll_id)
@@ -715,7 +749,7 @@ def cutoff_poll_availability(poll_id: str, req: CutoffSuggestionsRequest):
             _finalize_time_slots(conn, str(row["id"]), now)
 
         poll_row = conn.execute(
-            "SELECT * FROM polls WHERE id = %(id)s",
+            f"{_SELECT_POLLS_WITH_THREAD} WHERE polls.id = %(id)s",
             {"id": poll_id},
         ).fetchone()
         question_rows = _fetch_questions(conn, poll_id)
@@ -749,6 +783,7 @@ def update_poll_thread_title(poll_id: str, req: UpdateThreadTitleRequest):
         ).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Poll not found")
+        row = _attach_thread_short_id(conn, row)
         question_rows = _fetch_questions(conn, poll_id)
         voter_names, anonymous_count = _compute_poll_voter_data(conn, poll_id)
     return _row_to_poll(row, question_rows, voter_names, anonymous_count)

--- a/server/services/threads.py
+++ b/server/services/threads.py
@@ -110,6 +110,12 @@ def polls_for_poll_ids(
         if show_prelim and (min_resp is None or response_counts.get(pid, 0) >= min_resp):
             preliminary_question_ids.append(pid)
     if preliminary_question_ids:
+        # Pre-seed empty vote lists for every prelim-eligible question so the
+        # results-attachment loop below picks them up even when 0 votes have
+        # been cast — `_compute_results` is well-defined on an empty list and
+        # returns the "no votes yet" shape that the FE expects.
+        for pid in preliminary_question_ids:
+            votes_by_question.setdefault(pid, [])
         prelim_vote_rows = conn.execute(
             "SELECT * FROM votes WHERE question_id = ANY(%(question_ids)s)",
             {"question_ids": preliminary_question_ids},

--- a/server/services/threads.py
+++ b/server/services/threads.py
@@ -41,10 +41,16 @@ def polls_for_poll_ids(
 
     now = datetime.now(timezone.utc)
 
+    # Phase B.4: surface threads.short_id alongside polls.* so _row_to_poll can
+    # populate `thread_short_id` on every PollResponse without a per-row lookup.
+    # Mirrors `_SELECT_POLLS_WITH_THREAD` in routers/polls.py — extending one
+    # without the other will silently drop the field on whichever path gets
+    # missed.
     poll_rows = conn.execute(
-        """SELECT * FROM polls
-            WHERE id = ANY(%(ids)s)
-            ORDER BY created_at DESC""",
+        """SELECT polls.*, t.short_id AS thread_short_id
+             FROM polls LEFT JOIN threads t ON polls.thread_id = t.id
+            WHERE polls.id = ANY(%(ids)s)
+            ORDER BY polls.created_at DESC""",
         {"ids": poll_ids},
     ).fetchall()
     if not poll_rows:

--- a/server/tests/test_threads_api.py
+++ b/server/tests/test_threads_api.py
@@ -239,3 +239,64 @@ class TestBrowserIdMiddleware:
         assert resp.status_code == 404
         echoed = resp.headers.get("X-Browser-Id") or resp.headers.get("x-browser-id")
         assert echoed and UUID_RE.match(echoed)
+
+
+class TestThreadShortIdKeyspace:
+    """Phase B.4: every PollResponse carries thread_id + thread_short_id, and
+    fresh threads.short_ids are minted from a separate `~`-prefixed keyspace
+    that's collision-free with polls.short_id."""
+
+    def test_create_poll_returns_thread_id_and_thread_short_id(
+        self, client, creator_secret,
+    ):
+        poll = _create_poll(client, creator_secret)
+        assert poll.get("thread_id") is not None
+        assert UUID_RE.match(poll["thread_id"])
+        # Fresh threads minted post-migration-101 are prefixed with `~`,
+        # which guarantees no collision with the base62-encoded poll
+        # short_ids (`0-9 A-Z a-z`).
+        assert poll.get("thread_short_id") is not None
+        assert poll["thread_short_id"].startswith("~")
+
+    def test_followup_inherits_parent_thread_short_id(
+        self, client, creator_secret,
+    ):
+        root = _create_poll(client, creator_secret)
+        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+        assert root["thread_id"] == child["thread_id"]
+        assert root["thread_short_id"] == child["thread_short_id"]
+
+    def test_get_poll_returns_thread_short_id(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        resp = client.get(f"/api/polls/{poll['short_id']}")
+        assert resp.status_code == 200
+        assert resp.json().get("thread_short_id") == poll["thread_short_id"]
+
+    def test_resolves_by_thread_short_id(self, client, creator_secret):
+        """Phase B.4: /t/<routeId> with the new `~`-prefixed thread short_id
+        resolves the same way as the legacy root-poll-short-id form."""
+        root = _create_poll(client, creator_secret)
+        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+        thread_short_id = root["thread_short_id"]
+        resp = client.get(f"/api/threads/by-route-id/{thread_short_id}")
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert ids == {root["id"], child["id"]}
+
+    def test_resolves_by_thread_id_uuid(self, client, creator_secret):
+        root = _create_poll(client, creator_secret)
+        resp = client.get(f"/api/threads/by-route-id/{root['thread_id']}")
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert root["id"] in ids
+
+    def test_my_threads_carries_thread_short_id(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": [poll["questions"][0]["id"]]},
+        )
+        assert resp.status_code == 200
+        polls = resp.json()
+        assert polls[0]["thread_short_id"] == poll["thread_short_id"]
+        assert polls[0]["thread_id"] == poll["thread_id"]


### PR DESCRIPTION
## Summary

- Mint fresh `threads.short_id` from a separate `~`-prefixed keyspace (migration 101) so `/t/<id>` can resolve directly to a thread row, with zero collision with poll short_ids.
- Surface `thread_id` + `thread_short_id` on every `PollResponse` via a shared `LEFT JOIN threads`; the FE builds `/t/<thread.short_id>?p=<poll.short_id>` URLs in one field read with no follow-up-chain walking.
- Bonus fix: `polls_for_poll_ids` now attaches `results` to 0-vote prelim-eligible questions (a B.3 regression that didn't surface in CI because the integration suite needs Postgres).

## Test plan

- [x] `pytest tests/test_threads_api.py` — 22/22 passing, including 6 new `TestThreadShortIdKeyspace` cases that cover thread_id/thread_short_id propagation through every API surface (create, get, my-threads, by-route-id with both forms).
- [x] All other test suites pass (187/187 across `test_poll_title`, `test_ranked_choice`, `test_related_polls`, `test_suggestion`, `test_threads_api`, `test_time_poll`, `test_vote_validation`, `test_yes_no`).
- [x] Manual: created a poll on the dev server → response carries `thread_short_id: "~CY"`. `GET /api/threads/by-route-id/~CY` and the legacy `GET /api/threads/by-route-id/<root-poll-short-id>` both resolve to the same thread.
- [x] FE: `https://sam-at-samcarey-com.dev.whoeverwants.com/t/~CY` returns 200 — the `~`-prefixed thread URL renders the correct page on the dev frontend.

## Notes for reviewers

- The 4 pre-existing failures in `tests/test_polls_api.py` are unchanged from `main` and unrelated to this branch — they predate Phase B.
- See updated `docs/thread-routing-redesign.md` and `CLAUDE.md` for the full plan + implementation notes.

https://claude.ai/code/session_01EyzpAXUhTrLwV87oFgeo4p