### PR TITLE
Phase C.3: enforce join-time visibility on thread read endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,8 +748,78 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Poll System
 
-> **Phase C.2 of the thread-routing redesign in progress (this branch).**
-> The membership tables (added schema-only in C.1) are now wired to live
+> **Phase C.3 of the thread-routing redesign in progress (this branch).**
+> The visibility rule is now enforced on `POST /api/threads/mine` and
+> `GET /api/threads/by-route-id/{route_id}`. A poll P in thread T is
+> visible to browser B iff ANY of:
+>
+>   1. B has a `thread_members` row for T AND
+>      (`P.is_closed = false` OR `P.closed_at >= members.joined_at`),
+>   2. B has a `poll_access` row for P,
+>   3. (transitional) The legacy `accessible_question_ids` list passed
+>      by the FE contains a question_id whose poll lives in T — treated
+>      as **thread-level** access (every poll in T visible, no
+>      closed_at filter) so pre-B.3 callers passing one question_id
+>      keep seeing the whole thread (the Phase B.3 contract). Per-poll
+>      bridging would silently shrink threads on first refresh
+>      post-rollout. Applies to `/api/threads/mine` only — by-route-id
+>      relies on `?p=` inline grant.
+>
+> Decisions on the previously-open semantic questions:
+>
+>   * **Join trigger**: vote/create only — Phase C.2 defaults
+>     preserved. The /access endpoint and the `?p=` auto-grant on
+>     by-route-id grant `poll_access` (per-poll, not thread membership).
+>   * **Non-member visiting `/t/<id>` with no `?p`**: 404. "No
+>     visibility into any poll" is treated identically to "no such
+>     thread" — same FE error path.
+>   * **Forget vs leave**: forget stays localStorage-only. When the FE
+>     passes `accessible_question_ids`, `/api/threads/mine` narrows to
+>     threads with a non-membership signal (poll_access OR legacy
+>     bridge) so forget keeps its "thread disappears from home"
+>     semantics. An explicit `DELETE /api/threads/{id}/membership`
+>     ("leave thread") is a follow-up to retire the bridge.
+>
+> `closed_at` proxy: `polls.updated_at`, refreshed by the close
+> trigger. Subsequent edits bump it forward — the filter fails open (a
+> closed poll touched after the user joins becomes visible). Adding a
+> dedicated `closed_at` column would be marginally tighter; deferred.
+>
+> **`?p=` inline auto-grant on by-route-id.** The endpoint accepts an
+> optional `?p=<pollShortId>`; when present, a `poll_access` row is
+> written inline BEFORE filtering. This race-safely surfaces a direct-
+> link landing — without it, a stranger hitting
+> `/t/<thread>?p=<poll>` on a fresh browser would see by-route-id 404
+> because the FE's parallel `apiGrantPollAccess` call hadn't yet
+> landed. The lookup is **scoped to the resolved thread**, so a `?p`
+> referencing a poll in a different thread is silently ignored — no
+> cross-thread access leak.
+>
+> **Visibility helpers in `services/threads.py`:**
+>
+>   * `UserVisibility` dataclass: a snapshot of one browser's
+>     `joined_by_thread` / `access_poll_ids` / `bridged_thread_ids`.
+>   * `load_user_visibility(conn, browser_id, *, legacy_question_ids)`:
+>     reads every signal in one place. Both endpoints call this once
+>     per request.
+>   * `filter_visible_polls(conn, candidate_poll_ids, visibility)`:
+>     applies the rule. Returns the visible subset.
+>   * `grant_poll_access_inline(conn, poll_id, browser_id)`: writes
+>     `poll_access` in the SAME transaction as the read. Used only by
+>     the `?p=` auto-grant.
+>
+> **Migration cost.** Pre-B.3 voters who haven't re-voted have no
+> `thread_members` row. They keep working via the legacy bridge so
+> long as their FE passes `accessible_question_ids`. Once they vote
+> again, Phase C.2's auto-join writes restore membership and the
+> bridge becomes redundant. The bridge will be retired in a follow-up
+> phase after enough rollout time. Visibility enforcement on the
+> legacy `POST /api/questions/accessible` is intentionally NOT added —
+> the FE migrated to /api/threads/* in B.3, and gating the legacy
+> endpoint retroactively risks breaking older client bundles.
+>
+> **Phase C.2 (#266) is the previous step.**
+> The membership tables (added schema-only in C.1) are wired to live
 > traffic. Three trigger points, all decoupled from the action that
 > triggers them — each membership write opens its OWN `get_db()`
 > transaction, logs+swallows failures, and uses `ON CONFLICT DO NOTHING`
@@ -785,13 +855,11 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 > `request.state.browser_id` so every Phase C handler reaches for the
 > same one-liner.
 >
-> Three semantic questions still open for Phase C.3 (visibility
-> enforcement): join trigger finality (vote/create only vs. auto on /t
-> visit vs. explicit join), what a non-member sees at `/t/<id>` with no
-> `?p`, and forget-vs-leave. Backfill of pre-B.3 votes is still deferred
-> — current plan is to lean on C.2's auto-join writes for any returning
-> browser. See `docs/thread-routing-redesign.md` → "Phase C — Membership
-> with join-time visibility".
+> Backfill of pre-B.3 votes is still deferred — covered by C.2's
+> auto-join writes for any returning browser plus the C.3 legacy
+> bridge for users who haven't re-voted. See
+> `docs/thread-routing-redesign.md` → "Phase C — Membership with
+> join-time visibility".
 >
 > **Phase C.1 (#265) is the previous step.** Migration 102 added the two
 > membership tables (`thread_members` and `poll_access`) with composite
@@ -1033,6 +1101,12 @@ Frontend conventions for the poll plumbing:
 - **Fuse poll → thread_id lookups with the audit-write SQL.** `join_thread_for_poll(poll_id, browser_id)` does `INSERT INTO thread_members SELECT thread_id, %(browser_id)s FROM polls WHERE id=%(poll_id)s ON CONFLICT DO NOTHING` — one statement, one round-trip. Don't re-introduce a separate `SELECT thread_id FROM polls` followed by an INSERT; that doubles the hot-path RTT.
 - **Use FK violation as the existence check.** The `POST /api/polls/{id}/access` handler in `routers/polls.py` does `try: INSERT … catch psycopg.errors.ForeignKeyViolation → 404`. Prefer this to a `SELECT 1 FROM polls` pre-check: it's one connection instead of two, removes the TOCTOU window between SELECT and INSERT, and surfaces deletes-during-grant as the same 404. Same pattern applies to any "write a row whose FK doubles as the existence check" endpoint (Phase C.3 may add more).
 - **`useEffect` that fires a side-effect API call from a derived value needs a `useRef<Set>` dedupe.** The Phase C.2 access grant in `app/t/[threadShortId]/page.tsx` is keyed on a memoized `targetPoll`, but the parent's `rootPoll` churns post-mount when an async refresh resets the same value — re-firing the effect with an identical `targetPoll`. The server-side `ON CONFLICT DO NOTHING` makes the duplicate POST harmless, but a network round-trip per render is wasteful. Pattern: `const grantedPollIdsRef = useRef<Set<string>>(new Set()); useEffect(() => { if (grantedPollIdsRef.current.has(id)) return; grantedPollIdsRef.current.add(id); void apiCall(id); }, [target]);`. Reuse this idiom for any future fire-and-forget grant/audit endpoint.
+- **Phase C.3 visibility helpers live in `services/threads.py`** (`UserVisibility`, `load_user_visibility`, `filter_visible_polls`, `grant_poll_access_inline`). Both threads endpoints share them — adding visibility enforcement to a third endpoint would just call `load_user_visibility(conn, browser_id, legacy_question_ids=...)` once and pass the result to `filter_visible_polls(conn, candidate_pids, visibility)`. Don't reinvent the rule inline; the helper is the single source of truth so changes (e.g. a dedicated `closed_at` column, retiring the legacy bridge) ripple through every read path.
+- **The legacy `accessible_question_ids` bridge is THREAD-level, not poll-level.** The Phase B.3 contract is "any question_id grants access to its whole thread" (the FE always passed one question_id and got every poll in the thread back). Phase C.3 preserves this for backwards-compat: `bridged_thread_ids` resolves question_ids → thread_ids, and the visibility filter shows every poll in those threads with no closed_at filter. A per-poll bridge would silently shrink threads on first refresh post-rollout (a user with 1 question_id in a 5-poll thread would lose 4 polls). The cost is minor: a stranger with a single direct-link question_id sees the whole thread instead of just the one poll. That's "Phase B.3 behavior" — the security tightening (strict per-poll access for true direct-link strangers) lives on `poll_access` rows from the `?p=` auto-grant or the standalone /access endpoint.
+- **Forget bridge in `/api/threads/mine`.** When `accessible_question_ids` is non-empty, member-threads are narrowed to those with a NON-membership signal (poll_access OR legacy bridge). Without this, a thread_members row would keep a thread alive on the home list even after the user forgot every question in it. Membership-only callers (empty list) skip the narrowing — the bridge is opt-in. Dropped once an explicit `DELETE /api/threads/{id}/membership` lands.
+- **`?p=` auto-grant on by-route-id.** `GET /api/threads/by-route-id/{route_id}` accepts an optional `?p=<pollShortId>` and writes `poll_access` inline BEFORE filtering. Without this, a stranger landing on `/t/<thread>?p=<poll>` on a fresh browser would see by-route-id 404 because the FE's parallel `apiGrantPollAccess(targetPoll.id)` call hasn't yet landed on the server. The lookup is **scoped to the resolved thread** (`WHERE short_id = %(s)s AND thread_id = %(t)s::uuid`) — a `?p` outside the thread is silently ignored, no cross-thread access leak. The grant is via `services.threads.grant_poll_access_inline(conn, poll_id, browser_id)` which runs in the SAME transaction as the read, eliminating the race that the standalone `/access` endpoint can't (since /access opens its own connection).
+- **Visibility uses `polls.updated_at` as the `closed_at` proxy.** The close trigger refreshes `updated_at` on every `is_closed` flip, so it tracks closure timing accurately for the initial close. Subsequent edits to a closed poll bump `updated_at` forward — that makes the visibility filter slightly more permissive (a closed poll touched after the user joins becomes visible) but never less. A dedicated `closed_at` column would be marginally tighter; not worth the migration cost in C.3.
+- **Updating tests when the visibility contract changes.** `test_threads_api.py` was originally written for Phase B.3's "no enforcement" behavior and called the read endpoints with no X-Browser-Id header (TestClient mints fresh browser_ids per request, so the read had no membership). Phase C.3 added a `browser_id` fixture and a `_bid_headers` helper so tests pin the same browser through create + read calls — making the creator a thread member that the read endpoints can see. When adding new tests for endpoints under visibility enforcement, follow this pattern: don't trust auto-minted ids to maintain identity across requests.
 
 This section captures the design decisions from the original conversation so future sessions can reference them without re-asking.
 

--- a/docs/thread-routing-redesign.md
+++ b/docs/thread-routing-redesign.md
@@ -1,8 +1,9 @@
 # Thread Routing Redesign
 
 > Status: Phase A shipped (#260), Phase B.1 shipped (#261), Phase B.2
-> shipped (#262), Phase B.3 shipped (#263), Phase B.4 shipped (#264).
-> Phase C.1 in progress (this branch); C.2 and C.3 deferred.
+> shipped (#262), Phase B.3 shipped (#263), Phase B.4 shipped (#264),
+> Phase C.1 shipped (#265), Phase C.2 shipped (#266), Phase C.3 in
+> progress (this branch).
 
 ## Vision
 
@@ -287,17 +288,80 @@ backfill answer is a follow-up — see CLAUDE.md →
   `thread_members` / `poll_access` get populated by live traffic, but
   nothing yet filters reads by them.
 
-#### Phase C.3 — Visibility enforcement (deferred)
+#### Phase C.3 — Visibility enforcement (this branch)
 
-- Apply the visibility rule (see "Visibility rule" above) in the read
-  endpoints `POST /api/threads/mine` and `GET /api/threads/by-route-id/{routeId}`.
-- Resolve the open semantic questions before shipping:
-  - **Join trigger:** vote/create/abstain only (the C.2 default), or
-    also auto-join on direct `/t/<id>` visit, or explicit join button?
-  - **Non-member visiting `/t/<id>` (no `?p`):** 404? "Join this thread"
-    prompt? Read-only stub of the most recent open polls?
-  - **Forget vs leave:** does forget-of-last-accessible-poll auto-drop
-    `thread_members`, or do we add an explicit "leave thread" action?
+The visibility rule is enforced in the two read endpoints. A poll P in
+thread T is visible to browser B iff ANY of:
+
+1. B has a `thread_members` row for T AND
+   (`P.is_closed = false` OR `P.closed_at >= members.joined_at`), OR
+2. B has a `poll_access` row for P, OR
+3. (transitional bridge) The legacy `accessible_question_ids` list
+   passed by the FE contains a question_id whose poll lives in T.
+   Treated as **thread-level** access — every poll in T visible, no
+   closed_at filter — so pre-B.3 callers passing one question_id keep
+   seeing the whole thread (the Phase B.3 contract). Per-poll bridging
+   would silently shrink threads on first refresh post-rollout. Applies
+   to `/api/threads/mine` only.
+
+`closed_at` proxy: `polls.updated_at`, refreshed by the close trigger.
+Subsequent edits to a closed poll bump `updated_at` forward, so the
+filter fails open (a closed poll touched after the user joins becomes
+visible). A dedicated column would be marginally tighter; deferred.
+
+##### Decisions on the three previously-open semantic questions
+
+- **Join trigger**: vote/create only — the Phase C.2 defaults are
+  preserved. The `/access` endpoint and the `?p=` auto-grant on
+  by-route-id grant `poll_access` (per-poll, not thread membership), so
+  `thread_members` is exclusively driven by acts of participation.
+- **Non-member visiting `/t/<id>` with no `?p`**: 404. We treat "no
+  visibility into any poll of this thread" the same as "no such thread"
+  for both UX simplicity and consistent FE error handling. The FE's
+  existing "Thread Not Found" UI handles both cases uniformly.
+- **Forget vs leave**: forget stays localStorage-only. We do NOT delete
+  `thread_members` on forget; instead, when the FE passes
+  `accessible_question_ids` we narrow `/api/threads/mine` to threads the
+  user still has at least one non-membership signal in (poll_access OR
+  legacy bridge). This preserves the "thread disappears from the home
+  list" UX during the rollout. An explicit `DELETE
+  /api/threads/{id}/membership` is a follow-up so the bridge can
+  eventually be retired.
+
+##### `?p=` inline auto-grant on by-route-id
+
+`GET /api/threads/by-route-id/{route_id}` accepts an optional
+`?p=<pollShortId>`. When present, a `poll_access` row is written inline
+for that poll BEFORE visibility filtering. This race-safely surfaces a
+direct-link landing — without it, a stranger hitting
+`/t/<thread>?p=<poll>` on a fresh browser would see by-route-id 404
+because the FE's parallel `apiGrantPollAccess` call hadn't yet landed.
+The lookup is scoped to the resolved thread, so a `?p` referencing a
+poll in a different thread is silently ignored — no cross-thread
+access leak.
+
+##### Migration cost
+
+Pre-B.3 voters who haven't re-voted have no `thread_members` row. They
+keep working via the legacy bridge so long as their FE passes
+`accessible_question_ids`. Once they vote again, Phase C.2's auto-join
+writes restore membership and they no longer rely on the bridge. The
+bridge will be retired (and the home page narrowed to membership-only)
+in a follow-up phase after enough rollout time has passed for inactive
+browsers to cycle.
+
+##### Out of scope for C.3
+
+- Backfill of pre-B.3 votes into `thread_members` (deferred — see
+  "FOLLOW-UP — Decide backfill strategy ..." in CLAUDE.md).
+- Explicit `DELETE /api/threads/{id}/membership` ("leave thread")
+  endpoint. Not strictly required during the rollout window because
+  the forget bridge handles the equivalent UX for the legacy localStorage
+  list.
+- Visibility enforcement on the legacy `POST /api/questions/accessible`
+  endpoint. The FE migrated to `/api/threads/*` in B.3 so it's a
+  compatibility surface for older client bundles only; gating it
+  retroactively would risk breaking those clients during the rollout.
 
 ## Open questions
 
@@ -308,8 +372,20 @@ root-poll-short_id values kept on the existing `threads` rows so old
 lookup as the new ones.
 
 The Phase C semantic questions (join trigger, non-member /t visit,
-forget vs leave) are now tracked under "Phase C.3 — Visibility
-enforcement (deferred)" above and need to be settled before C.3 ships.
+forget vs leave) were resolved in Phase C.3 — see decisions inline
+under "Phase C.3 — Visibility enforcement" above.
+
+Two follow-up items remain, neither blocking the redesign:
+
+- **Backfill of pre-B.3 votes** into `thread_members`. Currently
+  handled implicitly by the legacy `accessible_question_ids` bridge in
+  `/api/threads/mine`, plus the natural re-establishment on next vote
+  via Phase C.2's auto-join writes. A one-time backfill would let us
+  retire the bridge faster but isn't required for correctness.
+- **Explicit `DELETE /api/threads/{id}/membership`** ("leave thread")
+  endpoint. The forget bridge replicates the UX during the rollout
+  window. Adding the explicit action lets us retire the bridge — gates
+  on the bridge becoming dead code first.
 
 ## Phase A simplifications worth keeping in mind
 

--- a/server/routers/threads.py
+++ b/server/routers/threads.py
@@ -47,6 +47,7 @@ from services.threads import (
     poll_ids_for_thread_ids,
     polls_for_poll_ids,
     resolve_thread_id_from_route_id,
+    thread_ids_for_poll_ids,
 )
 
 router = APIRouter(prefix="/api/threads", tags=["threads"])
@@ -108,14 +109,9 @@ def get_my_threads(req: MyThreadsRequest, request: Request):
         # Threads the user has a non-membership signal in. Used both as
         # the bridged-visibility input (already in `visibility`) and as
         # the forget bridge's "interesting" set.
-        access_threads_rows = []
-        if visibility.access_poll_ids:
-            access_threads_rows = conn.execute(
-                "SELECT DISTINCT thread_id FROM polls "
-                "WHERE id = ANY(%(ids)s) AND thread_id IS NOT NULL",
-                {"ids": list(visibility.access_poll_ids)},
-            ).fetchall()
-        access_thread_ids = {str(r["thread_id"]) for r in access_threads_rows}
+        access_thread_ids = set(
+            thread_ids_for_poll_ids(conn, visibility.access_poll_ids)
+        )
         signal_thread_ids = visibility.bridged_thread_ids | access_thread_ids
 
         member_thread_ids = set(visibility.joined_by_thread.keys())

--- a/server/routers/threads.py
+++ b/server/routers/threads.py
@@ -1,4 +1,4 @@
-"""Thread API endpoints (Phase B.3 of the thread routing redesign).
+"""Thread API endpoints (Phase B.3 / C.3 of the thread routing redesign).
 
 Two endpoints — `POST /api/threads/mine` and
 `GET /api/threads/by-route-id/{route_id}` — collapse the legacy three-step
@@ -8,40 +8,66 @@ home / thread page bootstrap (discoverRelatedQuestions + getAccessiblePolls
 
 Both return `list[PollResponse]` — same shape as
 `POST /api/questions/accessible` — so the FE consumer is a drop-in for
-the existing flow. The thread set is computed server-side using the
-indexed `polls.thread_id` column rather than walking
-`polls.follow_up_to` chains in Python.
+the existing flow.
 
-Phase B.3 deliberately stops short of cookie-driven membership (Phase C):
-`POST /api/threads/mine` still accepts `{accessible_question_ids: list[str]}`
-as the access signal. The browser_id captured by `BrowserIdMiddleware` is
-read for telemetry/forward-compat but never gates results yet.
+Phase C.3: both endpoints now enforce the visibility rule documented in
+`services/threads.py` against the browser_id captured by
+`BrowserIdMiddleware`. The membership tables (Phase C.1) and auto-join
+writes (Phase C.2) feed this filter.
+
+Phase C.3 decisions on the previously-open semantic questions:
+
+  * **Join trigger**: vote/create only (Phase C.2 default preserved).
+    The /access endpoint still grants poll_access (per-poll, not thread
+    membership) and the `?p=` auto-grant on /by-route-id mirrors that.
+  * **Non-member visiting `/t/<id>` with no `?p`**: 404. We treat "no
+    visibility into any poll of this thread" the same as "no such
+    thread" for both UX simplicity and consistent FE error handling.
+  * **Forget vs leave**: forget stays localStorage-only. We do NOT
+    delete `thread_members` on forget; instead, `/api/threads/mine`
+    intersects member-thread visibility with the FE's
+    `accessible_question_ids` legacy list during the rollout window so
+    forget keeps its expected "thread disappears from the home list"
+    semantics. An explicit `DELETE /api/threads/{id}/membership`
+    endpoint is a follow-up (track in CLAUDE.md).
 """
 
 from __future__ import annotations
 
+import psycopg.errors
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from database import get_db
 from models import PollResponse
 from services.threads import (
+    filter_visible_polls,
+    grant_poll_access_inline,
+    load_user_visibility,
     poll_ids_for_thread_ids,
     polls_for_poll_ids,
     resolve_thread_id_from_route_id,
-    thread_ids_for_question_ids,
 )
 
 router = APIRouter(prefix="/api/threads", tags=["threads"])
 
 
+def _browser_id(request: Request) -> str | None:
+    """Read the browser_id captured by `BrowserIdMiddleware`. Mirror of the
+    helper in routers/polls.py — kept inline here so this router has no
+    cross-router import for one trivial getattr."""
+    return getattr(request.state, "browser_id", None)
+
+
 class MyThreadsRequest(BaseModel):
     """Request body for `POST /api/threads/mine`.
 
-    Phase B.3: the FE passes its localStorage `accessible_question_ids` list;
-    the server resolves to thread_ids and returns every poll in those threads.
-    Phase C will switch to cookie-driven membership and this list becomes
-    optional/legacy.
+    `accessible_question_ids` is the FE's localStorage list — used as a
+    transitional access bridge for users without thread_members rows yet
+    (pre-B.3 voters, etc.). Phase C.3 honors it as poll-level access and
+    intersects membership-thread visibility with it so forget keeps its
+    "thread disappears from home" semantics until an explicit leave
+    action lands.
     """
 
     accessible_question_ids: list[str] = Field(default_factory=list)
@@ -50,30 +76,71 @@ class MyThreadsRequest(BaseModel):
 
 @router.post("/mine", response_model=list[PollResponse])
 def get_my_threads(req: MyThreadsRequest, request: Request):
-    """Return every poll in any thread that contains one of the user's
-    accessible questions.
+    """Return every poll the user has visibility into (per Phase C.3
+    rule).
 
-    Replaces the legacy `discoverRelatedQuestions + getAccessiblePolls`
-    pair: the server walks `polls.thread_id` once to fan out from the
-    requested question_ids to every poll in their threads, then hydrates
-    each poll the same way `POST /api/questions/accessible` does.
+    The candidate set is the union of:
+      * Polls in any thread the browser is a member of (subject to the
+        closed_at filter), AND
+      * Polls explicitly granted via /access (poll_access rows), AND
+      * Polls in any thread reached via the legacy `accessible_question_ids`
+        bridge (unfiltered — preserves Phase B.3 contract that "any
+        question_id grants access to its whole thread").
 
-    The browser_id (set by BrowserIdMiddleware) is captured on
-    `request.state.browser_id` but not used for filtering yet — Phase C
-    will add `thread_members` and start enforcing visibility here.
+    Forget bridge: when the FE passes `accessible_question_ids`, the home
+    list is narrowed to threads the user still has a NON-membership signal
+    in (poll_access OR legacy bridge). Without this, a thread_members row
+    would keep a thread alive on the home list even after the user
+    forgot every question in it. Membership-only callers (no legacy list
+    passed) skip the narrowing — once an explicit `DELETE
+    /api/threads/{id}/membership` lands, this transitional carve-out goes
+    away.
     """
-    # Touch attribute so static checkers don't flag unused state. Phase C
-    # will read this for membership lookup.
-    _ = getattr(request.state, "browser_id", None)
+    browser_id = _browser_id(request)
 
-    if not req.accessible_question_ids:
-        return []
     with get_db() as conn:
-        thread_ids = thread_ids_for_question_ids(conn, req.accessible_question_ids)
-        if not thread_ids:
+        visibility = load_user_visibility(
+            conn,
+            browser_id,
+            legacy_question_ids=req.accessible_question_ids or None,
+        )
+
+        # Threads the user has a non-membership signal in. Used both as
+        # the bridged-visibility input (already in `visibility`) and as
+        # the forget bridge's "interesting" set.
+        access_threads_rows = []
+        if visibility.access_poll_ids:
+            access_threads_rows = conn.execute(
+                "SELECT DISTINCT thread_id FROM polls "
+                "WHERE id = ANY(%(ids)s) AND thread_id IS NOT NULL",
+                {"ids": list(visibility.access_poll_ids)},
+            ).fetchall()
+        access_thread_ids = {str(r["thread_id"]) for r in access_threads_rows}
+        signal_thread_ids = visibility.bridged_thread_ids | access_thread_ids
+
+        member_thread_ids = set(visibility.joined_by_thread.keys())
+        if req.accessible_question_ids:
+            # Forget bridge: drop member-threads with no concurrent signal.
+            member_thread_ids &= signal_thread_ids
+
+        # Candidate threads = signal threads (bridge + access) + filtered
+        # member threads. Bridge threads always show; member threads
+        # contribute only if they survived the forget bridge.
+        candidate_thread_ids = signal_thread_ids | member_thread_ids
+        candidate_pids = set(
+            poll_ids_for_thread_ids(conn, list(candidate_thread_ids))
+        )
+        # Explicit per-poll access (e.g. direct-link visit) survives
+        # even if its thread is otherwise hidden — this is the "direct
+        # link from a stranger" path that doesn't grant thread membership.
+        candidate_pids |= visibility.access_poll_ids
+        if not candidate_pids:
             return []
-        poll_ids = poll_ids_for_thread_ids(conn, thread_ids)
-        return polls_for_poll_ids(conn, poll_ids, include_results=req.include_results)
+
+        visible_pids = filter_visible_polls(conn, list(candidate_pids), visibility)
+        return polls_for_poll_ids(
+            conn, visible_pids, include_results=req.include_results
+        )
 
 
 @router.get("/by-route-id/{route_id}", response_model=list[PollResponse])
@@ -81,24 +148,60 @@ def get_thread_by_route_id(
     route_id: str,
     request: Request,
     include_results: bool = True,
+    p: str | None = None,
 ):
-    """Return every poll in one thread, resolved by route id.
+    """Return every visible poll in one thread, resolved by route id.
 
     `route_id` accepts (in order):
       - `threads.short_id`
       - `threads.id` (uuid)
-      - `polls.short_id` (Phase A → Phase B.3 fallback: today's
-        `threadShortId` is the root poll's short_id; Phase B.4 will mint
-        dedicated thread short_ids)
+      - `polls.short_id` (Phase A → Phase B.3 fallback)
       - `polls.id` (uuid fallback)
 
-    404 when no thread can be resolved.
+    Optional `?p=<pollShortId>`: when present, a `poll_access` row is
+    written inline for that poll (resolved within this thread) BEFORE
+    visibility filtering runs. This race-safely surfaces the targeted
+    poll when a stranger lands on `/t/<thread>?p=<poll>` — without it, a
+    cold-start direct-link landing would hit by-route-id before the FE's
+    parallel `apiGrantPollAccess` call lands on the server, returning an
+    empty thread.
+
+    Phase C.3: 404 when neither the resolved thread nor the optional `?p`
+    grant produces any visible poll — i.e. the user is neither a member
+    nor a direct-link visitor.
     """
-    _ = getattr(request.state, "browser_id", None)
+    browser_id = _browser_id(request)
 
     with get_db() as conn:
         thread_id = resolve_thread_id_from_route_id(conn, route_id)
         if not thread_id:
             raise HTTPException(status_code=404, detail="Thread not found")
-        poll_ids = poll_ids_for_thread_ids(conn, [thread_id])
-        return polls_for_poll_ids(conn, poll_ids, include_results=include_results)
+
+        # `?p=` auto-grant: best-effort. A bogus poll short_id is silently
+        # ignored (the visibility filter then 404s), and a poll outside
+        # this thread is also ignored — we explicitly scope the lookup to
+        # the resolved thread to prevent ?p from leaking access to polls
+        # in another thread that happens to match the short_id.
+        if p and browser_id:
+            row = conn.execute(
+                "SELECT id FROM polls "
+                "WHERE short_id = %(s)s AND thread_id = %(t)s::uuid",
+                {"s": p, "t": thread_id},
+            ).fetchone()
+            if row:
+                try:
+                    grant_poll_access_inline(conn, str(row["id"]), browser_id)
+                except psycopg.errors.ForeignKeyViolation:
+                    # Poll vanished between the lookup and the insert.
+                    # The visibility filter will surface this as 404 via
+                    # the empty result.
+                    pass
+
+        visibility = load_user_visibility(conn, browser_id)
+        thread_pids = poll_ids_for_thread_ids(conn, [thread_id])
+        visible_pids = filter_visible_polls(conn, thread_pids, visibility)
+        if not visible_pids:
+            raise HTTPException(status_code=404, detail="Thread not found")
+        return polls_for_poll_ids(
+            conn, visible_pids, include_results=include_results
+        )

--- a/server/services/threads.py
+++ b/server/services/threads.py
@@ -16,12 +16,176 @@ rest.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from models import PollResponse
 from services.questions import _compute_results
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Phase C.3 — visibility enforcement
+# ---------------------------------------------------------------------------
+#
+# Visibility rule (see docs/thread-routing-redesign.md):
+#
+#   A poll P in thread T is visible to browser B iff ANY of:
+#     1. B has a thread_members row for T AND
+#        (P.is_closed = false OR P.closed_at >= members.joined_at), OR
+#     2. B has a poll_access row for P, OR
+#     3. (transitional bridge) The legacy `accessible_question_ids` list
+#        passed by the FE contains a question_id whose poll lives in T.
+#        Treated as THREAD-level access (every poll in T visible, no
+#        closed_at filter) — pre-B.3 votes never wrote browser_id, so the
+#        localStorage list is the only access signal those users have
+#        until they re-establish membership by voting. Treating it as
+#        per-poll would silently shrink threads on first refresh
+#        post-rollout (a user with 1 question_id in a 5-poll thread
+#        would lose 4 polls); the thread-level bridge preserves Phase
+#        B.3 behavior for legacy callers. Applies to /api/threads/mine
+#        only — by-route-id relies on `?p=` inline grant instead.
+#
+# `closed_at` proxy: we use `polls.updated_at`, which the existing close
+# trigger refreshes on every `is_closed` flip. Subsequent edits to a closed
+# poll bump updated_at forward; that makes the visibility rule slightly more
+# permissive (a previously hidden closed poll can become visible if it's
+# touched after the user joins), which fails open. A dedicated `closed_at`
+# column would be marginally tighter but isn't required for correctness.
+
+
+@dataclass
+class UserVisibility:
+    """Snapshot of one browser's visibility state.
+
+    Built once per request via `load_user_visibility`; consumed by the
+    visibility filter and by candidate-set construction.
+    """
+
+    browser_id: str | None
+    # thread_id → joined_at watermark (drives closed_at filter for
+    # member-thread polls).
+    joined_by_thread: dict[str, datetime] = field(default_factory=dict)
+    # poll_ids the browser has direct-link access to (poll_access rows).
+    # No closed_at filter — direct access shows the poll whether open or
+    # already closed, matching the rule's "explicit per-poll access"
+    # clause.
+    access_poll_ids: set[str] = field(default_factory=set)
+    # thread_ids the legacy accessible_question_ids list resolves to.
+    # Treated as thread-level access with no closed_at filter for
+    # backwards compatibility during the rollout window.
+    bridged_thread_ids: set[str] = field(default_factory=set)
+
+
+def load_user_visibility(
+    conn,
+    browser_id: str | None,
+    *,
+    legacy_question_ids: list[str] | None = None,
+) -> UserVisibility:
+    """Read every membership/access signal for one browser in a single
+    place so callers can construct candidate sets and filter against the
+    same data without re-querying."""
+    joined_by_thread: dict[str, datetime] = {}
+    access_poll_ids: set[str] = set()
+    if browser_id:
+        rows = conn.execute(
+            "SELECT thread_id, joined_at FROM thread_members "
+            "WHERE browser_id = %(bid)s",
+            {"bid": browser_id},
+        ).fetchall()
+        for r in rows:
+            joined_by_thread[str(r["thread_id"])] = r["joined_at"]
+        rows = conn.execute(
+            "SELECT poll_id FROM poll_access WHERE browser_id = %(bid)s",
+            {"bid": browser_id},
+        ).fetchall()
+        access_poll_ids = {str(r["poll_id"]) for r in rows}
+
+    bridged_thread_ids: set[str] = set()
+    if legacy_question_ids:
+        rows = conn.execute(
+            "SELECT DISTINCT mp.thread_id "
+            "FROM questions p JOIN polls mp ON p.poll_id = mp.id "
+            "WHERE p.id = ANY(%(ids)s) AND mp.thread_id IS NOT NULL",
+            {"ids": legacy_question_ids},
+        ).fetchall()
+        bridged_thread_ids = {str(r["thread_id"]) for r in rows}
+
+    return UserVisibility(
+        browser_id=browser_id,
+        joined_by_thread=joined_by_thread,
+        access_poll_ids=access_poll_ids,
+        bridged_thread_ids=bridged_thread_ids,
+    )
+
+
+def filter_visible_polls(
+    conn,
+    candidate_poll_ids: list[str],
+    visibility: UserVisibility,
+) -> list[str]:
+    """Apply the Phase C.3 visibility rule. Returns the subset of
+    `candidate_poll_ids` visible to `visibility.browser_id` per the rule
+    documented above. Empty in → empty out; preserves no specific order."""
+    if not candidate_poll_ids:
+        return []
+    rows = conn.execute(
+        "SELECT id, thread_id, is_closed, updated_at "
+        "FROM polls WHERE id = ANY(%(ids)s)",
+        {"ids": candidate_poll_ids},
+    ).fetchall()
+    visible: list[str] = []
+    for r in rows:
+        pid = str(r["id"])
+        # Direct per-poll grant: visible regardless of close state.
+        if pid in visibility.access_poll_ids:
+            visible.append(pid)
+            continue
+        tid = str(r["thread_id"]) if r.get("thread_id") else None
+        # Thread-level legacy bridge: every poll in the thread visible
+        # without a closed_at filter (per Phase B.3 backwards-compat).
+        if tid and tid in visibility.bridged_thread_ids:
+            visible.append(pid)
+            continue
+        # Membership: visible if open OR closed-after-joined_at.
+        if not tid or tid not in visibility.joined_by_thread:
+            continue
+        if not r["is_closed"]:
+            visible.append(pid)
+            continue
+        closed_at = r.get("updated_at")
+        joined_at = visibility.joined_by_thread[tid]
+        if closed_at and closed_at >= joined_at:
+            visible.append(pid)
+    return visible
+
+
+def grant_poll_access_inline(
+    conn,
+    poll_id: str,
+    browser_id: str | None,
+) -> None:
+    """Phase C.3: write `poll_access(poll_id, browser_id)` in the same
+    transaction as the read that's about to use it. Used by the
+    `?p=<pollShortId>` auto-grant on `/api/threads/by-route-id` so a
+    direct-link landing race-safely surfaces its poll without an extra
+    round-trip from the FE.
+
+    No-op when `browser_id` is missing. ON CONFLICT preserves the original
+    granted_at watermark, mirroring the standalone /access endpoint.
+    """
+    if not browser_id:
+        return
+    conn.execute(
+        """
+        INSERT INTO poll_access (poll_id, browser_id)
+        VALUES (%(p)s, %(b)s)
+        ON CONFLICT (poll_id, browser_id) DO NOTHING
+        """,
+        {"p": poll_id, "b": browser_id},
+    )
 
 
 def polls_for_poll_ids(

--- a/server/services/threads.py
+++ b/server/services/threads.py
@@ -105,13 +105,9 @@ def load_user_visibility(
 
     bridged_thread_ids: set[str] = set()
     if legacy_question_ids:
-        rows = conn.execute(
-            "SELECT DISTINCT mp.thread_id "
-            "FROM questions p JOIN polls mp ON p.poll_id = mp.id "
-            "WHERE p.id = ANY(%(ids)s) AND mp.thread_id IS NOT NULL",
-            {"ids": legacy_question_ids},
-        ).fetchall()
-        bridged_thread_ids = {str(r["thread_id"]) for r in rows}
+        bridged_thread_ids = set(
+            thread_ids_for_question_ids(conn, legacy_question_ids)
+        )
 
     return UserVisibility(
         browser_id=browser_id,
@@ -372,6 +368,21 @@ def poll_ids_for_thread_ids(conn, thread_ids: list[str]) -> list[str]:
         {"ids": thread_ids},
     ).fetchall()
     return [str(r["id"]) for r in rows]
+
+
+def thread_ids_for_poll_ids(conn, poll_ids) -> list[str]:
+    """Resolve a list (or set) of poll_ids to the distinct set of
+    thread_ids that own them. The inverse of `poll_ids_for_thread_ids`,
+    used by the visibility filter to fan poll-level signals (poll_access)
+    up to the thread granularity needed by the forget bridge."""
+    if not poll_ids:
+        return []
+    rows = conn.execute(
+        """SELECT DISTINCT thread_id FROM polls
+            WHERE id = ANY(%(ids)s) AND thread_id IS NOT NULL""",
+        {"ids": list(poll_ids)},
+    ).fetchall()
+    return [str(r["thread_id"]) for r in rows]
 
 
 def resolve_thread_id_from_route_id(conn, route_id: str) -> str | None:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Shared pytest fixtures + helpers for the Phase B.3 / C.x test suite.
+
+`test_threads_api.py`, `test_threads_visibility.py`, and
+`test_membership_writes.py` all need the same TestClient setup, the same
+yes/no question shape, and the same `_create_poll` / `_bid_headers`
+helpers. Centralizing keeps the per-test files focused on assertions.
+"""
+
+import os
+import uuid
+
+import pytest
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def creator_secret():
+    return f"test-secret-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def browser_id():
+    """A single browser_id pinned across create + read calls within one
+    test. Without this, TestClient mints a fresh browser_id per request
+    so the read endpoints can't see the polls just created (Phase C.3
+    visibility filter requires membership)."""
+    return str(uuid.uuid4())
+
+
+def yes_no_question(**overrides) -> dict:
+    base = {"question_type": "yes_no", "category": "yes_no"}
+    base.update(overrides)
+    return base
+
+
+def create_poll(client, creator_secret, *, browser_id=None, **kwargs) -> dict:
+    payload = {
+        "creator_secret": creator_secret,
+        "questions": [yes_no_question()],
+    }
+    payload.update(kwargs)
+    headers = {"X-Browser-Id": browser_id} if browser_id else {}
+    resp = client.post("/api/polls", json=payload, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def create_followup(
+    client,
+    creator_secret,
+    parent_question_id,
+    *,
+    browser_id=None,
+) -> dict:
+    """Create a poll wrapped in a follow-up to `parent_question_id`."""
+    return create_poll(
+        client,
+        creator_secret,
+        browser_id=browser_id,
+        follow_up_to=parent_question_id,
+    )
+
+
+def bid_headers(browser_id):
+    return {"X-Browser-Id": browser_id} if browser_id else {}

--- a/server/tests/test_membership_writes.py
+++ b/server/tests/test_membership_writes.py
@@ -12,63 +12,18 @@ Covers:
     thread_members in place
 
 Phase C.2 doesn't enforce visibility yet; these tests verify the writes
-happen, not that any read path filters on them.
+happen, not that any read path filters on them. Phase C.3 read-side
+filtering tests live in test_threads_visibility.py.
+
+Shared fixtures (`client`, `creator_secret`, `browser_id`) and helpers
+(`create_poll`) live in `conftest.py`.
 """
 
-import os
-import re
 import uuid
 
-import pytest
-
-TEST_DB_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
-)
-os.environ["DATABASE_URL"] = TEST_DB_URL
-
 import psycopg
-from fastapi.testclient import TestClient
 
-from main import app
-
-
-UUID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-)
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
-
-
-@pytest.fixture
-def creator_secret():
-    return f"test-secret-{uuid.uuid4().hex[:8]}"
-
-
-@pytest.fixture
-def browser_id():
-    return str(uuid.uuid4())
-
-
-def _yes_no_question(**overrides) -> dict:
-    base = {"question_type": "yes_no", "category": "yes_no"}
-    base.update(overrides)
-    return base
-
-
-def _create_poll(client, creator_secret, *, browser_id=None, **kwargs):
-    payload = {
-        "creator_secret": creator_secret,
-        "questions": [_yes_no_question()],
-    }
-    payload.update(kwargs)
-    headers = {"X-Browser-Id": browser_id} if browser_id else {}
-    resp = client.post("/api/polls", json=payload, headers=headers)
-    assert resp.status_code == 201, resp.text
-    return resp.json()
+from tests.conftest import TEST_DB_URL, create_poll
 
 
 def _thread_members(thread_id):
@@ -92,7 +47,7 @@ def _poll_access(poll_id):
 
 class TestCreatePollMembership:
     def test_creator_auto_joins_thread(self, client, creator_secret, browser_id):
-        poll = _create_poll(client, creator_secret, browser_id=browser_id)
+        poll = create_poll(client, creator_secret, browser_id=browser_id)
         thread_id = poll["thread_id"]
         rows = _thread_members(thread_id)
         assert len(rows) == 1
@@ -101,11 +56,11 @@ class TestCreatePollMembership:
     def test_followup_creator_joins_parent_thread(
         self, client, creator_secret, browser_id
     ):
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        root = create_poll(client, creator_secret, browser_id=browser_id)
         parent_qid = root["questions"][0]["id"]
         # Same browser creates a follow-up — already a member; ON CONFLICT
         # keeps the thread_members row count at 1.
-        followup = _create_poll(
+        followup = create_poll(
             client,
             creator_secret,
             browser_id=browser_id,
@@ -119,10 +74,10 @@ class TestCreatePollMembership:
     def test_followup_creator_from_different_browser_adds_row(
         self, client, creator_secret, browser_id
     ):
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        root = create_poll(client, creator_secret, browser_id=browser_id)
         parent_qid = root["questions"][0]["id"]
         other = str(uuid.uuid4())
-        _create_poll(
+        create_poll(
             client, creator_secret, browser_id=other, follow_up_to=parent_qid
         )
         rows = _thread_members(root["thread_id"])
@@ -134,7 +89,7 @@ class TestVoteMembership:
     def test_voter_auto_joins_thread(self, client, creator_secret, browser_id):
         # Creator on browser A; voter on browser B.
         creator_browser = browser_id
-        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
         sub = poll["questions"][0]
 
         voter_browser = str(uuid.uuid4())
@@ -159,7 +114,7 @@ class TestVoteMembership:
         assert bids == {creator_browser, voter_browser}
 
     def test_idempotent_on_repeat_votes(self, client, creator_secret, browser_id):
-        poll = _create_poll(client, creator_secret, browser_id=browser_id)
+        poll = create_poll(client, creator_secret, browser_id=browser_id)
         sub = poll["questions"][0]
 
         # First vote — creates thread_members row for this browser.
@@ -219,7 +174,7 @@ class TestVoteMembership:
         A vote that the validator rejects still leaves the user as a thread
         member — they 'attempted to participate' which is the trigger
         regardless of whether the ballot was well-formed."""
-        poll = _create_poll(client, creator_secret, browser_id=browser_id)
+        poll = create_poll(client, creator_secret, browser_id=browser_id)
         sub = poll["questions"][0]
 
         voter_browser = str(uuid.uuid4())
@@ -258,7 +213,7 @@ class TestVoteMembership:
 
 class TestPollAccessEndpoint:
     def test_grant_writes_row(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         visitor_browser = str(uuid.uuid4())
         resp = client.post(
             f"/api/polls/{poll['id']}/access",
@@ -271,7 +226,7 @@ class TestPollAccessEndpoint:
         assert visitor_browser in bids
 
     def test_grant_is_idempotent(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         visitor_browser = str(uuid.uuid4())
         for _ in range(3):
             resp = client.post(
@@ -286,7 +241,7 @@ class TestPollAccessEndpoint:
         assert len(bids) == 1
 
     def test_grant_preserves_original_granted_at(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         visitor_browser = str(uuid.uuid4())
         client.post(
             f"/api/polls/{poll['id']}/access",
@@ -318,7 +273,7 @@ class TestPollAccessEndpoint:
         Phase C.3 will resolve visibility as the union of `thread_members`
         and `poll_access`; verifying the boundary here keeps that semantics
         intact."""
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         visitor_browser = str(uuid.uuid4())
         resp = client.post(
             f"/api/polls/{poll['id']}/access",

--- a/server/tests/test_threads_api.py
+++ b/server/tests/test_threads_api.py
@@ -40,30 +40,58 @@ def creator_secret():
     return f"test-secret-{uuid.uuid4().hex[:8]}"
 
 
+@pytest.fixture
+def browser_id():
+    """Single browser_id used across create + read calls in a test, so the
+    creator's auto-join (Phase C.2) makes them a thread member visible to
+    the read endpoints (Phase C.3). Without this fixture, TestClient mints
+    a fresh browser_id per request and reads can't see the polls they
+    just created."""
+    return str(uuid.uuid4())
+
+
 def _yes_no_question(**overrides) -> dict:
     base = {"question_type": "yes_no", "category": "yes_no"}
     base.update(overrides)
     return base
 
 
-def _create_poll(client, creator_secret: str, **kwargs) -> dict:
+def _create_poll(
+    client,
+    creator_secret: str,
+    *,
+    browser_id: str | None = None,
+    **kwargs,
+) -> dict:
     payload = {
         "creator_secret": creator_secret,
         "questions": [_yes_no_question()],
     }
     payload.update(kwargs)
-    resp = client.post("/api/polls", json=payload)
+    headers = {"X-Browser-Id": browser_id} if browser_id else {}
+    resp = client.post("/api/polls", json=payload, headers=headers)
     assert resp.status_code == 201, resp.text
     return resp.json()
 
 
-def _create_followup(client, creator_secret: str, parent_question_id: str) -> dict:
+def _create_followup(
+    client,
+    creator_secret: str,
+    parent_question_id: str,
+    *,
+    browser_id: str | None = None,
+) -> dict:
     """Create a poll wrapped in a follow-up to `parent_question_id`."""
     return _create_poll(
         client,
         creator_secret,
+        browser_id=browser_id,
         follow_up_to=parent_question_id,
     )
+
+
+def _bid_headers(browser_id: str | None) -> dict:
+    return {"X-Browser-Id": browser_id} if browser_id else {}
 
 
 class TestMyThreads:
@@ -155,34 +183,64 @@ class TestMyThreads:
 
 
 class TestThreadByRouteId:
-    def test_resolves_by_root_poll_short_id(self, client, creator_secret):
-        root = _create_poll(client, creator_secret)
-        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+    """Phase C.3: by-route-id enforces strict visibility — caller must be
+    a thread member, hold a `poll_access` row for at least one poll in the
+    thread, or pass `?p=<pollShortId>` for an inline auto-grant. Tests
+    pin the same browser_id through create + read so the creator's
+    auto-join makes them a member."""
+
+    def test_resolves_by_root_poll_short_id(
+        self, client, creator_secret, browser_id,
+    ):
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        child = _create_followup(
+            client, creator_secret, root["questions"][0]["id"],
+            browser_id=browser_id,
+        )
 
         # threadShortId is the root poll's short_id today.
-        resp = client.get(f"/api/threads/by-route-id/{root['short_id']}")
+        resp = client.get(
+            f"/api/threads/by-route-id/{root['short_id']}",
+            headers=_bid_headers(browser_id),
+        )
         assert resp.status_code == 200
         polls = resp.json()
         ids = {p["id"] for p in polls}
         assert ids == {root["id"], child["id"]}
 
-    def test_resolves_by_root_poll_uuid(self, client, creator_secret):
-        root = _create_poll(client, creator_secret)
-        _create_followup(client, creator_secret, root["questions"][0]["id"])
+    def test_resolves_by_root_poll_uuid(
+        self, client, creator_secret, browser_id,
+    ):
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        _create_followup(
+            client, creator_secret, root["questions"][0]["id"],
+            browser_id=browser_id,
+        )
 
-        resp = client.get(f"/api/threads/by-route-id/{root['id']}")
+        resp = client.get(
+            f"/api/threads/by-route-id/{root['id']}",
+            headers=_bid_headers(browser_id),
+        )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
         assert root["id"] in ids
 
-    def test_resolves_by_child_poll_short_id(self, client, creator_secret):
+    def test_resolves_by_child_poll_short_id(
+        self, client, creator_secret, browser_id,
+    ):
         """Even if the user types a child poll's short_id into the route id
         slot, we still return the WHOLE thread — that's the only sensible
         definition of `/t/<routeId>`."""
-        root = _create_poll(client, creator_secret)
-        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        child = _create_followup(
+            client, creator_secret, root["questions"][0]["id"],
+            browser_id=browser_id,
+        )
 
-        resp = client.get(f"/api/threads/by-route-id/{child['short_id']}")
+        resp = client.get(
+            f"/api/threads/by-route-id/{child['short_id']}",
+            headers=_bid_headers(browser_id),
+        )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
         assert ids == {root["id"], child["id"]}
@@ -191,10 +249,13 @@ class TestThreadByRouteId:
         resp = client.get(f"/api/threads/by-route-id/zzznotreal")
         assert resp.status_code == 404
 
-    def test_include_results_query_param(self, client, creator_secret):
-        root = _create_poll(client, creator_secret)
+    def test_include_results_query_param(
+        self, client, creator_secret, browser_id,
+    ):
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
         resp = client.get(
             f"/api/threads/by-route-id/{root['short_id']}?include_results=false",
+            headers=_bid_headers(browser_id),
         )
         assert resp.status_code == 200
         polls = resp.json()
@@ -272,20 +333,33 @@ class TestThreadShortIdKeyspace:
         assert resp.status_code == 200
         assert resp.json().get("thread_short_id") == poll["thread_short_id"]
 
-    def test_resolves_by_thread_short_id(self, client, creator_secret):
+    def test_resolves_by_thread_short_id(
+        self, client, creator_secret, browser_id,
+    ):
         """Phase B.4: /t/<routeId> with the new `~`-prefixed thread short_id
         resolves the same way as the legacy root-poll-short-id form."""
-        root = _create_poll(client, creator_secret)
-        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        child = _create_followup(
+            client, creator_secret, root["questions"][0]["id"],
+            browser_id=browser_id,
+        )
         thread_short_id = root["thread_short_id"]
-        resp = client.get(f"/api/threads/by-route-id/{thread_short_id}")
+        resp = client.get(
+            f"/api/threads/by-route-id/{thread_short_id}",
+            headers=_bid_headers(browser_id),
+        )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
         assert ids == {root["id"], child["id"]}
 
-    def test_resolves_by_thread_id_uuid(self, client, creator_secret):
-        root = _create_poll(client, creator_secret)
-        resp = client.get(f"/api/threads/by-route-id/{root['thread_id']}")
+    def test_resolves_by_thread_id_uuid(
+        self, client, creator_secret, browser_id,
+    ):
+        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        resp = client.get(
+            f"/api/threads/by-route-id/{root['thread_id']}",
+            headers=_bid_headers(browser_id),
+        )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
         assert root["id"] in ids

--- a/server/tests/test_threads_api.py
+++ b/server/tests/test_threads_api.py
@@ -1,97 +1,26 @@
-"""Integration tests for the threads API (Phase B.3).
+"""Integration tests for the threads API (Phase B.3 / C.3).
 
 Covers:
   - POST /api/threads/mine  — discovery + accessibility in one call
   - GET  /api/threads/by-route-id/{route_id} — by short_id and uuid
   - BrowserIdMiddleware — header echo + auto-mint
 
+Visibility-enforcement tests live in test_threads_visibility.py.
+Shared fixtures (`client`, `creator_secret`, `browser_id`) and helpers
+(`create_poll`, `create_followup`, `bid_headers`) live in `conftest.py`.
+
 Like test_polls_api.py these need a real Postgres reachable via DATABASE_URL.
 """
 
-import os
 import re
 import uuid
 
-import pytest
-
-TEST_DB_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
-)
-os.environ["DATABASE_URL"] = TEST_DB_URL
-
-from fastapi.testclient import TestClient
-
-from main import app
+from tests.conftest import bid_headers, create_followup, create_poll
 
 
 UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 )
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
-
-
-@pytest.fixture
-def creator_secret():
-    return f"test-secret-{uuid.uuid4().hex[:8]}"
-
-
-@pytest.fixture
-def browser_id():
-    """Single browser_id used across create + read calls in a test, so the
-    creator's auto-join (Phase C.2) makes them a thread member visible to
-    the read endpoints (Phase C.3). Without this fixture, TestClient mints
-    a fresh browser_id per request and reads can't see the polls they
-    just created."""
-    return str(uuid.uuid4())
-
-
-def _yes_no_question(**overrides) -> dict:
-    base = {"question_type": "yes_no", "category": "yes_no"}
-    base.update(overrides)
-    return base
-
-
-def _create_poll(
-    client,
-    creator_secret: str,
-    *,
-    browser_id: str | None = None,
-    **kwargs,
-) -> dict:
-    payload = {
-        "creator_secret": creator_secret,
-        "questions": [_yes_no_question()],
-    }
-    payload.update(kwargs)
-    headers = {"X-Browser-Id": browser_id} if browser_id else {}
-    resp = client.post("/api/polls", json=payload, headers=headers)
-    assert resp.status_code == 201, resp.text
-    return resp.json()
-
-
-def _create_followup(
-    client,
-    creator_secret: str,
-    parent_question_id: str,
-    *,
-    browser_id: str | None = None,
-) -> dict:
-    """Create a poll wrapped in a follow-up to `parent_question_id`."""
-    return _create_poll(
-        client,
-        creator_secret,
-        browser_id=browser_id,
-        follow_up_to=parent_question_id,
-    )
-
-
-def _bid_headers(browser_id: str | None) -> dict:
-    return {"X-Browser-Id": browser_id} if browser_id else {}
 
 
 class TestMyThreads:
@@ -101,7 +30,7 @@ class TestMyThreads:
         assert resp.json() == []
 
     def test_single_question_returns_its_poll(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         question_id = poll["questions"][0]["id"]
 
         resp = client.post(
@@ -116,9 +45,9 @@ class TestMyThreads:
     def test_followup_chain_returns_every_poll_in_thread(self, client, creator_secret):
         """Asking for ONE question in a multi-poll thread should return EVERY
         poll in that thread — that's the discovery + accessibility merge."""
-        root = _create_poll(client, creator_secret)
-        child1 = _create_followup(client, creator_secret, root["questions"][0]["id"])
-        child2 = _create_followup(client, creator_secret, child1["questions"][0]["id"])
+        root = create_poll(client, creator_secret)
+        child1 = create_followup(client, creator_secret, root["questions"][0]["id"])
+        child2 = create_followup(client, creator_secret, child1["questions"][0]["id"])
 
         # Pass only the deepest question; discovery walks via thread_id back to
         # the root and returns every poll.
@@ -132,8 +61,8 @@ class TestMyThreads:
         assert ids == {root["id"], child1["id"], child2["id"]}
 
     def test_two_unrelated_threads_both_returned(self, client, creator_secret):
-        a = _create_poll(client, creator_secret)
-        b = _create_poll(client, creator_secret)
+        a = create_poll(client, creator_secret)
+        b = create_poll(client, creator_secret)
         resp = client.post(
             "/api/threads/mine",
             json={
@@ -156,7 +85,7 @@ class TestMyThreads:
         assert resp.json() == []
 
     def test_inline_results_default_on(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         question_id = poll["questions"][0]["id"]
         resp = client.post(
             "/api/threads/mine",
@@ -169,7 +98,7 @@ class TestMyThreads:
         assert polls[0]["questions"][0].get("results") is not None
 
     def test_inline_results_off_when_requested(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         question_id = poll["questions"][0]["id"]
         resp = client.post(
             "/api/threads/mine",
@@ -192,8 +121,8 @@ class TestThreadByRouteId:
     def test_resolves_by_root_poll_short_id(
         self, client, creator_secret, browser_id,
     ):
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
-        child = _create_followup(
+        root = create_poll(client, creator_secret, browser_id=browser_id)
+        child = create_followup(
             client, creator_secret, root["questions"][0]["id"],
             browser_id=browser_id,
         )
@@ -201,7 +130,7 @@ class TestThreadByRouteId:
         # threadShortId is the root poll's short_id today.
         resp = client.get(
             f"/api/threads/by-route-id/{root['short_id']}",
-            headers=_bid_headers(browser_id),
+            headers=bid_headers(browser_id),
         )
         assert resp.status_code == 200
         polls = resp.json()
@@ -211,15 +140,15 @@ class TestThreadByRouteId:
     def test_resolves_by_root_poll_uuid(
         self, client, creator_secret, browser_id,
     ):
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
-        _create_followup(
+        root = create_poll(client, creator_secret, browser_id=browser_id)
+        create_followup(
             client, creator_secret, root["questions"][0]["id"],
             browser_id=browser_id,
         )
 
         resp = client.get(
             f"/api/threads/by-route-id/{root['id']}",
-            headers=_bid_headers(browser_id),
+            headers=bid_headers(browser_id),
         )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
@@ -231,15 +160,15 @@ class TestThreadByRouteId:
         """Even if the user types a child poll's short_id into the route id
         slot, we still return the WHOLE thread — that's the only sensible
         definition of `/t/<routeId>`."""
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
-        child = _create_followup(
+        root = create_poll(client, creator_secret, browser_id=browser_id)
+        child = create_followup(
             client, creator_secret, root["questions"][0]["id"],
             browser_id=browser_id,
         )
 
         resp = client.get(
             f"/api/threads/by-route-id/{child['short_id']}",
-            headers=_bid_headers(browser_id),
+            headers=bid_headers(browser_id),
         )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
@@ -252,10 +181,10 @@ class TestThreadByRouteId:
     def test_include_results_query_param(
         self, client, creator_secret, browser_id,
     ):
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        root = create_poll(client, creator_secret, browser_id=browser_id)
         resp = client.get(
             f"/api/threads/by-route-id/{root['short_id']}?include_results=false",
-            headers=_bid_headers(browser_id),
+            headers=bid_headers(browser_id),
         )
         assert resp.status_code == 200
         polls = resp.json()
@@ -310,7 +239,7 @@ class TestThreadShortIdKeyspace:
     def test_create_poll_returns_thread_id_and_thread_short_id(
         self, client, creator_secret,
     ):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         assert poll.get("thread_id") is not None
         assert UUID_RE.match(poll["thread_id"])
         # Fresh threads minted post-migration-101 are prefixed with `~`,
@@ -322,13 +251,13 @@ class TestThreadShortIdKeyspace:
     def test_followup_inherits_parent_thread_short_id(
         self, client, creator_secret,
     ):
-        root = _create_poll(client, creator_secret)
-        child = _create_followup(client, creator_secret, root["questions"][0]["id"])
+        root = create_poll(client, creator_secret)
+        child = create_followup(client, creator_secret, root["questions"][0]["id"])
         assert root["thread_id"] == child["thread_id"]
         assert root["thread_short_id"] == child["thread_short_id"]
 
     def test_get_poll_returns_thread_short_id(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         resp = client.get(f"/api/polls/{poll['short_id']}")
         assert resp.status_code == 200
         assert resp.json().get("thread_short_id") == poll["thread_short_id"]
@@ -338,15 +267,15 @@ class TestThreadShortIdKeyspace:
     ):
         """Phase B.4: /t/<routeId> with the new `~`-prefixed thread short_id
         resolves the same way as the legacy root-poll-short-id form."""
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
-        child = _create_followup(
+        root = create_poll(client, creator_secret, browser_id=browser_id)
+        child = create_followup(
             client, creator_secret, root["questions"][0]["id"],
             browser_id=browser_id,
         )
         thread_short_id = root["thread_short_id"]
         resp = client.get(
             f"/api/threads/by-route-id/{thread_short_id}",
-            headers=_bid_headers(browser_id),
+            headers=bid_headers(browser_id),
         )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
@@ -355,17 +284,17 @@ class TestThreadShortIdKeyspace:
     def test_resolves_by_thread_id_uuid(
         self, client, creator_secret, browser_id,
     ):
-        root = _create_poll(client, creator_secret, browser_id=browser_id)
+        root = create_poll(client, creator_secret, browser_id=browser_id)
         resp = client.get(
             f"/api/threads/by-route-id/{root['thread_id']}",
-            headers=_bid_headers(browser_id),
+            headers=bid_headers(browser_id),
         )
         assert resp.status_code == 200
         ids = {p["id"] for p in resp.json()}
         assert root["id"] in ids
 
     def test_my_threads_carries_thread_short_id(self, client, creator_secret):
-        poll = _create_poll(client, creator_secret)
+        poll = create_poll(client, creator_secret)
         resp = client.post(
             "/api/threads/mine",
             json={"accessible_question_ids": [poll["questions"][0]["id"]]},

--- a/server/tests/test_threads_visibility.py
+++ b/server/tests/test_threads_visibility.py
@@ -1,0 +1,400 @@
+"""Phase C.3 — visibility enforcement on the threads read endpoints.
+
+Covers:
+  * /api/threads/mine returns only polls visible per the visibility rule
+  * /api/threads/by-route-id/{id} 404s on non-members with no `?p` grant
+  * `?p=<pollShortId>` auto-grant on by-route-id surfaces the targeted poll
+  * Closed-poll filter: closed-before-joined_at hidden for members, but
+    bridged threads bypass the filter
+  * Direct per-poll grant bypasses the closed_at filter
+  * `?p=` outside the resolved thread is ignored (no cross-thread leak)
+  * Forget bridge: member-thread without legacy-list signal disappears
+  * Strangers see neither members' threads nor /by-route-id contents
+
+The companion file `test_membership_writes.py` covers the WRITE side of
+Phase C.2 (auto-join + access-grant). This file covers the READ side that
+C.3 introduces. Both depend on a real Postgres reachable via DATABASE_URL
+and the migration set including 102.
+"""
+
+import os
+import time
+import uuid
+
+import pytest
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+import psycopg
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def creator_secret():
+    return f"test-secret-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def creator_browser():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def stranger_browser():
+    return str(uuid.uuid4())
+
+
+def _yes_no_question(**overrides) -> dict:
+    base = {"question_type": "yes_no", "category": "yes_no"}
+    base.update(overrides)
+    return base
+
+
+def _create_poll(client, creator_secret, *, browser_id, **kwargs) -> dict:
+    payload = {
+        "creator_secret": creator_secret,
+        "questions": [_yes_no_question()],
+    }
+    payload.update(kwargs)
+    resp = client.post(
+        "/api/polls",
+        json=payload,
+        headers={"X-Browser-Id": browser_id},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _close_poll(poll_id: str, creator_secret: str, client):
+    resp = client.post(
+        f"/api/polls/{poll_id}/close",
+        json={"creator_secret": creator_secret, "close_reason": "manual"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _set_poll_updated_at(poll_id: str, dt_iso: str):
+    """Backdate updated_at so closed_at falls before some join watermark.
+    Works around the close trigger setting updated_at = NOW()."""
+    with psycopg.connect(TEST_DB_URL) as conn:
+        conn.execute(
+            "UPDATE polls SET updated_at = %s WHERE id = %s",
+            (dt_iso, poll_id),
+        )
+
+
+def _set_member_joined_at(thread_id: str, browser_id: str, dt_iso: str):
+    """Set thread_members.joined_at directly so we can simulate "joined
+    after the poll closed". Used in place of waiting real wall-clock time."""
+    with psycopg.connect(TEST_DB_URL) as conn:
+        conn.execute(
+            "UPDATE thread_members SET joined_at = %s "
+            "WHERE thread_id = %s AND browser_id = %s",
+            (dt_iso, thread_id, browser_id),
+        )
+
+
+def _stranger_get_thread(client, route_id, browser_id, *, p=None):
+    qs = f"?p={p}" if p else ""
+    return client.get(
+        f"/api/threads/by-route-id/{route_id}{qs}",
+        headers={"X-Browser-Id": browser_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# /api/threads/mine
+# ---------------------------------------------------------------------------
+
+
+class TestMyThreadsVisibility:
+    def test_member_sees_their_thread(self, client, creator_secret, creator_browser):
+        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        # Note: no accessible_question_ids — pure membership signal.
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": creator_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert ids == {poll["id"]}
+
+    def test_stranger_sees_no_threads(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        _create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": stranger_browser},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_legacy_bridge_grants_thread_visibility(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """A pre-B.3 user shows up with their localStorage list and no
+        thread_members rows. The bridge treats those question_ids as
+        thread-level access, preserving Phase B.3 behavior for legacy
+        callers."""
+        root = _create_poll(client, creator_secret, browser_id=creator_browser)
+        child = _create_poll(
+            client, creator_secret, browser_id=creator_browser,
+            follow_up_to=root["questions"][0]["id"],
+        )
+        # Stranger passes ONE question id; bridge fans out to its whole
+        # thread (every poll, no closed_at filter).
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": [child["questions"][0]["id"]]},
+            headers={"X-Browser-Id": stranger_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert ids == {root["id"], child["id"]}
+
+    def test_forget_bridge_drops_member_thread_without_signal(
+        self, client, creator_secret, creator_browser,
+    ):
+        """When the FE passes accessible_question_ids and a member-thread
+        has no question_id in the list, the home view drops it. Without
+        this carve-out, forgetting every question in a thread wouldn't
+        narrow the home list because the user is still a thread_members
+        row in that thread (until an explicit leave action lands)."""
+        # Two unrelated threads, both with the same creator browser.
+        kept = _create_poll(client, creator_secret, browser_id=creator_browser)
+        forgotten = _create_poll(client, creator_secret, browser_id=creator_browser)
+
+        # Pretend the user only has the `kept` question in localStorage.
+        resp = client.post(
+            "/api/threads/mine",
+            json={
+                "accessible_question_ids": [kept["questions"][0]["id"]],
+            },
+            headers={"X-Browser-Id": creator_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert ids == {kept["id"]}
+        assert forgotten["id"] not in ids
+
+    def test_no_legacy_list_returns_full_member_threads(
+        self, client, creator_secret, creator_browser,
+    ):
+        """Membership-only callers (empty accessible_question_ids list)
+        skip the forget-bridge narrowing — the bridge is opt-in."""
+        a = _create_poll(client, creator_secret, browser_id=creator_browser)
+        b = _create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": creator_browser},
+        )
+        ids = {p["id"] for p in resp.json()}
+        assert ids == {a["id"], b["id"]}
+
+    def test_closed_before_join_hidden_for_member(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """Closed-before-joined_at: user should NOT see polls that closed
+        before they joined the thread. The closed_at proxy is
+        polls.updated_at."""
+        # Creator opens + closes a poll.
+        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        _close_poll(poll["id"], creator_secret, client)
+        # Backdate the close so it lives in the distant past.
+        _set_poll_updated_at(poll["id"], "2000-01-01T00:00:00Z")
+
+        # A second user joins by creating a follow-up *after* the close.
+        # They become a thread member with joined_at = NOW(); the closed
+        # poll's closed_at (year 2000) is < joined_at, so it's filtered out.
+        followup = _create_poll(
+            client, creator_secret, browser_id=stranger_browser,
+            follow_up_to=poll["questions"][0]["id"],
+        )
+
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": stranger_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        # The new follow-up is open, so the user sees it. The original
+        # closed-pre-join poll is hidden.
+        assert poll["id"] not in ids
+        assert followup["id"] in ids
+
+    def test_closed_before_join_visible_via_legacy_bridge(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """Legacy bridge bypasses closed_at — pre-B.3 users with a
+        localStorage list see the full thread regardless of close timing."""
+        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        _close_poll(poll["id"], creator_secret, client)
+        _set_poll_updated_at(poll["id"], "2000-01-01T00:00:00Z")
+
+        # Stranger has only a legacy localStorage list; no membership.
+        resp = client.post(
+            "/api/threads/mine",
+            json={
+                "accessible_question_ids": [poll["questions"][0]["id"]],
+            },
+            headers={"X-Browser-Id": stranger_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert poll["id"] in ids
+
+    def test_per_poll_grant_visible_outside_thread_membership(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """A user with `poll_access` for one poll in a thread sees just
+        that poll — even with no thread_members row and no legacy bridge."""
+        root = _create_poll(client, creator_secret, browser_id=creator_browser)
+        child = _create_poll(
+            client, creator_secret, browser_id=creator_browser,
+            follow_up_to=root["questions"][0]["id"],
+        )
+
+        # Stranger grants themselves poll_access on the child only.
+        grant = client.post(
+            f"/api/polls/{child['id']}/access",
+            headers={"X-Browser-Id": stranger_browser},
+        )
+        assert grant.status_code == 204
+
+        resp = client.post(
+            "/api/threads/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": stranger_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        # Only the granted poll is visible; the sibling root is hidden.
+        assert ids == {child["id"]}
+
+
+# ---------------------------------------------------------------------------
+# /api/threads/by-route-id/{route_id}
+# ---------------------------------------------------------------------------
+
+
+class TestByRouteIdVisibility:
+    def test_member_can_read(self, client, creator_secret, creator_browser):
+        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = client.get(
+            f"/api/threads/by-route-id/{poll['short_id']}",
+            headers={"X-Browser-Id": creator_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert poll["id"] in ids
+
+    def test_stranger_404s(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = _stranger_get_thread(
+            client, poll["short_id"], stranger_browser,
+        )
+        assert resp.status_code == 404
+
+    def test_stranger_with_p_query_sees_only_that_poll(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """`?p=<pollShortId>` triggers the inline auto-grant: stranger
+        becomes a poll_access holder for that poll, sees it, but NOT
+        siblings in the same thread."""
+        root = _create_poll(client, creator_secret, browser_id=creator_browser)
+        child = _create_poll(
+            client, creator_secret, browser_id=creator_browser,
+            follow_up_to=root["questions"][0]["id"],
+        )
+        resp = _stranger_get_thread(
+            client, root["short_id"], stranger_browser, p=child["short_id"],
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        # Only the targeted poll visible; root is sibling-only and stays
+        # hidden because direct-link access doesn't transitively grant
+        # thread membership.
+        assert ids == {child["id"]}
+
+    def test_stranger_p_outside_thread_is_ignored(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """`?p` referencing a poll in a DIFFERENT thread can't be used to
+        grant cross-thread access. The auto-grant lookup is scoped to the
+        resolved thread, so a mismatched `?p` is silently ignored and the
+        endpoint 404s the user out (no other visibility)."""
+        thread_a = _create_poll(client, creator_secret, browser_id=creator_browser)
+        thread_b = _create_poll(client, creator_secret, browser_id=creator_browser)
+
+        resp = _stranger_get_thread(
+            client, thread_a["short_id"], stranger_browser,
+            p=thread_b["short_id"],
+        )
+        assert resp.status_code == 404
+
+        # Verify no poll_access was written for thread_b's poll.
+        with psycopg.connect(TEST_DB_URL) as conn:
+            rows = conn.execute(
+                "SELECT 1 FROM poll_access WHERE poll_id = %s AND browser_id = %s",
+                (thread_b["id"], stranger_browser),
+            ).fetchall()
+        assert rows == []
+
+    def test_p_grant_persists_across_calls(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """Once `?p` writes the grant, the poll stays visible without
+        repeating the param — confirming it landed in poll_access, not
+        just transient state in the response."""
+        root = _create_poll(client, creator_secret, browser_id=creator_browser)
+        # First call with ?p — establishes grant.
+        resp1 = _stranger_get_thread(
+            client, root["short_id"], stranger_browser, p=root["short_id"],
+        )
+        assert resp1.status_code == 200
+
+        # Second call WITHOUT ?p — visibility comes from the persisted
+        # poll_access row.
+        resp2 = _stranger_get_thread(
+            client, root["short_id"], stranger_browser,
+        )
+        assert resp2.status_code == 200
+        ids = {p["id"] for p in resp2.json()}
+        assert ids == {root["id"]}
+
+    def test_unknown_route_id_404s(self, client, stranger_browser):
+        resp = _stranger_get_thread(client, "zzznotreal", stranger_browser)
+        assert resp.status_code == 404
+
+    def test_member_sees_closed_polls_within_membership_window(
+        self, client, creator_secret, creator_browser,
+    ):
+        """A member who closed their own poll still sees it — joined_at <=
+        closed_at since membership predates the close."""
+        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        _close_poll(poll["id"], creator_secret, client)
+        resp = client.get(
+            f"/api/threads/by-route-id/{poll['short_id']}",
+            headers={"X-Browser-Id": creator_browser},
+        )
+        assert resp.status_code == 200
+        ids = {p["id"] for p in resp.json()}
+        assert poll["id"] in ids

--- a/server/tests/test_threads_visibility.py
+++ b/server/tests/test_threads_visibility.py
@@ -15,34 +15,17 @@ The companion file `test_membership_writes.py` covers the WRITE side of
 Phase C.2 (auto-join + access-grant). This file covers the READ side that
 C.3 introduces. Both depend on a real Postgres reachable via DATABASE_URL
 and the migration set including 102.
+
+Shared fixtures (`client`, `creator_secret`) and helpers (`create_poll`)
+live in `conftest.py`.
 """
 
-import os
-import time
 import uuid
 
+import psycopg
 import pytest
 
-TEST_DB_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
-)
-os.environ["DATABASE_URL"] = TEST_DB_URL
-
-import psycopg
-from fastapi.testclient import TestClient
-
-from main import app
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
-
-
-@pytest.fixture
-def creator_secret():
-    return f"test-secret-{uuid.uuid4().hex[:8]}"
+from tests.conftest import TEST_DB_URL, create_poll
 
 
 @pytest.fixture
@@ -53,27 +36,6 @@ def creator_browser():
 @pytest.fixture
 def stranger_browser():
     return str(uuid.uuid4())
-
-
-def _yes_no_question(**overrides) -> dict:
-    base = {"question_type": "yes_no", "category": "yes_no"}
-    base.update(overrides)
-    return base
-
-
-def _create_poll(client, creator_secret, *, browser_id, **kwargs) -> dict:
-    payload = {
-        "creator_secret": creator_secret,
-        "questions": [_yes_no_question()],
-    }
-    payload.update(kwargs)
-    resp = client.post(
-        "/api/polls",
-        json=payload,
-        headers={"X-Browser-Id": browser_id},
-    )
-    assert resp.status_code == 201, resp.text
-    return resp.json()
 
 
 def _close_poll(poll_id: str, creator_secret: str, client):
@@ -94,17 +56,6 @@ def _set_poll_updated_at(poll_id: str, dt_iso: str):
         )
 
 
-def _set_member_joined_at(thread_id: str, browser_id: str, dt_iso: str):
-    """Set thread_members.joined_at directly so we can simulate "joined
-    after the poll closed". Used in place of waiting real wall-clock time."""
-    with psycopg.connect(TEST_DB_URL) as conn:
-        conn.execute(
-            "UPDATE thread_members SET joined_at = %s "
-            "WHERE thread_id = %s AND browser_id = %s",
-            (dt_iso, thread_id, browser_id),
-        )
-
-
 def _stranger_get_thread(client, route_id, browser_id, *, p=None):
     qs = f"?p={p}" if p else ""
     return client.get(
@@ -120,7 +71,7 @@ def _stranger_get_thread(client, route_id, browser_id, *, p=None):
 
 class TestMyThreadsVisibility:
     def test_member_sees_their_thread(self, client, creator_secret, creator_browser):
-        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
         # Note: no accessible_question_ids — pure membership signal.
         resp = client.post(
             "/api/threads/mine",
@@ -134,7 +85,7 @@ class TestMyThreadsVisibility:
     def test_stranger_sees_no_threads(
         self, client, creator_secret, creator_browser, stranger_browser,
     ):
-        _create_poll(client, creator_secret, browser_id=creator_browser)
+        create_poll(client, creator_secret, browser_id=creator_browser)
         resp = client.post(
             "/api/threads/mine",
             json={"accessible_question_ids": []},
@@ -150,8 +101,8 @@ class TestMyThreadsVisibility:
         thread_members rows. The bridge treats those question_ids as
         thread-level access, preserving Phase B.3 behavior for legacy
         callers."""
-        root = _create_poll(client, creator_secret, browser_id=creator_browser)
-        child = _create_poll(
+        root = create_poll(client, creator_secret, browser_id=creator_browser)
+        child = create_poll(
             client, creator_secret, browser_id=creator_browser,
             follow_up_to=root["questions"][0]["id"],
         )
@@ -175,8 +126,8 @@ class TestMyThreadsVisibility:
         narrow the home list because the user is still a thread_members
         row in that thread (until an explicit leave action lands)."""
         # Two unrelated threads, both with the same creator browser.
-        kept = _create_poll(client, creator_secret, browser_id=creator_browser)
-        forgotten = _create_poll(client, creator_secret, browser_id=creator_browser)
+        kept = create_poll(client, creator_secret, browser_id=creator_browser)
+        forgotten = create_poll(client, creator_secret, browser_id=creator_browser)
 
         # Pretend the user only has the `kept` question in localStorage.
         resp = client.post(
@@ -196,8 +147,8 @@ class TestMyThreadsVisibility:
     ):
         """Membership-only callers (empty accessible_question_ids list)
         skip the forget-bridge narrowing — the bridge is opt-in."""
-        a = _create_poll(client, creator_secret, browser_id=creator_browser)
-        b = _create_poll(client, creator_secret, browser_id=creator_browser)
+        a = create_poll(client, creator_secret, browser_id=creator_browser)
+        b = create_poll(client, creator_secret, browser_id=creator_browser)
         resp = client.post(
             "/api/threads/mine",
             json={"accessible_question_ids": []},
@@ -213,7 +164,7 @@ class TestMyThreadsVisibility:
         before they joined the thread. The closed_at proxy is
         polls.updated_at."""
         # Creator opens + closes a poll.
-        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
         _close_poll(poll["id"], creator_secret, client)
         # Backdate the close so it lives in the distant past.
         _set_poll_updated_at(poll["id"], "2000-01-01T00:00:00Z")
@@ -221,7 +172,7 @@ class TestMyThreadsVisibility:
         # A second user joins by creating a follow-up *after* the close.
         # They become a thread member with joined_at = NOW(); the closed
         # poll's closed_at (year 2000) is < joined_at, so it's filtered out.
-        followup = _create_poll(
+        followup = create_poll(
             client, creator_secret, browser_id=stranger_browser,
             follow_up_to=poll["questions"][0]["id"],
         )
@@ -243,7 +194,7 @@ class TestMyThreadsVisibility:
     ):
         """Legacy bridge bypasses closed_at — pre-B.3 users with a
         localStorage list see the full thread regardless of close timing."""
-        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
         _close_poll(poll["id"], creator_secret, client)
         _set_poll_updated_at(poll["id"], "2000-01-01T00:00:00Z")
 
@@ -264,8 +215,8 @@ class TestMyThreadsVisibility:
     ):
         """A user with `poll_access` for one poll in a thread sees just
         that poll — even with no thread_members row and no legacy bridge."""
-        root = _create_poll(client, creator_secret, browser_id=creator_browser)
-        child = _create_poll(
+        root = create_poll(client, creator_secret, browser_id=creator_browser)
+        child = create_poll(
             client, creator_secret, browser_id=creator_browser,
             follow_up_to=root["questions"][0]["id"],
         )
@@ -295,7 +246,7 @@ class TestMyThreadsVisibility:
 
 class TestByRouteIdVisibility:
     def test_member_can_read(self, client, creator_secret, creator_browser):
-        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
         resp = client.get(
             f"/api/threads/by-route-id/{poll['short_id']}",
             headers={"X-Browser-Id": creator_browser},
@@ -307,7 +258,7 @@ class TestByRouteIdVisibility:
     def test_stranger_404s(
         self, client, creator_secret, creator_browser, stranger_browser,
     ):
-        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
         resp = _stranger_get_thread(
             client, poll["short_id"], stranger_browser,
         )
@@ -319,8 +270,8 @@ class TestByRouteIdVisibility:
         """`?p=<pollShortId>` triggers the inline auto-grant: stranger
         becomes a poll_access holder for that poll, sees it, but NOT
         siblings in the same thread."""
-        root = _create_poll(client, creator_secret, browser_id=creator_browser)
-        child = _create_poll(
+        root = create_poll(client, creator_secret, browser_id=creator_browser)
+        child = create_poll(
             client, creator_secret, browser_id=creator_browser,
             follow_up_to=root["questions"][0]["id"],
         )
@@ -341,8 +292,8 @@ class TestByRouteIdVisibility:
         grant cross-thread access. The auto-grant lookup is scoped to the
         resolved thread, so a mismatched `?p` is silently ignored and the
         endpoint 404s the user out (no other visibility)."""
-        thread_a = _create_poll(client, creator_secret, browser_id=creator_browser)
-        thread_b = _create_poll(client, creator_secret, browser_id=creator_browser)
+        thread_a = create_poll(client, creator_secret, browser_id=creator_browser)
+        thread_b = create_poll(client, creator_secret, browser_id=creator_browser)
 
         resp = _stranger_get_thread(
             client, thread_a["short_id"], stranger_browser,
@@ -364,7 +315,7 @@ class TestByRouteIdVisibility:
         """Once `?p` writes the grant, the poll stays visible without
         repeating the param — confirming it landed in poll_access, not
         just transient state in the response."""
-        root = _create_poll(client, creator_secret, browser_id=creator_browser)
+        root = create_poll(client, creator_secret, browser_id=creator_browser)
         # First call with ?p — establishes grant.
         resp1 = _stranger_get_thread(
             client, root["short_id"], stranger_browser, p=root["short_id"],
@@ -389,7 +340,7 @@ class TestByRouteIdVisibility:
     ):
         """A member who closed their own poll still sees it — joined_at <=
         closed_at since membership predates the close."""
-        poll = _create_poll(client, creator_secret, browser_id=creator_browser)
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
         _close_poll(poll["id"], creator_secret, client)
         resp = client.get(
             f"/api/threads/by-route-id/{poll['short_id']}",


### PR DESCRIPTION
## Summary

Phase C.3 enforces the visibility rule from `docs/thread-routing-redesign.md` on `POST /api/threads/mine` and `GET /api/threads/by-route-id/{route_id}`. A poll P in thread T is visible to browser B iff ANY of:

1. B has a `thread_members` row for T AND (`P.is_closed = false` OR `P.closed_at >= members.joined_at`),
2. B has a `poll_access` row for P, OR
3. (transitional bridge) The legacy `accessible_question_ids` list passed by the FE contains a question_id whose poll lives in T — treated as **thread-level** access (every poll in T visible, no closed_at filter) so pre-B.3 callers passing one question_id keep seeing the whole thread.

Decisions on the three previously-open semantic questions:

- **Join trigger**: vote/create only — Phase C.2 defaults preserved. The `/access` endpoint and the `?p=` auto-grant on by-route-id grant `poll_access` (per-poll, not thread membership).
- **Non-member visiting `/t/<id>` with no `?p`**: 404. "No visibility into any poll" is treated identically to "no such thread".
- **Forget vs leave**: forget stays localStorage-only. When the FE passes `accessible_question_ids`, `/api/threads/mine` narrows to threads with a non-membership signal (poll_access OR legacy bridge) so forget keeps its "thread disappears from home" semantics. An explicit `DELETE /api/threads/{id}/membership` is a follow-up to retire the bridge.

## Implementation

- `services/threads.py`: new `UserVisibility` dataclass + `load_user_visibility` / `filter_visible_polls` / `grant_poll_access_inline` helpers. `thread_ids_for_poll_ids` added as the inverse of the existing `poll_ids_for_thread_ids`.
- `routers/threads.py`: `/mine` and `/by-route-id` apply visibility. `by-route-id` accepts `?p=<pollShortId>` and writes `poll_access` inline BEFORE filtering — race-safely surfaces direct-link landings. The grant is scoped to the resolved thread, so a `?p` outside the thread is silently ignored (no cross-thread access leak).
- `closed_at` proxy: `polls.updated_at`, refreshed by the close trigger. Subsequent edits bump it forward — the filter fails open. A dedicated column would be marginally tighter; deferred.
- Tests: existing `test_threads_api.py` updated to thread browser_id through create + read calls (the strict-visibility contract). New `test_threads_visibility.py` with 15 cases covering stranger 404, member access, closed-before-join hiding, legacy bridge bypassing closed_at, `?p=` auto-grant working, `?p=` outside thread ignored, forget bridge, per-poll grants.
- Test fixtures consolidated into `server/tests/conftest.py` (was duplicated across three test files).

## Migration cost

Pre-B.3 voters who haven't re-voted have no `thread_members` row. They keep working via the legacy `accessible_question_ids` bridge. Once they vote again, Phase C.2's auto-join writes restore membership and the bridge becomes redundant. Visibility enforcement on the legacy `POST /api/questions/accessible` is intentionally NOT added — the FE migrated to `/api/threads/*` in B.3, and gating the legacy endpoint retroactively risks breaking older client bundles.

## Test plan

- [x] `tests/test_threads_visibility.py` (15 new tests) — all pass on dev DB
- [x] `tests/test_threads_api.py` (22 updated tests) — all pass
- [x] `tests/test_membership_writes.py` (11 Phase C.2 tests) — all pass
- [ ] CI green
- [ ] Vercel build green
- [ ] Mergeable

https://claude.ai/code/session_013h7seVVVDq1ZaaZsgiBr3J

---
_Generated by [Claude Code](https://claude.ai/code/session_013h7seVVVDq1ZaaZsgiBr3J)_