### PR TITLE
Add ntfy Stop hook for input-ready notifications

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,19 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$NTFY_TOPIC\" ] && curl -fsS --max-time 5 -d \"Claude is ready for your input\" -H \"Title: Claude Code\" \"https://ntfy.sh/$NTFY_TOPIC\" >/dev/null 2>&1 || true",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `Stop` hook to `.claude/settings.json` that POSTs to `https://ntfy.sh/$NTFY_TOPIC` whenever Claude Code finishes a turn and is ready for user input.
- The `[ -n "$NTFY_TOPIC" ]` guard makes it a no-op for any contributor who hasn't set the env var, so shipping it project-wide is safe — anyone who wants iOS push notifications just sets `NTFY_TOPIC` in their Claude Code environment and subscribes to that topic in the ntfy iOS app.
- Hook runs `async: true` with a 10s timeout so it never blocks the turn.

## Test plan
- [x] Verified the curl command against ntfy.sh manually (received notification on iOS).
- [ ] Confirm hook fires on next Stop event after merge (requires `NTFY_TOPIC` to be set in the contributor's Claude Code env vars; depends on the harness reloading `.claude/settings.json` — may need `/hooks` open or session restart).

https://claude.ai/code/session_013cGr3Q8hWjyaNedzK1u2i6

---
_Generated by [Claude Code](https://claude.ai/code/session_013cGr3Q8hWjyaNedzK1u2i6)_