### PR TITLE
Redesign create-poll form: label-left, value-right rows with hairlines

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1462,7 +1462,19 @@ export function CreateQuestionContent() {
         </>
       )}
 
-      {questionType === 'question' && category !== 'yes_no' && category !== 'time' && (
+    </form>
+  );
+
+  // Options card — rendered as a separate card below the bottom card,
+  // with an external left-justified "Options" header. Only meaningful
+  // for ranked-choice (non-yes_no, non-time) questions.
+  const showOptionsCard = questionType === 'question' && category !== 'yes_no' && category !== 'time';
+  const optionsCard = showOptionsCard ? (
+    <div>
+      <label className="block text-sm font-medium mb-1 px-1">
+        Options <span className="font-normal text-xs text-gray-500 dark:text-gray-400">(leave blank to ask for suggestions)</span>
+      </label>
+      <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-1">
         <OptionsInput
           options={options}
           setOptions={setOptions}
@@ -1473,12 +1485,11 @@ export function CreateQuestionContent() {
           referenceLatitude={refLatitude}
           referenceLongitude={refLongitude}
           searchRadius={searchRadius}
-          label={<>Options <span className="font-normal">(leave blank to ask for suggestions)</span></>}
           variant="compact"
         />
-      )}
-    </form>
-  );
+      </section>
+    </div>
+  ) : null;
 
   return (
     <div className="question-content">
@@ -1742,7 +1753,9 @@ export function CreateQuestionContent() {
                   </form>
                 </section>
 
-                {/* Notes card — third card with the label as an external
+                {optionsCard}
+
+                {/* Notes card — last card with the label as an external
                     left-justified header (per spec). The textarea is always
                     visible (no collapse/expand toggle); auto-grows as the
                     user types. */}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -116,7 +116,6 @@ export function CreateQuestionContent() {
   const [customSuggestionTime, setCustomSuggestionTime] = useState('');
   const [allowPreRanking, setAllowPreRanking] = useState(true);
   const [details, setDetails] = useState("");
-  const [detailsOpen, setDetailsOpen] = useState(false);
   const detailsRef = useRef<HTMLTextAreaElement>(null);
   const [category, setCategory] = useState<string>('custom');
   const [forField, setForField] = useState("");
@@ -203,13 +202,6 @@ export function CreateQuestionContent() {
     // time
     return appendFor("Time?");
   }, [questionType, category, options, forField]);
-
-  // Focus details textarea when opening
-  useEffect(() => {
-    if (detailsOpen) {
-      detailsRef.current?.focus();
-    }
-  }, [detailsOpen]);
 
   // Focus name input when editing starts
   useEffect(() => {
@@ -374,7 +366,6 @@ export function CreateQuestionContent() {
           if (formState.isAutoTitle === false) setIsAutoTitle(false);
           if (formState.questionType === 'time') setQuestionType('time');
           setDetails(formState.details || '');
-          if (formState.details) setDetailsOpen(true);
           setOptions(formState.options || ['']);
           setDeadlineOption(formState.deadlineOption || '10min');
           setCustomDate(formState.customDate || '');
@@ -802,7 +793,6 @@ export function CreateQuestionContent() {
           // copied — it regenerates fresh from the new input fields (or stays
           // empty for user-typed yes_no prompts). See buildQuestionSnapshot.
           setDetails(duplicateData.details || "");
-          if (duplicateData.details) setDetailsOpen(true);
 
           // Set question type based on duplicated question
           if (duplicateData.question_type === 'ranked_choice') {
@@ -1484,6 +1474,7 @@ export function CreateQuestionContent() {
           referenceLongitude={refLongitude}
           searchRadius={searchRadius}
           label={<>Options <span className="font-normal">(leave blank to ask for suggestions)</span></>}
+          variant="compact"
         />
       )}
 
@@ -1620,6 +1611,7 @@ export function CreateQuestionContent() {
                             value={category}
                             onChange={handleCategoryChange}
                             disabled={isLoading}
+                            borderless
                           />
                         </div>
                       </div>
@@ -1704,53 +1696,6 @@ export function CreateQuestionContent() {
                       </label>
                     )}
 
-                    <div className="py-3">
-                      {detailsOpen ? (
-                        <div>
-                          <label htmlFor="details" className="block text-sm font-medium mb-2">
-                            Notes
-                          </label>
-                          <textarea
-                            ref={detailsRef}
-                            id="details"
-                            value={details}
-                            onChange={(e) => {
-                              setDetails(e.target.value);
-                              const el = e.target;
-                              el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
-                              const maxH = 5 * 20 + 16;
-                              el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
-                              el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
-                            }}
-                            onBlur={() => {
-                              const trimmed = details.trim();
-                              if (!trimmed) {
-                                setDetailsOpen(false);
-                                setDetails('');
-                              } else if (trimmed !== details) {
-                                setDetails(trimmed);
-                              }
-                            }}
-                            disabled={isLoading}
-                            style={{ height: SINGLE_LINE_INPUT_HEIGHT }}
-                            className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
-                            placeholder="Add more context or instructions..."
-                          />
-                        </div>
-                      ) : (
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="text-sm font-medium">Notes</span>
-                          <button
-                            type="button"
-                            onClick={() => setDetailsOpen(true)}
-                            className="text-sm font-normal text-blue-600 dark:text-blue-400"
-                          >
-                            Add
-                          </button>
-                        </div>
-                      )}
-                    </div>
-
                     {/* Voter name row — inline custom version (instead of
                         shared CompactNameField) so we can apply the
                         label-left / value-right layout without affecting
@@ -1795,6 +1740,42 @@ export function CreateQuestionContent() {
                     </div>
                   </form>
                 </section>
+
+                {/* Notes card — third card with the label as an external
+                    left-justified header (per spec). The textarea is always
+                    visible (no collapse/expand toggle); auto-grows as the
+                    user types. */}
+                <div>
+                  <label
+                    htmlFor="details"
+                    className="block text-sm font-medium mb-1 px-1"
+                  >
+                    Notes
+                  </label>
+                  <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-3">
+                    <textarea
+                      ref={detailsRef}
+                      id="details"
+                      value={details}
+                      onChange={(e) => {
+                        setDetails(e.target.value);
+                        const el = e.target;
+                        el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
+                        const maxH = 5 * 20 + 16;
+                        el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
+                        el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
+                      }}
+                      onBlur={() => {
+                        const trimmed = details.trim();
+                        if (trimmed !== details) setDetails(trimmed);
+                      }}
+                      disabled={isLoading}
+                      rows={3}
+                      className="block w-full bg-transparent text-sm focus:outline-none dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
+                      placeholder="Add more context or instructions..."
+                    />
+                  </section>
+                </div>
 
                 {error && (
                   <div className="p-2 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1277,56 +1277,29 @@ export function CreateQuestionContent() {
   };
 
   const titleField = (
-    <div>
-      {isAutoTitle ? (
-        <button
-          type="button"
-          onClick={() => {
-            setIsAutoTitle(false);
-            setTitle('');
-            setTimeout(() => titleInputRef.current?.focus(), 0);
-          }}
-          className="block text-sm font-medium text-left"
-        >
-          Title: <span className="text-blue-600 dark:text-blue-400 font-normal">{title || <span className="italic">auto</span>}</span>
-        </button>
-      ) : (
-        <>
-          <div className="flex items-center justify-between mb-1">
-            <label htmlFor="title" className="text-sm font-medium">
-              Title
-            </label>
-            {category !== 'yes_no' && (
-              <button
-                type="button"
-                onClick={() => setIsAutoTitle(true)}
-                className="text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
-              >
-                Generate
-              </button>
-            )}
-          </div>
-          <input
-            type="text"
-            id="title"
-            ref={titleInputRef}
-            value={title}
-            onChange={(e) => {
-              setTitle(e.target.value);
-              setIsAutoTitle(false);
-            }}
-            onBlur={(e) => {
-              const trimmed = e.target.value.trim();
-              if (trimmed !== title) setTitle(trimmed);
-            }}
-            disabled={isLoading}
-            maxLength={100}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-            placeholder="Enter your title..."
-            required
-          />
-        </>
-      )}
+    <div className="flex items-center justify-between gap-3">
+      <label htmlFor="title" className="text-sm font-medium shrink-0">
+        Title
+      </label>
+      <input
+        type="text"
+        id="title"
+        ref={titleInputRef}
+        value={title}
+        onChange={(e) => {
+          setTitle(e.target.value);
+          setIsAutoTitle(false);
+        }}
+        onBlur={(e) => {
+          const trimmed = e.target.value.trim();
+          if (trimmed !== title) setTitle(trimmed);
+        }}
+        disabled={isLoading}
+        maxLength={100}
+        className="flex-1 min-w-0 text-sm bg-transparent text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
+        placeholder={isAutoTitle ? "auto" : "Enter your title..."}
+        required={!isAutoTitle}
+      />
     </div>
   );
 
@@ -1335,56 +1308,54 @@ export function CreateQuestionContent() {
   // poll-level. Mirrors the legacy per-question rendering.
   const suggestionCutoffField = (
     <div>
-      <div className="flex items-center justify-between">
-        <label className="block text-sm font-medium cursor-pointer">
-          <span>Suggestion/Availability Cutoff: </span>
-          <span className="relative inline-flex">
-            <span className="font-normal text-blue-600 dark:text-blue-400">
-              {(() => {
-                if (suggestionCutoff === 'custom') return 'Custom';
-                const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
-                if (frac) {
-                  const votingMin = getVotingDeadlineMinutes();
-                  if (votingMin != null) return formatMinutesLabel(votingMin * frac.fraction);
-                  return `${frac.fraction}x`;
-                }
-                const absOpt = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
-                if (!absOpt) return suggestionCutoff;
-                return formatDeadlineLabel(absOpt.minutes, absOpt.label);
-              })()}
-            </span>
-            <select
-              value={suggestionCutoff}
-              onChange={(e) => setSuggestionCutoff(e.target.value)}
-              disabled={isLoading}
-              className="absolute inset-0 opacity-0 cursor-pointer"
-              aria-label="Prephase cutoff duration"
-            >
-              {getVotingDeadlineMinutes() != null && (
-                <optgroup label="Relative to Voting Cutoff">
-                  {FRACTIONAL_CUTOFF_OPTIONS.map(opt => {
-                    const votingMin = getVotingDeadlineMinutes()!;
-                    const mins = votingMin * opt.fraction;
-                    return (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.fraction}x ({formatMinutesLabel(mins)})
-                      </option>
-                    );
-                  })}
-                </optgroup>
-              )}
-              <optgroup label="Fixed Duration">
-                {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value}>
-                    {formatDeadlineLabel(opt.minutes, opt.label)}
-                  </option>
-                ))}
-              </optgroup>
-              <option value="custom">Custom</option>
-            </select>
+      <label className="flex items-center justify-between gap-3 cursor-pointer">
+        <span className="text-sm font-medium">Suggestion/Availability Cutoff</span>
+        <span className="relative inline-flex">
+          <span className="text-sm font-normal text-blue-600 dark:text-blue-400 text-right">
+            {(() => {
+              if (suggestionCutoff === 'custom') return 'Custom';
+              const frac = FRACTIONAL_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+              if (frac) {
+                const votingMin = getVotingDeadlineMinutes();
+                if (votingMin != null) return formatMinutesLabel(votingMin * frac.fraction);
+                return `${frac.fraction}x`;
+              }
+              const absOpt = ABSOLUTE_CUTOFF_OPTIONS.find(o => o.value === suggestionCutoff);
+              if (!absOpt) return suggestionCutoff;
+              return formatDeadlineLabel(absOpt.minutes, absOpt.label);
+            })()}
           </span>
-        </label>
-      </div>
+          <select
+            value={suggestionCutoff}
+            onChange={(e) => setSuggestionCutoff(e.target.value)}
+            disabled={isLoading}
+            className="absolute inset-0 opacity-0 cursor-pointer"
+            aria-label="Prephase cutoff duration"
+          >
+            {getVotingDeadlineMinutes() != null && (
+              <optgroup label="Relative to Voting Cutoff">
+                {FRACTIONAL_CUTOFF_OPTIONS.map(opt => {
+                  const votingMin = getVotingDeadlineMinutes()!;
+                  const mins = votingMin * opt.fraction;
+                  return (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.fraction}x ({formatMinutesLabel(mins)})
+                    </option>
+                  );
+                })}
+              </optgroup>
+            )}
+            <optgroup label="Fixed Duration">
+              {ABSOLUTE_CUTOFF_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>
+                  {formatDeadlineLabel(opt.minutes, opt.label)}
+                </option>
+              ))}
+            </optgroup>
+            <option value="custom">Custom</option>
+          </select>
+        </span>
+      </label>
       {isClient && (() => {
         const warnings: string[] = [];
         const cutoffMin = getSuggestionCutoffMinutes();
@@ -1475,18 +1446,20 @@ export function CreateQuestionContent() {
             highlightDaysButton={dayTimeWindows.length === 0}
           />
 
-          <div className="text-sm font-medium">
-            Minimum Availability:{' '}
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium shrink-0">
+              Minimum Availability{' '}
+              <span className="font-normal text-xs text-gray-500 dark:text-gray-400">of the top slot</span>
+            </span>
             <button
               type="button"
               onClick={() => setShowMinParticipationModal(true)}
               disabled={isLoading}
-              className="font-normal text-blue-600 dark:text-blue-400 disabled:opacity-50"
+              className="text-sm font-normal text-blue-600 dark:text-blue-400 disabled:opacity-50"
               aria-label="Adjust minimum availability percentage"
             >
               {minimumParticipation}%
-            </button>{' '}
-            of the top slot
+            </button>
           </div>
         </>
       )}
@@ -1619,26 +1592,32 @@ export function CreateQuestionContent() {
                   </span>
                 </div>
 
-                {/* Top card: question form. */}
+                {/* Top card: question form. Simple fields (Category, Context,
+                    Title) sit as inline rows in a divide-y container — labels
+                    left, values right, hairlines between. Complex widgets
+                    (reference location, time fields, options list) render
+                    full-width below the simple-row group. */}
                 <section
                   data-draft-poll-card
-                  className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-4"
+                  className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-2"
                 >
                   {questionType === 'question' && (
-                    <div className="space-y-3 mb-3">
-                      <div>
-                        <label className="block text-sm font-medium mb-1">
+                    <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                      <div className="flex items-center justify-between gap-3 py-3">
+                        <label className="text-sm font-medium shrink-0">
                           Category
                         </label>
-                        <TypeFieldInput
-                          value={category}
-                          onChange={handleCategoryChange}
-                          disabled={isLoading}
-                        />
+                        <div className="flex-1 min-w-0">
+                          <TypeFieldInput
+                            value={category}
+                            onChange={handleCategoryChange}
+                            disabled={isLoading}
+                          />
+                        </div>
                       </div>
                       {category !== 'yes_no' && (
-                        <div>
-                          <label htmlFor="forField" className="block text-sm font-medium mb-1">
+                        <div className="flex items-center justify-between gap-3 py-3">
+                          <label htmlFor="forField" className="text-sm font-medium shrink-0">
                             Context
                           </label>
                           <input
@@ -1653,7 +1632,7 @@ export function CreateQuestionContent() {
                             disabled={isLoading}
                             maxLength={100}
                             placeholder={FOR_FIELD_PLACEHOLDERS[category] || "Context"}
-                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="flex-1 min-w-0 text-sm bg-transparent text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
                           />
                         </div>
                       )}
@@ -1662,57 +1641,65 @@ export function CreateQuestionContent() {
                   {questionFormBody}
                 </section>
 
-                {/* Bottom card: poll-level settings. */}
-                <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-4">
+                {/* Bottom card: poll-level settings. Each setting is a row
+                    with label left, value right; hairlines between rows
+                    (inset to the card's px-4 padding). */}
+                <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-2">
                   <form
                     onSubmit={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                    className="space-y-3"
+                    className="divide-y divide-gray-200 dark:divide-gray-700"
                   >
-                    <VotingCutoffField
-                      deadlineOption={deadlineOption}
-                      setDeadlineOption={setDeadlineOption}
-                      customDate={customDate}
-                      setCustomDate={setCustomDate}
-                      customTime={customTime}
-                      setCustomTime={setCustomTime}
-                      isLoading={isLoading}
-                      isClient={isClient}
-                    />
+                    <div className="py-3">
+                      <VotingCutoffField
+                        deadlineOption={deadlineOption}
+                        setDeadlineOption={setDeadlineOption}
+                        customDate={customDate}
+                        setCustomDate={setCustomDate}
+                        customTime={customTime}
+                        setCustomTime={setCustomTime}
+                        isLoading={isLoading}
+                        isClient={isClient}
+                      />
+                    </div>
 
-                    {pollHasPrephase && suggestionCutoffField}
+                    {pollHasPrephase && (
+                      <div className="py-3">{suggestionCutoffField}</div>
+                    )}
 
                     {pollHasRankedChoice && (
-                      <CompactMinResponsesField
-                        value={minResponses}
-                        setValue={(val) => {
-                          setMinResponses(val);
-                          saveUserMinResponses(val);
-                        }}
-                        showPreliminary={showPreliminaryResults}
-                        setShowPreliminary={setShowPreliminaryResults}
-                        disabled={isLoading}
-                      />
+                      <div className="py-3">
+                        <CompactMinResponsesField
+                          value={minResponses}
+                          setValue={(val) => {
+                            setMinResponses(val);
+                            saveUserMinResponses(val);
+                          }}
+                          showPreliminary={showPreliminaryResults}
+                          setShowPreliminary={setShowPreliminaryResults}
+                          disabled={isLoading}
+                        />
+                      </div>
                     )}
 
                     {pollHasPrephase && (
-                      <label className="flex items-center gap-2 cursor-pointer">
+                      <label className="flex items-center justify-between gap-3 py-3 cursor-pointer">
+                        <span className="text-sm font-medium">
+                          Allow voting before options are finalized
+                        </span>
                         <input
                           type="checkbox"
                           checked={allowPreRanking}
                           onChange={(e) => setAllowPreRanking(e.target.checked)}
                           disabled={isLoading}
-                          className="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                          className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
                         />
-                        <span className="text-sm text-gray-600 dark:text-gray-400">
-                          allow voting before options are finalized
-                        </span>
                       </label>
                     )}
 
-                    <div>
+                    <div className="py-3">
                       {detailsOpen ? (
-                        <>
-                          <label htmlFor="details" className="block text-sm font-medium mb-1">
+                        <div>
+                          <label htmlFor="details" className="block text-sm font-medium mb-2">
                             Notes
                           </label>
                           <textarea
@@ -1741,14 +1728,14 @@ export function CreateQuestionContent() {
                             className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none overflow-hidden"
                             placeholder="Add more context or instructions..."
                           />
-                        </>
+                        </div>
                       ) : (
-                        <div className="text-sm font-medium">
-                          Notes:{' '}
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-sm font-medium">Notes</span>
                           <button
                             type="button"
                             onClick={() => setDetailsOpen(true)}
-                            className="font-normal text-blue-600 dark:text-blue-400"
+                            className="text-sm font-normal text-blue-600 dark:text-blue-400"
                           >
                             Add
                           </button>
@@ -1756,11 +1743,13 @@ export function CreateQuestionContent() {
                       )}
                     </div>
 
-                    <CompactNameField
-                      name={creatorName}
-                      setName={setCreatorName}
-                      disabled={isLoading}
-                    />
+                    <div className="py-3 empty:hidden">
+                      <CompactNameField
+                        name={creatorName}
+                        setName={setCreatorName}
+                        disabled={isLoading}
+                      />
+                    </div>
                   </form>
                 </section>
 

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1653,6 +1653,42 @@ export function CreateQuestionContent() {
                   {questionFormBody}
                 </section>
 
+                {/* Notes card — sits as the second card, between question
+                    fields and poll settings. The label is rendered as an
+                    external left-justified header above the card. The
+                    textarea is always visible (no collapse/expand) and
+                    auto-grows up to ~5 rows. */}
+                <div>
+                  <label
+                    htmlFor="details"
+                    className="block text-sm font-medium mb-1 px-1"
+                  >
+                    Notes
+                  </label>
+                  <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-3">
+                    <textarea
+                      ref={detailsRef}
+                      id="details"
+                      value={details}
+                      onChange={(e) => {
+                        setDetails(e.target.value);
+                        const el = e.target;
+                        el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
+                        const maxH = 5 * 20 + 16;
+                        el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
+                        el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
+                      }}
+                      onBlur={() => {
+                        const trimmed = details.trim();
+                        if (trimmed !== details) setDetails(trimmed);
+                      }}
+                      disabled={isLoading}
+                      rows={3}
+                      className="block w-full bg-transparent text-sm focus:outline-none dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none"
+                    />
+                  </section>
+                </div>
+
                 {/* Bottom card: poll-level settings. Each setting is a row
                     with label left, value right; hairlines between rows
                     (inset to the card's px-4 padding). */}
@@ -1754,42 +1790,6 @@ export function CreateQuestionContent() {
                 </section>
 
                 {optionsCard}
-
-                {/* Notes card — last card with the label as an external
-                    left-justified header (per spec). The textarea is always
-                    visible (no collapse/expand toggle); auto-grows as the
-                    user types. */}
-                <div>
-                  <label
-                    htmlFor="details"
-                    className="block text-sm font-medium mb-1 px-1"
-                  >
-                    Notes
-                  </label>
-                  <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-3">
-                    <textarea
-                      ref={detailsRef}
-                      id="details"
-                      value={details}
-                      onChange={(e) => {
-                        setDetails(e.target.value);
-                        const el = e.target;
-                        el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
-                        const maxH = 5 * 20 + 16;
-                        el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
-                        el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
-                      }}
-                      onBlur={() => {
-                        const trimmed = details.trim();
-                        if (trimmed !== details) setDetails(trimmed);
-                      }}
-                      disabled={isLoading}
-                      rows={3}
-                      className="block w-full bg-transparent text-sm focus:outline-none dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
-                      placeholder="Add more context or instructions..."
-                    />
-                  </section>
-                </div>
 
                 {error && (
                   <div className="p-2 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -9,7 +9,6 @@ import {
   CreateQuestionParams,
 } from "@/lib/api";
 import type { Poll, OptionsMetadata, Question } from "@/lib/types";
-import CompactNameField from "@/components/CompactNameField";
 import TypeFieldInput, { BUILT_IN_TYPES, FOR_FIELD_PLACEHOLDERS, getBuiltInType, isLocationLikeCategory } from "@/components/TypeFieldInput";
 import ModalPortal from "@/components/ModalPortal";
 import ConfirmationModal from "@/components/ConfirmationModal";
@@ -106,6 +105,8 @@ export function CreateQuestionContent() {
   const [shouldFocusNewOption, setShouldFocusNewOption] = useState(false);
   const isSubmittingRef = useRef(false);
   const [creatorName, setCreatorName] = useState<string>("");
+  const [creatorNameEditing, setCreatorNameEditing] = useState(false);
+  const creatorNameInputRef = useRef<HTMLInputElement>(null);
   const [isAutoTitle, setIsAutoTitle] = useState(true);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const loadedTitleRef = useRef<string | null>(null);
@@ -209,6 +210,13 @@ export function CreateQuestionContent() {
       detailsRef.current?.focus();
     }
   }, [detailsOpen]);
+
+  // Focus name input when editing starts
+  useEffect(() => {
+    if (creatorNameEditing) {
+      creatorNameInputRef.current?.focus();
+    }
+  }, [creatorNameEditing]);
 
   // Auto-update title when form fields change (if user hasn't manually edited)
   useEffect(() => {
@@ -1743,12 +1751,47 @@ export function CreateQuestionContent() {
                       )}
                     </div>
 
-                    <div className="py-3 empty:hidden">
-                      <CompactNameField
-                        name={creatorName}
-                        setName={setCreatorName}
-                        disabled={isLoading}
-                      />
+                    {/* Voter name row — inline custom version (instead of
+                        shared CompactNameField) so we can apply the
+                        label-left / value-right layout without affecting
+                        the voting-flow consumers of CompactNameField. */}
+                    <div className="py-3">
+                      {creatorNameEditing || creatorName.trim() ? (
+                        <div className="flex items-center justify-between gap-3">
+                          <label htmlFor="creatorName" className="text-sm font-medium shrink-0">
+                            Your Name <span className="font-normal text-xs text-gray-500 dark:text-gray-400">(optional)</span>
+                          </label>
+                          <input
+                            ref={creatorNameInputRef}
+                            id="creatorName"
+                            type="text"
+                            value={creatorName}
+                            onChange={(e) => setCreatorName(e.target.value)}
+                            onBlur={() => {
+                              setCreatorName(creatorName.trim());
+                              setCreatorNameEditing(false);
+                            }}
+                            disabled={isLoading}
+                            maxLength={50}
+                            placeholder="Enter your name..."
+                            className="flex-1 min-w-0 text-sm bg-transparent text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
+                          />
+                        </div>
+                      ) : (
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-sm font-medium">
+                            Your Name <span className="font-normal text-xs text-gray-500 dark:text-gray-400">(optional)</span>
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => setCreatorNameEditing(true)}
+                            disabled={isLoading}
+                            className="text-sm font-normal text-blue-600 dark:text-blue-400 disabled:opacity-50"
+                          >
+                            Add
+                          </button>
+                        </div>
+                      )}
                     </div>
                   </form>
                 </section>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1477,8 +1477,6 @@ export function CreateQuestionContent() {
           variant="compact"
         />
       )}
-
-      {category === 'yes_no' && titleField}
     </form>
   );
 
@@ -1635,6 +1633,9 @@ export function CreateQuestionContent() {
                             className="flex-1 min-w-0 text-sm bg-transparent text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
                           />
                         </div>
+                      )}
+                      {category === 'yes_no' && (
+                        <div className="py-3">{titleField}</div>
                       )}
                     </div>
                   )}

--- a/components/CompactMinResponsesField.tsx
+++ b/components/CompactMinResponsesField.tsx
@@ -23,51 +23,48 @@ export default function CompactMinResponsesField({ value, setValue, showPrelimin
     }
   }, [isEditing]);
 
-  if (isEditing) {
-    return (
-      <div>
-        <label htmlFor={id} className="block text-sm font-medium mb-1">
-          Min Responses
-        </label>
-        <input
-          ref={inputRef}
-          type="number"
-          id={id}
-          min={1}
-          value={value}
-          onChange={(e) => {
-            const num = parseInt(e.target.value, 10);
-            if (!isNaN(num) && num >= 1) setValue(num);
-          }}
-          onBlur={() => setIsEditing(false)}
-          onKeyDown={(e) => { if (e.key === 'Enter') setIsEditing(false); }}
-          disabled={disabled}
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-        />
-      </div>
-    );
-  }
-
   return (
-    <div className="flex items-center justify-between">
-      <button
-        type="button"
-        onClick={() => setIsEditing(true)}
-        className="text-sm font-medium text-left"
-      >
-        Min Responses: <span className="font-normal text-blue-600 dark:text-blue-400">{value}</span>
-      </button>
-      <label htmlFor={checkboxId} className="flex items-center gap-1.5 cursor-pointer">
-        <span className="text-xs text-gray-500 dark:text-gray-400">then show results</span>
+    <div className="flex items-center justify-between gap-3">
+      <label htmlFor={isEditing ? id : checkboxId} className="text-sm font-medium shrink-0">
+        Min Responses{' '}
+        <span className="font-normal text-xs text-gray-500 dark:text-gray-400">then show results</span>
+      </label>
+      <div className="flex items-center gap-3">
+        {isEditing ? (
+          <input
+            ref={inputRef}
+            type="number"
+            id={id}
+            min={1}
+            value={value}
+            onChange={(e) => {
+              const num = parseInt(e.target.value, 10);
+              if (!isNaN(num) && num >= 1) setValue(num);
+            }}
+            onBlur={() => setIsEditing(false)}
+            onKeyDown={(e) => { if (e.key === 'Enter') setIsEditing(false); }}
+            disabled={disabled}
+            className="w-16 text-sm bg-transparent text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsEditing(true)}
+            disabled={disabled}
+            className="text-sm font-normal text-blue-600 dark:text-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {value}
+          </button>
+        )}
         <input
           type="checkbox"
           id={checkboxId}
           checked={showPreliminary}
           onChange={(e) => setShowPreliminary(e.target.checked)}
           disabled={disabled}
-          className="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
         />
-      </label>
+      </div>
     </div>
   );
 }

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -253,21 +253,24 @@ export default function OptionsInput({
                 />
               )}
               {isLastField ? (
-                // Empty space for alignment on the last field
-                <div className="w-9 h-9"></div>
+                // Empty space for alignment on the last field. Compact
+                // variant uses a 5-unit (20px) placeholder so the row
+                // height (py-3 + 20px = 44px) matches the other settings
+                // rows; default keeps the legacy 9-unit footprint.
+                <div className={variant === 'compact' ? "w-5 h-5 shrink-0" : "w-9 h-9"}></div>
               ) : (
                 <button
                   type="button"
                   onClick={() => canDelete ? removeOption(index) : undefined}
                   disabled={isLoading || !canDelete}
-                  className={`p-2 transition-colors ${
+                  className={`${variant === 'compact' ? 'shrink-0' : 'p-2'} transition-colors ${
                     canDelete
                       ? 'text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300'
                       : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
                   } disabled:opacity-50 disabled:cursor-not-allowed`}
                   aria-label={canDelete ? "Remove option" : "Cannot remove last option"}
                 >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className={variant === 'compact' ? "w-5 h-5" : "w-5 h-5"} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                   </svg>
                 </button>

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -21,6 +21,9 @@ interface OptionsInputProps {
   referenceLongitude?: number;
   searchRadius?: number;
   hideReferenceLocationWarning?: boolean;
+  /** When 'compact', each option input is rendered borderless with right-
+   *  aligned text — for use inside row-style settings lists. */
+  variant?: 'default' | 'compact';
 }
 
 export default function OptionsInput({
@@ -36,6 +39,7 @@ export default function OptionsInput({
   referenceLongitude,
   searchRadius,
   hideReferenceLocationWarning = false,
+  variant = 'default',
 }: OptionsInputProps) {
   const optionRefs = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -165,11 +169,17 @@ export default function OptionsInput({
     isLocationLikeCategory(category) &&
     (referenceLatitude === undefined || referenceLongitude === undefined);
   const inputClassName = (isDuplicate: boolean) =>
-    `flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
-      isDuplicate
-        ? 'bg-red-50 dark:bg-red-900/30 border-red-400 dark:border-red-600 text-red-900 dark:text-red-100'
-        : 'border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-    }`;
+    variant === 'compact'
+      ? `flex-1 min-w-0 bg-transparent text-sm text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic ${
+          isDuplicate
+            ? 'text-red-700 dark:text-red-300'
+            : 'text-blue-600 dark:text-blue-400'
+        }`
+      : `flex-1 px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
+          isDuplicate
+            ? 'bg-red-50 dark:bg-red-900/30 border-red-400 dark:border-red-600 text-red-900 dark:text-red-100'
+            : 'border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+        }`;
 
   return (
     <div>

--- a/components/OptionsInput.tsx
+++ b/components/OptionsInput.tsx
@@ -181,6 +181,13 @@ export default function OptionsInput({
             : 'border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
         }`;
 
+  const rowsClassName = variant === 'compact'
+    ? "divide-y divide-gray-200 dark:divide-gray-700"
+    : "space-y-2";
+  const rowItemClassName = variant === 'compact'
+    ? "flex items-center gap-2 py-3"
+    : "flex items-start gap-2";
+
   return (
     <div>
       {label && (
@@ -193,7 +200,7 @@ export default function OptionsInput({
           Choose a reference location above to enable search.
         </p>
       )}
-      <div className="space-y-2">
+      <div className={rowsClassName}>
         {(() => {
           const filledCount = options.filter(opt => opt.trim() !== '').length;
           const hasDuplicates = options.some((_, idx) => isDuplicateOption(idx));
@@ -205,7 +212,7 @@ export default function OptionsInput({
           const optionMeta = optionsMetadata?.[option];
 
           return (
-            <div key={index} className="flex items-start gap-2">
+            <div key={index} className={rowItemClassName}>
               {useAutocomplete ? (
                 <div className="flex-1">
                   <AutocompleteInput

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -175,6 +175,11 @@ export default function TypeFieldInput({ value, onChange, disabled = false, bord
   // left while the whole pair sits at the right edge of its container.
   if (borderless) {
     const showIcon = builtIn && !isOpen;
+    // Auto-size the input width to its content so the icon + value text
+    // sit as a tight group flush against the row's right edge. Minimum
+    // width keeps the cursor visible when the field is empty.
+    const placeholderText = "Type or pick…";
+    const widthCh = Math.max((inputText || placeholderText).length, 8);
     return (
       <div ref={containerRef} className="relative">
         <div className="flex items-center justify-end gap-1.5">
@@ -190,8 +195,9 @@ export default function TypeFieldInput({ value, onChange, disabled = false, bord
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
             disabled={disabled}
-            placeholder="Type or pick…"
-            className="flex-1 min-w-0 bg-transparent text-sm text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
+            placeholder={placeholderText}
+            style={{ width: `${widthCh}ch` }}
+            className="bg-transparent text-sm text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
           />
           {value !== "custom" && !isOpen && (
             <button

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -174,20 +174,32 @@ export default function TypeFieldInput({ value, onChange, disabled = false, bord
   // input (in the same flex row) so it visually hugs the text from the
   // left while the whole pair sits at the right edge of its container.
   if (borderless) {
-    const showIcon = builtIn && !isOpen;
-    // Auto-size the input width via the native `size` attribute so the icon
-    // and value text stay flush together at the row's right edge. `size`
-    // uses the font's actual average-char width (unlike `ch` which is
-    // computed from the digit-zero glyph and overshoots for proportional
-    // fonts). Min size keeps the cursor visible when the field is empty.
+    // Display mode: when value is a built-in AND not currently typing/
+    // dropdown-open, render `<icon> <label>` as plain inline text inside
+    // a button — keeps the icon and label visually flush together (a
+    // text-right <input> with a proportional font leaves empty space on
+    // the left which detaches the leading icon). Tapping the button
+    // focuses the input, which opens the dropdown. A non-built-in or
+    // empty value falls through to the input directly so the user can
+    // type immediately.
+    const inDisplayMode = !!builtIn && !isOpen && editText === null;
     const placeholderText = "Type or pick…";
     const inputSize = Math.max((inputText || placeholderText).length, 8);
     return (
       <div ref={containerRef} className="relative">
         <div className="flex items-center justify-end gap-1.5">
-          {showIcon && (
-            <span className="text-base leading-none shrink-0" aria-hidden>{builtIn.icon}</span>
-          )}
+          {inDisplayMode ? (
+            <button
+              type="button"
+              onClick={() => inputRef.current?.focus()}
+              disabled={disabled}
+              className="inline-flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Change category"
+            >
+              <span className="text-base leading-none" aria-hidden>{builtIn!.icon}</span>
+              <span>{builtIn!.label}</span>
+            </button>
+          ) : null}
           <input
             ref={inputRef}
             type="text"
@@ -199,7 +211,13 @@ export default function TypeFieldInput({ value, onChange, disabled = false, bord
             disabled={disabled}
             placeholder={placeholderText}
             size={inputSize}
-            className="bg-transparent text-sm text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic w-auto"
+            tabIndex={inDisplayMode ? -1 : 0}
+            aria-hidden={inDisplayMode || undefined}
+            className={
+              inDisplayMode
+                ? "sr-only"
+                : "bg-transparent text-sm text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic w-auto"
+            }
           />
           {value !== "custom" && !isOpen && (
             <button

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -175,11 +175,13 @@ export default function TypeFieldInput({ value, onChange, disabled = false, bord
   // left while the whole pair sits at the right edge of its container.
   if (borderless) {
     const showIcon = builtIn && !isOpen;
-    // Auto-size the input width to its content so the icon + value text
-    // sit as a tight group flush against the row's right edge. Minimum
-    // width keeps the cursor visible when the field is empty.
+    // Auto-size the input width via the native `size` attribute so the icon
+    // and value text stay flush together at the row's right edge. `size`
+    // uses the font's actual average-char width (unlike `ch` which is
+    // computed from the digit-zero glyph and overshoots for proportional
+    // fonts). Min size keeps the cursor visible when the field is empty.
     const placeholderText = "Type or pick…";
-    const widthCh = Math.max((inputText || placeholderText).length, 8);
+    const inputSize = Math.max((inputText || placeholderText).length, 8);
     return (
       <div ref={containerRef} className="relative">
         <div className="flex items-center justify-end gap-1.5">
@@ -196,8 +198,8 @@ export default function TypeFieldInput({ value, onChange, disabled = false, bord
             onKeyDown={handleKeyDown}
             disabled={disabled}
             placeholder={placeholderText}
-            style={{ width: `${widthCh}ch` }}
-            className="bg-transparent text-sm text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
+            size={inputSize}
+            className="bg-transparent text-sm text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic w-auto"
           />
           {value !== "custom" && !isOpen && (
             <button

--- a/components/TypeFieldInput.tsx
+++ b/components/TypeFieldInput.tsx
@@ -43,9 +43,14 @@ interface TypeFieldInputProps {
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
+  /** When true, renders the input borderless with right-aligned text — for
+   *  use inside row-style settings lists where the field is the right column
+   *  of a `<label>     <value>` layout. The icon (if any) sits next to the
+   *  text on the right instead of being absolute-positioned on the left. */
+  borderless?: boolean;
 }
 
-export default function TypeFieldInput({ value, onChange, disabled = false }: TypeFieldInputProps) {
+export default function TypeFieldInput({ value, onChange, disabled = false, borderless = false }: TypeFieldInputProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [editText, setEditText] = useState<string | null>(null);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
@@ -163,6 +168,79 @@ export default function TypeFieldInput({ value, onChange, disabled = false }: Ty
   }
 
   const isCustomValue = value !== "" && value !== "custom" && !builtIn;
+
+  // Borderless variant: input has no border/bg/ring, text right-aligned;
+  // the built-in icon is rendered as an inline span to the left of the
+  // input (in the same flex row) so it visually hugs the text from the
+  // left while the whole pair sits at the right edge of its container.
+  if (borderless) {
+    const showIcon = builtIn && !isOpen;
+    return (
+      <div ref={containerRef} className="relative">
+        <div className="flex items-center justify-end gap-1.5">
+          {showIcon && (
+            <span className="text-base leading-none shrink-0" aria-hidden>{builtIn.icon}</span>
+          )}
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputText}
+            onChange={(e) => handleInputChange(e.target.value)}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            disabled={disabled}
+            placeholder="Type or pick…"
+            className="flex-1 min-w-0 bg-transparent text-sm text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
+          />
+          {value !== "custom" && !isOpen && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange("custom");
+                inputRef.current?.focus();
+              }}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-sm shrink-0"
+              aria-label="Clear category"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+        {isOpen && filteredTypes.length > 0 && (
+          <div
+            ref={listRef}
+            className="absolute z-50 right-0 mt-1 min-w-[14rem] bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-48 overflow-y-auto"
+          >
+            {filteredTypes.map((type, index) => (
+              <button
+                key={type.value}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  selectType(type);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 ${
+                  highlightedIndex === index
+                    ? "bg-blue-50 dark:bg-blue-900/30"
+                    : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                } ${
+                  value === type.value
+                    ? "text-blue-600 dark:text-blue-400 font-medium"
+                    : "text-gray-900 dark:text-white"
+                }`}
+              >
+                <span className="text-base">{type.icon}</span>
+                <span>{type.label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div ref={containerRef} className="relative">

--- a/components/VotingCutoffField.tsx
+++ b/components/VotingCutoffField.tsx
@@ -32,10 +32,10 @@ export default function VotingCutoffField({
 }: VotingCutoffFieldProps) {
   return (
     <div>
-      <label className="block text-sm font-medium cursor-pointer">
-        <span>Voting Cutoff: </span>
+      <label className="flex items-center justify-between gap-3 cursor-pointer">
+        <span className="text-sm font-medium">Voting Cutoff</span>
         <span className="relative inline-flex">
-          <span className="font-normal text-blue-600 dark:text-blue-400">
+          <span className="text-sm font-normal text-blue-600 dark:text-blue-400 text-right">
             {(() => {
               if (deadlineOption === 'none') return 'None';
               if (deadlineOption === 'custom') {


### PR DESCRIPTION
## Summary

Reshapes every simple field in the create-poll sheet into iOS-settings-style single-line rows (`<label>     <value>`) separated by inset hairlines, replacing the previous label-above-control stacked layout.

Final card order in the sheet:

1. **Top card — question fields.** `Category` (borderless TypeFieldInput showing `<icon> <label>` flush together on the right), `Context` (right-justified borderless text input with italic placeholder), and `Title` (only for yes_no). Reference Location and Time question fields still render full-width below the simple rows.
2. **Notes card.** External left-justified `Notes` header above its own card. Always-visible multiline textarea (3 rows, auto-grows to ~5); no placeholder text.
3. **Bottom card — poll settings.** `Voting Cutoff`, `Suggestion/Availability Cutoff`, `Min Responses` (with the inline `then show results` toggle), `Allow voting before options are finalized`, `Your Name`.
4. **Options card** (only for ranked-choice questions). External left-justified `Options (leave blank to ask for suggestions)` header above its own card; each option row is a hairline-separated inline row matching the height of bottom-card rows.

Component changes:

- `VotingCutoffField` and `CompactMinResponsesField` (create-poll-only) restructured to `flex justify-between`.
- `TypeFieldInput` gains a `borderless` prop. In that mode, when the value is a built-in category, the row renders `<icon> <label>` as a tight inline button (clicking focuses a hidden input that opens the dropdown). The previous text-right `<input size=N>` approach left empty space inside the input that detached the leading icon from the label.
- `OptionsInput` gains a `variant: 'default' | 'compact'` prop. The compact variant uses transparent right-aligned inputs, swaps the `space-y-2` between-rows gap for `divide-y` hairlines, and shrinks the delete button hitbox from 36px → 20px so each row totals 44px (matching `py-3 + text-sm` rows elsewhere).
- `CompactNameField` left untouched (it's shared with voting flows). The create-poll sheet inlines its own version of the voter-name row so the new label-left/value-right layout doesn't leak into vote flows.

## Test plan
- [ ] Open `/g/` on a dev server; tap each bubble bar entry (Yes/No, Time, Restaurant, Place, Movie, Video Game, Other) and verify the modal renders the new row layout cleanly across all categories.
- [ ] Verify hairlines appear between every consecutive row inside each card and that hairlines do not bleed past the card's `px-4` content padding.
- [ ] Type a Custom category value and confirm the input switches from the inline button display to the editable text input.
- [ ] Fill multiple options on a ranked-choice (e.g. Movie) and verify option rows + delete buttons stay vertically aligned with the bottom-card rows.
- [ ] Submit a poll and confirm: voter name persists, Notes save correctly, all cutoffs still pass server validation.
- [ ] Verify `CompactNameField` in the vote flows (QuestionBallot, TimeBallotSection, RankingSection, SuggestionVotingInterface) is visually unchanged — that component was deliberately not modified.

https://claude.ai/code/session_01SWbfoMhPgFpyC8YTUvduCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWbfoMhPgFpyC8YTUvduCk)_