### PR TITLE
Blank Context placeholder when no category-specific example

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1636,7 +1636,7 @@ export function CreateQuestionContent() {
                             }}
                             disabled={isLoading}
                             maxLength={100}
-                            placeholder={FOR_FIELD_PLACEHOLDERS[category] || "Context"}
+                            placeholder={FOR_FIELD_PLACEHOLDERS[category] || ""}
                             className="flex-1 min-w-0 text-base bg-transparent text-blue-600 dark:text-blue-400 text-right focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-gray-400 dark:placeholder:text-gray-500 placeholder:italic"
                           />
                         </div>


### PR DESCRIPTION
## Summary
- For categories without a `FOR_FIELD_PLACEHOLDERS` entry, the Context input in the new-poll form now renders a blank placeholder instead of the literal word "Context" (which was already the label to the left).

## Test plan
- [ ] Open the new-poll modal with a category that has a placeholder (e.g. Restaurant) — placeholder still reads "Dinner, Lunch, etc."
- [ ] Switch to a category without a placeholder (e.g. Custom) — Context input is blank.

https://claude.ai/code/session_01U1R6mipfQQsJ13TRC6Hozu

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1R6mipfQQsJ13TRC6Hozu)_