### PR TITLE
Polish new-poll bottom sheet: scroll, layout, header buttons

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1409,8 +1409,15 @@ export function CreateQuestionContent() {
 
   // Question-specific JSX rendered inline at the top of the draft poll card,
   // right above the staged-questions list and the "+ Question" button.
+  // The form gets a top hairline (matching the divide-y above it) whenever
+  // it has content, so Context → Near / Context → Time fields keep the same
+  // visual rhythm as the rows in the Category/Context block.
+  const formHasContent =
+    isLocationLikeCategory(category) ||
+    questionType === 'time' ||
+    (questionType === 'question' && category === 'time');
   const questionFormBody = (
-    <form onSubmit={(e) => { e.preventDefault(); e.stopPropagation(); }} className="space-y-4">
+    <form onSubmit={(e) => { e.preventDefault(); e.stopPropagation(); }} className={`space-y-4${formHasContent ? ' border-t border-gray-200 dark:border-gray-700 pt-3' : ''}`}>
       {isLocationLikeCategory(category) && (
         <ReferenceLocationInput
           latitude={refLatitude}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1590,7 +1590,7 @@ export function CreateQuestionContent() {
                   `paddingBottom: '4.5rem'` so elements have the same
                   breathing room above the sheet edge that the bubbles
                   have above the screen edge. */}
-              <div className="flex-1 overflow-y-auto px-3 pb-[4.5rem] space-y-3">
+              <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 pb-[4.5rem] space-y-3">
                 <div className="text-center px-2 pt-1 break-words">
                   <span
                     className="text-xl font-bold text-blue-600 dark:text-blue-400"

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1409,13 +1409,12 @@ export function CreateQuestionContent() {
 
   // Question-specific JSX rendered inline at the top of the draft poll card,
   // right above the staged-questions list and the "+ Question" button.
-  // The form gets a top hairline (matching the divide-y above it) whenever
-  // it has content, so Context → Near / Context → Time fields keep the same
-  // visual rhythm as the rows in the Category/Context block.
-  const formHasContent =
-    isLocationLikeCategory(category) ||
-    questionType === 'time' ||
-    (questionType === 'question' && category === 'time');
+  // The form gets a top hairline + matching py-3 when it has content, so
+  // Context → first form field keeps the same vertical rhythm as the
+  // divide-y rows above it.
+  const showTimeFields =
+    questionType === 'time' || (questionType === 'question' && category === 'time');
+  const formHasContent = isLocationLikeCategory(category) || showTimeFields;
   const questionFormBody = (
     <form onSubmit={(e) => { e.preventDefault(); e.stopPropagation(); }} className={`space-y-4${formHasContent ? ' border-t border-gray-200 dark:border-gray-700 py-3' : ''}`}>
       {isLocationLikeCategory(category) && (
@@ -1434,7 +1433,7 @@ export function CreateQuestionContent() {
         />
       )}
 
-      {(questionType === 'time' || (questionType === 'question' && category === 'time')) && (
+      {showTimeFields && (
         <>
           <TimeQuestionFields
             disabled={isLoading}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1681,18 +1681,16 @@ export function CreateQuestionContent() {
                     )}
 
                     {pollHasRankedChoice && (
-                      <div className="py-3">
-                        <CompactMinResponsesField
-                          value={minResponses}
-                          setValue={(val) => {
-                            setMinResponses(val);
-                            saveUserMinResponses(val);
-                          }}
-                          showPreliminary={showPreliminaryResults}
-                          setShowPreliminary={setShowPreliminaryResults}
-                          disabled={isLoading}
-                        />
-                      </div>
+                      <CompactMinResponsesField
+                        value={minResponses}
+                        setValue={(val) => {
+                          setMinResponses(val);
+                          saveUserMinResponses(val);
+                        }}
+                        showPreliminary={showPreliminaryResults}
+                        setShowPreliminary={setShowPreliminaryResults}
+                        disabled={isLoading}
+                      />
                     )}
 
                     {pollHasPrephase && (

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1556,15 +1556,15 @@ export function CreateQuestionContent() {
               aria-modal="true"
               aria-label="New poll"
             >
-              <div className="relative flex items-center justify-center px-4 py-2 min-h-[3.25rem]">
+              <div className="relative flex items-center justify-center px-4 py-2 min-h-[3.75rem]">
                 <button
                   type="button"
                   onClick={handleCloseClick}
                   disabled={isLoading}
                   aria-label="Close poll form"
-                  className="absolute left-2 top-2 w-9 h-9 flex items-center justify-center rounded-full text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="absolute left-2 top-2 w-11 h-11 flex items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>
@@ -1576,15 +1576,15 @@ export function CreateQuestionContent() {
                   onClick={handleSubmitClick}
                   disabled={isLoading || isSubmitted || !inlineFormHasDraftableContent}
                   aria-label="Submit poll"
-                  className="absolute right-2 top-2 w-9 h-9 flex items-center justify-center rounded-full bg-blue-500 text-white cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="absolute right-2 top-2 w-11 h-11 flex items-center justify-center rounded-full bg-blue-500 text-white cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   {isSubmitted || isLoading ? (
-                    <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <svg className="animate-spin h-6 w-6 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                       <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
                   ) : (
-                    <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
+                    <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                     </svg>
                   )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1653,41 +1653,7 @@ export function CreateQuestionContent() {
                   {questionFormBody}
                 </section>
 
-                {/* Notes card — sits as the second card, between question
-                    fields and poll settings. The label is rendered as an
-                    external left-justified header above the card. The
-                    textarea is always visible (no collapse/expand) and
-                    auto-grows up to ~5 rows. */}
-                <div>
-                  <label
-                    htmlFor="details"
-                    className="block text-sm font-medium mb-1 px-1"
-                  >
-                    Notes
-                  </label>
-                  <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-3">
-                    <textarea
-                      ref={detailsRef}
-                      id="details"
-                      value={details}
-                      onChange={(e) => {
-                        setDetails(e.target.value);
-                        const el = e.target;
-                        el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
-                        const maxH = 5 * 20 + 16;
-                        el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
-                        el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
-                      }}
-                      onBlur={() => {
-                        const trimmed = details.trim();
-                        if (trimmed !== details) setDetails(trimmed);
-                      }}
-                      disabled={isLoading}
-                      rows={3}
-                      className="block w-full bg-transparent text-sm focus:outline-none dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none"
-                    />
-                  </section>
-                </div>
+                {optionsCard}
 
                 {/* Bottom card: poll-level settings. Each setting is a row
                     with label left, value right; hairlines between rows
@@ -1789,7 +1755,40 @@ export function CreateQuestionContent() {
                   </form>
                 </section>
 
-                {optionsCard}
+                {/* Notes card — sits at the bottom, after poll settings.
+                    The label is rendered as an external left-justified
+                    header above the card. The textarea is always visible
+                    (no collapse/expand) and auto-grows up to ~5 rows. */}
+                <div>
+                  <label
+                    htmlFor="details"
+                    className="block text-sm font-medium mb-1 px-1"
+                  >
+                    Notes
+                  </label>
+                  <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-3">
+                    <textarea
+                      ref={detailsRef}
+                      id="details"
+                      value={details}
+                      onChange={(e) => {
+                        setDetails(e.target.value);
+                        const el = e.target;
+                        el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
+                        const maxH = 5 * 20 + 16;
+                        el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
+                        el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
+                      }}
+                      onBlur={() => {
+                        const trimmed = details.trim();
+                        if (trimmed !== details) setDetails(trimmed);
+                      }}
+                      disabled={isLoading}
+                      rows={3}
+                      className="block w-full bg-transparent text-sm focus:outline-none dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none"
+                    />
+                  </section>
+                </div>
 
                 {error && (
                   <div className="p-2 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1417,7 +1417,7 @@ export function CreateQuestionContent() {
     questionType === 'time' ||
     (questionType === 'question' && category === 'time');
   const questionFormBody = (
-    <form onSubmit={(e) => { e.preventDefault(); e.stopPropagation(); }} className={`space-y-4${formHasContent ? ' border-t border-gray-200 dark:border-gray-700 pt-3' : ''}`}>
+    <form onSubmit={(e) => { e.preventDefault(); e.stopPropagation(); }} className={`space-y-4${formHasContent ? ' border-t border-gray-200 dark:border-gray-700 py-3' : ''}`}>
       {isLocationLikeCategory(category) && (
         <ReferenceLocationInput
           latitude={refLatitude}

--- a/components/CompactMinResponsesField.tsx
+++ b/components/CompactMinResponsesField.tsx
@@ -24,12 +24,11 @@ export default function CompactMinResponsesField({ value, setValue, showPrelimin
   }, [isEditing]);
 
   return (
-    <div className="flex items-center justify-between gap-3">
-      <label htmlFor={isEditing ? id : checkboxId} className="text-sm font-medium shrink-0">
-        Min Responses{' '}
-        <span className="font-normal text-xs text-gray-500 dark:text-gray-400">then show results</span>
-      </label>
-      <div className="flex items-center gap-3">
+    <>
+      <div className="flex items-center justify-between gap-3 py-3">
+        <label htmlFor={id} className="text-sm font-medium shrink-0">
+          Min Responses
+        </label>
         {isEditing ? (
           <input
             ref={inputRef}
@@ -56,6 +55,11 @@ export default function CompactMinResponsesField({ value, setValue, showPrelimin
             {value}
           </button>
         )}
+      </div>
+      <label htmlFor={checkboxId} className="flex items-center justify-between gap-3 py-3 cursor-pointer">
+        <span className="text-sm font-medium">
+          Share Results
+        </span>
         <input
           type="checkbox"
           id={checkboxId}
@@ -64,7 +68,7 @@ export default function CompactMinResponsesField({ value, setValue, showPrelimin
           disabled={disabled}
           className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
         />
-      </div>
-    </div>
+      </label>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

A handful of small visual / layout fixes to the new-poll bottom sheet (`app/create-poll/page.tsx` + `components/CompactMinResponsesField.tsx`):

- **Lock the form to vertical scroll only.** Added `overflow-x-hidden` to the modal's scroll body so sub-pixel horizontal overflow no longer makes the form feel side-swipeable.
- **Reorder cards.** Options card moves up to sit right under the Category/Context block (where users expect to extend the question they're defining); Notes card moves to the bottom after poll settings.
- **Split Min Responses and Share Results into separate rows.** `CompactMinResponsesField` now renders two label/value rows inside a fragment so the parent's `divide-y` form gives each its own hairline. Drops the inline "then show results" hint — the "Share Results" label carries the meaning.
- **Add a hairline above the Near / time-fields block** so the rhythm of the divide-y Category/Context rows continues into the first form field.
- **Match Near-field padding to Category/Context rows.** Promoted the form's `pt-3` to `py-3` so its content has the same 12px breathing room above and below — Near no longer reads as a shorter row.
- **Enlarge header buttons and round-fill the close.** Both modal-header buttons grow 36→44px (≈20%) with proportional SVGs, and the X picks up a gray fill so it reads as a sibling circle to the blue check.
- **Simplify**: hoisted the duplicated `(questionType === 'time' || (questionType === 'question' && category === 'time'))` expression into a shared `showTimeFields` variable so the form-gate and the time-render block can't drift.

## Test plan

- [ ] Open the new-poll form on a group page (any bubble) — confirm the modal can't scroll side-to-side.
- [ ] Confirm the card order top→bottom: title preview, Category/Context/Title card, Options card, Poll Settings card, Notes card.
- [ ] For a ranked-choice draft (Options card showing), confirm Min Responses and Share Results render as two separate hairline-divided rows in the settings card.
- [ ] For Location/Restaurant categories, confirm there's a hairline between Context and Near, and that Near's row height matches Category/Context.
- [ ] For Time category, confirm the same hairline between Context and the time-window block.
- [ ] Confirm both header buttons (X left, check right) are visibly the same size, both filled circles (gray X, blue check).

https://claude.ai/code/session_01FDjHdAPUWRLeZgUuofe6ti

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDjHdAPUWRLeZgUuofe6ti)_