### PR TITLE
Phase C.1: schema-only thread_members + poll_access tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,7 +748,23 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Poll System
 
-> **Phase B.4 of the thread-routing redesign shipped (this branch).**
+> **Phase C.1 of the thread-routing redesign in progress (this branch).**
+> Migration 102 adds two empty membership tables — `thread_members(thread_id,
+> browser_id, joined_at)` and `poll_access(poll_id, browser_id, granted_at)`,
+> both with composite PKs and a secondary index on `browser_id`. No
+> application code reads or writes either table yet; Phase C.2 will start
+> writing them on vote/create/abstain (auto-join) and on the `?p=`
+> direct-link grant path, and Phase C.3 will gate visibility in
+> `/api/threads/*` on the union of the two. Three semantic questions stay
+> open until C.3: join trigger (vote/create only? auto on /t visit?), what
+> a non-member sees at `/t/<id>` with no `?p`, and forget-vs-leave. Backfill
+> of legacy votes/creates is deferred — `browser_id` was only captured
+> starting in Phase B.3, so pre-B.3 rows have no browser_id to attach a
+> membership row to; the current plan is to lean on C.2's auto-join writes
+> for any returning browser. See `docs/thread-routing-redesign.md` →
+> "Phase C — Membership with join-time visibility".
+>
+> **Phase B.4 of the thread-routing redesign shipped (#264).**
 > Every `PollResponse` now carries `thread_id` (uuid) and `thread_short_id`
 > so the FE builds `/t/<thread.short_id>?p=<poll.short_id>` URLs in a
 > single field read — no follow_up_to chain walking, no extra round-trips.

--- a/database/migrations/102_create_membership_tables_down.sql
+++ b/database/migrations/102_create_membership_tables_down.sql
@@ -1,0 +1,20 @@
+-- Down migration for 102_create_membership_tables.
+-- Drops poll_access and thread_members. Safe because no application code
+-- reads or writes either table in Phase C.1 — Phase C.2 wires the writes
+-- and Phase C.3 wires the reads.
+
+BEGIN;
+
+DROP POLICY IF EXISTS "Allow public delete access on poll_access" ON poll_access;
+DROP POLICY IF EXISTS "Allow public insert access on poll_access" ON poll_access;
+DROP POLICY IF EXISTS "Allow public read access on poll_access" ON poll_access;
+DROP INDEX IF EXISTS idx_poll_access_browser_id;
+DROP TABLE IF EXISTS poll_access;
+
+DROP POLICY IF EXISTS "Allow public delete access on thread_members" ON thread_members;
+DROP POLICY IF EXISTS "Allow public insert access on thread_members" ON thread_members;
+DROP POLICY IF EXISTS "Allow public read access on thread_members" ON thread_members;
+DROP INDEX IF EXISTS idx_thread_members_browser_id;
+DROP TABLE IF EXISTS thread_members;
+
+COMMIT;

--- a/database/migrations/102_create_membership_tables_up.sql
+++ b/database/migrations/102_create_membership_tables_up.sql
@@ -1,0 +1,108 @@
+-- Phase C.1 of the thread routing redesign.
+-- Migration: 102_create_membership_tables
+--
+-- Materializes the per-browser membership tables that Phase C will use to
+-- enforce join-time visibility (see docs/thread-routing-redesign.md →
+-- "Visibility rule (Phase C target)"):
+--
+--   * thread_members(thread_id, browser_id, joined_at) — a browser is a
+--     member of a thread once it has voted/abstained/created in any poll in
+--     that thread. Membership grants visibility to every poll in the thread
+--     except those closed before joined_at.
+--   * poll_access(poll_id, browser_id, granted_at) — a browser has explicit
+--     per-poll access from following a direct link to that poll. Direct-link
+--     access does NOT transitively grant thread membership.
+--
+-- Phase C.1 stops at schema. Nothing in the app reads or writes either
+-- table yet:
+--   * C.2 will start writing thread_members + poll_access on
+--     vote/create/abstain (the auto-join writes), and from `?p=<poll>` and
+--     legacy /p/<id> redirect resolutions (the direct-link grants).
+--   * C.3 will gate visibility in the read endpoints (POST /api/threads/mine
+--     and GET /api/threads/by-route-id/{routeId}) on the union of the two
+--     tables.
+--
+-- Backfill of legacy votes/creates is deferred. browser_id was only captured
+-- starting in Phase B.3 (PR #263), so pre-B.3 votes/creates have no
+-- browser_id to attach a membership row to. The current plan is to lean on
+-- C.2's auto-join writes for any returning browser (they'll re-establish
+-- membership the next time they vote in the thread), backed by the existing
+-- localStorage `accessible_question_ids` list which the FE will continue to
+-- consult during the transition. Settling on a final answer here is a
+-- follow-up — see CLAUDE.md → "FOLLOW-UP — Decide backfill strategy ...".
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. thread_members
+-- ---------------------------------------------------------------------------
+--
+-- Composite primary key (thread_id, browser_id) — a browser can only be a
+-- member of a given thread once. joined_at is the moment they earned
+-- membership; visibility filters compare poll closure timestamps against it.
+--
+-- Index on (browser_id) supports the "all threads I'm a member of" lookup
+-- that POST /api/threads/mine will use in Phase C.3.
+
+CREATE TABLE IF NOT EXISTS thread_members (
+  thread_id UUID NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+  browser_id UUID NOT NULL,
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (thread_id, browser_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_thread_members_browser_id
+  ON thread_members(browser_id);
+
+ALTER TABLE thread_members ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow public read access on thread_members" ON thread_members;
+CREATE POLICY "Allow public read access on thread_members" ON thread_members
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Allow public insert access on thread_members" ON thread_members;
+CREATE POLICY "Allow public insert access on thread_members" ON thread_members
+  FOR INSERT WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Allow public delete access on thread_members" ON thread_members;
+CREATE POLICY "Allow public delete access on thread_members" ON thread_members
+  FOR DELETE USING (true);
+
+-- ---------------------------------------------------------------------------
+-- 2. poll_access
+-- ---------------------------------------------------------------------------
+--
+-- Composite primary key (poll_id, browser_id). granted_at is when the
+-- browser first received the access grant. Direct-link access lets a user
+-- view ONE poll without joining the thread — useful for cases like "someone
+-- shared one specific poll's link with me, but I'm not part of the broader
+-- thread".
+--
+-- Index on (browser_id) supports the "all polls I have direct access to"
+-- lookup the read endpoints will use in Phase C.3.
+
+CREATE TABLE IF NOT EXISTS poll_access (
+  poll_id UUID NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
+  browser_id UUID NOT NULL,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (poll_id, browser_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_poll_access_browser_id
+  ON poll_access(browser_id);
+
+ALTER TABLE poll_access ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow public read access on poll_access" ON poll_access;
+CREATE POLICY "Allow public read access on poll_access" ON poll_access
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Allow public insert access on poll_access" ON poll_access;
+CREATE POLICY "Allow public insert access on poll_access" ON poll_access
+  FOR INSERT WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Allow public delete access on poll_access" ON poll_access;
+CREATE POLICY "Allow public delete access on poll_access" ON poll_access
+  FOR DELETE USING (true);
+
+COMMIT;

--- a/docs/thread-routing-redesign.md
+++ b/docs/thread-routing-redesign.md
@@ -1,8 +1,8 @@
 # Thread Routing Redesign
 
 > Status: Phase A shipped (#260), Phase B.1 shipped (#261), Phase B.2
-> shipped (#262), Phase B.3 shipped (#263), Phase B.4 in progress (this
-> branch). Phase C is deferred.
+> shipped (#262), Phase B.3 shipped (#263), Phase B.4 shipped (#264).
+> Phase C.1 in progress (this branch); C.2 and C.3 deferred.
 
 ## Vision
 
@@ -239,33 +239,77 @@ through the rollout window.
     per-poll `apiGetPollByShortId` call which couldn't resolve
     `~`-prefixed thread route ids.
 
-### Phase C — Membership with join-time visibility (deferred)
+### Phase C — Membership with join-time visibility
 
-- Add `thread_members(thread_id, browser_id, joined_at)` and
-  `poll_access(poll_id, browser_id, granted_at)`.
-- Visibility filter applies in the new server endpoints.
-- "Join" trigger: voting / abstaining / creating in any poll in the thread auto-joins
-  the user. (Reading via direct poll link does not.) Open question: should visiting
-  `/t/<id>` directly join you, or show a "join thread" prompt?
-- Migration:
-  - Existing creators → `thread_members(thread_id, browser_id, joined_at = poll.created_at)`
-    for every thread containing one of their creations.
-  - Existing voters → `thread_members(thread_id, browser_id, joined_at = first_vote_timestamp)`.
-  - Existing `accessible_question_ids` localStorage entries → grant `poll_access` rows.
+Broken into three sub-phases mirroring Phase B's pattern, so each is
+independently shippable and behavior changes only land once the schema +
+writes are in place.
+
+#### Phase C.1 — Schema only (this branch)
+
+- Add `thread_members(thread_id, browser_id, joined_at)` with composite
+  PK `(thread_id, browser_id)` and `joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`.
+- Add `poll_access(poll_id, browser_id, granted_at)` with composite PK
+  `(poll_id, browser_id)` and `granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`.
+- Both tables FK to `threads(id)` / `polls(id)` with `ON DELETE CASCADE`
+  so dropping a thread/poll cleans up its membership/access rows.
+- Both tables get a secondary index on `browser_id` for the "all
+  threads/polls this browser belongs to" lookup that C.3's read endpoints
+  will use.
+- RLS enabled with public select/insert/delete policies, mirroring the
+  pattern used by `threads`. The actual visibility / write authorization
+  lives in application code (Phase C.3), not in RLS, since `browser_id`
+  is captured by middleware and not exposed to Postgres roles.
+- No application code reads or writes either table yet. Phase C.1 leaves
+  `main` shippable: pure additive schema, no behavior change.
+- Migration: `102_create_membership_tables_{up,down}.sql`.
+
+Backfill of legacy votes/creates is **not** part of C.1. `browser_id`
+was only captured starting in Phase B.3 (#263), so pre-B.3 votes/creates
+have no `browser_id` to attach a membership row to. The current plan is
+to lean on C.2's auto-join writes for any returning browser (they
+re-establish membership the next time they vote in the thread), backed
+by the existing localStorage `accessible_question_ids` list which the FE
+will continue to consult during the transition. Settling on a final
+backfill answer is a follow-up — see CLAUDE.md →
+"FOLLOW-UP — Decide backfill strategy ...".
+
+#### Phase C.2 — Auto-join writes (deferred)
+
+- Insert `thread_members(thread_id, browser_id, joined_at = NOW())` on
+  vote / abstain / poll-create. Idempotent via `ON CONFLICT DO NOTHING`
+  on the composite PK.
+- Insert `poll_access(poll_id, browser_id, granted_at = NOW())` on the
+  redirect resolution path for legacy `/p/<id>` URLs and on the `?p=`
+  query-param expansion in `/t/<thread>?p=<poll>` — i.e. anywhere a
+  user lands on a *specific* poll without already being a thread member.
+- No reads gated yet. C.2 is purely additive at the storage layer:
+  `thread_members` / `poll_access` get populated by live traffic, but
+  nothing yet filters reads by them.
+
+#### Phase C.3 — Visibility enforcement (deferred)
+
+- Apply the visibility rule (see "Visibility rule" above) in the read
+  endpoints `POST /api/threads/mine` and `GET /api/threads/by-route-id/{routeId}`.
+- Resolve the open semantic questions before shipping:
+  - **Join trigger:** vote/create/abstain only (the C.2 default), or
+    also auto-join on direct `/t/<id>` visit, or explicit join button?
+  - **Non-member visiting `/t/<id>` (no `?p`):** 404? "Join this thread"
+    prompt? Read-only stub of the most recent open polls?
+  - **Forget vs leave:** does forget-of-last-accessible-poll auto-drop
+    `thread_members`, or do we add an explicit "leave thread" action?
 
 ## Open questions
 
-- **Join trigger:** voting/creating only (proposed default), explicit join button, or
-  also auto-join on direct `/t/<id>` visit?
-- **Non-member visiting `/t/<id>` (no `?p`):** 404? "Join this thread" prompt? Render
-  a read-only stub of the most recent open polls?
-- **Forget vs leave:** today "forget" removes a poll from the browser's accessible list.
-  Does Phase C add an explicit "leave thread" action that drops `thread_members`, or do
-  we treat forget-of-the-last-accessible-poll as the leave signal?
-- **Thread short_id keyspace:** in Phase B, do we keep root-poll-short_id as the thread
-  short_id forever, or mint fresh thread short_ids and add a redirect for the old form?
-  (Keeping the same form simplifies Phase A → Phase B; minting fresh decouples the two
-  entities.)
+The thread-short_id-keyspace question was resolved in Phase B.4: fresh
+thread short_ids minted from a `~`-prefixed namespace, with the legacy
+root-poll-short_id values kept on the existing `threads` rows so old
+`/t/<root>` URLs still resolve through the same `threads.short_id`
+lookup as the new ones.
+
+The Phase C semantic questions (join trigger, non-member /t visit,
+forget vs leave) are now tracked under "Phase C.3 — Visibility
+enforcement (deferred)" above and need to be settled before C.3 ships.
 
 ## Phase A simplifications worth keeping in mind
 


### PR DESCRIPTION
## Summary

Phase C.1 of the thread-routing redesign: adds the two membership tables Phase C will use to enforce join-time visibility. Pure additive schema; no application code reads or writes either table yet.

```
thread_members(thread_id, browser_id, joined_at)
poll_access(poll_id, browser_id, granted_at)
```

Both have composite primary keys, FK to `threads` / `polls` with `ON DELETE CASCADE`, secondary index on `browser_id` for the "all threads/polls this browser belongs to" lookup the C.3 read endpoints will use, and RLS with public select/insert/delete policies (matching the `threads` table — actual authorization will live in the application layer since `browser_id` is captured by middleware, not exposed to Postgres roles).

C.1 leaves `main` shippable. Behavior change lands in later sub-phases:
- **C.2** will write `thread_members` on vote/create/abstain (auto-join) and `poll_access` on `?p=` + legacy `/p/<id>` direct-link grant paths.
- **C.3** will gate visibility in `POST /api/threads/mine` and `GET /api/threads/by-route-id/{routeId}` on the union of the two tables.

Three semantic questions stay open until C.3:
- Join trigger (vote/create only? auto on `/t/<id>` visit? explicit join button?)
- Non-member visiting `/t/<id>` with no `?p` (404? join prompt? read-only stub?)
- Forget vs leave (forget-of-last-poll auto-leaves, or separate "leave thread" action?)

Backfill of legacy votes/creates is deferred too — `browser_id` was only captured starting in Phase B.3 (#263), so pre-B.3 rows have no `browser_id` to attach a membership row to. Current plan is to lean on C.2's auto-join writes for any returning browser.

Round-tripped (up → down → up) against `dev_sam_at_samcarey_com` to verify both directions run cleanly.

See `docs/thread-routing-redesign.md` → "Phase C — Membership with join-time visibility" for the full plan.

## Test plan

- [x] `102_create_membership_tables_up.sql` applies cleanly on `dev_sam_at_samcarey_com` (migration 101 → 102)
- [x] `102_create_membership_tables_down.sql` cleans up both tables, indexes, and RLS policies
- [x] Re-applying up after down works (idempotent)
- [x] Schema verified via `\d thread_members` / `\d poll_access`: composite PK, FK with `ON DELETE CASCADE`, `idx_*_browser_id`, three RLS policies each
- [ ] Apply migration to prod via `npm run publish` after merge

https://claude.ai/code/session_01RGFXzM3GPHBKysbBpuDgPT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGFXzM3GPHBKysbBpuDgPT)_