### PR TITLE
Hide seconds in countdown timers when ≥ 60s remain

### DIFF
--- a/components/Countdown.tsx
+++ b/components/Countdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { formatCountdownTime } from "@/lib/timeUtils";
 
 interface CountdownProps {
   deadline: string | null;
@@ -32,24 +33,7 @@ export default function Countdown({ deadline, label, onExpire }: CountdownProps)
         return;
       }
 
-      const days = Math.floor(difference / (1000 * 60 * 60 * 24));
-      const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-      const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
-      const seconds = Math.floor((difference % (1000 * 60)) / 1000);
-
-      let timeString = "";
-      
-      if (days > 0) {
-        timeString = `${days}d ${hours}h ${minutes}m`;
-      } else if (hours > 0) {
-        timeString = `${hours}h ${minutes}m ${seconds}s`;
-      } else if (minutes > 0) {
-        timeString = `${minutes}m ${seconds}s`;
-      } else {
-        timeString = `${seconds}s`;
-      }
-
-      setTimeLeft(timeString);
+      setTimeLeft(formatCountdownTime(difference));
     };
 
     updateCountdown();

--- a/components/SimpleCountdown.tsx
+++ b/components/SimpleCountdown.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { formatCountdownTime } from "@/lib/timeUtils";
 
 interface SimpleCountdownProps {
   deadline: string;
   label?: string;
   colorClass?: string;
-  /** When the deadline is days away, hide the seconds component.
-   *  List views use this to keep countdown widths stable and compact. */
-  hideSecondsInDays?: boolean;
 }
 
 /** Ticks countdown text via a ref + textContent to avoid a per-second React
@@ -19,7 +17,6 @@ export default function SimpleCountdown({
   deadline,
   label,
   colorClass = "text-blue-600 dark:text-blue-400",
-  hideSecondsInDays = false,
 }: SimpleCountdownProps) {
   const spanRef = useRef<HTMLSpanElement>(null);
 
@@ -29,22 +26,14 @@ export default function SimpleCountdown({
     const render = () => {
       const difference = new Date(deadline).getTime() - Date.now();
       if (difference <= 0) { el.textContent = 'Expired'; return false; }
-      const days = Math.floor(difference / (1000 * 60 * 60 * 24));
-      const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-      const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
-      const seconds = Math.floor((difference % (1000 * 60)) / 1000);
-      let next: string;
-      if (days > 0) next = hideSecondsInDays ? `${days}d ${hours}h ${minutes}m` : `${days}d ${hours}h ${minutes}m ${seconds}s`;
-      else if (hours > 0) next = `${hours}h ${minutes}m ${seconds}s`;
-      else if (minutes > 0) next = `${minutes}m ${seconds}s`;
-      else next = `${seconds}s`;
+      const next = formatCountdownTime(difference);
       if (el.textContent !== next) el.textContent = next;
       return true;
     };
     if (!render()) return;
     const interval = setInterval(() => { if (!render()) clearInterval(interval); }, 1000);
     return () => clearInterval(interval);
-  }, [deadline, hideSecondsInDays]);
+  }, [deadline]);
 
   return <>{label ? `${label}: ` : null}<span ref={spanRef} className={`font-mono font-semibold ${colorClass}`} /></>;
 }

--- a/components/ThreadListItem.tsx
+++ b/components/ThreadListItem.tsx
@@ -165,7 +165,6 @@ export default function ThreadListItem(props: ThreadListItemProps) {
                   <SimpleCountdown
                     deadline={soonestUnvotedDeadline}
                     colorClass="text-green-600 dark:text-green-400"
-                    hideSecondsInDays
                   />
                 </ClientOnly>
               </div>

--- a/lib/timeUtils.ts
+++ b/lib/timeUtils.ts
@@ -32,6 +32,20 @@ export function formatDurationLabel(minutes: number): string {
   return `${mins}m`;
 }
 
+/** Format a remaining-time milliseconds difference for countdown display.
+ *  Hides seconds whenever ≥ 60 seconds remain — only the final sub-minute
+ *  window shows the seconds counter ticking down. */
+export function formatCountdownTime(diffMs: number): string {
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((diffMs % (1000 * 60)) / 1000);
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+}
+
 /** Format "label (clock time)" showing the absolute time `minutes` from now.
  *  Returns just the label on the server or when minutes <= 0. */
 export function formatDeadlineLabel(minutes: number, label: string): string {


### PR DESCRIPTION
## Summary
- Both `Countdown` and `SimpleCountdown` now drop the trailing seconds field in the days / hours / minutes branches; seconds only render in the final sub-60s window
- Extracted the now-shared formatting into `formatCountdownTime(diffMs)` in `lib/timeUtils.ts`
- Removed the now-redundant `hideSecondsInDays` prop on `SimpleCountdown` and dropped its sole usage in `ThreadListItem`

## Test plan
- [ ] On the home page, the unvoted-thread countdown reads `Xh Ym` / `Xd Yh Zm` without a trailing `Zs`
- [ ] On a thread card, the Suggestions / Availability / Voting countdowns read without seconds
- [ ] When a deadline is under a minute away, the countdown shows `Ns` and ticks every second
- [ ] No type / lint regressions

https://claude.ai/code/session_01D7ryNvWdSKchRyNPkADK5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7ryNvWdSKchRyNPkADK5n)_