### PR TITLE
Show "+ Group" label on home page FAB

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -270,15 +270,15 @@ function TemplateInner({ children }: AppTemplateProps) {
       {isMounted && pathname === '/' && createPortal(
         <button
           onClick={() => navigateWithTransition(router, '/g', 'forward')}
-          className="fixed z-50 h-12 px-3 rounded-full flex items-center justify-center gap-1 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-semibold"
+          className="fixed z-50 h-12 px-3 rounded-full flex items-center justify-center gap-1 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-normal"
           style={{
             right: 'max(1.5rem, env(safe-area-inset-right, 0px))',
             bottom: '1rem',
           }}
           aria-label="Create new group"
         >
-          <span aria-hidden="true" className="text-3xl leading-none">+</span>
-          <span className="text-xl leading-none">Group</span>
+          <span aria-hidden="true" className="text-4xl leading-none">+</span>
+          <span className="text-lg leading-none">Group</span>
         </button>,
         document.getElementById('floating-fab-portal')!
       )}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -270,16 +270,15 @@ function TemplateInner({ children }: AppTemplateProps) {
       {isMounted && pathname === '/' && createPortal(
         <button
           onClick={() => navigateWithTransition(router, '/g', 'forward')}
-          className="fixed z-50 w-12 h-12 rounded-full flex items-center justify-center bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer"
+          className="fixed z-50 h-12 px-5 rounded-full flex items-center justify-center gap-1 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-semibold"
           style={{
             right: 'max(1.5rem, env(safe-area-inset-right, 0px))',
             bottom: '1rem',
           }}
-          aria-label="Create new question"
+          aria-label="Create new group"
         >
-          <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
+          <span aria-hidden="true">+</span>
+          <span>Group</span>
         </button>,
         document.getElementById('floating-fab-portal')!
       )}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -270,15 +270,15 @@ function TemplateInner({ children }: AppTemplateProps) {
       {isMounted && pathname === '/' && createPortal(
         <button
           onClick={() => navigateWithTransition(router, '/g', 'forward')}
-          className="fixed z-50 h-12 px-5 rounded-full flex items-center justify-center gap-1 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-semibold"
+          className="fixed z-50 h-12 px-3 rounded-full flex items-center justify-center gap-1 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-semibold"
           style={{
             right: 'max(1.5rem, env(safe-area-inset-right, 0px))',
             bottom: '1rem',
           }}
           aria-label="Create new group"
         >
-          <span aria-hidden="true">+</span>
-          <span>Group</span>
+          <span aria-hidden="true" className="text-3xl leading-none">+</span>
+          <span className="text-xl leading-none">Group</span>
         </button>,
         document.getElementById('floating-fab-portal')!
       )}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -270,7 +270,7 @@ function TemplateInner({ children }: AppTemplateProps) {
       {isMounted && pathname === '/' && createPortal(
         <button
           onClick={() => navigateWithTransition(router, '/g', 'forward')}
-          className="fixed z-50 h-12 px-3 rounded-full flex items-center justify-center gap-1 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-normal"
+          className="fixed z-50 h-12 px-3 rounded-full flex items-center justify-center gap-1.5 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-normal"
           style={{
             right: 'max(1.5rem, env(safe-area-inset-right, 0px))',
             bottom: '1rem',


### PR DESCRIPTION
## Summary
- Replaces the home page's icon-only "+" FAB with a pill-shaped button reading `+ Group`, making the destination (the empty-group placeholder) obvious before tapping.
- Tunes the typography: "+" at `text-4xl`, "Group" at `text-lg`, `gap-1.5` between them, weight pinned to `font-normal` so neither span renders bold.
- Tightens horizontal padding from `px-5` → `px-3` so the pill hugs its contents.

## Test plan
- [ ] On the home page (`/`), confirm the FAB reads `+ Group` with the plus visibly larger than the text and no bold weight on either glyph.
- [ ] Confirm tapping it still navigates to `/g/` (the empty group placeholder with the bubble bar).
- [ ] Confirm the FAB does not appear on group pages, settings, or other routes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7JXBbwjJncMkggb1XYxve)_