### PR TITLE
Wire apiLeaveThread into the thread-page forget flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -749,7 +749,7 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 ## Poll System
 
 > **`DELETE /api/threads/{route_id}/membership` ("leave thread") shipped
-> on this branch** as the explicit teardown counterpart to Phase C.2's
+> in #268** as the explicit teardown counterpart to Phase C.2's
 > auto-join writes. The endpoint removes the caller's `thread_members`
 > row for the resolved thread (idempotent — strangers and
 > already-left-and-leaving-again both 204; only an unresolvable
@@ -757,10 +757,22 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 > access survives the leave. Resolves all four route_id forms
 > (`threads.short_id`, `threads.id`, `polls.short_id`, `polls.id`).
 > FE helper: `apiLeaveThread(routeId)` in `lib/api/threads.ts`,
-> fire-and-forget like `apiGrantPollAccess`. Wiring it up to the FE's
-> forget flow (or an explicit "leave thread" UX) is the next step
-> required to retire the legacy `accessible_question_ids` bridge in
-> `/api/threads/mine`.
+> fire-and-forget like `apiGrantPollAccess`.
+>
+> **Wired into the thread-page forget flow on this branch.** When the
+> user forgets their last remaining question in the thread (the
+> existing `remaining.length === 0` branch in
+> `app/t/[threadShortId]/page.tsx`'s `pendingAction.kind === 'forget'`
+> handler — i.e. the same condition that already triggers
+> `router.push('/')`), we additionally call `apiLeaveThread(threadId)`
+> before navigating home. This is the unambiguous "no FE-visible
+> questions left in this thread for this browser" case. Forgetting one
+> question of a multi-question/multi-poll thread does NOT fire leave —
+> the user is still consuming the thread via the remaining questions.
+> Once enough rollout time has passed for active browsers to exercise
+> this path, the legacy `accessible_question_ids` bridge in
+> `/api/threads/mine` becomes retirable (membership + poll_access
+> become the sole sources of truth).
 >
 > **Phase C.3 of the thread-routing redesign shipped (#267).**
 > The visibility rule is now enforced on `POST /api/threads/mine` and

--- a/app/t/[threadShortId]/page.tsx
+++ b/app/t/[threadShortId]/page.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { Question } from "@/lib/types";
 import { getMyThreads } from "@/lib/simpleQuestionQueries";
 import { buildThreadFromPollDown, buildThreadSyncFromCache, buildPollMap, isPendingPollId, POLL_QUERY_PARAM } from "@/lib/threadUtils";
-import { apiGetQuestionById, apiGetQuestionByShortId, apiGetQuestionResults, apiGetThreadByRouteId, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiGetPollById, apiGetPollByShortId, apiGrantPollAccess, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
+import { apiGetQuestionById, apiGetQuestionByShortId, apiGetQuestionResults, apiGetThreadByRouteId, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiGetPollById, apiGetPollByShortId, apiGrantPollAccess, apiLeaveThread, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
 import type { Poll } from "@/lib/types";
 import { useThreadVoting } from "@/lib/useThreadVoting";
 import type { QuestionResults } from "@/lib/types";
@@ -1658,15 +1658,16 @@ export function ThreadContent({ threadId, initialExpandedQuestionId = null }: Th
             // If the forgotten question was expanded, collapse it so the URL `?p=`
             // doesn't still point at the deleted poll.
             setExpandedQuestionId((curr) => (curr === action.question.id ? null : curr));
-            setThread((prev) => {
-              if (!prev) return prev;
-              const remaining = prev.questions.filter((p) => p.id !== action.question.id);
-              if (remaining.length === 0) {
-                router.push('/');
-                return prev;
-              }
-              return { ...prev, questions: remaining };
-            });
+            const remaining = thread ? thread.questions.filter((p) => p.id !== action.question.id) : [];
+            if (thread && remaining.length === 0) {
+              // Drop the server-side `thread_members` row so the thread
+              // doesn't reappear via Phase C.3 membership-based visibility
+              // on the next /api/threads/mine call. Fire-and-forget.
+              void apiLeaveThread(threadId);
+              router.push('/');
+            } else {
+              setThread((prev) => (prev ? { ...prev, questions: prev.questions.filter((p) => p.id !== action.question.id) } : prev));
+            }
           } else if (action.kind === 'reopen') {
             try {
               const secret = getCreatorSecret(action.question.id) || 'dev-override';


### PR DESCRIPTION
## Summary

When the user forgets their last remaining question in a thread, also drop their `thread_members` row server-side so the thread doesn't reappear on the home page via Phase C.3 membership-based visibility — even after the FE has lost every `accessible_question_ids` entry that maps into the thread.

- Calls `apiLeaveThread(threadId)` only on the existing `remaining.length === 0` branch (same condition that already navigates home), so single-question threads leave on first forget and multi-question threads leave only after the last remaining question is forgotten.
- Side effects (`apiLeaveThread` + `router.push('/')`) hoisted out of the `setThread` updater — they were inside the updater before and would double-fire under React StrictMode.
- Drops the redundant `if (threadId)` guard since `ThreadContent`'s `threadId: string` prop is non-optional.
- Fire-and-forget; `apiLeaveThread` swallows errors and the server is idempotent.

This is the prerequisite for retiring the legacy `accessible_question_ids` bridge in `/api/threads/mine` (membership + `poll_access` then become the sole sources of truth).

## Test plan

- [ ] Forget the only question in a 1-question thread → thread disappears from home, server `thread_members` row is gone (`SELECT * FROM thread_members WHERE browser_id=...`).
- [ ] Forget one of N questions in a multi-question thread → still on the thread page, `thread_members` row still present.
- [ ] Forget the last question of a multi-question thread → leave fires, thread gone from home.
- [ ] No double-DELETE in dev (StrictMode) — confirm via API logs.

https://claude.ai/code/session_01KTDioTvbsjWSmwv1c5buHr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTDioTvbsjWSmwv1c5buHr)_