### PR TITLE
Fix thread title override silently dropping on save

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1000,14 +1000,18 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 > page remains as a last-ditch safety net for very old URL forms during
 > a partial rollout.
 >
-> Server side: `_SELECT_POLLS_WITH_THREAD` in `routers/polls.py` and the
-> mirrored JOIN in `services/threads.py: polls_for_poll_ids` are the
+> Server side: `_SELECT_POLLS_WITH_THREAD` in `routers/polls.py` is the
 > single source of truth for "every polls SELECT must surface
-> `thread_short_id`". `_attach_thread_short_id(conn, row)` enriches
-> `RETURNING *` rows from INSERT/UPDATE paths with the same field.
-> Adding another threads-table field to `PollResponse` requires
-> extending only those two SELECT-prefix strings + the helper — every
-> read path picks it up automatically.
+> `thread_short_id` + `thread_title`". `services/threads.py:
+> polls_for_poll_ids` imports the constant via the same deferred import
+> as `_row_to_poll` / `_compute_poll_voter_data`, so there is no second
+> SELECT to keep in sync — extending the constant with a new threads-table
+> field reaches every read path automatically. (Earlier this section
+> documented two "mirrored" SELECTs and warned that "extending one
+> without the other will silently drop the field" — Migration 105 hit
+> exactly that failure mode for `thread_title`, which is why the second
+> SELECT was retired in favor of the import.) `_attach_thread_fields(conn, row)`
+> enriches `RETURNING *` rows from INSERT/UPDATE paths with the same fields.
 >
 > Pitfall: `BIGSERIAL` populates existing rows on `ALTER TABLE ADD
 > COLUMN` (Postgres 10+) so the migration's backfill UPDATE works. If

--- a/server/services/threads.py
+++ b/server/services/threads.py
@@ -193,24 +193,27 @@ def polls_for_poll_ids(
     """Build PollResponse[] (with inline results / voter aggregates) for the
     given poll_ids. Order: most recently created first. Empty list in →
     empty list out (no DB roundtrip)."""
-    # Local import keeps services/* free of router cycles.
-    from routers.polls import _compute_poll_voter_data, _row_to_poll
+    # Local import keeps services/* free of router cycles. Reusing
+    # `_SELECT_POLLS_WITH_THREAD` (rather than re-writing the JOIN) is what
+    # actually keeps this read in lockstep with the rest of the polls reads —
+    # the previous local copy quietly went stale after Migration 105 moved
+    # `thread_title` from polls to threads, returning thread_title=null on
+    # every /api/threads/* read.
+    from routers.polls import (
+        _SELECT_POLLS_WITH_THREAD,
+        _compute_poll_voter_data,
+        _row_to_poll,
+    )
 
     if not poll_ids:
         return []
 
     now = datetime.now(timezone.utc)
 
-    # Phase B.4: surface threads.short_id alongside polls.* so _row_to_poll can
-    # populate `thread_short_id` on every PollResponse without a per-row lookup.
-    # Mirrors `_SELECT_POLLS_WITH_THREAD` in routers/polls.py — extending one
-    # without the other will silently drop the field on whichever path gets
-    # missed.
     poll_rows = conn.execute(
-        """SELECT polls.*, t.short_id AS thread_short_id
-             FROM polls LEFT JOIN threads t ON polls.thread_id = t.id
-            WHERE polls.id = ANY(%(ids)s)
-            ORDER BY polls.created_at DESC""",
+        f"{_SELECT_POLLS_WITH_THREAD} "
+        "WHERE polls.id = ANY(%(ids)s) "
+        "ORDER BY polls.created_at DESC",
         {"ids": poll_ids},
     ).fetchall()
     if not poll_rows:


### PR DESCRIPTION
## Summary

- Setting a thread title via `/t/<id>/edit-title` appeared to do nothing — the API persisted the override (visible via `/api/polls/by-id/...`), but the FE thread loader read `thread_title=null` and fell back to the participant-names default.
- Root cause: Migration 105 moved the override from `polls.thread_title` to `threads.title` and updated `routers/polls.py: _SELECT_POLLS_WITH_THREAD` to JOIN threads and select `t.title AS thread_title`, but the duplicated SELECT in `services/threads.py: polls_for_poll_ids` was only extended to pull `t.short_id`, not `t.title`. Every read through that helper (`POST /api/threads/mine` and `GET /api/threads/by-route-id/{id}`) returned `thread_title=null` because `polls.*` no longer carries the column.
- Fix: import `_SELECT_POLLS_WITH_THREAD` from `routers/polls` (via the same deferred import already used for `_row_to_poll` / `_compute_poll_voter_data`) and reuse it in `polls_for_poll_ids`. The "single source of truth" claim in the constant's comment is now actually true — there's only one SELECT prefix, so the next threads-table field added can't drift again. CLAUDE.md updated to reflect the consolidation and document the regression.

## Test plan

- [x] `apiUpdateThreadTitle` persists the title server-side (already worked pre-fix; confirmed via direct API).
- [x] `GET /api/threads/by-route-id/<id>?p=<short>` now returns `thread_title: "<override>"` for polls in the thread (was previously `null`).
- [x] After a fresh reload of `/t/<id>?p=<short>`, the thread page H1 displays the override (was previously the participant-names default).
- [ ] Manual UI flow on dev server: thread → tap title → /info → Edit → type override → Save → new title visible on /info and on the thread page.

https://claude.ai/code/session_012azk5uP3TEnkshSaSkaTxy

---
_Generated by [Claude Code](https://claude.ai/code/session_012azk5uP3TEnkshSaSkaTxy)_