### PR TITLE
Phase C.2: auto-join membership writes + poll_access grant endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,21 +748,54 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Poll System
 
-> **Phase C.1 of the thread-routing redesign in progress (this branch).**
-> Migration 102 adds two empty membership tables — `thread_members(thread_id,
-> browser_id, joined_at)` and `poll_access(poll_id, browser_id, granted_at)`,
-> both with composite PKs and a secondary index on `browser_id`. No
-> application code reads or writes either table yet; Phase C.2 will start
-> writing them on vote/create/abstain (auto-join) and on the `?p=`
-> direct-link grant path, and Phase C.3 will gate visibility in
-> `/api/threads/*` on the union of the two. Three semantic questions stay
-> open until C.3: join trigger (vote/create only? auto on /t visit?), what
-> a non-member sees at `/t/<id>` with no `?p`, and forget-vs-leave. Backfill
-> of legacy votes/creates is deferred — `browser_id` was only captured
-> starting in Phase B.3, so pre-B.3 rows have no browser_id to attach a
-> membership row to; the current plan is to lean on C.2's auto-join writes
-> for any returning browser. See `docs/thread-routing-redesign.md` →
-> "Phase C — Membership with join-time visibility".
+> **Phase C.2 of the thread-routing redesign in progress (this branch).**
+> The membership tables (added schema-only in C.1) are now wired to live
+> traffic. Three trigger points, all decoupled from the action that
+> triggers them — each membership write opens its OWN `get_db()`
+> transaction, logs+swallows failures, and uses `ON CONFLICT DO NOTHING`
+> on the composite PK so re-votes/re-grants preserve the original
+> `joined_at`/`granted_at` watermark (the Phase C.3 visibility filter
+> compares poll closure timestamps against it):
+>
+>   * **Creator auto-join** — `POST /api/polls` writes `thread_members`
+>     AFTER the create commits (root polls' `thread_id` only exists
+>     post-`_insert_poll`).
+>   * **Voter auto-join** — `POST /api/polls/{id}/votes` writes
+>     `thread_members` BEFORE the vote runs, so a vote rejected by
+>     validation still records "attempted to participate" as the trigger.
+>     `services.memberships.join_thread_for_poll` fuses the
+>     `polls.thread_id` lookup with the insert via `INSERT … SELECT
+>     thread_id FROM polls WHERE id=… ON CONFLICT DO NOTHING` — single
+>     round-trip on the vote hot path.
+>   * **Direct-link grant** — new `POST /api/polls/{id}/access` endpoint
+>     called by the FE when the user lands on `/t/<thread>?p=<poll>` (and
+>     transitively from legacy `/p/<id>` redirects, which funnel through
+>     the same canonical URL once they resolve). The endpoint inlines the
+>     INSERT and uses the FK violation as the existence check:
+>     `psycopg.errors.ForeignKeyViolation` → 404 — single connection, no
+>     TOCTOU window. Returns 204 on success.
+>
+> FE: `apiGrantPollAccess(pollId)` in `lib/api/polls.ts` is fire-and-forget
+> (catches and discards). The thread page (`app/t/[threadShortId]/page.tsx`)
+> fires it from a `useEffect` keyed on a memoized `targetPoll` (resolved
+> from `?p=` via `getCachedPollForShortId`); a `useRef<Set<string>>`
+> dedupes the call so `rootPoll` churn (cache-hit initial paint then
+> async refresh resets the same value) doesn't fire duplicate POSTs.
+> `_browser_id(request)` helper in `routers/polls.py` reads
+> `request.state.browser_id` so every Phase C handler reaches for the
+> same one-liner.
+>
+> Three semantic questions still open for Phase C.3 (visibility
+> enforcement): join trigger finality (vote/create only vs. auto on /t
+> visit vs. explicit join), what a non-member sees at `/t/<id>` with no
+> `?p`, and forget-vs-leave. Backfill of pre-B.3 votes is still deferred
+> — current plan is to lean on C.2's auto-join writes for any returning
+> browser. See `docs/thread-routing-redesign.md` → "Phase C — Membership
+> with join-time visibility".
+>
+> **Phase C.1 (#265) is the previous step.** Migration 102 added the two
+> membership tables (`thread_members` and `poll_access`) with composite
+> PKs and a secondary index on `browser_id`, schema-only. C.2 wires them.
 >
 > **Phase B.4 of the thread-routing redesign shipped (#264).**
 > Every `PollResponse` now carries `thread_id` (uuid) and `thread_short_id`
@@ -995,6 +1028,11 @@ Frontend conventions for the poll plumbing:
 - **`dev_sam_at_samcarey_com` lacks the `questions.short_id` INSERT trigger.** Migration 093 self-heals the `questions.short_id` and `questions.sequential_id` columns on dev DBs but doesn't recreate the `trigger_generate_short_id` BEFORE-INSERT trigger that prod has. Result: legacy `POST /api/questions` tests (`tests/test_questions_api.py::TestCreateQuestion`, `TestGetQuestion::test_get_question_by_short_id`) fail on dev_sam with `short_id IS NULL` in the response. They pass against the prod-shape `whoeverwants` DB. If you need the legacy create endpoint to work on dev_sam, add the trigger via a one-shot psql command (don't bake it into a migration — prod already has it).
 - **Surfacing a poll-level field on every `Question` response means updating *every* questions SELECT that feeds `_row_to_question`.** Phase 3.5 added `poll_follow_up_to` (the wrapper's chain pointer). The pattern: a `_SELECT_QUESTION_WITH_POLL_PREFIX` helper that does `SELECT p.*, mp.follow_up_to AS poll_follow_up_to FROM questions p LEFT JOIN polls mp ON p.poll_id = mp.id` (callers append `WHERE p.<column> = ...`), plus an `_attach_poll_chain_fields(conn, row)` helper for `RETURNING *` paths (UPDATE/INSERT) that does a separate lookup. `_row_to_question` reads `row.get("poll_follow_up_to")` and gracefully returns None when the field is absent — so SELECTs that don't go through the prefix simply produce a None field on the FE rather than an error. The legacy `POST /api/questions` create path skips `_attach_poll_chain_fields` entirely because it always inserts `poll_id IS NULL`. When adding a similar wrapper-level field in the future (Phase 5 will add more), follow this pattern and don't forget the `PollResponse` questions list — `_row_to_poll` enriches each question row inline since it already has the wrapper's value in scope (no extra DB lookup).
 - **Don't reinvent the `poll_id → Question` Map lookup.** `lib/threadUtils.ts` exports `buildQuestionByPollMap(questions)` — every callsite that needs to resolve a question for a poll_id (e.g. for `findThreadRootRouteId`'s chain walk) should use it, prepending the current question if it isn't yet in the cached accessible list (`buildQuestionByPollMap([question, ...accessible])`). The first occurrence per poll wins, so the prepend ensures the live question wins over a stale cache entry. Earlier Phase 3.5 code had this pattern duplicated inline in three places; consolidate any new callsite onto the helper.
+- **Phase C.2 audit-write rule: decoupled transactions for membership writes.** Anything triggered by a vote/create/abstain that needs to write to `thread_members` / `poll_access` MUST run in its own `get_db()` transaction, NOT share the action's transaction. Pattern: helper functions in `services/memberships.py` that open their own connection, run `INSERT … ON CONFLICT DO NOTHING`, and `try/except Exception: log+continue` so audit failures don't block the action and action failures don't strand audit rows. The composite-PK `ON CONFLICT` is also load-bearing: re-voting / re-grant must NOT advance `joined_at`/`granted_at`, since Phase C.3 visibility compares poll closure timestamps against that watermark. Order in the handler: vote/abstain endpoint writes membership BEFORE the vote (so a rejected vote still records "attempted to participate"); poll-create endpoint writes membership AFTER the create (the root-poll's `thread_id` only exists post-`_insert_poll`).
+- **Use `_browser_id(request)` in `routers/polls.py` rather than `getattr(request.state, "browser_id", None)`.** `BrowserIdMiddleware` always sets the field, but the `getattr` fallback is the safe form for the rare path that doesn't go through middleware (direct `TestClient` instantiation, internal call sites). The helper exists because Phase C handlers will all reach for it; don't re-inline the `getattr`.
+- **Fuse poll → thread_id lookups with the audit-write SQL.** `join_thread_for_poll(poll_id, browser_id)` does `INSERT INTO thread_members SELECT thread_id, %(browser_id)s FROM polls WHERE id=%(poll_id)s ON CONFLICT DO NOTHING` — one statement, one round-trip. Don't re-introduce a separate `SELECT thread_id FROM polls` followed by an INSERT; that doubles the hot-path RTT.
+- **Use FK violation as the existence check.** The `POST /api/polls/{id}/access` handler in `routers/polls.py` does `try: INSERT … catch psycopg.errors.ForeignKeyViolation → 404`. Prefer this to a `SELECT 1 FROM polls` pre-check: it's one connection instead of two, removes the TOCTOU window between SELECT and INSERT, and surfaces deletes-during-grant as the same 404. Same pattern applies to any "write a row whose FK doubles as the existence check" endpoint (Phase C.3 may add more).
+- **`useEffect` that fires a side-effect API call from a derived value needs a `useRef<Set>` dedupe.** The Phase C.2 access grant in `app/t/[threadShortId]/page.tsx` is keyed on a memoized `targetPoll`, but the parent's `rootPoll` churns post-mount when an async refresh resets the same value — re-firing the effect with an identical `targetPoll`. The server-side `ON CONFLICT DO NOTHING` makes the duplicate POST harmless, but a network round-trip per render is wasteful. Pattern: `const grantedPollIdsRef = useRef<Set<string>>(new Set()); useEffect(() => { if (grantedPollIdsRef.current.has(id)) return; grantedPollIdsRef.current.add(id); void apiCall(id); }, [target]);`. Reuse this idiom for any future fire-and-forget grant/audit endpoint.
 
 This section captures the design decisions from the original conversation so future sessions can reference them without re-asking.
 

--- a/app/t/[threadShortId]/page.tsx
+++ b/app/t/[threadShortId]/page.tsx
@@ -11,7 +11,7 @@ import type { Poll } from "@/lib/types";
 import { useThreadVoting } from "@/lib/useThreadVoting";
 import type { QuestionResults } from "@/lib/types";
 import { addAccessibleQuestionId, getCreatorSecret } from "@/lib/browserQuestionAccess";
-import { getCachedQuestionById, getCachedQuestionByShortId, getCachedAccessiblePolls, getCachedPollById, getCachedPollByShortId } from "@/lib/questionCache";
+import { getCachedQuestionById, getCachedQuestionByShortId, getCachedAccessiblePolls, getCachedPollById, getCachedPollByShortId, getCachedPollForShortId } from "@/lib/questionCache";
 import {
   POLL_PENDING_EVENT,
   POLL_HYDRATED_EVENT,
@@ -1934,30 +1934,26 @@ function ThreadPageInner() {
     return () => { cancelled = true; };
   }, [threadShortId, router, rootInitial]);
 
-  // `?p=<id>` → first question of that poll. Missing poll falls through to
-  // null; page renders without auto-expand and scrolls to bottom.
-  const initialExpandedQuestionId = useMemo<string | null>(() => {
+  // `?p=<id>` → resolve to the cached Poll once, drive both the
+  // initial-expand target AND the Phase C.2 access grant from it.
+  const targetPoll = useMemo<Poll | null>(() => {
     if (typeof window === "undefined" || !pollParam || !rootPoll) return null;
-    const targetPoll = isUuidLike(pollParam)
-      ? getCachedPollById(pollParam)
-      : getCachedPollByShortId(pollParam);
-    return targetPoll?.questions[0]?.id ?? null;
+    return getCachedPollForShortId(pollParam);
   }, [pollParam, rootPoll]);
 
-  // Phase C.2: when the user lands with `?p=<poll>`, record direct-link
-  // access to that poll. Resolves the param to a poll uuid via the cache
-  // (warmed by the rootPoll fetch above) and POSTs to /api/polls/<id>/access.
-  // Idempotent server-side, fire-and-forget client-side. Skipped when the
-  // param is missing or the cache lookup misses — the next thread load
-  // will retry once the cache warms.
+  const initialExpandedQuestionId = targetPoll?.questions[0]?.id ?? null;
+
+  // Phase C.2: idempotent server-side via ON CONFLICT, but the useRef
+  // guard avoids the duplicate POST that fires when `rootPoll` churns
+  // post-mount (e.g. cache-hit initial paint then async refresh resets
+  // the same value).
+  const grantedPollIdsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (typeof window === "undefined" || !pollParam || !rootPoll) return;
-    const targetPoll = isUuidLike(pollParam)
-      ? getCachedPollById(pollParam)
-      : getCachedPollByShortId(pollParam);
     if (!targetPoll) return;
+    if (grantedPollIdsRef.current.has(targetPoll.id)) return;
+    grantedPollIdsRef.current.add(targetPoll.id);
     void apiGrantPollAccess(targetPoll.id);
-  }, [pollParam, rootPoll]);
+  }, [targetPoll]);
 
   if (error) {
     return (

--- a/app/t/[threadShortId]/page.tsx
+++ b/app/t/[threadShortId]/page.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { Question } from "@/lib/types";
 import { getMyThreads } from "@/lib/simpleQuestionQueries";
 import { buildThreadFromPollDown, buildThreadSyncFromCache, buildPollMap, isPendingPollId, POLL_QUERY_PARAM } from "@/lib/threadUtils";
-import { apiGetQuestionById, apiGetQuestionByShortId, apiGetQuestionResults, apiGetThreadByRouteId, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiGetPollById, apiGetPollByShortId, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
+import { apiGetQuestionById, apiGetQuestionByShortId, apiGetQuestionResults, apiGetThreadByRouteId, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiGetPollById, apiGetPollByShortId, apiGrantPollAccess, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
 import type { Poll } from "@/lib/types";
 import { useThreadVoting } from "@/lib/useThreadVoting";
 import type { QuestionResults } from "@/lib/types";
@@ -1942,6 +1942,21 @@ function ThreadPageInner() {
       ? getCachedPollById(pollParam)
       : getCachedPollByShortId(pollParam);
     return targetPoll?.questions[0]?.id ?? null;
+  }, [pollParam, rootPoll]);
+
+  // Phase C.2: when the user lands with `?p=<poll>`, record direct-link
+  // access to that poll. Resolves the param to a poll uuid via the cache
+  // (warmed by the rootPoll fetch above) and POSTs to /api/polls/<id>/access.
+  // Idempotent server-side, fire-and-forget client-side. Skipped when the
+  // param is missing or the cache lookup misses — the next thread load
+  // will retry once the cache warms.
+  useEffect(() => {
+    if (typeof window === "undefined" || !pollParam || !rootPoll) return;
+    const targetPoll = isUuidLike(pollParam)
+      ? getCachedPollById(pollParam)
+      : getCachedPollByShortId(pollParam);
+    if (!targetPoll) return;
+    void apiGrantPollAccess(targetPoll.id);
   }, [pollParam, rootPoll]);
 
   if (error) {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -25,6 +25,7 @@ export {
   apiReopenPoll,
   apiCutoffPollSuggestions,
   apiCutoffPollAvailability,
+  apiGrantPollAccess,
   apiUpdatePollThreadTitle,
 } from "./polls";
 export type { QuestionType, CreateQuestionParams, CreatePollParams } from "./polls";

--- a/lib/api/polls.ts
+++ b/lib/api/polls.ts
@@ -141,6 +141,28 @@ export async function apiCutoffPollAvailability(
   return pollOperation(pollId, 'cutoff-availability', { creator_secret: creatorSecret });
 }
 
+/**
+ * Phase C.2: record direct-link access to a poll. Called when the user
+ * lands on `/t/<thread>?p=<poll>` (or via the legacy `/p/<id>` redirect
+ * once it resolves to that form). Idempotent — server uses
+ * ON CONFLICT DO NOTHING on (poll_id, browser_id), so callers don't need
+ * to dedupe. Fails silently in the FE: a missing access row degrades to
+ * "Phase C.3 visibility falls back to thread membership" rather than
+ * blocking the user from seeing the poll they just clicked through to.
+ *
+ * The browser_id ride-along happens in `_internal.ts: fetchWithBase`;
+ * callers don't need to attach it.
+ */
+export async function apiGrantPollAccess(pollId: string): Promise<void> {
+  try {
+    await pollFetch(`/${encodeURIComponent(pollId)}/access`, { method: 'POST' });
+  } catch {
+    // Phase C.2: no read enforcement yet, so a transient failure here is
+    // never user-visible. Phase C.3 may want to surface a stronger signal
+    // (retry, telemetry) but for now log-and-move-on is correct.
+  }
+}
+
 /** Update (or clear) a poll's thread_title override. Empty string clears it. */
 export async function apiUpdatePollThreadTitle(pollId: string, threadTitle: string | null): Promise<Poll> {
   const data = await pollFetch<any>(`/${encodeURIComponent(pollId)}/thread-title`, {

--- a/lib/api/polls.ts
+++ b/lib/api/polls.ts
@@ -141,25 +141,14 @@ export async function apiCutoffPollAvailability(
   return pollOperation(pollId, 'cutoff-availability', { creator_secret: creatorSecret });
 }
 
-/**
- * Phase C.2: record direct-link access to a poll. Called when the user
- * lands on `/t/<thread>?p=<poll>` (or via the legacy `/p/<id>` redirect
- * once it resolves to that form). Idempotent — server uses
- * ON CONFLICT DO NOTHING on (poll_id, browser_id), so callers don't need
- * to dedupe. Fails silently in the FE: a missing access row degrades to
- * "Phase C.3 visibility falls back to thread membership" rather than
- * blocking the user from seeing the poll they just clicked through to.
- *
- * The browser_id ride-along happens in `_internal.ts: fetchWithBase`;
- * callers don't need to attach it.
- */
+/** Phase C.2: record direct-link access to a poll. Idempotent server-side
+ *  (ON CONFLICT DO NOTHING) and fire-and-forget client-side — Phase C.2 has
+ *  no read enforcement, so a transient failure is never user-visible. */
 export async function apiGrantPollAccess(pollId: string): Promise<void> {
   try {
     await pollFetch(`/${encodeURIComponent(pollId)}/access`, { method: 'POST' });
   } catch {
-    // Phase C.2: no read enforcement yet, so a transient failure here is
-    // never user-visible. Phase C.3 may want to surface a stronger signal
-    // (retry, telemetry) but for now log-and-move-on is correct.
+    // intentional: see jsdoc
   }
 }
 

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import psycopg.errors
 from fastapi import APIRouter, HTTPException, Request
 
 from algorithms.poll_title import generate_poll_title
@@ -23,7 +24,7 @@ from models import (
     UpdateThreadTitleRequest,
     VoteResponse,
 )
-from services.memberships import grant_poll_access, join_thread, join_thread_for_poll
+from services.memberships import join_thread, join_thread_for_poll
 from services.questions import (
     _edit_vote_on_question,
     _finalize_suggestion_options,
@@ -63,6 +64,12 @@ def _iso_or_none(value) -> str | None:
     if isinstance(value, datetime):
         return value.isoformat()
     return str(value)
+
+
+def _browser_id(request: Request) -> str | None:
+    """Phase C.2: read the browser_id captured by `BrowserIdMiddleware`.
+    Helper exists because Phase C handlers will all reach for this."""
+    return getattr(request.state, "browser_id", None)
 
 
 def _validate_request(req: CreatePollRequest) -> None:
@@ -418,15 +425,11 @@ def create_poll(req: CreatePollRequest, request: Request):
             for index, sub in enumerate(req.questions)
         ]
 
-    # Phase C.2: record creator membership in the (just-minted or inherited)
-    # thread. Runs in its own transaction AFTER the poll is committed —
-    # follow-up creates can't predict the parent's thread_id without a
-    # lookup, root creates literally don't have one until `_insert_poll`
-    # mints it. Failure here is logged + swallowed; the create succeeds
-    # regardless.
+    # Phase C.2: creator auto-joins the thread. Runs after the create
+    # commits — root polls' thread_id only exists post-`_insert_poll`.
     join_thread(
         str(poll_row["thread_id"]) if poll_row.get("thread_id") else None,
-        getattr(request.state, "browser_id", None),
+        _browser_id(request),
     )
 
     # Newly-created poll has no votes yet — skip the voter aggregation.
@@ -463,32 +466,28 @@ def get_poll(short_id: str):
 
 @router.post("/{poll_id}/access", status_code=204)
 def grant_poll_access_endpoint(poll_id: str, request: Request):
-    """Phase C.2: record direct-link access to a single poll.
-
-    Called by the FE when a user lands on a thread URL with the `?p=<poll>`
-    query param (and as part of the legacy `/p/<id>` redirect resolution
-    flow once that lands on `/t/<root>?p=<short>`). Direct-link access lets
-    a non-member of the thread see this one poll without joining the thread
-    — Phase C.3 will gate visibility on the union of `thread_members` and
-    `poll_access`.
-
-    Verifies the poll exists (404 otherwise) so a hostile or stale client
-    can't pollute `poll_access` with rows pointing at non-existent polls.
-    The actual write happens in its own transaction inside
-    `grant_poll_access` so a failure there cannot affect the response shape.
-    Returns 204 — there's nothing useful to send back; the FE just needs to
-    know the request was accepted (and the middleware echoes the
-    `X-Browser-Id` header on every response anyway).
-    """
-    with get_db() as conn:
-        exists = conn.execute(
-            "SELECT 1 FROM polls WHERE id = %(id)s",
-            {"id": poll_id},
-        ).fetchone()
-    if not exists:
+    """Phase C.2: record direct-link access to one poll. Called when a user
+    lands on `/t/<thread>?p=<poll>` so non-thread-members can still see the
+    poll they followed a link to. Phase C.3 will read these rows."""
+    browser_id = _browser_id(request)
+    if not browser_id:
+        return
+    # The FK on poll_access.poll_id IS the existence check — a missing poll
+    # surfaces as `ForeignKeyViolation`, which we translate to 404 without
+    # the second SELECT (and without the TOCTOU window between SELECT and
+    # INSERT).
+    try:
+        with get_db() as conn:
+            conn.execute(
+                """
+                INSERT INTO poll_access (poll_id, browser_id)
+                VALUES (%(poll_id)s, %(browser_id)s)
+                ON CONFLICT (poll_id, browser_id) DO NOTHING
+                """,
+                {"poll_id": poll_id, "browser_id": browser_id},
+            )
+    except psycopg.errors.ForeignKeyViolation:
         raise HTTPException(status_code=404, detail="Poll not found")
-
-    grant_poll_access(poll_id, getattr(request.state, "browser_id", None))
 
 
 # ---------------------------------------------------------------------------
@@ -700,12 +699,10 @@ def submit_poll_votes(poll_id: str, req: SubmitPollVotesRequest, request: Reques
     """
     now = datetime.now(timezone.utc)
 
-    # Phase C.2: record thread membership BEFORE the vote runs, in its own
-    # transaction. "Attempted to participate" is the membership trigger, so
-    # a vote that fails validation still leaves the user as a member of the
-    # thread for Phase C.3 visibility purposes. One write per batch — the
-    # composite PK on (thread_id, browser_id) makes any extra writes no-ops.
-    join_thread_for_poll(poll_id, getattr(request.state, "browser_id", None))
+    # Phase C.2: thread join runs BEFORE the vote in its own transaction so
+    # "attempted to participate" is the membership trigger — a vote that
+    # fails validation still leaves the user as a thread member.
+    join_thread_for_poll(poll_id, _browser_id(request))
 
     question_ids = [item.question_id for item in req.items]
     if len(set(question_ids)) != len(question_ids):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from algorithms.poll_title import generate_poll_title
 from database import get_db
@@ -23,6 +23,7 @@ from models import (
     UpdateThreadTitleRequest,
     VoteResponse,
 )
+from services.memberships import grant_poll_access, join_thread, join_thread_for_poll
 from services.questions import (
     _edit_vote_on_question,
     _finalize_suggestion_options,
@@ -393,7 +394,7 @@ def _compute_poll_voter_data(conn, poll_id: str) -> tuple[list[str], int]:
 
 
 @router.post("", response_model=PollResponse, status_code=201)
-def create_poll(req: CreatePollRequest):
+def create_poll(req: CreatePollRequest, request: Request):
     _validate_request(req)
 
     # questions.title is NOT NULL, so each question row needs a value even though
@@ -416,6 +417,17 @@ def create_poll(req: CreatePollRequest):
             _insert_question(conn, poll_row, req, sub, index, question_title, now)
             for index, sub in enumerate(req.questions)
         ]
+
+    # Phase C.2: record creator membership in the (just-minted or inherited)
+    # thread. Runs in its own transaction AFTER the poll is committed —
+    # follow-up creates can't predict the parent's thread_id without a
+    # lookup, root creates literally don't have one until `_insert_poll`
+    # mints it. Failure here is logged + swallowed; the create succeeds
+    # regardless.
+    join_thread(
+        str(poll_row["thread_id"]) if poll_row.get("thread_id") else None,
+        getattr(request.state, "browser_id", None),
+    )
 
     # Newly-created poll has no votes yet — skip the voter aggregation.
     return _row_to_poll(poll_row, question_rows)
@@ -447,6 +459,36 @@ def get_poll(short_id: str):
         question_rows = _fetch_questions(conn, str(row["id"]))
         voter_names, anonymous_count = _compute_poll_voter_data(conn, str(row["id"]))
     return _row_to_poll(row, question_rows, voter_names, anonymous_count)
+
+
+@router.post("/{poll_id}/access", status_code=204)
+def grant_poll_access_endpoint(poll_id: str, request: Request):
+    """Phase C.2: record direct-link access to a single poll.
+
+    Called by the FE when a user lands on a thread URL with the `?p=<poll>`
+    query param (and as part of the legacy `/p/<id>` redirect resolution
+    flow once that lands on `/t/<root>?p=<short>`). Direct-link access lets
+    a non-member of the thread see this one poll without joining the thread
+    — Phase C.3 will gate visibility on the union of `thread_members` and
+    `poll_access`.
+
+    Verifies the poll exists (404 otherwise) so a hostile or stale client
+    can't pollute `poll_access` with rows pointing at non-existent polls.
+    The actual write happens in its own transaction inside
+    `grant_poll_access` so a failure there cannot affect the response shape.
+    Returns 204 — there's nothing useful to send back; the FE just needs to
+    know the request was accepted (and the middleware echoes the
+    `X-Browser-Id` header on every response anyway).
+    """
+    with get_db() as conn:
+        exists = conn.execute(
+            "SELECT 1 FROM polls WHERE id = %(id)s",
+            {"id": poll_id},
+        ).fetchone()
+    if not exists:
+        raise HTTPException(status_code=404, detail="Poll not found")
+
+    grant_poll_access(poll_id, getattr(request.state, "browser_id", None))
 
 
 # ---------------------------------------------------------------------------
@@ -644,7 +686,7 @@ def _vote_item_to_edit_req(item: PollVoteItem, voter_name: str | None) -> EditVo
     response_model=list[VoteResponse],
     status_code=201,
 )
-def submit_poll_votes(poll_id: str, req: SubmitPollVotesRequest):
+def submit_poll_votes(poll_id: str, req: SubmitPollVotesRequest, request: Request):
     """Atomic batch vote across multiple questions of one poll.
 
     Each `items[i]` either inserts a new vote (vote_id null) or updates an
@@ -657,6 +699,13 @@ def submit_poll_votes(poll_id: str, req: SubmitPollVotesRequest):
     voter_name is poll-level: one voter, many question ballots.
     """
     now = datetime.now(timezone.utc)
+
+    # Phase C.2: record thread membership BEFORE the vote runs, in its own
+    # transaction. "Attempted to participate" is the membership trigger, so
+    # a vote that fails validation still leaves the user as a member of the
+    # thread for Phase C.3 visibility purposes. One write per batch — the
+    # composite PK on (thread_id, browser_id) makes any extra writes no-ops.
+    join_thread_for_poll(poll_id, getattr(request.state, "browser_id", None))
 
     question_ids = [item.question_id for item in req.items]
     if len(set(question_ids)) != len(question_ids):

--- a/server/services/memberships.py
+++ b/server/services/memberships.py
@@ -1,0 +1,112 @@
+"""Phase C.2 — write-only helpers for thread_members + poll_access.
+
+These helpers are deliberately decoupled from the vote / create / access
+endpoints they're triggered by:
+
+  * Each helper opens its OWN database transaction (its own `get_db()` block).
+    A failure here cannot roll back the action that triggered it, and a
+    failure in the triggering action cannot roll back a successful membership
+    write.
+  * Failures are logged + swallowed. Phase C.2 is purely additive — no
+    read path enforces these tables yet (Phase C.3 will), so a missed write
+    today degrades silently into "user re-establishes membership the next
+    time they vote" rather than blocking a vote on an audit-table issue.
+  * Inserts are idempotent via `ON CONFLICT (...) DO NOTHING` on the
+    composite PK. Re-voting / re-visiting a poll never overwrites the
+    original `joined_at` / `granted_at` watermark — Phase C.3 visibility
+    compares poll closure timestamps against that watermark, so preserving
+    the original value is what gives "joined first → see the most" the
+    correct semantics.
+
+Callers should treat these as fire-and-forget. None of them return a value.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from database import get_db
+
+logger = logging.getLogger(__name__)
+
+
+def join_thread(thread_id: str | None, browser_id: str | None) -> None:
+    """Idempotently insert a `thread_members(thread_id, browser_id)` row in
+    its own transaction. Skips silently when either id is missing."""
+    if not thread_id or not browser_id:
+        return
+    try:
+        with get_db() as conn:
+            conn.execute(
+                """
+                INSERT INTO thread_members (thread_id, browser_id)
+                VALUES (%(thread_id)s, %(browser_id)s)
+                ON CONFLICT (thread_id, browser_id) DO NOTHING
+                """,
+                {"thread_id": thread_id, "browser_id": browser_id},
+            )
+    except Exception:
+        logger.warning(
+            "Phase C.2: thread_members insert failed (thread=%s, browser=%s)",
+            thread_id,
+            browser_id,
+            exc_info=True,
+        )
+
+
+def join_thread_for_poll(poll_id: str | None, browser_id: str | None) -> None:
+    """Resolve a poll_id → its thread_id and join. One-stop helper for the
+    vote endpoint (which has a poll_id but not a thread_id) so callers don't
+    re-implement the lookup. Runs in its own transaction; failures are
+    logged + swallowed."""
+    if not poll_id or not browser_id:
+        return
+    try:
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT thread_id FROM polls WHERE id = %(id)s",
+                {"id": poll_id},
+            ).fetchone()
+            if not row or not row.get("thread_id"):
+                return
+            conn.execute(
+                """
+                INSERT INTO thread_members (thread_id, browser_id)
+                VALUES (%(thread_id)s, %(browser_id)s)
+                ON CONFLICT (thread_id, browser_id) DO NOTHING
+                """,
+                {"thread_id": str(row["thread_id"]), "browser_id": browser_id},
+            )
+    except Exception:
+        logger.warning(
+            "Phase C.2: thread_members insert failed (poll=%s, browser=%s)",
+            poll_id,
+            browser_id,
+            exc_info=True,
+        )
+
+
+def grant_poll_access(poll_id: str | None, browser_id: str | None) -> None:
+    """Idempotently insert a `poll_access(poll_id, browser_id)` row in its
+    own transaction. Triggered when a user lands on a specific poll via a
+    direct link (`/t/<thread>?p=<poll>` query param, or the legacy
+    `/p/<id>` redirect resolution path)."""
+    if not poll_id or not browser_id:
+        return
+    try:
+        with get_db() as conn:
+            conn.execute(
+                """
+                INSERT INTO poll_access (poll_id, browser_id)
+                VALUES (%(poll_id)s, %(browser_id)s)
+                ON CONFLICT (poll_id, browser_id) DO NOTHING
+                """,
+                {"poll_id": poll_id, "browser_id": browser_id},
+            )
+    except Exception:
+        logger.warning(
+            "Phase C.2: poll_access insert failed (poll=%s, browser=%s)",
+            poll_id,
+            browser_id,
+            exc_info=True,
+        )

--- a/server/services/memberships.py
+++ b/server/services/memberships.py
@@ -1,24 +1,17 @@
-"""Phase C.2 — write-only helpers for thread_members + poll_access.
+"""Phase C.2 — fire-and-forget thread_members writes for vote/create paths.
 
-These helpers are deliberately decoupled from the vote / create / access
-endpoints they're triggered by:
+The poll_access write (direct-link grant) is inline in the
+`grant_poll_access_endpoint` handler so a missing poll can surface as 404 via
+the FK violation. The helpers here are for the vote/create paths where the
+action's own transaction must NOT be coupled to the audit write:
 
-  * Each helper opens its OWN database transaction (its own `get_db()` block).
-    A failure here cannot roll back the action that triggered it, and a
-    failure in the triggering action cannot roll back a successful membership
-    write.
-  * Failures are logged + swallowed. Phase C.2 is purely additive — no
-    read path enforces these tables yet (Phase C.3 will), so a missed write
-    today degrades silently into "user re-establishes membership the next
-    time they vote" rather than blocking a vote on an audit-table issue.
-  * Inserts are idempotent via `ON CONFLICT (...) DO NOTHING` on the
-    composite PK. Re-voting / re-visiting a poll never overwrites the
-    original `joined_at` / `granted_at` watermark — Phase C.3 visibility
-    compares poll closure timestamps against that watermark, so preserving
-    the original value is what gives "joined first → see the most" the
-    correct semantics.
-
-Callers should treat these as fire-and-forget. None of them return a value.
+  * Each helper opens its OWN `get_db()` transaction. A failure here cannot
+    roll back the triggering action, and vice versa.
+  * Failures are logged + swallowed — Phase C.2 doesn't enforce reads, so a
+    missed write degrades into "user re-establishes membership next vote".
+  * `ON CONFLICT DO NOTHING` on the composite PK preserves the original
+    `joined_at` watermark across re-votes — Phase C.3 visibility compares
+    poll closure timestamps against that watermark.
 """
 
 from __future__ import annotations
@@ -31,8 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def join_thread(thread_id: str | None, browser_id: str | None) -> None:
-    """Idempotently insert a `thread_members(thread_id, browser_id)` row in
-    its own transaction. Skips silently when either id is missing."""
+    """Insert a `thread_members(thread_id, browser_id)` row."""
     if not thread_id or not browser_id:
         return
     try:
@@ -55,27 +47,21 @@ def join_thread(thread_id: str | None, browser_id: str | None) -> None:
 
 
 def join_thread_for_poll(poll_id: str | None, browser_id: str | None) -> None:
-    """Resolve a poll_id → its thread_id and join. One-stop helper for the
-    vote endpoint (which has a poll_id but not a thread_id) so callers don't
-    re-implement the lookup. Runs in its own transaction; failures are
-    logged + swallowed."""
+    """Join the thread that owns this poll. INSERT ... SELECT fuses the
+    poll → thread_id lookup with the thread_members write so the vote
+    hot path pays one round-trip instead of two."""
     if not poll_id or not browser_id:
         return
     try:
         with get_db() as conn:
-            row = conn.execute(
-                "SELECT thread_id FROM polls WHERE id = %(id)s",
-                {"id": poll_id},
-            ).fetchone()
-            if not row or not row.get("thread_id"):
-                return
             conn.execute(
                 """
                 INSERT INTO thread_members (thread_id, browser_id)
-                VALUES (%(thread_id)s, %(browser_id)s)
+                SELECT thread_id, %(browser_id)s FROM polls
+                 WHERE id = %(poll_id)s AND thread_id IS NOT NULL
                 ON CONFLICT (thread_id, browser_id) DO NOTHING
                 """,
-                {"thread_id": str(row["thread_id"]), "browser_id": browser_id},
+                {"poll_id": poll_id, "browser_id": browser_id},
             )
     except Exception:
         logger.warning(
@@ -86,27 +72,3 @@ def join_thread_for_poll(poll_id: str | None, browser_id: str | None) -> None:
         )
 
 
-def grant_poll_access(poll_id: str | None, browser_id: str | None) -> None:
-    """Idempotently insert a `poll_access(poll_id, browser_id)` row in its
-    own transaction. Triggered when a user lands on a specific poll via a
-    direct link (`/t/<thread>?p=<poll>` query param, or the legacy
-    `/p/<id>` redirect resolution path)."""
-    if not poll_id or not browser_id:
-        return
-    try:
-        with get_db() as conn:
-            conn.execute(
-                """
-                INSERT INTO poll_access (poll_id, browser_id)
-                VALUES (%(poll_id)s, %(browser_id)s)
-                ON CONFLICT (poll_id, browser_id) DO NOTHING
-                """,
-                {"poll_id": poll_id, "browser_id": browser_id},
-            )
-    except Exception:
-        logger.warning(
-            "Phase C.2: poll_access insert failed (poll=%s, browser=%s)",
-            poll_id,
-            browser_id,
-            exc_info=True,
-        )

--- a/server/tests/test_membership_writes.py
+++ b/server/tests/test_membership_writes.py
@@ -1,0 +1,331 @@
+"""Phase C.2 — write-only membership tests.
+
+Covers:
+  * thread_members written on POST /api/polls (creator auto-joins)
+  * thread_members written on POST /api/polls/{id}/votes (voter auto-joins)
+  * poll_access written on POST /api/polls/{id}/access (direct-link grant)
+  * Idempotency: composite PK + ON CONFLICT DO NOTHING preserves the
+    original joined_at / granted_at watermark
+  * Browser_id isolation: two browsers voting in one thread produce two rows
+  * Decoupling: membership write is in a separate transaction from the
+    triggering action — a vote that fails validation still leaves
+    thread_members in place
+
+Phase C.2 doesn't enforce visibility yet; these tests verify the writes
+happen, not that any read path filters on them.
+"""
+
+import os
+import re
+import uuid
+
+import pytest
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+import psycopg
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def creator_secret():
+    return f"test-secret-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def browser_id():
+    return str(uuid.uuid4())
+
+
+def _yes_no_question(**overrides) -> dict:
+    base = {"question_type": "yes_no", "category": "yes_no"}
+    base.update(overrides)
+    return base
+
+
+def _create_poll(client, creator_secret, *, browser_id=None, **kwargs):
+    payload = {
+        "creator_secret": creator_secret,
+        "questions": [_yes_no_question()],
+    }
+    payload.update(kwargs)
+    headers = {"X-Browser-Id": browser_id} if browser_id else {}
+    resp = client.post("/api/polls", json=payload, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _thread_members(thread_id):
+    """Return list of (browser_id, joined_at) tuples for a thread."""
+    with psycopg.connect(TEST_DB_URL) as conn:
+        rows = conn.execute(
+            "SELECT browser_id, joined_at FROM thread_members WHERE thread_id = %s",
+            (thread_id,),
+        ).fetchall()
+    return rows
+
+
+def _poll_access(poll_id):
+    with psycopg.connect(TEST_DB_URL) as conn:
+        rows = conn.execute(
+            "SELECT browser_id, granted_at FROM poll_access WHERE poll_id = %s",
+            (poll_id,),
+        ).fetchall()
+    return rows
+
+
+class TestCreatePollMembership:
+    def test_creator_auto_joins_thread(self, client, creator_secret, browser_id):
+        poll = _create_poll(client, creator_secret, browser_id=browser_id)
+        thread_id = poll["thread_id"]
+        rows = _thread_members(thread_id)
+        assert len(rows) == 1
+        assert str(rows[0][0]) == browser_id
+
+    def test_followup_creator_joins_parent_thread(
+        self, client, creator_secret, browser_id
+    ):
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        parent_qid = root["questions"][0]["id"]
+        # Same browser creates a follow-up — already a member; ON CONFLICT
+        # keeps the thread_members row count at 1.
+        followup = _create_poll(
+            client,
+            creator_secret,
+            browser_id=browser_id,
+            follow_up_to=parent_qid,
+        )
+        # Both polls share the same thread_id.
+        assert followup["thread_id"] == root["thread_id"]
+        rows = _thread_members(root["thread_id"])
+        assert len(rows) == 1
+
+    def test_followup_creator_from_different_browser_adds_row(
+        self, client, creator_secret, browser_id
+    ):
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        parent_qid = root["questions"][0]["id"]
+        other = str(uuid.uuid4())
+        _create_poll(
+            client, creator_secret, browser_id=other, follow_up_to=parent_qid
+        )
+        rows = _thread_members(root["thread_id"])
+        bids = {str(r[0]) for r in rows}
+        assert bids == {browser_id, other}
+
+
+class TestVoteMembership:
+    def test_voter_auto_joins_thread(self, client, creator_secret, browser_id):
+        # Creator on browser A; voter on browser B.
+        creator_browser = browser_id
+        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        sub = poll["questions"][0]
+
+        voter_browser = str(uuid.uuid4())
+        resp = client.post(
+            f"/api/polls/{poll['id']}/votes",
+            json={
+                "voter_name": "Alice",
+                "items": [
+                    {
+                        "question_id": sub["id"],
+                        "vote_type": "yes_no",
+                        "yes_no_choice": "yes",
+                    },
+                ],
+            },
+            headers={"X-Browser-Id": voter_browser},
+        )
+        assert resp.status_code == 201, resp.text
+
+        rows = _thread_members(poll["thread_id"])
+        bids = {str(r[0]) for r in rows}
+        assert bids == {creator_browser, voter_browser}
+
+    def test_idempotent_on_repeat_votes(self, client, creator_secret, browser_id):
+        poll = _create_poll(client, creator_secret, browser_id=browser_id)
+        sub = poll["questions"][0]
+
+        # First vote — creates thread_members row for this browser.
+        first = client.post(
+            f"/api/polls/{poll['id']}/votes",
+            json={
+                "voter_name": "Alice",
+                "items": [
+                    {
+                        "question_id": sub["id"],
+                        "vote_type": "yes_no",
+                        "yes_no_choice": "yes",
+                    },
+                ],
+            },
+            headers={"X-Browser-Id": browser_id},
+        )
+        assert first.status_code == 201
+
+        rows_before = _thread_members(poll["thread_id"])
+        joined_at_before = next(
+            r[1] for r in rows_before if str(r[0]) == browser_id
+        )
+
+        # Edit the vote — same browser, same thread; ON CONFLICT preserves
+        # the original joined_at watermark (critical for Phase C.3 visibility).
+        vote_id = first.json()[0]["id"]
+        edit = client.post(
+            f"/api/polls/{poll['id']}/votes",
+            json={
+                "voter_name": "Alice",
+                "items": [
+                    {
+                        "question_id": sub["id"],
+                        "vote_id": vote_id,
+                        "vote_type": "yes_no",
+                        "yes_no_choice": "no",
+                    },
+                ],
+            },
+            headers={"X-Browser-Id": browser_id},
+        )
+        assert edit.status_code == 201
+
+        rows_after = _thread_members(poll["thread_id"])
+        # Same row count (one per distinct browser, deduped by composite PK).
+        assert len(rows_after) == len(rows_before)
+        joined_at_after = next(
+            r[1] for r in rows_after if str(r[0]) == browser_id
+        )
+        assert joined_at_before == joined_at_after
+
+    def test_membership_survives_vote_validation_failure(
+        self, client, creator_secret, browser_id
+    ):
+        """Membership writes run BEFORE the vote in their own transaction.
+        A vote that the validator rejects still leaves the user as a thread
+        member — they 'attempted to participate' which is the trigger
+        regardless of whether the ballot was well-formed."""
+        poll = _create_poll(client, creator_secret, browser_id=browser_id)
+        sub = poll["questions"][0]
+
+        voter_browser = str(uuid.uuid4())
+        # Same question_id twice — the endpoint rejects this with 400.
+        resp = client.post(
+            f"/api/polls/{poll['id']}/votes",
+            json={
+                "voter_name": "Bob",
+                "items": [
+                    {
+                        "question_id": sub["id"],
+                        "vote_type": "yes_no",
+                        "yes_no_choice": "yes",
+                    },
+                    {
+                        "question_id": sub["id"],
+                        "vote_type": "yes_no",
+                        "yes_no_choice": "no",
+                    },
+                ],
+            },
+            headers={"X-Browser-Id": voter_browser},
+        )
+        assert resp.status_code == 400
+
+        # No vote landed.
+        votes = client.get(f"/api/questions/{sub['id']}/votes").json()
+        assert all(v["voter_name"] != "Bob" for v in votes)
+
+        # But the membership write fired (it ran in its own transaction
+        # before the vote validation triggered the rollback).
+        rows = _thread_members(poll["thread_id"])
+        bids = {str(r[0]) for r in rows}
+        assert voter_browser in bids
+
+
+class TestPollAccessEndpoint:
+    def test_grant_writes_row(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        visitor_browser = str(uuid.uuid4())
+        resp = client.post(
+            f"/api/polls/{poll['id']}/access",
+            headers={"X-Browser-Id": visitor_browser},
+        )
+        assert resp.status_code == 204
+
+        rows = _poll_access(poll["id"])
+        bids = {str(r[0]) for r in rows}
+        assert visitor_browser in bids
+
+    def test_grant_is_idempotent(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        visitor_browser = str(uuid.uuid4())
+        for _ in range(3):
+            resp = client.post(
+                f"/api/polls/{poll['id']}/access",
+                headers={"X-Browser-Id": visitor_browser},
+            )
+            assert resp.status_code == 204
+
+        rows = _poll_access(poll["id"])
+        # Same browser, multiple grants → exactly one row.
+        bids = [str(r[0]) for r in rows if str(r[0]) == visitor_browser]
+        assert len(bids) == 1
+
+    def test_grant_preserves_original_granted_at(self, client, creator_secret):
+        poll = _create_poll(client, creator_secret)
+        visitor_browser = str(uuid.uuid4())
+        client.post(
+            f"/api/polls/{poll['id']}/access",
+            headers={"X-Browser-Id": visitor_browser},
+        )
+        first = next(
+            r[1] for r in _poll_access(poll["id"]) if str(r[0]) == visitor_browser
+        )
+        # Re-grant; granted_at watermark must NOT advance.
+        client.post(
+            f"/api/polls/{poll['id']}/access",
+            headers={"X-Browser-Id": visitor_browser},
+        )
+        second = next(
+            r[1] for r in _poll_access(poll["id"]) if str(r[0]) == visitor_browser
+        )
+        assert first == second
+
+    def test_grant_404_for_unknown_poll(self, client):
+        bogus = str(uuid.uuid4())
+        resp = client.post(
+            f"/api/polls/{bogus}/access",
+            headers={"X-Browser-Id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 404
+
+    def test_grant_does_not_create_thread_members(self, client, creator_secret):
+        """Direct-link access does NOT transitively grant thread membership.
+        Phase C.3 will resolve visibility as the union of `thread_members`
+        and `poll_access`; verifying the boundary here keeps that semantics
+        intact."""
+        poll = _create_poll(client, creator_secret)
+        visitor_browser = str(uuid.uuid4())
+        resp = client.post(
+            f"/api/polls/{poll['id']}/access",
+            headers={"X-Browser-Id": visitor_browser},
+        )
+        assert resp.status_code == 204
+
+        rows = _thread_members(poll["thread_id"])
+        bids = {str(r[0]) for r in rows}
+        assert visitor_browser not in bids


### PR DESCRIPTION
## Summary

Wires the per-browser membership tables (added schema-only in C.1, #265) to live traffic. Phase C.2 is purely additive at the storage layer — no read path enforces these tables yet (Phase C.3 will gate visibility on the union of `thread_members` and `poll_access`).

Three trigger points, all decoupled from the action that triggers them:

- **Creator auto-join** — `POST /api/polls` writes `thread_members` AFTER the create commits (root polls' `thread_id` only exists post-`_insert_poll`).
- **Voter auto-join** — `POST /api/polls/{id}/votes` writes `thread_members` BEFORE the vote runs, so a vote rejected by validation still records "attempted to participate" as the trigger. `services/memberships.py: join_thread_for_poll` fuses the `polls.thread_id` lookup with the insert into a single statement.
- **Direct-link grant** — new `POST /api/polls/{id}/access` endpoint called by the FE when the user lands on `/t/<thread>?p=<poll>` (and transitively from legacy `/p/<id>` redirects, which funnel through the same canonical URL once they resolve). The endpoint inlines the INSERT and uses `psycopg.errors.ForeignKeyViolation` as the existence check → 404. Returns 204 on success.

### Decoupling spec

Per discussion: each membership write opens its OWN `get_db()` transaction, logs+swallows failures, and uses `ON CONFLICT (composite_pk) DO NOTHING`. A failure in the audit write cannot roll back the action; a failure in the action cannot strand the audit row. The composite-PK conflict is also load-bearing — re-voting / re-grant must NOT advance `joined_at`/`granted_at`, since Phase C.3 visibility compares poll closure timestamps against that watermark.

### FE wiring

- `apiGrantPollAccess(pollId)` in `lib/api/polls.ts` — fire-and-forget (catches and discards).
- Thread page (`app/t/[threadShortId]/page.tsx`) memoizes `targetPoll` via `getCachedPollForShortId(?p)`, drives both `initialExpandedQuestionId` and the access-grant `useEffect` from it, and dedupes via a `useRef<Set<string>>` so `rootPoll` churn (cache-hit initial paint then async refresh) doesn't fire duplicate POSTs.

### Out of scope

- The three open semantic questions (join trigger finality, what a non-member sees at `/t/<id>` with no `?p`, forget-vs-leave) stay open for Phase C.3.
- Pre-B.3 backfill remains deferred.
- No read enforcement — that's Phase C.3.
- No demo (Phase C.2 has no user-visible behavior change).

## Test plan

- [x] 11 new tests in `server/tests/test_membership_writes.py` covering creator auto-join, follow-up creator (same browser → 1 row, different browser → 2 rows), voter auto-join, idempotency on re-vote (preserves `joined_at`), membership-survives-vote-validation-failure (decoupled-transaction proof), grant writes row, grant idempotent (3 calls → 1 row), grant preserves `granted_at`, grant 404 for unknown poll, grant does NOT spill into `thread_members`. All pass against `dev_sam_at_samcarey_com`.
- [x] Existing `test_polls_api.py` and `test_threads_api.py` still pass (4 unrelated failures are pre-existing on main: Phase 5b dropped `is_closed` from `QuestionResponse`, those tests still assert it).
- [x] FE: `?p=` mount fires one POST to `/api/polls/<id>/access`; identical re-renders are deduped via the useRef Set; missing-poll-cache misses skip silently.

https://claude.ai/code/session_01U2xekRQqYqmNyVkhh3CC3V