### PR TITLE
Mac mini dev box: infrastructure foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,34 @@ This installs Docker, Caddy, the command execution API, clones the repo, starts 
 - The remote execution API has a configurable timeout (default 120s, max via 3rd arg)
 - The API returns stdout, stderr, and exit code for every command
 
+## Mac Mini Dev Box (Migration In Progress)
+
+The dev-server side of the system is migrating from the droplet to a Mac mini at home (`samcarey@mini4`, public IP `65.28.10.210`, Apple M4, 32 GB RAM, macOS 26). Production API stays on the droplet — only per-author dev servers are moving.
+
+**Status: foundation complete, dev-server-manager port pending.** What's running:
+- Colima VM (Apple Virtualization Framework, 6 CPU / 12 GB / 80 GB) as Claude's sandbox
+- Per-hostname HTTPS at `*.dev.whoeverwants.com` via home-router port forwarding (80/443) → Caddy on Mac → containers in VM
+- DDNS (launchd → AWS Route 53) keeping the home IP record self-healing
+- `cmd-api.dev.whoeverwants.com` — Claude→VM control endpoint, same model as droplet's cmd-api
+- `webhook.dev.whoeverwants.com` — GitHub push receiver, HMAC-verified (no-op until dev-server-manager lands)
+- `mac-test.dev.whoeverwants.com` — placeholder serving nginx
+- Postgres 16 in VM (persistent volume, network-only)
+
+**Where to look:**
+- `docs/mac-mini-setup.md` — full reproduction guide (modeled after droplet-setup.md)
+- `docs/mac-mini-next-steps.md` — remaining work + open architectural decisions (`dev-server-manager` port, wildcard cert via DNS-01, GitHub webhook URL change, droplet decommission)
+- `scripts/mac-mini/` — production source files (cmd-api.py, webhook.py, Dockerfiles, ddns, Caddyfile, compose, LaunchAgent plist)
+
+**Calling cmd-api on the Mac mini** (analogous to `bash scripts/remote.sh "command"` for the droplet) — set in your shell:
+```
+export MAC_API_URL=https://cmd-api.dev.whoeverwants.com
+export MAC_API_TOKEN=<from ~/devbox/.env on the Mac>
+curl -s -X POST -H "Authorization: Bearer $MAC_API_TOKEN" -H "Content-Type: application/json" \
+  -d '{"cmd":"hostname; docker ps"}' "$MAC_API_URL/"
+```
+
+The cmd-api lives in the VM, not on the Mac host. It can spawn/manage VM containers (Docker socket mounted) but cannot touch the Mac filesystem — that boundary is deliberate. To edit infrastructure config (Caddyfile, docker-compose.yml, .env), edits happen on the Mac side at `~/devbox/`.
+
 ## Tech Stack
 
 | Layer | Technology |

--- a/docs/mac-mini-next-steps.md
+++ b/docs/mac-mini-next-steps.md
@@ -1,0 +1,158 @@
+# Mac Mini Migration — Remaining Work
+
+The infrastructure foundation in `docs/mac-mini-setup.md` is complete. The remaining work is to actually use it for per-author dev servers (replacing the droplet's dev side) and decommission the droplet's dev pieces.
+
+## 1. Port `dev-server-manager.sh`
+
+The droplet's `scripts/dev-server-manager.sh` is 854 lines designed for a **process-based model**:
+- Each author's dev server runs as TWO processes on the droplet: `next dev` + `uv run uvicorn`
+- Ports 3001-3005 (frontend) + 8001-8005 (API) allocated dynamically
+- Per-author Caddy config snippet generated and `import`-ed by main Caddy
+- Per-author Postgres database in the shared instance
+- Process lifecycle tracked via PID files at `/root/dev-servers/<slug>/.api.pid`
+
+For the Mac VM, we need to decide how to host these dev servers. **This decision was deferred.** Three live options:
+
+### Option A — Per-author container with both processes inside (recommended baseline)
+One Docker container per author. Image has Node + uv + git + bash. Container starts: clone repo, checkout branch, `npm ci`, `uv sync`, run `next dev` + `uv run uvicorn` as background processes.
+
+**Pros**: closest mental model to the droplet's process orchestration; single container per author is easy to reason about.
+**Cons**: container is a "fat" container (~1 GB image); restarting the API process means restarting both processes.
+
+### Option B — Two containers per author (frontend + API split)
+Each author = a `docker-compose-per-author` project with two services. Frontend image is `node:20-alpine` + bind-mount of repo; API image is `python:3.12` + uv. Compose project name = author slug.
+
+**Pros**: clean separation; can rebuild frontend without touching API; easier debugging.
+**Cons**: significant rewrite of dev-server-manager; bookkeeping for two containers per author.
+
+### Option C — Process-based directly inside the Colima VM (closest to droplet)
+Don't containerize per-author dev servers at all. Install Node + uv inside the Colima VM root filesystem, run dev servers as processes there. Manage with `dev-server-manager.sh` ported with minimal changes — most of the original script still applies.
+
+**Pros**: lowest-friction port (smallest diff from existing script).
+**Cons**: compromises the "VM = container host only" cleanliness; one rogue dev server can affect the others (no per-process resource isolation).
+
+### Routing strategy (independent of A/B/C)
+
+In all three options, Caddy needs to reach each per-author dev server by hostname. Two paths:
+
+#### Routing 1 — Per-author Caddyfile snippet (closest to droplet)
+`dev-server-manager` writes `/opt/homebrew/etc/Caddyfile.d/<slug>.caddy` and signals Caddy reload. Caddyfile imports the directory.
+
+**Friction**: dev-server-manager runs in the VM, but the Caddyfile lives on the Mac. Either (a) cmd-api proxies the file write to the Mac (requires a "write file on Mac" hatch we deliberately don't have), (b) move Caddy into the VM (rewires port forwarding), or (c) Colima-mount `~/devbox/caddy.d/` from Mac into the VM as RW.
+
+#### Routing 2 — Wildcard + sub-proxy (recommended for cleanliness)
+Mac Caddy has one `*.dev.whoeverwants.com` site block reverse-proxying to a single VM-side proxy (Traefik). Traefik watches Docker for containers labeled `traefik.http.routers.<slug>.rule=Host(\`<slug>.dev.whoeverwants.com\`)` and routes accordingly. dev-server-manager just spawns containers with the right labels — no Caddyfile editing needed.
+
+**Pros**: zero Caddyfile churn; dev-server-manager stays VM-side; dynamic discovery.
+**Cons**: one more container (Traefik); needs wildcard cert (HTTP-01 won't work for unknown hostnames; need DNS-01 below).
+
+### TLS strategy
+
+#### Per-host HTTP-01 (current approach)
+Caddy auto-acquires a per-hostname Let's Encrypt cert on first request. Works for known hostnames in Caddyfile.
+
+**Constraint**: Let's Encrypt rate limit is 50 certs per registered domain per week. With ~5 active dev servers churning across feature branches, this is comfortable. For 50+ hostnames or rapid churn, would hit the limit.
+
+#### Wildcard cert via DNS-01 (needed for Routing 2)
+Single cert for `*.dev.whoeverwants.com`. Caddy needs the `caddy-dns/route53` plugin which isn't in the default brew distribution.
+
+```bash
+brew install xcaddy
+xcaddy build --with github.com/caddy-dns/route53
+sudo mv caddy /opt/homebrew/opt/caddy/bin/caddy
+sudo brew services restart caddy
+```
+
+Then in Caddyfile:
+```
+*.dev.whoeverwants.com {
+    tls {
+        dns route53 {
+            access_key_id {env.AWS_ACCESS_KEY_ID}
+            secret_access_key {env.AWS_SECRET_ACCESS_KEY}
+        }
+    }
+    reverse_proxy localhost:9092  # Traefik
+}
+```
+
+Caddy uses Route 53 API for DNS-01 challenge; the existing `mac-devbox-ddns` IAM user already has the needed permissions.
+
+### Suggested first step
+
+Build the simplest thing that works end-to-end for a single author, then iterate. Suggest:
+
+1. **Option A** (single container per author) + **Routing 1** with a one-shot manual Caddyfile entry per author for the FIRST dev server. Just to prove the container model works.
+2. Once one author's dev server provisions and serves correctly, add automation (signal-based reload via Caddy admin API, OR move to Routing 2 + Traefik + wildcard cert).
+
+## 2. Wildcard A record cutover
+
+Currently:
+- `*.dev.whoeverwants.com` → `142.93.60.29` (droplet)
+- `mac-test.dev.whoeverwants.com` → `65.28.10.210` (Mac, via DDNS)
+- `cmd-api.dev.whoeverwants.com` CNAME → mac-test
+- `webhook.dev.whoeverwants.com` CNAME → mac-test
+
+Cutover plan (after dev-server-manager is working and end-to-end-tested with a single author):
+1. Pre-create per-author CNAMEs in Route 53 for any active dev users (CNAME `<slug>.dev.whoeverwants.com` → mac-test). Avoids relying on the wildcard during transition.
+2. Update DDNS script (`scripts/mac-mini/ddns.sh`) to update the wildcard `*.dev.whoeverwants.com` A record alongside `mac-test.dev.whoeverwants.com`. Two `aws route53 change-resource-record-sets` calls.
+3. **OR** retire the droplet wildcard A record and have everything CNAME to mac-test.
+
+Recommended: keep `*.dev.whoeverwants.com` as a wildcard A record managed by DDNS (so any new ad-hoc dev server URL works without manual DNS edits).
+
+## 3. GitHub webhook URL change
+
+Currently the GitHub repo webhook points at `hooks.api.whoeverwants.com` (droplet). Once the Mac webhook receiver is end-to-end with a working dev-server-manager:
+
+1. In GitHub: `samcarey/whoeverwants` → Settings → Webhooks → edit existing webhook
+2. Change Payload URL from `https://hooks.api.whoeverwants.com/github` to `https://webhook.dev.whoeverwants.com/github`
+3. Update the secret to match `~/devbox/.env`'s `GITHUB_WEBHOOK_SECRET` on the Mac
+4. Click "Redeliver" on a recent push to test, verify Mac webhook logs receive it
+
+## 4. Droplet decommission
+
+After 2+ weeks of stable Mac dev server operation:
+
+1. On droplet: `systemctl disable --now dev-webhook` and `rm /etc/systemd/system/dev-webhook.service`
+2. On droplet: `dev-server-manager.sh destroy-all`, then disable the service
+3. Drop the wildcard A record at Route 53 (or leave it pointing at Mac via DDNS — covered in §2)
+4. Production API stays on droplet — leave that infrastructure alone
+
+The droplet's `cmd-api`, `caddy`, and prod API should remain running indefinitely. The Mac is replacing only the dev-server side.
+
+## 5. Optional — Move Caddy into the VM
+
+**Why consider this**: simplifies dev-server-manager (Caddyfile edits stay VM-side). Eliminates the cross-boundary friction in Routing 1.
+
+**Why we kept Caddy on Mac initially**: less rewiring. Mac firewall is the only thing that needs to know about ports 80/443; moving Caddy into VM means the Mac forwards 80/443 to the VM (via Colima), the VM Caddy listens on those, and the firewall fix transfers to whichever process now binds them on Mac (probably the colima/qemu/vz process).
+
+If/when this is done:
+1. Stop Caddy on Mac: `sudo brew services stop caddy`
+2. Remove Caddy from Application Firewall allowlist (`socketfilterfw --remove`)
+3. Add a `caddy` service to `~/devbox/docker-compose.yml` with `ports: ["0.0.0.0:80:80", "0.0.0.0:443:443"]`
+4. Ensure Colima publishes those ports to all Mac interfaces (default for non-127.0.0.1-prefixed publishes — verify with `lsof -i :80`)
+5. Move `/opt/homebrew/etc/Caddyfile` into a Caddy compose volume
+
+## 6. Optional — Tighten DDNS IAM scope
+
+The `mac-devbox-ddns` user currently has `AmazonRoute53FullAccess`. Tighter scope:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["route53:ListHostedZonesByName", "route53:GetChange"],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["route53:ListResourceRecordSets", "route53:ChangeResourceRecordSets"],
+      "Resource": "arn:aws:route53:::hostedzone/Z000095423MM09UF7IBWG"
+    }
+  ]
+}
+```
+
+Worth doing once the migration is stable; not blocking.

--- a/docs/mac-mini-setup.md
+++ b/docs/mac-mini-setup.md
@@ -1,0 +1,295 @@
+# Mac Mini Dev Server Setup
+
+## Status
+
+**Foundation infrastructure complete; dev-server-manager port is the remaining work.**
+
+This document captures the architecture and reproduction steps for migrating the dev-server side of WhoeverWants from the DigitalOcean droplet to a Mac mini at home. The Mac is the new control plane for per-author dev servers; the droplet keeps the production API.
+
+What's working today:
+- Colima VM as Claude's sandbox
+- Per-hostname HTTPS via home-router port forwarding + Caddy + Let's Encrypt
+- Self-healing public IP via DDNS into Route 53
+- `cmd-api` container — Claude can drive the Mac via HTTPS, same model as the droplet
+- `webhook` container — receives GitHub push events, HMAC-verifies, routes to dev-server-manager
+- Postgres 16 container with persistent volume
+
+What's NOT yet ported (see `docs/mac-mini-next-steps.md`):
+- `dev-server-manager.sh` — the script that actually provisions per-author dev servers
+- Wildcard `*.dev.whoeverwants.com` cutover from droplet IP to home IP
+- GitHub webhook URL change
+
+## Architecture
+
+```
+Internet
+  │
+  ▼  DNS (Route 53 — DDNS-managed home IP record + per-service CNAMEs)
+Home router (port-forwards 80 + 443 → Mac LAN IP)
+  │
+  ▼
+Mac mini host
+  ├─ macOS Application Firewall (Caddy in allowlist)
+  ├─ Caddy (Homebrew, system LaunchDaemon)
+  │     • Listens on 0.0.0.0:80 + 0.0.0.0:443
+  │     • Per-hostname Let's Encrypt certs (HTTP-01)
+  │     • Reverse-proxies to Mac localhost ports (where Colima publishes container ports)
+  ├─ Colima daemon (Apple Virtualization Framework)
+  │   └─ Linux ARM64 VM ── Claude's sandbox ── isolated from Mac filesystem
+  │       ├─ docker-compose stack at /Users/<you>/devbox/docker-compose.yml
+  │       │   ├─ cmd-api      — published 127.0.0.1:9090 — bearer-token auth
+  │       │   ├─ webhook      — published 127.0.0.1:9091 — HMAC-verified
+  │       │   ├─ postgres     — internal only (no published port)
+  │       │   └─ nginx-test   — published 127.0.0.1:8080 — placeholder
+  │       └─ Docker socket mounted into cmd-api & webhook (so they can spawn dev-server containers)
+  ├─ DDNS launchd job (5-min interval, AWS Route 53 UPSERT)
+  └─ Other LaunchAgents (iOS GH runner, Ollama, etc.) — independent
+```
+
+**Key isolation boundary**: cmd-api lives in the VM. It can spawn/manage VM containers (via Docker socket) but cannot touch the Mac filesystem. The Mac host runs only Colima + Caddy + DDNS + the user's pre-existing services. To update infrastructure config (Caddyfile, docker-compose.yml, .env), edits happen on the Mac filesystem at `~/devbox/`.
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| Apple Silicon Mac mini (M1+) | Tested on M4, 32 GB RAM, macOS 26 |
+| Free disk ≥ 100 GB | VM allocated 80 GB |
+| Real public IP from ISP, not CGNAT | Verify by comparing `curl ifconfig.co` with router WAN IP |
+| ISP doesn't block port 80/443 inbound | Verify with `curl https://ifconfig.co/port/443?ip=<your-ip>` after enabling a test listener |
+| Home router with port forwarding + DHCP reservation for Mac | Most consumer routers support both |
+| AWS account with the `whoeverwants.com` Route 53 hosted zone | Pre-existing |
+| Homebrew installed | `brew --version` |
+
+## Reproduction
+
+The companion script is `scripts/provision-mac-mini.sh`. It encodes the steps that *can* be scripted; manual steps (router config, AWS console, etc.) are called out below.
+
+### 1. Mac baseline (one-time)
+
+```bash
+# Application firewall + stealth mode
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
+
+# FileVault — disk encryption. Save the recovery key prompted out somewhere safe.
+sudo fdesetup enable
+```
+
+### 2. Install tooling
+
+```bash
+brew install colima docker docker-compose caddy awscli
+mkdir -p ~/.docker/cli-plugins
+ln -sfn /opt/homebrew/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
+```
+
+### 3. Colima VM
+
+```bash
+colima start --profile devbox \
+  --arch aarch64 --vm-type vz \
+  --cpu 6 --memory 12 --disk 80 \
+  --mount-type virtiofs --ssh-agent
+
+docker context use colima-devbox
+docker run --rm hello-world  # smoke
+```
+
+### 4. AWS IAM user for Route 53 (manual + CLI)
+
+In the AWS console, create an IAM user (`mac-devbox-ddns`) with `AmazonRoute53FullAccess`. Generate an access key. On the Mac:
+
+```bash
+aws configure   # paste Access Key ID + Secret; region us-east-1; output json
+aws sts get-caller-identity   # smoke
+ZONE=$(printf '%s.%s' whoeverwants com)
+aws route53 list-hosted-zones-by-name --dns-name "$ZONE" \
+  --query 'HostedZones[*].[Id,Name]' --output text
+# → /hostedzone/Z000095423MM09UF7IBWG  whoeverwants.com.
+```
+
+Note the hosted zone ID for later steps.
+
+### 5. Initial DNS record + DDNS
+
+Create an "anchor" A record that DDNS will keep in sync with the home IP. Other hostnames will CNAME to this:
+
+```bash
+HOST=$(printf 'mac-test.dev.%s.%s' whoeverwants com)
+aws route53 change-resource-record-sets \
+    --hosted-zone-id Z000095423MM09UF7IBWG \
+    --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"$HOST\",\"Type\":\"A\",\"TTL\":60,\"ResourceRecords\":[{\"Value\":\"$(curl -s ifconfig.co)\"}]}}]}"
+```
+
+Install the DDNS script + LaunchAgent (full source in `scripts/mac-mini/ddns.sh` and `scripts/mac-mini/com.devbox.ddns.plist`):
+
+```bash
+mkdir -p ~/devbox ~/Library/Logs ~/Library/LaunchAgents
+cp scripts/mac-mini/ddns.sh ~/devbox/ddns.sh
+chmod +x ~/devbox/ddns.sh
+cp scripts/mac-mini/com.devbox.ddns.plist ~/Library/LaunchAgents/com.devbox.ddns.plist
+launchctl load ~/Library/LaunchAgents/com.devbox.ddns.plist
+launchctl list | grep ddns   # confirm loaded
+```
+
+### 6. Router port forwarding (manual)
+
+Log into your router admin (typically `http://192.168.1.1`). Add **two** port-forward rules:
+
+| External | Internal IP | Internal port | Protocol |
+|---|---|---|---|
+| 80 | `<Mac LAN IP>` | 80 | TCP |
+| 443 | `<Mac LAN IP>` | 443 | TCP |
+
+Get your Mac's LAN IP via `ifconfig en1 | grep "inet " | grep -v 127.0.0.1`. Set a DHCP reservation for the Mac so its LAN IP doesn't rotate.
+
+Verify after both rules are saved:
+
+```bash
+curl -s "https://ifconfig.co/port/80?ip=$(curl -s ifconfig.co)"
+curl -s "https://ifconfig.co/port/443?ip=$(curl -s ifconfig.co)"
+# Both should show "reachable":true (when something IS listening) or "reachable":false (otherwise)
+```
+
+### 7. Caddy + Application Firewall fix
+
+```bash
+# Initial Caddyfile — start with one site for the anchor hostname
+HOST=$(printf 'mac-test.dev.%s.%s' whoeverwants com)
+sudo tee /opt/homebrew/etc/Caddyfile <<EOF
+$HOST {
+    bind 0.0.0.0 ::
+    reverse_proxy localhost:8080
+}
+EOF
+
+# Application Firewall fix — Caddy is brew-installed (unsigned), the firewall blocks
+# inbound to it by default and there's no UI prompt for daemons. The fix is to add it
+# explicitly to the allowlist AND restart the service afterwards (the restart is what
+# actually unblocks).
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /opt/homebrew/opt/caddy/bin/caddy
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblockapp /opt/homebrew/opt/caddy/bin/caddy
+
+sudo brew services start caddy
+```
+
+`sudo` is required for `brew services start` so the LaunchDaemon runs as root and can bind ports < 1024.
+
+### 8. devbox docker-compose stack
+
+Generate per-secret values, write the compose file, build & start everything. Full templates in `scripts/mac-mini/`.
+
+```bash
+mkdir -p ~/devbox/cmd-api ~/devbox/webhook
+cp scripts/mac-mini/cmd-api.py     ~/devbox/cmd-api/
+cp scripts/mac-mini/Dockerfile.cmd-api ~/devbox/cmd-api/Dockerfile
+cp scripts/mac-mini/webhook.py     ~/devbox/webhook/
+cp scripts/mac-mini/Dockerfile.webhook ~/devbox/webhook/Dockerfile
+cp scripts/mac-mini/docker-compose.yml ~/devbox/docker-compose.yml
+
+# Generate secrets (NEVER commit these)
+{
+  echo "CMD_API_TOKEN=$(openssl rand -hex 32)"
+  echo "POSTGRES_PASSWORD=$(openssl rand -hex 24)"
+  echo "GITHUB_WEBHOOK_SECRET=$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+} > ~/devbox/.env
+chmod 600 ~/devbox/.env
+
+cd ~/devbox && docker compose up -d --build
+docker compose ps   # nginx-test, cmd-api, postgres, webhook all "Up"
+```
+
+### 9. DNS + Caddy entries for cmd-api and webhook
+
+```bash
+ZONE_ID=Z000095423MM09UF7IBWG
+ANCHOR=$(printf 'mac-test.dev.%s.%s' whoeverwants com)
+for SUB in cmd-api webhook; do
+  HOST=$(printf '%s.dev.%s.%s' "$SUB" whoeverwants com)
+  aws route53 change-resource-record-sets --hosted-zone-id "$ZONE_ID" \
+    --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"$HOST\",\"Type\":\"CNAME\",\"TTL\":60,\"ResourceRecords\":[{\"Value\":\"$ANCHOR\"}]}}]}"
+done
+
+# Update Caddyfile to add the additional site blocks
+HOST1=$(printf 'mac-test.dev.%s.%s' whoeverwants com)
+HOST2=$(printf 'cmd-api.dev.%s.%s' whoeverwants com)
+HOST3=$(printf 'webhook.dev.%s.%s' whoeverwants com)
+sudo tee /opt/homebrew/etc/Caddyfile <<EOF
+$HOST1 { bind 0.0.0.0 :: ; reverse_proxy localhost:8080 }
+$HOST2 { bind 0.0.0.0 :: ; reverse_proxy localhost:9090 }
+$HOST3 { bind 0.0.0.0 :: ; reverse_proxy localhost:9091 }
+EOF
+sudo brew services restart caddy
+sleep 45  # cert provisioning
+```
+
+### 10. Verify externally
+
+```bash
+# Test from anywhere external — phone on cellular, another machine, this:
+curl -sv https://cmd-api.dev.whoeverwants.com/   # 403 (no auth) → cert is valid
+curl -sv https://webhook.dev.whoeverwants.com/health   # {"status":"ok"}
+```
+
+Then test cmd-api with the bearer token:
+
+```bash
+TOKEN=$(grep CMD_API_TOKEN ~/devbox/.env | cut -d= -f2)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"cmd":"hostname; uname -a; docker ps"}' \
+  https://cmd-api.dev.whoeverwants.com/
+```
+
+Output should be JSON with `exit_code: 0` and the cmd-api container's hostname/uname plus a list of running containers.
+
+## Important pitfalls (learned the hard way)
+
+- **Cloudflare Tunnel free tier ≠ subdomain zones.** We started with Cloudflare Tunnel as the public-ingress mechanism but discovered that Cloudflare's "Published application routes" feature requires the zone to be *active* on Cloudflare — meaning the apex domain's NS records must point at Cloudflare. Subdomain delegation isn't supported on free tier (Enterprise only). Pivoting to direct port-forwarding ended up being simpler.
+- **macOS Application Firewall silently blocks unsigned daemons from accepting inbound connections.** Caddy via brew is unsigned. The firewall doesn't prompt for daemons launched via launchd, it just drops connections at the kernel layer. TCP handshake completes (something accepts SYN) but actual data packets get dropped. Symptoms: `nc -l 80` (system binary) works; Caddy doesn't. Fix: `socketfilterfw --add` + `--unblockapp` + restart Caddy. The `--add` alone wasn't enough — the restart is what cleared the broken state.
+- **Let's Encrypt multi-perspective validation needs all five validators to succeed.** Earlier rate-limit failures were caused by the App-Firewall block, not L.E. policies. Once the firewall fix landed, HTTP-01 worked first try.
+- **Hairpin NAT on home routers tests TCP only.** `ifconfig.co/port/N` reachability checks just complete TCP handshakes. They do NOT prove that HTTP requests would actually flow end-to-end. Use a real GET (e.g., `curl` from an external machine) to verify the full path.
+- **Caddy on macOS reports IPv4 listeners as IPv6 in lsof** when bound via `bind 0.0.0.0 ::`. Looks weird but works. Don't waste time trying to "fix" it.
+- **chat-client autolinking corrupts heredoc bodies.** Anything that looks like a hostname (`foo.com`, `log.info`, `subprocess.run`) gets wrapped in `<>` markdown autolinks during copy-paste, which breaks shell parsing and Python syntax. Workaround: build hostnames at runtime via `printf '%s.%s' x y`. For Python, use sed-fix `s/<\([a-z_]*\)\.\([a-z_]*\)>/\1.\2/g` after pasting if needed.
+- **Mac VM filesystem is intentionally NOT mounted.** cmd-api in the VM cannot edit `~/devbox/` files on the Mac. All config edits happen on the Mac side; cmd-api handles runtime operations only. This is the deliberate isolation.
+
+## Operational reference
+
+| Concern | Where |
+|---|---|
+| Compose stack | `~/devbox/docker-compose.yml` |
+| Secrets | `~/devbox/.env` (mode 600, never commit) |
+| Caddy config | `/opt/homebrew/etc/Caddyfile` |
+| Caddy logs | `/opt/homebrew/var/log/caddy.log` |
+| Caddy data (certs etc.) | `/opt/homebrew/var/lib/caddy/` |
+| DDNS script | `~/devbox/ddns.sh` |
+| DDNS LaunchAgent | `~/Library/LaunchAgents/com.devbox.ddns.plist` |
+| DDNS logs | `~/Library/Logs/ddns.log` |
+| Container logs | `docker compose logs -f <service>` |
+| Restart Caddy | `sudo brew services restart caddy` |
+| Restart a service | `cd ~/devbox && docker compose restart <service>` |
+
+## Calling cmd-api from elsewhere
+
+Same pattern as `scripts/remote.sh` for the droplet. Set in your shell:
+
+```bash
+export MAC_API_URL=https://cmd-api.dev.whoeverwants.com
+export MAC_API_TOKEN=<from ~/devbox/.env CMD_API_TOKEN>
+```
+
+Then any HTTPS POST works:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $MAC_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd":"hostname; docker ps"}' \
+  "$MAC_API_URL/"
+```
+
+## See also
+
+- `scripts/mac-mini/` — production source files (cmd-api, webhook, ddns, Dockerfiles, etc.)
+- `scripts/provision-mac-mini.sh` — partial automation script
+- `docs/mac-mini-next-steps.md` — remaining migration work + open architectural decisions
+- `docs/droplet-setup.md` — the predecessor system; some patterns are shared

--- a/scripts/mac-mini/Caddyfile
+++ b/scripts/mac-mini/Caddyfile
@@ -1,0 +1,26 @@
+# /opt/homebrew/etc/Caddyfile on the Mac mini.
+#
+# Each site block:
+#   - bind 0.0.0.0 ::  ensures both IPv4 and IPv6 listeners (macOS dual-stack
+#     can be flaky for hairpin packets — explicit binds are safer)
+#   - reverse_proxy localhost:NNNN  hits the Mac-published port that Colima
+#     forwards from the corresponding container in the VM
+#
+# When dev-server-manager is ported, per-author site blocks land here too,
+# OR (preferred) replaced by a wildcard *.dev.whoeverwants.com block forwarding
+# to a single in-VM router (Traefik). See docs/mac-mini-next-steps.md §1.
+
+mac-test.dev.whoeverwants.com {
+    bind 0.0.0.0 ::
+    reverse_proxy localhost:8080
+}
+
+cmd-api.dev.whoeverwants.com {
+    bind 0.0.0.0 ::
+    reverse_proxy localhost:9090
+}
+
+webhook.dev.whoeverwants.com {
+    bind 0.0.0.0 ::
+    reverse_proxy localhost:9091
+}

--- a/scripts/mac-mini/Dockerfile.cmd-api
+++ b/scripts/mac-mini/Dockerfile.cmd-api
@@ -1,0 +1,5 @@
+FROM python:3.12-alpine
+RUN apk add --no-cache docker-cli git curl bash
+COPY cmd-api.py /app/cmd-api.py
+EXPOSE 9090
+CMD ["python", "/app/cmd-api.py"]

--- a/scripts/mac-mini/Dockerfile.webhook
+++ b/scripts/mac-mini/Dockerfile.webhook
@@ -1,0 +1,5 @@
+FROM python:3.12-alpine
+RUN apk add --no-cache docker-cli git bash
+COPY webhook.py /app/webhook.py
+EXPOSE 9091
+CMD ["python", "/app/webhook.py"]

--- a/scripts/mac-mini/README.md
+++ b/scripts/mac-mini/README.md
@@ -1,0 +1,16 @@
+# scripts/mac-mini/
+
+Production source files for the Mac mini Colima-VM dev box. See `docs/mac-mini-setup.md` for the reproduction walkthrough that uses them.
+
+| File | Lives at on Mac | Purpose |
+|---|---|---|
+| `cmd-api.py` | `~/devbox/cmd-api/cmd-api.py` | Bearer-token-auth HTTP server that runs shell commands inside the cmd-api container. Mounted Docker socket = Claude/CI can manage VM containers. Mirrors `/opt/cmd-api.py` on the droplet. |
+| `webhook.py` | `~/devbox/webhook/webhook.py` | GitHub push-event webhook receiver. HMAC-verifies, parses commits, dispatches to dev-server-manager (when ported). |
+| `Dockerfile.cmd-api` | `~/devbox/cmd-api/Dockerfile` | Minimal Python + docker-cli + git + bash for cmd-api. |
+| `Dockerfile.webhook` | `~/devbox/webhook/Dockerfile` | Same base; will eventually invoke dev-server-manager. |
+| `docker-compose.yml` | `~/devbox/docker-compose.yml` | The whole stack: nginx-test + cmd-api + postgres + webhook + shared `devbox-net`. |
+| `ddns.sh` | `~/devbox/ddns.sh` | Polls public IP, UPSERTs Route 53 A record if changed. |
+| `com.devbox.ddns.plist` | `~/Library/LaunchAgents/com.devbox.ddns.plist` | LaunchAgent running ddns.sh every 5 min (300s). |
+| `Caddyfile` | `/opt/homebrew/etc/Caddyfile` | Caddy site blocks. Per-author blocks land here later (or get replaced by a wildcard + in-VM router). |
+
+**Not committed**: `.env` in `~/devbox/` containing `CMD_API_TOKEN`, `POSTGRES_PASSWORD`, `GITHUB_WEBHOOK_SECRET`. Generated fresh per-machine via `openssl rand -hex 32` (cmd-api), `openssl rand -hex 24` (postgres), `python3 -c 'import secrets; print(secrets.token_urlsafe(32))'` (webhook).

--- a/scripts/mac-mini/cmd-api.py
+++ b/scripts/mac-mini/cmd-api.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Command-execution HTTP server for the Mac mini Colima VM.
+
+Listens on 0.0.0.0:9090 inside its container; Caddy on the Mac terminates TLS at
+cmd-api.dev.whoeverwants.com and reverse-proxies here. Bearer-token auth, per-IP
+rate limit (60/min), and a JSON request/response shape mirroring the droplet's
+/opt/cmd-api.py for compatibility with scripts/remote.sh.
+
+Request:  POST / with Authorization: Bearer <token>
+          Body: {"cmd": "...", "cwd": "/root", "timeout": 120}
+Response: 200 with {"exit_code": int, "stdout": str, "stderr": str}
+"""
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from collections import defaultdict
+import json, subprocess, os, datetime, time
+
+SECRET = os.environ.get("API_SECRET", "")
+
+REQUEST_LOG = defaultdict(list)
+MAX_REQUESTS_PER_MINUTE = 60
+
+
+def _check_rate_limit(ip):
+    now = time.time()
+    REQUEST_LOG[ip] = [t for t in REQUEST_LOG[ip] if now - t < 60]
+    if len(REQUEST_LOG[ip]) >= MAX_REQUESTS_PER_MINUTE:
+        return True
+    REQUEST_LOG[ip].append(now)
+    return False
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        timestamp = datetime.datetime.now().isoformat()
+        client_ip = self.client_address[0]
+
+        if _check_rate_limit(client_ip):
+            print(f"[{timestamp}] RATE LIMITED {client_ip}", flush=True)
+            self.send_response(429)
+            self.send_header("Retry-After", "60")
+            self.end_headers()
+            self.wfile.write(b"rate limited")
+            return
+
+        auth = self.headers.get("Authorization", "")
+        if auth != f"Bearer {SECRET}":
+            print(f"[{timestamp}] AUTH FAILURE from {client_ip}", flush=True)
+            self.send_response(403)
+            self.end_headers()
+            self.wfile.write(b"forbidden")
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        cmd = body.get("cmd", "echo no command")
+        cwd = body.get("cwd", "/root")
+        timeout = body.get("timeout", 120)
+        print(f"[{timestamp}] {client_ip} CMD: {cmd[:200]}", flush=True)
+        try:
+            result = subprocess.run(
+                cmd, shell=True, capture_output=True, text=True,
+                timeout=timeout, cwd=cwd,
+            )
+            resp = {
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        except subprocess.TimeoutExpired:
+            resp = {"exit_code": -1, "stdout": "", "stderr": "timeout"}
+        except Exception as e:
+            resp = {"exit_code": -1, "stdout": "", "stderr": str(e)}
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(resp).encode())
+
+    def log_message(self, format, *args):
+        timestamp = datetime.datetime.now().isoformat()
+        print(f"[{timestamp}] {self.client_address[0]} {format % args}", flush=True)
+
+
+HTTPServer(("0.0.0.0", 9090), Handler).serve_forever()

--- a/scripts/mac-mini/com.devbox.ddns.plist
+++ b/scripts/mac-mini/com.devbox.ddns.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.devbox.ddns</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/sccarey/devbox/ddns.sh</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/sccarey/Library/Logs/ddns.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/sccarey/Library/Logs/ddns.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HOME</key>
+    <string>/Users/sccarey</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/mac-mini/ddns.sh
+++ b/scripts/mac-mini/ddns.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Dynamic DNS updater for the Mac mini home IP.
+#
+# Reads current public IP from one of three providers (fallback chain),
+# compares against the A record at Route 53, and UPSERTs only if changed.
+# Runs every 5 minutes via ~/Library/LaunchAgents/com.devbox.ddns.plist.
+#
+# Requires `aws configure` already done with an IAM user that has
+# AmazonRoute53FullAccess (or scoped equivalent — see docs/mac-mini-next-steps.md).
+
+set -euo pipefail
+
+HOSTED_ZONE_ID="Z000095423MM09UF7IBWG"
+RECORD_NAME="mac-test.dev.whoeverwants.com"
+TTL=60
+PROVIDERS="https://ifconfig.co https://ipv4.icanhazip.com https://api.ipify.org"
+
+fetch_public_ip() {
+    for url in $PROVIDERS; do
+        local ip
+        ip=$(curl -s --max-time 5 -4 "$url" | tr -d '[:space:]' || true)
+        if [[ "$ip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            echo "$ip"
+            return 0
+        fi
+    done
+    return 1
+}
+
+current_ip=$(fetch_public_ip) || {
+    echo "ERROR: couldn't fetch public IP" >&2
+    exit 1
+}
+
+current_record=$(aws route53 list-resource-record-sets \
+    --hosted-zone-id "$HOSTED_ZONE_ID" \
+    --query "ResourceRecordSets[?Name == '${RECORD_NAME}.' && Type == 'A'].ResourceRecords[0].Value | [0]" \
+    --output text 2>/dev/null || echo "")
+
+if [ "$current_record" = "$current_ip" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') unchanged ($current_ip)"
+    exit 0
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') updating $RECORD_NAME: ${current_record:-NONE} -> $current_ip"
+
+aws route53 change-resource-record-sets \
+    --hosted-zone-id "$HOSTED_ZONE_ID" \
+    --change-batch "{
+        \"Changes\": [{
+            \"Action\": \"UPSERT\",
+            \"ResourceRecordSet\": {
+                \"Name\": \"$RECORD_NAME\",
+                \"Type\": \"A\",
+                \"TTL\": $TTL,
+                \"ResourceRecords\": [{\"Value\": \"$current_ip\"}]
+            }
+        }]
+    }" > /dev/null
+echo "$(date '+%Y-%m-%d %H:%M:%S') done"

--- a/scripts/mac-mini/docker-compose.yml
+++ b/scripts/mac-mini/docker-compose.yml
@@ -1,0 +1,63 @@
+# ~/devbox/docker-compose.yml on the Mac mini.
+#
+# Reads secrets from ~/devbox/.env (mode 600, gitignored):
+#   CMD_API_TOKEN          — bearer token for cmd-api
+#   POSTGRES_PASSWORD      — postgres superuser password
+#   GITHUB_WEBHOOK_SECRET  — HMAC secret for GitHub webhook signatures
+#
+# All containers run inside the Colima VM. Caddy on the Mac terminates TLS for
+# *.dev.whoeverwants.com and reverse-proxies to the published 127.0.0.1 ports.
+
+services:
+  nginx-test:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:80"
+    networks:
+      - devbox-net
+
+  cmd-api:
+    build:
+      context: ./cmd-api
+    restart: unless-stopped
+    environment:
+      - API_SECRET=${CMD_API_TOKEN}
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - devbox-net
+
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: whoeverwants
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: whoeverwants
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - devbox-net
+
+  webhook:
+    build:
+      context: ./webhook
+    restart: unless-stopped
+    environment:
+      - GITHUB_WEBHOOK_SECRET=${GITHUB_WEBHOOK_SECRET}
+    ports:
+      - "127.0.0.1:9091:9091"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - devbox-net
+
+volumes:
+  postgres-data:
+
+networks:
+  devbox-net:
+    driver: bridge

--- a/scripts/mac-mini/webhook.py
+++ b/scripts/mac-mini/webhook.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+GitHub webhook handler for the Mac mini Colima VM.
+
+Listens on 0.0.0.0:9091 inside its container; Caddy on the Mac terminates TLS at
+webhook.dev.whoeverwants.com and reverse-proxies here. HMAC-SHA256 signature
+verification, JSON push event parsing, dispatches to dev-server-manager (when
+MANAGER_CMD is set) in a background thread.
+
+Adapted from scripts/dev-webhook.py (the droplet's version). Differences:
+- Binds 0.0.0.0 (Docker port-publishing requires this; the droplet ran on the
+  host network so 127.0.0.1 was fine)
+- Secret comes from GITHUB_WEBHOOK_SECRET env var (no /etc/dev-webhook-secret)
+- MANAGER_CMD is unset until dev-server-manager is ported; trigger_upsert
+  becomes a no-op log line in the meantime
+- Production-deploy logic removed (production stays on the droplet)
+"""
+import hashlib, hmac, http.server, json, logging, os, subprocess, sys, threading
+
+PORT = 9091
+SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "").encode()
+MANAGER_CMD = os.environ.get("MANAGER_CMD", "")
+IGNORE_PATTERNS = ["@anthropic.com", "noreply@github.com", "actions@github.com"]
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("webhook")
+
+if not SECRET:
+    log.error("GITHUB_WEBHOOK_SECRET not set")
+    sys.exit(1)
+
+
+def verify_signature(payload, signature):
+    if not signature.startswith("sha256="):
+        return False
+    expected = hmac.new(SECRET, payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(f"sha256={expected}", signature)
+
+
+def is_ignored(email):
+    el = email.lower()
+    return any(p in el for p in IGNORE_PATTERNS)
+
+
+def extract_emails(payload):
+    emails = set()
+    for c in payload.get("commits", []):
+        e = c.get("author", {}).get("email", "")
+        if e and not is_ignored(e):
+            emails.add(e)
+    head = payload.get("head_commit", {})
+    if head:
+        e = head.get("author", {}).get("email", "")
+        if e and not is_ignored(e):
+            emails.add(e)
+    return emails
+
+
+def get_branch(payload):
+    ref = payload.get("ref", "")
+    return ref[len("refs/heads/"):] if ref.startswith("refs/heads/") else None
+
+
+def trigger_upsert(email, branch):
+    if not MANAGER_CMD:
+        log.info(f"NO-OP (MANAGER_CMD unset): would upsert email={email} branch={branch}")
+        return
+    log.info(f"Triggering upsert: email={email} branch={branch}")
+    try:
+        r = subprocess.run(
+            ["bash", MANAGER_CMD, "upsert", email, branch],
+            capture_output=True, text=True, timeout=600,
+        )
+        if r.returncode == 0:
+            log.info(f"Upsert OK for {email}: {r.stdout[-200:]}")
+        else:
+            log.error(f"Upsert FAIL for {email}: {r.stderr[-500:]}")
+    except subprocess.TimeoutExpired:
+        log.error(f"Upsert timed out for {email}")
+    except Exception as e:
+        log.error(f"Upsert error for {email}: {e}")
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != "/github":
+            self.send_error(404)
+            return
+        n = int(self.headers.get("Content-Length", 0))
+        if n > 10 * 1024 * 1024:
+            self.send_error(413)
+            return
+        body = self.rfile.read(n)
+        sig = self.headers.get("X-Hub-Signature-256", "")
+        if not verify_signature(body, sig):
+            log.warning(f"Bad signature from {self.client_address[0]}")
+            self.send_error(403)
+            return
+        ev = self.headers.get("X-GitHub-Event", "")
+        if ev == "ping":
+            log.info("ping")
+            self.send_response(200); self.end_headers()
+            self.wfile.write(b'{"status": "pong"}')
+            return
+        if ev != "push":
+            self.send_response(200); self.end_headers()
+            self.wfile.write(b'{"status": "ignored"}')
+            return
+        try:
+            p = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_error(400)
+            return
+        branch = get_branch(p)
+        if not branch:
+            self.send_response(200); self.end_headers()
+            self.wfile.write(b'{"status": "no branch"}')
+            return
+        if p.get("deleted"):
+            self.send_response(200); self.end_headers()
+            self.wfile.write(b'{"status": "deleted"}')
+            return
+        emails = extract_emails(p)
+        if not emails:
+            self.send_response(200); self.end_headers()
+            self.wfile.write(b'{"status": "no authors"}')
+            return
+        log.info(f"Push to {branch} by {emails}")
+        self.send_response(202); self.end_headers()
+        self.wfile.write(json.dumps({
+            "status": "accepted", "branch": branch, "authors": list(emails),
+        }).encode())
+        for e in emails:
+            threading.Thread(target=trigger_upsert, args=(e, branch), daemon=True).start()
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200); self.end_headers()
+            self.wfile.write(b'{"status": "ok"}')
+            return
+        self.send_error(404)
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+def main():
+    server = http.server.HTTPServer(("0.0.0.0", PORT), Handler)
+    log.info(f"Webhook listening on 0.0.0.0:{PORT}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Captures the work from a long session migrating the dev-server side of WhoeverWants from the DigitalOcean droplet to a Mac mini at home. Production API stays on the droplet — only per-author dev servers are moving.

This PR is **docs + extracted source files only**. No live system changes; the actual VM/container/DNS state lives on the Mac mini and at AWS Route 53. The intent is to make the Mac mini setup reproducible and to document where we left off so future sessions (or future-you) can pick up cleanly.

## What's running today (foundation complete)

- Colima VM (Apple Virtualization Framework, 6 CPU / 12 GB / 80 GB) on the M4 Mac mini, isolated from the Mac filesystem
- Per-hostname HTTPS at `*.dev.whoeverwants.com` via home-router port forwarding (80/443) → Caddy on Mac (Let's Encrypt HTTP-01) → containers in VM
- DDNS (launchd → AWS Route 53) keeps the home IP A record self-healing
- `cmd-api.dev.whoeverwants.com` — Claude→VM control endpoint, mirrors the droplet's `/opt/cmd-api.py`
- `webhook.dev.whoeverwants.com` — GitHub push receiver, HMAC-verified (no-op until dev-server-manager is ported)
- `mac-test.dev.whoeverwants.com` — placeholder serving nginx
- Postgres 16 in VM, persistent volume, network-only

## What's NOT done yet

Outlined with concrete options in `docs/mac-mini-next-steps.md`:

1. **Port `dev-server-manager.sh`** — the droplet's 854-line process-based script needs to be adapted for the containerized VM model. Three architectures sketched (per-author container w/ both processes, two containers per author, processes inside VM). Decision deferred.
2. **Wildcard cert via DNS-01** — needed if we go the wildcard `*.dev.whoeverwants.com` + in-VM Traefik route.
3. **Wildcard A record cutover** — `*.dev.whoeverwants.com` currently points at droplet; will move to home IP via DDNS.
4. **GitHub webhook URL change** — `samcarey/whoeverwants` webhook needs to repoint from `hooks.api.whoeverwants.com` to `webhook.dev.whoeverwants.com` once dev-server-manager is wired up.
5. **Droplet dev-side decommission** — keep prod API, retire dev pieces.

## Files

- `docs/mac-mini-setup.md` — full reproduction walkthrough modeled after `docs/droplet-setup.md`
- `docs/mac-mini-next-steps.md` — pending work + open architectural decisions
- `scripts/mac-mini/` — production source files (`cmd-api.py`, `webhook.py`, `Dockerfile.cmd-api`, `Dockerfile.webhook`, `docker-compose.yml`, `Caddyfile`, `ddns.sh`, `com.devbox.ddns.plist`, `README.md`)
- `CLAUDE.md` — brief peer section to the existing droplet section, pointing future sessions at the new docs and explaining how to call cmd-api on the Mac mini

## Pitfalls captured for future reference

The setup doc has a "learned the hard way" section covering:
- Cloudflare Tunnel free tier doesn't support subdomain delegation — pivoted to direct port-forwarding
- macOS Application Firewall silently blocks unsigned daemons (Caddy via brew); fix is `socketfilterfw --add` + `--unblockapp` + restart
- Let's Encrypt validators were timing out because of the firewall block, not L.E. policy
- Hairpin NAT TCP probes (ifconfig.co) don't prove HTTP works end-to-end
- Caddy on macOS reports IPv4 listeners as IPv6 in `lsof` when bound dual-stack — cosmetic, works fine
- Chat-client autolinking corrupts heredoc bodies (any `word.tld`-like string gets wrapped in `<>`); workarounds documented

## Test plan

- [ ] No live system to test in this PR (docs + extracted source files only)
- [ ] Foundation already verified end-to-end manually during the session: external HTTPS curl to all three hostnames returns expected responses; cmd-api executes commands inside VM; webhook accepts HMAC-signed pings and rejects unsigned ones; Postgres reachable from cmd-api via Docker DNS

https://claude.ai/code/session_01Nss5f1VZfGZLbQRhSvTfcz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nss5f1VZfGZLbQRhSvTfcz)_