### PR TITLE
Fix non-user suggestion bubble contrast on light mode

### DIFF
--- a/components/SuggestionsList.tsx
+++ b/components/SuggestionsList.tsx
@@ -87,7 +87,7 @@ export default function SuggestionsList({
                 className={`flex items-center rounded-xl overflow-hidden ${
                   isUserSuggestion
                     ? 'bg-blue-100 dark:bg-blue-900/30'
-                    : 'bg-gray-100 dark:bg-gray-700'
+                    : 'bg-gray-200 dark:bg-gray-700'
                 }`}
               >
                 <div className={`min-w-0 flex-1 px-3 py-1.5 text-sm font-medium overflow-hidden ${
@@ -101,7 +101,7 @@ export default function SuggestionsList({
                   <span className={`px-2.5 self-stretch flex items-center text-sm font-bold flex-shrink-0 ${
                     isUserSuggestion
                       ? 'bg-blue-500 text-white'
-                      : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'
+                      : 'bg-gray-400 dark:bg-gray-600 text-gray-900 dark:text-gray-100'
                   }`}>
                     {suggestion.count}
                   </span>
@@ -122,7 +122,7 @@ export default function SuggestionsList({
                 className={`inline-flex items-center rounded-full overflow-hidden ${
                   isUserSuggestion
                     ? 'bg-blue-100 dark:bg-blue-900/30'
-                    : 'bg-gray-100 dark:bg-gray-700'
+                    : 'bg-gray-200 dark:bg-gray-700'
                 }`}
               >
                 <div className={`px-3 py-1 text-sm font-medium ${
@@ -136,7 +136,7 @@ export default function SuggestionsList({
                   <span className={`px-2.5 self-stretch flex items-center text-sm font-bold ${
                     isUserSuggestion
                       ? 'bg-blue-500 text-white'
-                      : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'
+                      : 'bg-gray-400 dark:bg-gray-600 text-gray-900 dark:text-gray-100'
                   }`}>
                     {suggestion.count}
                   </span>


### PR DESCRIPTION
## Summary
- Non-user suggestion bubbles used `bg-gray-100` — exactly matching the poll card's light-mode `bg-gray-100`, so the bubbles vanished into the card.
- Bumped the bubble bg to `bg-gray-200` on light (dark `bg-gray-700` already contrasts with the card's `bg-gray-900` and is unchanged).
- Bumped the count badge from `gray-300` → `gray-400` on light to preserve the original 2-step hierarchy between bubble and count.

## Test plan
- [ ] On light theme, suggestion bubbles for other users' suggestions are visibly distinct from the poll card behind them.
- [ ] On dark theme, contrast is preserved (no regression).
- [ ] Count badge still reads as a distinct "pill on a pill" against the new bubble bg.
- [ ] User's own suggestion bubbles (blue) unchanged.

https://claude.ai/code/session_01LGqLkzWU3CzxecVrj7twVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGqLkzWU3CzxecVrj7twVK)_