### PR TITLE
Add group avatar image upload with circular crop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1620,6 +1620,52 @@ See `docs/ios-setup.md` for the full one-time setup walkthrough.
 
 ---
 
+## Group Avatar Images
+
+Groups can have a custom uploaded image avatar that replaces the participant-initials graphic. **Storage**: inline on the `groups` row — migration 108 added `image_data BYTEA`, `image_mime_type TEXT`, `image_updated_at TIMESTAMPTZ` columns. Keeping bytes in Postgres (vs filesystem / object storage) means pg_dump captures them automatically, no second storage surface to provision per-branch on the Mac dev infrastructure, and "destroy + recreate dev DB" stays a one-step operation. Trade-off accepted for the current scale.
+
+**API**:
+- `POST /api/groups/{route_id}/image` — base64 JSON body (`{image_base64, mime_type}`); JPEG/PNG only; 5 MiB cap. No creator-secret check, same trust model as `/title`.
+- `DELETE /api/groups/{route_id}/image` — idempotent clear; returns 200 even when no image was set.
+- `GET /api/groups/by-route-id/{route_id}/image` — raw bytes with the stored MIME type and `Cache-Control: public, max-age=31536000, immutable`. The FE's `?v=<image_updated_at>` query string is the cache-buster.
+
+**`image_updated_at` propagates as a wrapper field on every `PollResponse`.** Surfaced via the same `_SELECT_POLLS_WITH_GROUP` JOIN as `group_title` / `group_short_id` (extend the constant when adding a new joined groups field, NOT a parallel SELECT). FE `Poll.group_image_updated_at` flows through `toPoll`; `Group.imageUrl` is derived in `lib/groupUtils.ts: buildGroupImageUrl(routeId, ts)` and consumed by the new `<GroupAvatar>` wrapper.
+
+**`<GroupAvatar imageUrl|names|anonymousCount|sizeClassName>`** in `components/GroupAvatar.tsx` replaces direct `<RespondentCircles>` use at every "this is the group's icon" surface: home list rows, group-page header, /info hero. When `imageUrl` is null, falls through to `RespondentCircles` for the initials graphic — same outer dimensions either way, so swapping doesn't shift layout. The image element uses `object-cover` as a safety net but the upload pipeline always feeds square-cropped bytes.
+
+**`<ImageCropModal>`** (`components/ImageCropModal.tsx`) is the drag + pinch-zoom + canvas-export cropper. Several traps learned the hard way:
+
+- **iOS WebKit (Safari + iOS Firefox) silently fails `<img src="data:image/...">` for data URLs over ~1-2 MB.** Phone photos at 5-15 MB produced an empty crop circle. The fix is `URL.createObjectURL` for the displayed source — blob URLs have no length limit. FileReader/data URLs are NOT a working substitute on mobile WebKit.
+- **Pair `URL.createObjectURL` + `URL.revokeObjectURL` + `setUrl` inside ONE `useEffect`.** First attempt put the URL in `useState(() => createObjectURL(file))` lazy init, assuming React StrictMode would re-run the initializer on the simulated remount. **It doesn't** — StrictMode preserves state across the dev mount→unmount→mount cycle; only effects re-run. So the cleanup revoked the URL while state kept pointing at it, and the img permanently displayed a dead URL. Pattern that works:
+  ```tsx
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    const u = URL.createObjectURL(file);
+    setUrl(u);
+    return () => { URL.revokeObjectURL(u); setUrl((prev) => prev === u ? null : prev); };
+  }, [file]);
+  ```
+  The `setUrl(...)` in cleanup is load-bearing — without it the img briefly keeps `src=URL_A` after the revoke, fires onError, and sets `loadError` permanently. With it, the img unmounts cleanly between StrictMode mounts.
+- **Tailwind preflight ships `img { max-width: 100%; height: auto }` globally.** When the displayed img has explicit `width: 1737px` set inline AND its parent container is 370px, max-width caps the width at 370 BEFORE the transform: scale() runs — so the transform downscales an already-clipped width, producing an image rendered at 1/N of the expected width and positioned off-screen. The fix is `maxWidth: 'none'` (and `maxHeight: 'none'` for safety) in the inline style. **This is a browser-agnostic bug**; my Playwright tests only checked `getBoundingClientRect().width > 0`, which was true even for the 78×658-px sliver, so it slipped through. When testing image-sizing fixes, validate the rendered dims match the math.
+- **Keep the displayed `<img>` mounted across the loadError → success transition.** Earlier the JSX gated the entire crop container on `!loadError`, so an onError firing for a stale URL_A unmounted the img — the subsequent URL_B never got a chance to load. Render the img unconditionally (once `url` is set); show loading/error overlays on top. Successful onLoad sets imageDims AND clears loadError.
+- **Don't allocate per-frame in pointermove.** The hot path runs at ~60Hz on touch. Iterate `pointersRef.current.values()` directly (Map iterator) — don't `Array.from(...values())`, which allocates a fresh array each frame. Capture first/second pointer in the same loop for pinch math.
+- **Canvas export**: 512×512 JPEG at quality 0.9 → ~50-80 KB typically. Drawn from the freshly-loaded blob URL (the modal's URL stays alive until unmount).
+- **5MP+ image render limits on iOS**: not actually a hard problem in practice (modern iPhones handle 12+ MP fine). Symptoms that look like image-decode failures on mobile have always traced back to one of the items above, not actual memory limits. Don't pre-resize on the client without evidence; the canvas export already downscales.
+
+**Edit-title flow** (`app/g/[groupShortId]/edit-title/page.tsx`) defers all image + title changes to local state and commits via the Save button:
+- Picking + cropping stages a `Blob` in `pendingCroppedBlob` and a derived blob URL in `localImagePreviewUrl` for the preview avatar. No server round-trip.
+- Tapping the X badge stages `pendingImageRemoval = true` (and clears any `pendingCroppedBlob`).
+- Save runs the staged image action (upload or delete), then the title update if changed, then navigates back. Skips the DELETE entirely when `pendingImageRemoval && !group.imageUrl` (no-op on a group without an image).
+- Back checks `hasUnsavedChanges = titleChanged || imageChanged` and shows a `ConfirmationModal` ("Discard your changes?", red Discard button) if anything is staged. Confirm → navigate away without committing; cancel → stay.
+
+The X-badge / camera-badge pattern needs both to be **siblings of the avatar button** inside a single `relative` wrapper — NOT children of the same button — so their click handlers stay independent (tapping X doesn't open the file picker). The X badge only renders when `effectiveImageUrl` is truthy (no point offering to remove a non-existent image).
+
+**Template `py-6` was retired for sub-routes** (`app/template.tsx`). The page-wrapper used to apply `py-6` (24px top + bottom padding) to every route that wasn't home, settings, or `isGroupLikePage` — so `/g/<id>/info` and `/g/<id>/edit-title` got 24px of extra top space ON TOP of their inline `paddingTop: headerHeight + Xrem` for the fixed header clearance. Changed to `pb-6` (drop top). Other routes in the bucket are redirect stubs where padding is irrelevant.
+
+**Pitfall: `accessibleQuestionIds` in localStorage can carry non-UUIDs and 500 `/api/groups/mine`.** Postgres casts the parameter array to `uuid[]`, and one bad element rejects the whole call. `server/services/groups.py: group_ids_for_question_ids` now filters its input through a UUID regex before the SELECT — same defensive pattern any future endpoint reading question_ids from FE-supplied lists should adopt. The corruption can come from any past code path that ever called `addAccessibleQuestionId(poll.id_or_short_id)` instead of a question_id; CLAUDE.md already flagged this pitfall but server-side resilience guards against it persisting in long-lived sessions.
+
+**Dev-infra trap**: `scripts/mac-mini/dev-server-manager.sh`'s `INSERT INTO _migrations (filename) VALUES (:'fname')` line has been broken since the script's inception — the `:'fname'` psql variable substitution fails with `syntax error at or near ":"`, so the `_migrations` table never gets populated. Every upsert re-applies all migrations from scratch, which works on a fresh DB (migrations run in order, succeed) but fails catastrophically when any earlier migration is non-idempotent and the DB drifted into a half-migrated state. Symptom we hit repeatedly during this branch: a push triggers upsert → migration 097 (renames `polls` → `questions`, `multipolls` → `polls`) fails because `questions` already exists → the rename is rolled back → migrations 098+ that ADD COLUMNS to "polls" go to the OLD polls table (which was supposed to be renamed) → the new `polls` table (formerly multipolls) is missing the columns the server expects. Recovery: `bash /opt/scripts/dev-server-manager.sh destroy <branch>` then `upsert` again forces a clean DB. **Fix the `:'fname'` syntax is filed but not done in this branch** — it'd touch dev infrastructure orthogonal to the feature work.
+
 ## App Icons
 
 The 👋 waving-hand emoji is the canonical app icon, rendered on a black rounded-rect background. Every icon file in the project is a render of the same SVG template — keep them in sync when changing the artwork.

--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -1612,6 +1612,7 @@ export function GroupContent({ groupId, initialExpandedQuestionId = null }: Grou
         title={group.title}
         participantNames={group.participantNames}
         anonymousCount={group.anonymousRespondentCount}
+        imageUrl={group.imageUrl}
         subtitle={
           group.questions.length === 0
             ? undefined

--- a/app/g/[groupShortId]/edit-title/page.tsx
+++ b/app/g/[groupShortId]/edit-title/page.tsx
@@ -156,38 +156,47 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
       />
 
       <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: `calc(${headerHeight}px + 1rem)` }}>
-        {/* Avatar + camera badge — centered above the title. Tap anywhere
-            on the avatar (or the badge) to open the native image picker. */}
+        {/* Avatar + badges — centered above the title. Camera badge in
+            the lower-right opens the file picker; X badge in the upper-
+            right stages an image removal (only shown when an image is
+            actually displayed). Both badges are siblings of the avatar
+            button inside a `relative` wrapper so their click handlers
+            stay independent. */}
         <div className="flex flex-col items-center mb-6">
-          <button
-            type="button"
-            onClick={openFilePicker}
-            disabled={saving}
-            aria-label="Change group image"
-            className="relative outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full disabled:opacity-60"
-          >
-            <GroupAvatar
-              imageUrl={effectiveImageUrl}
-              names={group.participantNames}
-              anonymousCount={group.anonymousRespondentCount}
-              sizeClassName="w-28"
-            />
-            <span
-              className="absolute bottom-0 right-0 w-9 h-9 rounded-full bg-blue-600 dark:bg-blue-500 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900"
-              aria-hidden
-            >
-              <CameraPencilIcon />
-            </span>
-          </button>
-          {effectiveImageUrl && !saving && (
+          <div className="relative">
             <button
               type="button"
-              onClick={onRemoveImage}
-              className="mt-3 text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 underline-offset-2 hover:underline"
+              onClick={openFilePicker}
+              disabled={saving}
+              aria-label="Change group image"
+              className="block outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full disabled:opacity-60"
             >
-              Remove image
+              <GroupAvatar
+                imageUrl={effectiveImageUrl}
+                names={group.participantNames}
+                anonymousCount={group.anonymousRespondentCount}
+                sizeClassName="w-28"
+              />
+              <span
+                className="absolute bottom-0 right-0 w-9 h-9 rounded-full bg-blue-600 dark:bg-blue-500 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900"
+                aria-hidden
+              >
+                <CameraPencilIcon />
+              </span>
             </button>
-          )}
+            {effectiveImageUrl && !saving && (
+              <button
+                type="button"
+                onClick={onRemoveImage}
+                aria-label="Remove group image"
+                className="absolute top-0 right-0 w-7 h-7 rounded-full bg-gray-500 dark:bg-gray-600 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900 hover:bg-gray-600 dark:hover:bg-gray-500 active:scale-95 transition-transform"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
           <input
             ref={fileInputRef}
             type="file"

--- a/app/g/[groupShortId]/edit-title/page.tsx
+++ b/app/g/[groupShortId]/edit-title/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, Suspense } from "react";
+import { useEffect, useRef, useState, Suspense } from "react";
 import { useRouter, useParams } from "next/navigation";
 import {
   apiUpdateGroupTitle,
@@ -10,104 +10,129 @@ import {
 import { navigateWithTransition, navigateBackWithTransition, hasAppHistory } from "@/lib/viewTransitions";
 import { useGroup } from "@/lib/useGroup";
 import { useMeasuredHeight } from "@/lib/useMeasuredHeight";
-import { buildGroupImageUrl, type Group } from "@/lib/groupUtils";
+import { type Group } from "@/lib/groupUtils";
 import GroupHeader from "@/components/GroupHeader";
 import GroupAvatar from "@/components/GroupAvatar";
 import ImageCropModal from "@/components/ImageCropModal";
+import ConfirmationModal from "@/components/ConfirmationModal";
 import { GroupLoading, GroupNotFound } from "@/components/GroupLoadState";
 
 function Editor({ group, groupId }: { group: Group; groupId: string }) {
   const router = useRouter();
-  // Migration 105: group_title lives on groups.title — surfaced on
-  // every poll in the group as the same value. Empty groups carry the
-  // override directly on `Group.groupTitleOverride` (no latestPoll to
-  // read from).
+  // Title state — the input value. The saved value is `group.groupTitleOverride`
+  // (raw value of `groups.title`, null when no override is set). Empty string in
+  // the input clears the override on save.
   const [value, setValue] = useState<string>(group.groupTitleOverride ?? '');
   const [saving, setSaving] = useState(false);
 
-  // Avatar state: local override of `group.imageUrl` so a freshly-uploaded
-  // (or cleared) image appears instantly without re-routing through the
-  // useGroup loader. `imageOverride === undefined` → use `group.imageUrl`;
-  // `null` → forced no image; string → forced new URL.
-  const [imageOverride, setImageOverride] = useState<string | null | undefined>(undefined);
-  const effectiveImageUrl =
-    imageOverride === undefined ? group.imageUrl : imageOverride;
+  // Image staging: changes accumulate in local state and only commit on Save.
+  // Back triggers a confirmation if any staging is present.
+  //   * pendingCroppedBlob — a fresh image the user just cropped (overrides
+  //     anything that was already on the server).
+  //   * pendingImageRemoval — user tapped Remove; the server's current image
+  //     should be deleted on save. Cleared if the user then picks a new image.
+  // The previewed avatar uses the local blob URL when a fresh image is staged,
+  // null when removal is staged, otherwise the server-side `group.imageUrl`.
+  const [pendingCroppedBlob, setPendingCroppedBlob] = useState<Blob | null>(null);
+  const [pendingImageRemoval, setPendingImageRemoval] = useState(false);
+  const [localImagePreviewUrl, setLocalImagePreviewUrl] = useState<string | null>(null);
+
+  // Blob URL lifecycle for the staged image preview. Created from the
+  // cropped Blob whenever it changes; revoked on cleanup. Same StrictMode-
+  // safe pattern as the cropper itself.
+  useEffect(() => {
+    if (!pendingCroppedBlob) {
+      setLocalImagePreviewUrl(null);
+      return;
+    }
+    const u = URL.createObjectURL(pendingCroppedBlob);
+    setLocalImagePreviewUrl(u);
+    return () => {
+      URL.revokeObjectURL(u);
+    };
+  }, [pendingCroppedBlob]);
+
+  const effectiveImageUrl = pendingCroppedBlob
+    ? localImagePreviewUrl
+    : pendingImageRemoval
+      ? null
+      : group.imageUrl;
+
+  const titleChanged = (value.trim() || null) !== (group.groupTitleOverride ?? null);
+  const imageChanged = pendingCroppedBlob !== null || pendingImageRemoval;
+  const hasUnsavedChanges = titleChanged || imageChanged;
 
   const [pickedFile, setPickedFile] = useState<File | null>(null);
-  const [imageBusy, setImageBusy] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const [headerRef, headerHeight] = useMeasuredHeight<HTMLDivElement>();
 
-  const goBack = () => {
-    console.log('[edit-title] goBack called', {
-      hasAppHistory: hasAppHistory(),
-      pickedFile: !!pickedFile,
-      saving,
-      imageBusy,
-    });
+  const navigateAway = () => {
     if (hasAppHistory()) navigateBackWithTransition();
     else navigateWithTransition(router, `/g/${groupId}/info`, 'back');
   };
 
+  const handleBack = () => {
+    if (hasUnsavedChanges) {
+      setShowDiscardConfirm(true);
+      return;
+    }
+    navigateAway();
+  };
+
+  const discardAndLeave = () => {
+    setShowDiscardConfirm(false);
+    navigateAway();
+  };
+
   const save = async () => {
-    console.log('[edit-title] save called', { saving, value, original: group.groupTitleOverride });
     if (saving) return;
     setSaving(true);
     try {
-      console.log('[edit-title] save: calling apiUpdateGroupTitle');
-      await apiUpdateGroupTitle(groupId, value.trim() || null);
-      console.log('[edit-title] save: apiUpdateGroupTitle resolved, calling goBack');
-      goBack();
-      console.log('[edit-title] save: goBack returned');
+      // Image first — the cache-invalidation in apiUpload/Delete primes the
+      // accessible-polls cache so subsequent title-update + group reads pick
+      // up the same updated_at watermark cleanly. Order doesn't otherwise
+      // matter (each endpoint is independent server-side).
+      if (pendingCroppedBlob) {
+        await apiUploadGroupImage(groupId, pendingCroppedBlob);
+      } else if (pendingImageRemoval && group.imageUrl) {
+        // Only call DELETE if there was actually an image to remove.
+        // (User-tapped Remove on a group with no image is a no-op.)
+        await apiDeleteGroupImage(groupId);
+      }
+      if (titleChanged) {
+        await apiUpdateGroupTitle(groupId, value.trim() || null);
+      }
+      navigateAway();
     } catch (err) {
-      console.error('Failed to update group title:', err);
+      console.error('Failed to save group changes:', err);
       setSaving(false);
     }
   };
 
   const openFilePicker = () => {
-    if (imageBusy) return;
+    if (saving) return;
     fileInputRef.current?.click();
   };
 
   const onFileChosen = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    // Reset the input so re-picking the same file fires `change` again.
     e.target.value = '';
     if (!file) return;
     setPickedFile(file);
   };
 
-  const onCropConfirm = async (croppedBlob: Blob) => {
-    setImageBusy(true);
-    try {
-      const result = await apiUploadGroupImage(groupId, croppedBlob);
-      setImageOverride(
-        buildGroupImageUrl(
-          result.group_short_id ?? result.group_id ?? groupId,
-          result.image_updated_at,
-        ),
-      );
-      setPickedFile(null);
-    } catch (err) {
-      console.error('Failed to upload group image:', err);
-    } finally {
-      setImageBusy(false);
-    }
+  const onCropConfirm = (croppedBlob: Blob) => {
+    setPendingCroppedBlob(croppedBlob);
+    setPendingImageRemoval(false);
+    setPickedFile(null);
   };
 
-  const onRemoveImage = async () => {
-    if (imageBusy) return;
-    setImageBusy(true);
-    try {
-      await apiDeleteGroupImage(groupId);
-      setImageOverride(null);
-    } catch (err) {
-      console.error('Failed to remove group image:', err);
-    } finally {
-      setImageBusy(false);
-    }
+  const onRemoveImage = () => {
+    if (saving) return;
+    setPendingImageRemoval(true);
+    setPendingCroppedBlob(null);
   };
 
   return (
@@ -115,7 +140,7 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
       <GroupHeader
         headerRef={headerRef}
         title="Edit Title"
-        onBack={goBack}
+        onBack={handleBack}
         rightSlot={
           <button
             onClick={save}
@@ -137,7 +162,7 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
           <button
             type="button"
             onClick={openFilePicker}
-            disabled={imageBusy}
+            disabled={saving}
             aria-label="Change group image"
             className="relative outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full disabled:opacity-60"
           >
@@ -147,8 +172,6 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
               anonymousCount={group.anonymousRespondentCount}
               sizeClassName="w-28"
             />
-            {/* Camera badge in lower-right. Sized so it slightly overlaps
-                the circle edge — same idiom as message-app avatar editors. */}
             <span
               className="absolute bottom-0 right-0 w-9 h-9 rounded-full bg-blue-600 dark:bg-blue-500 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900"
               aria-hidden
@@ -156,7 +179,7 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
               <CameraPencilIcon />
             </span>
           </button>
-          {effectiveImageUrl && !imageBusy && (
+          {effectiveImageUrl && !saving && (
             <button
               type="button"
               onClick={onRemoveImage}
@@ -164,9 +187,6 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
             >
               Remove image
             </button>
-          )}
-          {imageBusy && (
-            <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">Uploading…</p>
           )}
           <input
             ref={fileInputRef}
@@ -199,13 +219,20 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
           onConfirm={onCropConfirm}
         />
       )}
+
+      <ConfirmationModal
+        isOpen={showDiscardConfirm}
+        message="Discard your changes?"
+        confirmText="Discard"
+        confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
+        onConfirm={discardAndLeave}
+        onCancel={() => setShowDiscardConfirm(false)}
+      />
     </>
   );
 }
 
 function CameraPencilIcon() {
-  // Combined camera + pencil glyph. Camera body with a tiny pencil
-  // overlapping the lower-right of the lens — reads as "edit photo".
   return (
     <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden>
       <path strokeLinecap="round" strokeLinejoin="round" d="M3 7h3l2-3h6l2 3h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" />

--- a/app/g/[groupShortId]/edit-title/page.tsx
+++ b/app/g/[groupShortId]/edit-title/page.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useState, Suspense } from "react";
+import { useRef, useState, Suspense } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { apiUpdateGroupTitle } from "@/lib/api";
+import {
+  apiUpdateGroupTitle,
+  apiUploadGroupImage,
+  apiDeleteGroupImage,
+} from "@/lib/api";
 import { navigateWithTransition, navigateBackWithTransition, hasAppHistory } from "@/lib/viewTransitions";
 import { useGroup } from "@/lib/useGroup";
 import { useMeasuredHeight } from "@/lib/useMeasuredHeight";
-import type { Group } from "@/lib/groupUtils";
+import { buildGroupImageUrl, type Group } from "@/lib/groupUtils";
 import GroupHeader from "@/components/GroupHeader";
+import GroupAvatar from "@/components/GroupAvatar";
+import ImageCropModal from "@/components/ImageCropModal";
 import { GroupLoading, GroupNotFound } from "@/components/GroupLoadState";
 
 function Editor({ group, groupId }: { group: Group; groupId: string }) {
@@ -18,6 +24,18 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
   // read from).
   const [value, setValue] = useState<string>(group.groupTitleOverride ?? '');
   const [saving, setSaving] = useState(false);
+
+  // Avatar state: local override of `group.imageUrl` so a freshly-uploaded
+  // (or cleared) image appears instantly without re-routing through the
+  // useGroup loader. `imageOverride === undefined` → use `group.imageUrl`;
+  // `null` → forced no image; string → forced new URL.
+  const [imageOverride, setImageOverride] = useState<string | null | undefined>(undefined);
+  const effectiveImageUrl =
+    imageOverride === undefined ? group.imageUrl : imageOverride;
+
+  const [pickedFile, setPickedFile] = useState<File | null>(null);
+  const [imageBusy, setImageBusy] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const [headerRef, headerHeight] = useMeasuredHeight<HTMLDivElement>();
 
@@ -42,6 +60,50 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
     }
   };
 
+  const openFilePicker = () => {
+    if (imageBusy) return;
+    fileInputRef.current?.click();
+  };
+
+  const onFileChosen = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Reset the input so re-picking the same file fires `change` again.
+    e.target.value = '';
+    if (!file) return;
+    setPickedFile(file);
+  };
+
+  const onCropConfirm = async (croppedBlob: Blob) => {
+    setImageBusy(true);
+    try {
+      const result = await apiUploadGroupImage(groupId, croppedBlob);
+      setImageOverride(
+        buildGroupImageUrl(
+          result.group_short_id ?? result.group_id ?? groupId,
+          result.image_updated_at,
+        ),
+      );
+      setPickedFile(null);
+    } catch (err) {
+      console.error('Failed to upload group image:', err);
+    } finally {
+      setImageBusy(false);
+    }
+  };
+
+  const onRemoveImage = async () => {
+    if (imageBusy) return;
+    setImageBusy(true);
+    try {
+      await apiDeleteGroupImage(groupId);
+      setImageOverride(null);
+    } catch (err) {
+      console.error('Failed to remove group image:', err);
+    } finally {
+      setImageBusy(false);
+    }
+  };
+
   return (
     <>
       <GroupHeader
@@ -63,6 +125,52 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
       />
 
       <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: `calc(${headerHeight}px + 1rem)` }}>
+        {/* Avatar + camera badge — centered above the title. Tap anywhere
+            on the avatar (or the badge) to open the native image picker. */}
+        <div className="flex flex-col items-center mb-6">
+          <button
+            type="button"
+            onClick={openFilePicker}
+            disabled={imageBusy}
+            aria-label="Change group image"
+            className="relative outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full disabled:opacity-60"
+          >
+            <GroupAvatar
+              imageUrl={effectiveImageUrl}
+              names={group.participantNames}
+              anonymousCount={group.anonymousRespondentCount}
+              sizeClassName="w-28"
+            />
+            {/* Camera badge in lower-right. Sized so it slightly overlaps
+                the circle edge — same idiom as message-app avatar editors. */}
+            <span
+              className="absolute bottom-0 right-0 w-9 h-9 rounded-full bg-blue-600 dark:bg-blue-500 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900"
+              aria-hidden
+            >
+              <CameraPencilIcon />
+            </span>
+          </button>
+          {effectiveImageUrl && !imageBusy && (
+            <button
+              type="button"
+              onClick={onRemoveImage}
+              className="mt-3 text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 underline-offset-2 hover:underline"
+            >
+              Remove image
+            </button>
+          )}
+          {imageBusy && (
+            <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">Uploading…</p>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={onFileChosen}
+            className="hidden"
+          />
+        </div>
+
         <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Group title</label>
         <input
           type="text"
@@ -77,7 +185,26 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
           Leave blank to use the default: <span className="italic">{group.defaultTitle}</span>
         </p>
       </div>
+
+      {pickedFile && (
+        <ImageCropModal
+          file={pickedFile}
+          onCancel={() => setPickedFile(null)}
+          onConfirm={onCropConfirm}
+        />
+      )}
     </>
+  );
+}
+
+function CameraPencilIcon() {
+  // Combined camera + pencil glyph. Camera body with a tiny pencil
+  // overlapping the lower-right of the lens — reads as "edit photo".
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 7h3l2-3h6l2 3h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" />
+      <circle cx="12" cy="13" r="3.5" />
+    </svg>
   );
 }
 

--- a/app/g/[groupShortId]/edit-title/page.tsx
+++ b/app/g/[groupShortId]/edit-title/page.tsx
@@ -40,20 +40,26 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
   const [headerRef, headerHeight] = useMeasuredHeight<HTMLDivElement>();
 
   const goBack = () => {
+    console.log('[edit-title] goBack called', {
+      hasAppHistory: hasAppHistory(),
+      pickedFile: !!pickedFile,
+      saving,
+      imageBusy,
+    });
     if (hasAppHistory()) navigateBackWithTransition();
     else navigateWithTransition(router, `/g/${groupId}/info`, 'back');
   };
 
   const save = async () => {
+    console.log('[edit-title] save called', { saving, value, original: group.groupTitleOverride });
     if (saving) return;
     setSaving(true);
     try {
-      // `groupId` is the route param — the server resolves any of
-      // `groups.short_id`, `groups.id`, `polls.short_id`, or
-      // `polls.id` to the same group. apiUpdateGroupTitle handles
-      // cache invalidation for every poll in the group.
+      console.log('[edit-title] save: calling apiUpdateGroupTitle');
       await apiUpdateGroupTitle(groupId, value.trim() || null);
+      console.log('[edit-title] save: apiUpdateGroupTitle resolved, calling goBack');
       goBack();
+      console.log('[edit-title] save: goBack returned');
     } catch (err) {
       console.error('Failed to update group title:', err);
       setSaving(false);

--- a/app/g/[groupShortId]/edit-title/page.tsx
+++ b/app/g/[groupShortId]/edit-title/page.tsx
@@ -17,29 +17,21 @@ import ImageCropModal from "@/components/ImageCropModal";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import { GroupLoading, GroupNotFound } from "@/components/GroupLoadState";
 
+/**
+ * Title + image staging: changes accumulate in local state and only commit
+ * on Save. Back triggers a "Discard changes?" confirmation when anything
+ * is staged. Picking a new image clears any pending removal; tapping
+ * Remove clears any pending blob.
+ */
 function Editor({ group, groupId }: { group: Group; groupId: string }) {
   const router = useRouter();
-  // Title state — the input value. The saved value is `group.groupTitleOverride`
-  // (raw value of `groups.title`, null when no override is set). Empty string in
-  // the input clears the override on save.
   const [value, setValue] = useState<string>(group.groupTitleOverride ?? '');
   const [saving, setSaving] = useState(false);
 
-  // Image staging: changes accumulate in local state and only commit on Save.
-  // Back triggers a confirmation if any staging is present.
-  //   * pendingCroppedBlob — a fresh image the user just cropped (overrides
-  //     anything that was already on the server).
-  //   * pendingImageRemoval — user tapped Remove; the server's current image
-  //     should be deleted on save. Cleared if the user then picks a new image.
-  // The previewed avatar uses the local blob URL when a fresh image is staged,
-  // null when removal is staged, otherwise the server-side `group.imageUrl`.
   const [pendingCroppedBlob, setPendingCroppedBlob] = useState<Blob | null>(null);
   const [pendingImageRemoval, setPendingImageRemoval] = useState(false);
   const [localImagePreviewUrl, setLocalImagePreviewUrl] = useState<string | null>(null);
 
-  // Blob URL lifecycle for the staged image preview. Created from the
-  // cropped Blob whenever it changes; revoked on cleanup. Same StrictMode-
-  // safe pattern as the cropper itself.
   useEffect(() => {
     if (!pendingCroppedBlob) {
       setLocalImagePreviewUrl(null);
@@ -90,15 +82,9 @@ function Editor({ group, groupId }: { group: Group; groupId: string }) {
     if (saving) return;
     setSaving(true);
     try {
-      // Image first — the cache-invalidation in apiUpload/Delete primes the
-      // accessible-polls cache so subsequent title-update + group reads pick
-      // up the same updated_at watermark cleanly. Order doesn't otherwise
-      // matter (each endpoint is independent server-side).
       if (pendingCroppedBlob) {
         await apiUploadGroupImage(groupId, pendingCroppedBlob);
       } else if (pendingImageRemoval && group.imageUrl) {
-        // Only call DELETE if there was actually an image to remove.
-        // (User-tapped Remove on a group with no image is a no-op.)
         await apiDeleteGroupImage(groupId);
       }
       if (titleChanged) {

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -73,12 +73,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         }
       />
 
-      {/* `-mt-6` neutralizes the 24px `py-6` top padding applied by the
-          page template wrapper (app/template.tsx) for non-root group
-          routes. Without it, content sits 24px below where our paddingTop
-          intends. With it, paddingTop ≈ headerHeight + small gap lands
-          the hero avatar just below the back/Edit header. */}
-      <div className="max-w-4xl mx-auto px-4 -mt-6" style={{ paddingTop: `calc(${headerHeight}px + 0.5rem)` }}>
+      <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: `calc(${headerHeight}px + 0.5rem)` }}>
         <div className="flex flex-col items-center text-center mb-8">
           <GroupAvatar
             imageUrl={group.imageUrl}

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -25,26 +25,8 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   const [headerRef, headerHeight] = useMeasuredHeight<HTMLDivElement>();
 
   const goBack = () => {
-    const hasHistory = hasAppHistory();
-    const supportsVT = typeof document !== 'undefined' && 'startViewTransition' in document;
-    console.log('[info-page] goBack called', {
-      hasHistory,
-      supportsVT,
-      currentPath: window.location.pathname,
-      groupId,
-      historyLength: window.history.length,
-    });
-    if (hasHistory) {
-      console.log('[info-page] calling navigateBackWithTransition');
-      navigateBackWithTransition();
-    } else {
-      console.log('[info-page] calling navigateWithTransition to /g/' + groupId);
-      navigateWithTransition(router, `/g/${groupId}`, 'back');
-    }
-    // Followup check to see if URL actually changed
-    setTimeout(() => {
-      console.log('[info-page] 1s after goBack', { currentPath: window.location.pathname });
-    }, 1000);
+    if (hasAppHistory()) navigateBackWithTransition();
+    else navigateWithTransition(router, `/g/${groupId}`, 'back');
   };
 
   // /info is the canonical roster — the viewer is always a member

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -25,8 +25,26 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   const [headerRef, headerHeight] = useMeasuredHeight<HTMLDivElement>();
 
   const goBack = () => {
-    if (hasAppHistory()) navigateBackWithTransition();
-    else navigateWithTransition(router, `/g/${groupId}`, 'back');
+    const hasHistory = hasAppHistory();
+    const supportsVT = typeof document !== 'undefined' && 'startViewTransition' in document;
+    console.log('[info-page] goBack called', {
+      hasHistory,
+      supportsVT,
+      currentPath: window.location.pathname,
+      groupId,
+      historyLength: window.history.length,
+    });
+    if (hasHistory) {
+      console.log('[info-page] calling navigateBackWithTransition');
+      navigateBackWithTransition();
+    } else {
+      console.log('[info-page] calling navigateWithTransition to /g/' + groupId);
+      navigateWithTransition(router, `/g/${groupId}`, 'back');
+    }
+    // Followup check to see if URL actually changed
+    setTimeout(() => {
+      console.log('[info-page] 1s after goBack', { currentPath: window.location.pathname });
+    }, 1000);
   };
 
   // /info is the canonical roster — the viewer is always a member

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -79,7 +79,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
             imageUrl={group.imageUrl}
             names={heroNames}
             anonymousCount={group.anonymousRespondentCount}
-            sizeClassName="w-28"
+            sizeClassName="w-[10.5rem]"
           />
           <h1 className="mt-4 text-3xl font-bold text-gray-900 dark:text-white break-words">
             {displayTitle}

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useParams } from "next/navigation";
 import { navigateWithTransition, navigateBackWithTransition, hasAppHistory } from "@/lib/viewTransitions";
 import { useGroup } from "@/lib/useGroup";
 import { useMeasuredHeight } from "@/lib/useMeasuredHeight";
-import RespondentCircles from "@/components/RespondentCircles";
+import GroupAvatar from "@/components/GroupAvatar";
 import GroupHeader from "@/components/GroupHeader";
 import { GroupLoading, GroupNotFound } from "@/components/GroupLoadState";
 import { getUserName } from "@/lib/userProfile";
@@ -75,7 +75,8 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
 
       <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: `calc(${headerHeight}px + 1.5rem)` }}>
         <div className="flex flex-col items-center text-center mb-8">
-          <RespondentCircles
+          <GroupAvatar
+            imageUrl={group.imageUrl}
             names={heroNames}
             anonymousCount={group.anonymousRespondentCount}
             sizeClassName="w-28"

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -73,7 +73,12 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         }
       />
 
-      <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: `calc(${headerHeight}px + 0.75rem)` }}>
+      {/* `-mt-6` neutralizes the 24px `py-6` top padding applied by the
+          page template wrapper (app/template.tsx) for non-root group
+          routes. Without it, content sits 24px below where our paddingTop
+          intends. With it, paddingTop ≈ headerHeight + small gap lands
+          the hero avatar just below the back/Edit header. */}
+      <div className="max-w-4xl mx-auto px-4 -mt-6" style={{ paddingTop: `calc(${headerHeight}px + 0.5rem)` }}>
         <div className="flex flex-col items-center text-center mb-8">
           <GroupAvatar
             imageUrl={group.imageUrl}

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -73,7 +73,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         }
       />
 
-      <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: `calc(${headerHeight}px + 1.5rem)` }}>
+      <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: `calc(${headerHeight}px + 0.75rem)` }}>
         <div className="flex flex-col items-center text-center mb-8">
           <GroupAvatar
             imageUrl={group.imageUrl}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -297,7 +297,7 @@ function TemplateInner({ children }: AppTemplateProps) {
         )}
 
         <div
-          className={`max-w-4xl mx-auto ${(pathname === '/' || isGroupLikePage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${isGroupLikePage ? '' : (isSettingsPage || pathname === '/') ? 'pt-0.5 pb-6' : 'py-6'}`}
+          className={`max-w-4xl mx-auto ${(pathname === '/' || isGroupLikePage) ? '-mx-4 sm:mx-auto sm:px-4' : 'px-4'} ${isGroupLikePage ? '' : (isSettingsPage || pathname === '/') ? 'pt-0.5 pb-6' : 'pb-6'}`}
           style={pathname === '/'
             // Home reserves enough room for the floating "+" FAB to clear the
             // last card.

--- a/components/GroupAvatar.tsx
+++ b/components/GroupAvatar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import RespondentCircles from '@/components/RespondentCircles';
+
+/**
+ * Group avatar — image-or-initials wrapper.
+ *
+ * When `imageUrl` is set, renders the uploaded image circle-clipped. When
+ * null, falls through to `RespondentCircles` (the multi-circle initials
+ * graphic). Same outer dimensions either way, so swapping at render time
+ * doesn't cause layout shift.
+ *
+ * Migration 108 added the image data; `Group.imageUrl` is the derived URL
+ * (already includes the `?v=<image_updated_at>` cache-buster, so changes
+ * propagate without explicit cache invalidation in the browser).
+ *
+ * The image is rendered with `object-fit: cover` so non-square sources
+ * still fill the circle, BUT the upload flow always crops to a square
+ * before sending, so this is just a safety net.
+ */
+interface GroupAvatarProps {
+  imageUrl: string | null;
+  names: string[];
+  anonymousCount: number;
+  sizeClassName?: string;
+}
+
+export default function GroupAvatar({
+  imageUrl,
+  names,
+  anonymousCount,
+  sizeClassName = 'w-16',
+}: GroupAvatarProps) {
+  if (imageUrl) {
+    return (
+      <div
+        className={`${sizeClassName} aspect-square flex-shrink-0 self-center rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700`}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={imageUrl}
+          alt=""
+          className="w-full h-full object-cover"
+          draggable={false}
+        />
+      </div>
+    );
+  }
+  return (
+    <RespondentCircles
+      names={names}
+      anonymousCount={anonymousCount}
+      sizeClassName={sizeClassName}
+    />
+  );
+}

--- a/components/GroupHeader.tsx
+++ b/components/GroupHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import RespondentCircles from "@/components/RespondentCircles";
+import GroupAvatar from "@/components/GroupAvatar";
 import { navigateWithTransition } from "@/lib/viewTransitions";
 
 export interface GroupHeaderProps {
@@ -9,6 +9,9 @@ export interface GroupHeaderProps {
   title?: string;
   participantNames?: string[];
   anonymousCount?: number;
+  /** Migration 108: when set, the header shows the uploaded image circle
+   *  instead of the initials graphic. Null/undefined → initials fallback. */
+  imageUrl?: string | null;
   subtitle?: string;
   onTitleClick?: () => void;
   onBack?: () => void;
@@ -43,6 +46,7 @@ export default function GroupHeader({
   title,
   participantNames,
   anonymousCount,
+  imageUrl,
   subtitle,
   onTitleClick,
   onBack,
@@ -67,7 +71,8 @@ export default function GroupHeader({
   const middleContent = (
     <>
       {participantNames && (
-        <RespondentCircles
+        <GroupAvatar
+          imageUrl={imageUrl ?? null}
           names={participantNames}
           anonymousCount={anonymousCount ?? 0}
         />

--- a/components/GroupList.tsx
+++ b/components/GroupList.tsx
@@ -333,6 +333,7 @@ export default function GroupList({ polls, emptyGroups = [], onGroupsForgotten }
             latestQuestionTitle={latestQuestion?.title ?? ''}
             participantNames={group.participantNames}
             anonymousRespondentCount={group.anonymousRespondentCount}
+            imageUrl={group.imageUrl}
             questionCount={group.questions.length}
             createdAt={latestQuestion?.created_at ?? null}
             statusBadge={group.isEmpty ? 'New group — tap to add a poll' : undefined}

--- a/components/GroupListItem.tsx
+++ b/components/GroupListItem.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import ClientOnly from "@/components/ClientOnly";
-import RespondentCircles from "@/components/RespondentCircles";
+import GroupAvatar from "@/components/GroupAvatar";
 import SimpleCountdown from "@/components/SimpleCountdown";
 import { relativeTime } from "@/lib/questionListUtils";
 
@@ -43,6 +43,10 @@ export interface GroupListItemProps {
    *  text content takes the full row width. Used by the draft poll card so the
    *  in-progress poll doesn't show pre-vote initials before anyone has voted. */
   hideRespondents?: boolean;
+  /** When set, the group has an uploaded avatar image — overrides the
+   *  initials graphic. Null/undefined → render the participant initials
+   *  (RespondentCircles). */
+  imageUrl?: string | null;
   /** Inline replacement for the relative-time stamp when `createdAt` is
    *  absent — e.g. "ready to submit" / "just now" for the draft poll card. */
   statusBadge?: React.ReactNode;
@@ -74,6 +78,7 @@ export default function GroupListItem(props: GroupListItemProps) {
     finalizing = false,
     isFirst = false,
     hideRespondents = false,
+    imageUrl = null,
     statusBadge,
     selectionMode = false,
     isSelected = false,
@@ -141,7 +146,8 @@ export default function GroupListItem(props: GroupListItemProps) {
         {/* Drafts skip this entirely so the "?" placeholder doesn't appear
             before anyone has actually voted. */}
         {!hideRespondents && (
-          <RespondentCircles
+          <GroupAvatar
+            imageUrl={imageUrl}
             names={participantNames}
             anonymousCount={anonymousRespondentCount}
           />

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -60,18 +60,29 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const imgRef = useRef<HTMLImageElement | null>(null);
 
-  // Load the file → image. Releasing the blob URL on cleanup.
+  // Load the file → image. The cancelled guard is load-bearing under
+  // React StrictMode (Next.js dev mode): StrictMode runs the effect →
+  // cleanup → effect again synchronously on mount. Without the guard,
+  // the first mount's cleanup revokes URL_A before its `img.onload` has
+  // a chance to fire, which then fires `onerror` (the blob is dead) and
+  // permanently sets `loadError` to "Couldn't read that image file" —
+  // overriding the second mount's successful load. Same trap applies to
+  // any async effect that maps a temporary blob URL to React state.
   useEffect(() => {
+    let cancelled = false;
     const url = URL.createObjectURL(file);
     const img = new Image();
     img.onload = () => {
+      if (cancelled) return;
       setImage({ url, width: img.naturalWidth, height: img.naturalHeight });
     };
     img.onerror = () => {
+      if (cancelled) return;
       setLoadError("Couldn't read that image file");
     };
     img.src = url;
     return () => {
+      cancelled = true;
       URL.revokeObjectURL(url);
     };
   }, [file]);

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -65,13 +65,16 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     const u = URL.createObjectURL(file);
+    console.log('[ImageCropModal] createObjectURL', {
+      url: u,
+      fileType: file.type,
+      fileSize: file.size,
+      fileName: (file as any).name,
+    });
     setUrl(u);
     return () => {
+      console.log('[ImageCropModal] revokeObjectURL', u);
       URL.revokeObjectURL(u);
-      // Also clear url state so a stale src isn't briefly applied to
-      // the img between cleanup and the next setup. Without this, the
-      // img would retain its src=URL_A attribute and fire onError as
-      // soon as the browser dispatches its load-fail event.
       setUrl((prev) => (prev === u ? null : prev));
     };
   }, [file]);
@@ -153,6 +156,13 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
     offsetXRef.current = 0;
     offsetYRef.current = 0;
     applyTransformToDom();
+    console.log('[ImageCropModal] applied initial transform', {
+      minScale,
+      frameSize,
+      imageW: imageDims.width,
+      imageH: imageDims.height,
+      imgStyle: imgRef.current?.getAttribute('style')?.slice(0, 200),
+    });
   }, [imageDims, frameSize, minScale]);
 
   function applyTransformToDom() {
@@ -384,6 +394,12 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
                 draggable={false}
                 onLoad={(e) => {
                   const t = e.currentTarget;
+                  console.log('[ImageCropModal] img onLoad', {
+                    naturalWidth: t.naturalWidth,
+                    naturalHeight: t.naturalHeight,
+                    src: t.src.slice(0, 60),
+                    complete: t.complete,
+                  });
                   if (t.naturalWidth > 0 && t.naturalHeight > 0) {
                     setImageDims({
                       width: t.naturalWidth,
@@ -392,7 +408,12 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
                     setLoadError(false);
                   }
                 }}
-                onError={() => setLoadError(true)}
+                onError={(e) => {
+                  console.log('[ImageCropModal] img onError', {
+                    src: (e.currentTarget as HTMLImageElement).src.slice(0, 60),
+                  });
+                  setLoadError(true);
+                }}
                 style={imageDims ? ({
                   position: 'absolute',
                   left: '50%',

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * Drag + pinch-zoom circular cropper.
+ *
+ * Renders a full-screen modal containing:
+ *  - a square crop frame whose visible area is a centered circle
+ *  - the source image rendered behind the frame, positioned by (offsetX, offsetY, scale)
+ *  - everything outside the circle is dimmed
+ *  - one-pointer drag → translate; two-pointer pinch → scale (around midpoint)
+ *  - on confirm, the visible-in-circle square is exported as a JPEG Blob
+ *
+ * Imperative pointer math (NOT React state per pointermove) so a 60Hz
+ * gesture doesn't cause 60 re-renders — the underlying transform is
+ * written directly to the image DOM, and React state only reflects the
+ * end-of-gesture snapshot. Same idiom as `RankableOptions`'s drag path.
+ *
+ * Minimum scale is "image must always fully cover the crop circle": the
+ * user can't zoom out far enough to expose blank space behind the crop.
+ *
+ * Output is `EXPORT_SIZE`-px JPEG with quality 0.9 (a couple dozen KB
+ * typically — well under the server's 5 MiB cap).
+ */
+
+const EXPORT_SIZE = 512;
+const JPEG_QUALITY = 0.9;
+const MAX_SCALE_OVER_MIN = 5;
+
+interface Props {
+  /** File the user just picked. Component owns the URL.createObjectURL
+   *  lifecycle — releases on unmount. */
+  file: File;
+  onCancel: () => void;
+  onConfirm: (croppedBlob: Blob) => void | Promise<void>;
+}
+
+interface ImageMeta {
+  url: string;
+  width: number;
+  height: number;
+}
+
+export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
+  const [image, setImage] = useState<ImageMeta | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Crop frame size — derived from viewport in a layout effect so the
+  // first paint already has the correct dimensions on iOS.
+  const [frameSize, setFrameSize] = useState(0);
+
+  // Transform state (committed end-of-gesture values; the in-flight
+  // transform is written imperatively to the DOM ref).
+  const offsetXRef = useRef(0);
+  const offsetYRef = useRef(0);
+  const scaleRef = useRef(1);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+
+  // Load the file → image. Releasing the blob URL on cleanup.
+  useEffect(() => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      setImage({ url, width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.onerror = () => {
+      setLoadError("Couldn't read that image file");
+    };
+    img.src = url;
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
+
+  // Pick the largest square that fits the viewport with sensible margins.
+  useLayoutEffect(() => {
+    const compute = () => {
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      // Leave room for header (cancel button) on top, save button on bottom.
+      const max = Math.min(vw - 32, vh - 200);
+      setFrameSize(Math.max(200, max));
+    };
+    compute();
+    window.addEventListener('resize', compute);
+    window.addEventListener('orientationchange', compute);
+    return () => {
+      window.removeEventListener('resize', compute);
+      window.removeEventListener('orientationchange', compute);
+    };
+  }, []);
+
+  // Body scroll lock — same pattern as other modals in the app.
+  useEffect(() => {
+    const scrollY = window.scrollY;
+    const prevStyle = {
+      position: document.body.style.position,
+      top: document.body.style.top,
+      width: document.body.style.width,
+    };
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = '100%';
+    return () => {
+      document.body.style.position = prevStyle.position;
+      document.body.style.top = prevStyle.top;
+      document.body.style.width = prevStyle.width;
+      window.scrollTo(0, scrollY);
+    };
+  }, []);
+
+  // Escape closes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  // Min scale: image must fully cover the crop frame in BOTH axes.
+  const minScale = useMemo(() => {
+    if (!image || frameSize === 0) return 1;
+    return Math.max(frameSize / image.width, frameSize / image.height);
+  }, [image, frameSize]);
+
+  // On image / frame-size change, reset the transform so the image is
+  // centered and minimally-zoomed inside the crop frame.
+  useLayoutEffect(() => {
+    if (!image || frameSize === 0) return;
+    scaleRef.current = minScale;
+    offsetXRef.current = 0;
+    offsetYRef.current = 0;
+    applyTransformToDom();
+  }, [image, frameSize, minScale]);
+
+  function applyTransformToDom() {
+    const el = imgRef.current;
+    if (!el) return;
+    // The img is positioned absolute, centered. translate first (so
+    // pan is in display pixels), then scale around its own center.
+    el.style.transform = `translate(${offsetXRef.current}px, ${offsetYRef.current}px) scale(${scaleRef.current})`;
+  }
+
+  // Clamp so the image always fully covers the crop frame.
+  function clamp(scale: number, ox: number, oy: number): [number, number, number] {
+    if (!image) return [scale, ox, oy];
+    const clampedScale = Math.max(minScale, Math.min(scale, minScale * MAX_SCALE_OVER_MIN));
+    const scaledW = image.width * clampedScale;
+    const scaledH = image.height * clampedScale;
+    const maxX = Math.max(0, (scaledW - frameSize) / 2);
+    const maxY = Math.max(0, (scaledH - frameSize) / 2);
+    const clampedX = Math.max(-maxX, Math.min(maxX, ox));
+    const clampedY = Math.max(-maxY, Math.min(maxY, oy));
+    return [clampedScale, clampedX, clampedY];
+  }
+
+  // --- Pointer state for drag + pinch ---
+  // Track active pointers by pointerId; pinch when 2 are down.
+  const pointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
+  const gestureStartRef = useRef<{
+    pointers: Map<number, { x: number; y: number }>;
+    centerX: number;
+    centerY: number;
+    distance: number;
+    scale: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+
+  function snapshotGesture() {
+    const pts = Array.from(pointersRef.current.values());
+    if (pts.length === 0) {
+      gestureStartRef.current = null;
+      return;
+    }
+    let cx = 0;
+    let cy = 0;
+    for (const p of pts) {
+      cx += p.x;
+      cy += p.y;
+    }
+    cx /= pts.length;
+    cy /= pts.length;
+    let dist = 1;
+    if (pts.length >= 2) {
+      const dx = pts[0].x - pts[1].x;
+      const dy = pts[0].y - pts[1].y;
+      dist = Math.max(1, Math.hypot(dx, dy));
+    }
+    gestureStartRef.current = {
+      pointers: new Map(pointersRef.current),
+      centerX: cx,
+      centerY: cy,
+      distance: dist,
+      scale: scaleRef.current,
+      offsetX: offsetXRef.current,
+      offsetY: offsetYRef.current,
+    };
+  }
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (!image) return;
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    snapshotGesture();
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!pointersRef.current.has(e.pointerId)) return;
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    const start = gestureStartRef.current;
+    if (!start || !image) return;
+
+    const pts = Array.from(pointersRef.current.values());
+    let cx = 0;
+    let cy = 0;
+    for (const p of pts) {
+      cx += p.x;
+      cy += p.y;
+    }
+    cx /= pts.length;
+    cy /= pts.length;
+
+    let newScale = start.scale;
+    if (pts.length >= 2) {
+      const dx = pts[0].x - pts[1].x;
+      const dy = pts[0].y - pts[1].y;
+      const dist = Math.max(1, Math.hypot(dx, dy));
+      newScale = start.scale * (dist / start.distance);
+    }
+
+    // Translate so the pinch midpoint stays put relative to the image.
+    // ox_new = ox_start + (cx_now - cx_start) + (centerX_relative_to_image
+    //   * (newScale - start.scale)). The "midpoint stays put" math:
+    //   pinch-midpoint in image-space = (centerX - frameCenterX - oxStart) / startScale
+    //   we want it to map to (centerX - frameCenterX - oxNew) / newScale
+    //   so oxNew = (centerX - frameCenterX) - newScale * imageX
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    if (!containerRect) return;
+    const frameCenterX = containerRect.left + containerRect.width / 2;
+    const frameCenterY = containerRect.top + containerRect.height / 2;
+    const imageXAtStart =
+      (start.centerX - frameCenterX - start.offsetX) / start.scale;
+    const imageYAtStart =
+      (start.centerY - frameCenterY - start.offsetY) / start.scale;
+    let newOffsetX = (cx - frameCenterX) - newScale * imageXAtStart;
+    let newOffsetY = (cy - frameCenterY) - newScale * imageYAtStart;
+
+    const [s, ox, oy] = clamp(newScale, newOffsetX, newOffsetY);
+    scaleRef.current = s;
+    offsetXRef.current = ox;
+    offsetYRef.current = oy;
+    applyTransformToDom();
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    pointersRef.current.delete(e.pointerId);
+    snapshotGesture();
+  };
+
+  // Wheel for desktop zoom (deltaY < 0 = zoom in).
+  const handleWheel = (e: React.WheelEvent) => {
+    if (!image || !containerRef.current) return;
+    e.preventDefault();
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const frameCenterX = containerRect.left + containerRect.width / 2;
+    const frameCenterY = containerRect.top + containerRect.height / 2;
+    const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+    const newScale = scaleRef.current * factor;
+    // Zoom around the cursor: keep cursor's image-space position fixed.
+    const imageXAtCursor =
+      (e.clientX - frameCenterX - offsetXRef.current) / scaleRef.current;
+    const imageYAtCursor =
+      (e.clientY - frameCenterY - offsetYRef.current) / scaleRef.current;
+    const newOffsetX = (e.clientX - frameCenterX) - newScale * imageXAtCursor;
+    const newOffsetY = (e.clientY - frameCenterY) - newScale * imageYAtCursor;
+    const [s, ox, oy] = clamp(newScale, newOffsetX, newOffsetY);
+    scaleRef.current = s;
+    offsetXRef.current = ox;
+    offsetYRef.current = oy;
+    applyTransformToDom();
+  };
+
+  async function handleConfirm() {
+    if (!image || submitting) return;
+    setSubmitting(true);
+    try {
+      const blob = await renderCropToBlob({
+        srcUrl: image.url,
+        imgWidth: image.width,
+        imgHeight: image.height,
+        frameSize,
+        scale: scaleRef.current,
+        offsetX: offsetXRef.current,
+        offsetY: offsetYRef.current,
+      });
+      await onConfirm(blob);
+    } catch (err) {
+      console.error('Crop export failed:', err);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] bg-black/90 flex flex-col items-center"
+      style={{
+        paddingTop: 'env(safe-area-inset-top, 0px)',
+        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+      }}
+    >
+      {/* Top bar: Cancel */}
+      <div className="w-full flex items-center justify-between px-4 py-3">
+        <button
+          onClick={onCancel}
+          className="px-3 py-2 text-white text-sm font-medium"
+          aria-label="Cancel"
+        >
+          Cancel
+        </button>
+        <span className="text-white text-sm font-medium select-none">
+          Drag to position · pinch to zoom
+        </span>
+        <div className="w-[68px]" aria-hidden />
+      </div>
+
+      {/* Crop frame */}
+      <div className="flex-1 flex items-center justify-center w-full px-4 overflow-hidden">
+        {loadError ? (
+          <p className="text-white text-sm">{loadError}</p>
+        ) : !image || frameSize === 0 ? (
+          <p className="text-white text-sm">Loading image…</p>
+        ) : (
+          <div
+            ref={containerRef}
+            className="relative overflow-hidden select-none"
+            style={{
+              width: frameSize,
+              height: frameSize,
+              touchAction: 'none',
+            }}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerCancel={handlePointerUp}
+            onWheel={handleWheel}
+          >
+            {/* Source image, transform applied imperatively */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              ref={imgRef}
+              src={image.url}
+              alt=""
+              draggable={false}
+              style={{
+                position: 'absolute',
+                left: '50%',
+                top: '50%',
+                width: image.width,
+                height: image.height,
+                marginLeft: -image.width / 2,
+                marginTop: -image.height / 2,
+                transformOrigin: 'center center',
+                userSelect: 'none',
+                WebkitUserDrag: 'none',
+              } as React.CSSProperties}
+            />
+            {/* Circular cutout overlay: darken everything outside the circle.
+                Implemented as an SVG mask so the inside stays crisp. */}
+            <svg
+              className="absolute inset-0 w-full h-full pointer-events-none"
+              viewBox={`0 0 ${frameSize} ${frameSize}`}
+              preserveAspectRatio="none"
+              aria-hidden
+            >
+              <defs>
+                <mask id="circle-mask">
+                  <rect width="100%" height="100%" fill="white" />
+                  <circle
+                    cx={frameSize / 2}
+                    cy={frameSize / 2}
+                    r={frameSize / 2}
+                    fill="black"
+                  />
+                </mask>
+              </defs>
+              <rect
+                width="100%"
+                height="100%"
+                fill="rgba(0,0,0,0.55)"
+                mask="url(#circle-mask)"
+              />
+              {/* Ring outline so the crop boundary reads clearly */}
+              <circle
+                cx={frameSize / 2}
+                cy={frameSize / 2}
+                r={frameSize / 2 - 1}
+                fill="none"
+                stroke="white"
+                strokeWidth={2}
+              />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom bar: Save */}
+      <div className="w-full flex items-center justify-center px-4 py-4">
+        <button
+          onClick={handleConfirm}
+          disabled={!image || submitting || !!loadError}
+          className="px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:opacity-50 text-white text-base font-semibold"
+        >
+          {submitting ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Render the visible-in-circle square of the source image to an
+ * `EXPORT_SIZE`-px JPEG Blob via canvas.
+ *
+ * The math: at confirm time, the displayed image fills a `frameSize`-sized
+ * square. Its CSS center is (offsetX, offsetY) relative to the frame
+ * center, scaled by `scale`. The visible square's image-space coordinates
+ * are derived by inverting that transform — top-left image px =
+ *   ((-frameSize/2) - offsetX) / scale + imgWidth/2  (etc.)
+ *
+ * The output is a square JPEG; the eventual circular display is just an
+ * `<img>` inside a `rounded-full overflow-hidden` div, so we don't need
+ * to alpha-mask the corners in the export.
+ */
+async function renderCropToBlob(args: {
+  srcUrl: string;
+  imgWidth: number;
+  imgHeight: number;
+  frameSize: number;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}): Promise<Blob> {
+  const { srcUrl, imgWidth, imgHeight, frameSize, scale, offsetX, offsetY } = args;
+
+  // Decode the image fresh into an HTMLImageElement so we can drawImage
+  // it onto a canvas. The blob URL is still alive (component unmount
+  // releases it) so this load is fast.
+  const img = await loadImage(srcUrl);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = EXPORT_SIZE;
+  canvas.height = EXPORT_SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('canvas 2d context unavailable');
+
+  // Visible square in image-space coordinates (px on the source).
+  const visibleLeftImg = (-frameSize / 2 - offsetX) / scale + imgWidth / 2;
+  const visibleTopImg = (-frameSize / 2 - offsetY) / scale + imgHeight / 2;
+  const visibleSizeImg = frameSize / scale;
+
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, EXPORT_SIZE, EXPORT_SIZE);
+  ctx.drawImage(
+    img,
+    visibleLeftImg,
+    visibleTopImg,
+    visibleSizeImg,
+    visibleSizeImg,
+    0,
+    0,
+    EXPORT_SIZE,
+    EXPORT_SIZE,
+  );
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error('canvas.toBlob returned null'));
+      },
+      'image/jpeg',
+      JPEG_QUALITY,
+    );
+  });
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('image load failed'));
+    img.src = url;
+  });
+}

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -65,15 +65,8 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     const u = URL.createObjectURL(file);
-    console.log('[ImageCropModal] createObjectURL', {
-      url: u,
-      fileType: file.type,
-      fileSize: file.size,
-      fileName: (file as any).name,
-    });
     setUrl(u);
     return () => {
-      console.log('[ImageCropModal] revokeObjectURL', u);
       URL.revokeObjectURL(u);
       setUrl((prev) => (prev === u ? null : prev));
     };
@@ -156,21 +149,6 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
     offsetXRef.current = 0;
     offsetYRef.current = 0;
     applyTransformToDom();
-    const el = imgRef.current;
-    const computed = el ? getComputedStyle(el) : null;
-    const rect = el?.getBoundingClientRect();
-    console.log('[ImageCropModal] applied initial transform', {
-      minScale,
-      frameSize,
-      imageW: imageDims.width,
-      imageH: imageDims.height,
-      inlineStyle: el?.getAttribute('style'),
-      computedTransform: computed?.transform,
-      computedDisplay: computed?.display,
-      computedVisibility: computed?.visibility,
-      computedOpacity: computed?.opacity,
-      rect: rect ? { w: rect.width, h: rect.height, x: rect.x, y: rect.y } : null,
-    });
   }, [imageDims, frameSize, minScale]);
 
   function applyTransformToDom() {
@@ -402,12 +380,6 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
                 draggable={false}
                 onLoad={(e) => {
                   const t = e.currentTarget;
-                  console.log('[ImageCropModal] img onLoad', {
-                    naturalWidth: t.naturalWidth,
-                    naturalHeight: t.naturalHeight,
-                    src: t.src.slice(0, 60),
-                    complete: t.complete,
-                  });
                   if (t.naturalWidth > 0 && t.naturalHeight > 0) {
                     setImageDims({
                       width: t.naturalWidth,
@@ -416,18 +388,24 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
                     setLoadError(false);
                   }
                 }}
-                onError={(e) => {
-                  console.log('[ImageCropModal] img onError', {
-                    src: (e.currentTarget as HTMLImageElement).src.slice(0, 60),
-                  });
-                  setLoadError(true);
-                }}
+                onError={() => setLoadError(true)}
                 style={imageDims ? ({
                   position: 'absolute',
                   left: '50%',
                   top: '50%',
                   width: imageDims.width,
                   height: imageDims.height,
+                  // Tailwind's preflight applies `img { max-width: 100%; height: auto }`
+                  // globally, which would cap our explicit width at the container's
+                  // 370px before the transform downscales it — producing the
+                  // "image is visibly 1/N the expected width" rendering on
+                  // every browser, not just iOS. We need the img to lay out at
+                  // its natural pixel size so transform: scale() correctly
+                  // fits the crop frame. (height: auto loses to our inline
+                  // height anyway, so only max-width is actually load-bearing
+                  // here, but maxHeight: 'none' is harmless insurance.)
+                  maxWidth: 'none',
+                  maxHeight: 'none',
                   marginLeft: -imageDims.width / 2,
                   marginTop: -imageDims.height / 2,
                   transformOrigin: 'center center',

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -156,12 +156,20 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
     offsetXRef.current = 0;
     offsetYRef.current = 0;
     applyTransformToDom();
+    const el = imgRef.current;
+    const computed = el ? getComputedStyle(el) : null;
+    const rect = el?.getBoundingClientRect();
     console.log('[ImageCropModal] applied initial transform', {
       minScale,
       frameSize,
       imageW: imageDims.width,
       imageH: imageDims.height,
-      imgStyle: imgRef.current?.getAttribute('style')?.slice(0, 200),
+      inlineStyle: el?.getAttribute('style'),
+      computedTransform: computed?.transform,
+      computedDisplay: computed?.display,
+      computedVisibility: computed?.visibility,
+      computedOpacity: computed?.opacity,
+      rect: rect ? { w: rect.width, h: rect.height, x: rect.x, y: rect.y } : null,
     });
   }, [imageDims, frameSize, minScale]);
 

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -36,14 +36,33 @@ interface Props {
   onConfirm: (croppedBlob: Blob) => void | Promise<void>;
 }
 
-interface ImageMeta {
-  url: string;
+interface ImageDims {
   width: number;
   height: number;
 }
 
 export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
-  const [image, setImage] = useState<ImageMeta | null>(null);
+  // Blob URL for the picked file. Created ONCE per mount instance via
+  // useState lazy init (which runs per component instance, including each
+  // React StrictMode mount) and revoked only on real unmount via an
+  // empty-deps useEffect cleanup. This avoids two pitfalls that bit
+  // earlier attempts:
+  //
+  //   1. StrictMode double-mount + useEffect cleanup that revoked the
+  //      URL while the in-flight load was still running. Now the URL
+  //      is decoupled from the load effect entirely.
+  //   2. iOS Safari/WKWebView (including iOS Firefox) silently refuses
+  //      to render data URLs longer than ~1-2 MB in <img src>. Phone
+  //      photos at 5-15 MB produced an empty crop frame. Blob URLs
+  //      have no such length limit.
+  //
+  // The displayed <img> is the only loader — its onLoad reports the
+  // natural dimensions and gates the rest of the cropper UI. No
+  // separate `new Image()` probe.
+  const [url] = useState(() => URL.createObjectURL(file));
+  useEffect(() => () => URL.revokeObjectURL(url), [url]);
+
+  const [imageDims, setImageDims] = useState<ImageDims | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -59,52 +78,6 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const imgRef = useRef<HTMLImageElement | null>(null);
-
-  // Load the file → image. Use FileReader → data URL rather than
-  // URL.createObjectURL: data URLs have no lifecycle (no
-  // revoke-vs-onload race under React StrictMode, no blob-URL quirks
-  // on iOS Safari / WebKit-based browsers like iOS Firefox where
-  // blob URLs created from <input type=file> have historically been
-  // flaky). The memory overhead is ~33% over the raw file, which is
-  // fine for a single image being cropped client-side.
-  //
-  // Cancellation guard is still kept: the effect can re-run if `file`
-  // changes (today: never, since the parent unmounts the modal to swap
-  // files — but cheap insurance against future callers).
-  useEffect(() => {
-    let cancelled = false;
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (cancelled) return;
-      const dataUrl = reader.result as string;
-      if (typeof dataUrl !== "string") {
-        setLoadError("Couldn't read that image file");
-        return;
-      }
-      const img = new Image();
-      img.onload = () => {
-        if (cancelled) return;
-        setImage({
-          url: dataUrl,
-          width: img.naturalWidth,
-          height: img.naturalHeight,
-        });
-      };
-      img.onerror = () => {
-        if (cancelled) return;
-        setLoadError("Couldn't read that image file");
-      };
-      img.src = dataUrl;
-    };
-    reader.onerror = () => {
-      if (cancelled) return;
-      setLoadError("Couldn't read that image file");
-    };
-    reader.readAsDataURL(file);
-    return () => {
-      cancelled = true;
-    };
-  }, [file]);
 
   // Pick the largest square that fits the viewport with sensible margins.
   useLayoutEffect(() => {
@@ -154,19 +127,19 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
 
   // Min scale: image must fully cover the crop frame in BOTH axes.
   const minScale = useMemo(() => {
-    if (!image || frameSize === 0) return 1;
-    return Math.max(frameSize / image.width, frameSize / image.height);
-  }, [image, frameSize]);
+    if (!imageDims || frameSize === 0) return 1;
+    return Math.max(frameSize / imageDims.width, frameSize / imageDims.height);
+  }, [imageDims, frameSize]);
 
   // On image / frame-size change, reset the transform so the image is
   // centered and minimally-zoomed inside the crop frame.
   useLayoutEffect(() => {
-    if (!image || frameSize === 0) return;
+    if (!imageDims || frameSize === 0) return;
     scaleRef.current = minScale;
     offsetXRef.current = 0;
     offsetYRef.current = 0;
     applyTransformToDom();
-  }, [image, frameSize, minScale]);
+  }, [imageDims, frameSize, minScale]);
 
   function applyTransformToDom() {
     const el = imgRef.current;
@@ -178,10 +151,10 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
 
   // Clamp so the image always fully covers the crop frame.
   function clamp(scale: number, ox: number, oy: number): [number, number, number] {
-    if (!image) return [scale, ox, oy];
+    if (!imageDims) return [scale, ox, oy];
     const clampedScale = Math.max(minScale, Math.min(scale, minScale * MAX_SCALE_OVER_MIN));
-    const scaledW = image.width * clampedScale;
-    const scaledH = image.height * clampedScale;
+    const scaledW = imageDims.width * clampedScale;
+    const scaledH = imageDims.height * clampedScale;
     const maxX = Math.max(0, (scaledW - frameSize) / 2);
     const maxY = Math.max(0, (scaledH - frameSize) / 2);
     const clampedX = Math.max(-maxX, Math.min(maxX, ox));
@@ -234,7 +207,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   }
 
   const handlePointerDown = (e: React.PointerEvent) => {
-    if (!image) return;
+    if (!imageDims) return;
     (e.target as Element).setPointerCapture?.(e.pointerId);
     pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     snapshotGesture();
@@ -244,7 +217,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
     if (!pointersRef.current.has(e.pointerId)) return;
     pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     const start = gestureStartRef.current;
-    if (!start || !image) return;
+    if (!start || !imageDims) return;
 
     const pts = Array.from(pointersRef.current.values());
     let cx = 0;
@@ -295,7 +268,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
 
   // Wheel for desktop zoom (deltaY < 0 = zoom in).
   const handleWheel = (e: React.WheelEvent) => {
-    if (!image || !containerRef.current) return;
+    if (!imageDims || !containerRef.current) return;
     e.preventDefault();
     const containerRect = containerRef.current.getBoundingClientRect();
     const frameCenterX = containerRect.left + containerRect.width / 2;
@@ -317,13 +290,13 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   };
 
   async function handleConfirm() {
-    if (!image || submitting) return;
+    if (!imageDims || submitting) return;
     setSubmitting(true);
     try {
       const blob = await renderCropToBlob({
-        srcUrl: image.url,
-        imgWidth: image.width,
-        imgHeight: image.height,
+        srcUrl: url,
+        imgWidth: imageDims.width,
+        imgHeight: imageDims.height,
         frameSize,
         scale: scaleRef.current,
         offsetX: offsetXRef.current,
@@ -363,7 +336,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
       <div className="flex-1 flex items-center justify-center w-full px-4 overflow-hidden">
         {loadError ? (
           <p className="text-white text-sm">{loadError}</p>
-        ) : !image || frameSize === 0 ? (
+        ) : frameSize === 0 ? (
           <p className="text-white text-sm">Loading image…</p>
         ) : (
           <div
@@ -380,26 +353,55 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
             onPointerCancel={handlePointerUp}
             onWheel={handleWheel}
           >
-            {/* Source image, transform applied imperatively */}
+            {/* Source image — always rendered so the browser loads it.
+                Until onLoad reports natural dimensions, the image is
+                hidden via `visibility: hidden` (so it still loads) and
+                the "Loading image…" overlay is shown on top. Once
+                imageDims is set, the inline width/height/margin/transform
+                math kicks in and the image becomes visible. */}
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               ref={imgRef}
-              src={image.url}
+              src={url}
               alt=""
               draggable={false}
-              style={{
+              onLoad={(e) => {
+                const t = e.currentTarget;
+                if (t.naturalWidth > 0 && t.naturalHeight > 0) {
+                  setImageDims({ width: t.naturalWidth, height: t.naturalHeight });
+                }
+              }}
+              onError={() => setLoadError("Couldn't read that image file")}
+              style={imageDims ? ({
                 position: 'absolute',
                 left: '50%',
                 top: '50%',
-                width: image.width,
-                height: image.height,
-                marginLeft: -image.width / 2,
-                marginTop: -image.height / 2,
+                width: imageDims.width,
+                height: imageDims.height,
+                marginLeft: -imageDims.width / 2,
+                marginTop: -imageDims.height / 2,
                 transformOrigin: 'center center',
                 userSelect: 'none',
                 WebkitUserDrag: 'none',
-              } as React.CSSProperties}
+              } as React.CSSProperties) : ({
+                // Pre-load: keep the img in the DOM (so it loads) but
+                // off-screen and zero-size so it doesn't affect layout
+                // or briefly flash at natural size before dimensions are
+                // captured.
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                width: 1,
+                height: 1,
+                opacity: 0,
+                pointerEvents: 'none',
+              } as React.CSSProperties)}
             />
+            {!imageDims && (
+              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <p className="text-white text-sm">Loading image…</p>
+              </div>
+            )}
             {/* Circular cutout overlay: darken everything outside the circle.
                 Implemented as an SVG mask so the inside stays crisp. */}
             <svg
@@ -443,7 +445,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
       <div className="w-full flex items-center justify-center px-4 py-4">
         <button
           onClick={handleConfirm}
-          disabled={!image || submitting || !!loadError}
+          disabled={!imageDims || submitting || !!loadError}
           className="px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:opacity-50 text-white text-base font-semibold"
         >
           {submitting ? 'Saving…' : 'Save'}

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -42,28 +42,42 @@ interface ImageDims {
 }
 
 export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
-  // Blob URL for the picked file. Created ONCE per mount instance via
-  // useState lazy init (which runs per component instance, including each
-  // React StrictMode mount) and revoked only on real unmount via an
-  // empty-deps useEffect cleanup. This avoids two pitfalls that bit
-  // earlier attempts:
+  // Blob URL for the picked file. Created+revoked inside the SAME effect
+  // so StrictMode's setup → cleanup → setup cycle pairs them correctly:
+  // mount 1 creates URL_A; cleanup revokes URL_A; mount 2 creates URL_B
+  // and writes it to state, triggering a re-render that swaps the
+  // displayed `<img src>` from the dead URL_A to the live URL_B. The
+  // first attempt at this pairing put the URL in `useState(() => ...)`
+  // lazy init — that locks the URL in state for the component's lifetime,
+  // so when StrictMode's cleanup revoked it, the setup effect couldn't
+  // create a replacement (state was already set), and the displayed img
+  // permanently pointed at a revoked URL.
   //
-  //   1. StrictMode double-mount + useEffect cleanup that revoked the
-  //      URL while the in-flight load was still running. Now the URL
-  //      is decoupled from the load effect entirely.
-  //   2. iOS Safari/WKWebView (including iOS Firefox) silently refuses
-  //      to render data URLs longer than ~1-2 MB in <img src>. Phone
-  //      photos at 5-15 MB produced an empty crop frame. Blob URLs
-  //      have no such length limit.
-  //
-  // The displayed <img> is the only loader — its onLoad reports the
-  // natural dimensions and gates the rest of the cropper UI. No
-  // separate `new Image()` probe.
-  const [url] = useState(() => URL.createObjectURL(file));
-  useEffect(() => () => URL.revokeObjectURL(url), [url]);
+  // Two other pitfalls this approach sidesteps:
+  //   - data URLs via FileReader are silently truncated by
+  //     iOS Safari/WKWebView (and iOS Firefox, which uses WKWebView)
+  //     beyond ~1-2 MB in `<img src>`. Phone photos at 5-15 MB
+  //     produced an empty crop frame. Blob URLs have no length limit.
+  //   - new Image() probes can mis-fire on mobile (decoded but with
+  //     naturalWidth=0 on iOS for some HEIC files); we let the
+  //     displayed `<img>` be the only loader and read dimensions from
+  //     its onLoad.
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    const u = URL.createObjectURL(file);
+    setUrl(u);
+    return () => {
+      URL.revokeObjectURL(u);
+      // Also clear url state so a stale src isn't briefly applied to
+      // the img between cleanup and the next setup. Without this, the
+      // img would retain its src=URL_A attribute and fire onError as
+      // soon as the browser dispatches its load-fail event.
+      setUrl((prev) => (prev === u ? null : prev));
+    };
+  }, [file]);
 
   const [imageDims, setImageDims] = useState<ImageDims | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   // Crop frame size — derived from viewport in a layout effect so the
@@ -334,9 +348,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
 
       {/* Crop frame */}
       <div className="flex-1 flex items-center justify-center w-full px-4 overflow-hidden">
-        {loadError ? (
-          <p className="text-white text-sm">{loadError}</p>
-        ) : frameSize === 0 ? (
+        {frameSize === 0 ? (
           <p className="text-white text-sm">Loading image…</p>
         ) : (
           <div
@@ -353,53 +365,61 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
             onPointerCancel={handlePointerUp}
             onWheel={handleWheel}
           >
-            {/* Source image — always rendered so the browser loads it.
-                Until onLoad reports natural dimensions, the image is
-                hidden via `visibility: hidden` (so it still loads) and
-                the "Loading image…" overlay is shown on top. Once
-                imageDims is set, the inline width/height/margin/transform
-                math kicks in and the image becomes visible. */}
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              ref={imgRef}
-              src={url}
-              alt=""
-              draggable={false}
-              onLoad={(e) => {
-                const t = e.currentTarget;
-                if (t.naturalWidth > 0 && t.naturalHeight > 0) {
-                  setImageDims({ width: t.naturalWidth, height: t.naturalHeight });
-                }
-              }}
-              onError={() => setLoadError("Couldn't read that image file")}
-              style={imageDims ? ({
-                position: 'absolute',
-                left: '50%',
-                top: '50%',
-                width: imageDims.width,
-                height: imageDims.height,
-                marginLeft: -imageDims.width / 2,
-                marginTop: -imageDims.height / 2,
-                transformOrigin: 'center center',
-                userSelect: 'none',
-                WebkitUserDrag: 'none',
-              } as React.CSSProperties) : ({
-                // Pre-load: keep the img in the DOM (so it loads) but
-                // off-screen and zero-size so it doesn't affect layout
-                // or briefly flash at natural size before dimensions are
-                // captured.
-                position: 'absolute',
-                left: 0,
-                top: 0,
-                width: 1,
-                height: 1,
-                opacity: 0,
-                pointerEvents: 'none',
-              } as React.CSSProperties)}
-            />
+            {/* Source image. Always rendered (when url is set) so the
+                browser loads it. Until onLoad reports natural dimensions,
+                the img is hidden 1×1px at top-left with opacity 0 — still
+                in the DOM, still loading. Once imageDims is set, the
+                inline width/height/margin/transform math takes over.
+                onError → loadError, but it doesn't unmount the img: a
+                src change (StrictMode mount 1 URL → mount 2 URL) will
+                trigger a fresh load attempt on the same img element, and
+                a successful onLoad both sets imageDims and clears
+                loadError. */}
+            {url && (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                ref={imgRef}
+                src={url}
+                alt=""
+                draggable={false}
+                onLoad={(e) => {
+                  const t = e.currentTarget;
+                  if (t.naturalWidth > 0 && t.naturalHeight > 0) {
+                    setImageDims({
+                      width: t.naturalWidth,
+                      height: t.naturalHeight,
+                    });
+                    setLoadError(false);
+                  }
+                }}
+                onError={() => setLoadError(true)}
+                style={imageDims ? ({
+                  position: 'absolute',
+                  left: '50%',
+                  top: '50%',
+                  width: imageDims.width,
+                  height: imageDims.height,
+                  marginLeft: -imageDims.width / 2,
+                  marginTop: -imageDims.height / 2,
+                  transformOrigin: 'center center',
+                  userSelect: 'none',
+                  WebkitUserDrag: 'none',
+                } as React.CSSProperties) : ({
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  width: 1,
+                  height: 1,
+                  opacity: 0,
+                  pointerEvents: 'none',
+                } as React.CSSProperties)}
+              />
+            )}
             {!imageDims && (
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                <p className="text-white text-sm">Loading image…</p>
+                <p className="text-white text-sm">
+                  {loadError ? "Couldn't read that image file" : "Loading image…"}
+                </p>
               </div>
             )}
             {/* Circular cutout overlay: darken everything outside the circle.
@@ -445,7 +465,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
       <div className="w-full flex items-center justify-center px-4 py-4">
         <button
           onClick={handleConfirm}
-          disabled={!imageDims || submitting || !!loadError}
+          disabled={!imageDims || submitting}
           className="px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:opacity-50 text-white text-base font-semibold"
         >
           {submitting ? 'Saving…' : 'Save'}

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -60,30 +60,49 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const imgRef = useRef<HTMLImageElement | null>(null);
 
-  // Load the file → image. The cancelled guard is load-bearing under
-  // React StrictMode (Next.js dev mode): StrictMode runs the effect →
-  // cleanup → effect again synchronously on mount. Without the guard,
-  // the first mount's cleanup revokes URL_A before its `img.onload` has
-  // a chance to fire, which then fires `onerror` (the blob is dead) and
-  // permanently sets `loadError` to "Couldn't read that image file" —
-  // overriding the second mount's successful load. Same trap applies to
-  // any async effect that maps a temporary blob URL to React state.
+  // Load the file → image. Use FileReader → data URL rather than
+  // URL.createObjectURL: data URLs have no lifecycle (no
+  // revoke-vs-onload race under React StrictMode, no blob-URL quirks
+  // on iOS Safari / WebKit-based browsers like iOS Firefox where
+  // blob URLs created from <input type=file> have historically been
+  // flaky). The memory overhead is ~33% over the raw file, which is
+  // fine for a single image being cropped client-side.
+  //
+  // Cancellation guard is still kept: the effect can re-run if `file`
+  // changes (today: never, since the parent unmounts the modal to swap
+  // files — but cheap insurance against future callers).
   useEffect(() => {
     let cancelled = false;
-    const url = URL.createObjectURL(file);
-    const img = new Image();
-    img.onload = () => {
+    const reader = new FileReader();
+    reader.onload = () => {
       if (cancelled) return;
-      setImage({ url, width: img.naturalWidth, height: img.naturalHeight });
+      const dataUrl = reader.result as string;
+      if (typeof dataUrl !== "string") {
+        setLoadError("Couldn't read that image file");
+        return;
+      }
+      const img = new Image();
+      img.onload = () => {
+        if (cancelled) return;
+        setImage({
+          url: dataUrl,
+          width: img.naturalWidth,
+          height: img.naturalHeight,
+        });
+      };
+      img.onerror = () => {
+        if (cancelled) return;
+        setLoadError("Couldn't read that image file");
+      };
+      img.src = dataUrl;
     };
-    img.onerror = () => {
+    reader.onerror = () => {
       if (cancelled) return;
       setLoadError("Couldn't read that image file");
     };
-    img.src = url;
+    reader.readAsDataURL(file);
     return () => {
       cancelled = true;
-      URL.revokeObjectURL(url);
     };
   }, [file]);
 

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -280,7 +280,7 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   };
 
   async function handleConfirm() {
-    if (!imageDims || submitting) return;
+    if (!imageDims || !url || submitting) return;
     setSubmitting(true);
     try {
       const blob = await renderCropToBlob({

--- a/components/ImageCropModal.tsx
+++ b/components/ImageCropModal.tsx
@@ -3,25 +3,11 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 /**
- * Drag + pinch-zoom circular cropper.
+ * Drag + pinch-zoom circular cropper modal.
  *
- * Renders a full-screen modal containing:
- *  - a square crop frame whose visible area is a centered circle
- *  - the source image rendered behind the frame, positioned by (offsetX, offsetY, scale)
- *  - everything outside the circle is dimmed
- *  - one-pointer drag → translate; two-pointer pinch → scale (around midpoint)
- *  - on confirm, the visible-in-circle square is exported as a JPEG Blob
- *
- * Imperative pointer math (NOT React state per pointermove) so a 60Hz
- * gesture doesn't cause 60 re-renders — the underlying transform is
- * written directly to the image DOM, and React state only reflects the
- * end-of-gesture snapshot. Same idiom as `RankableOptions`'s drag path.
- *
- * Minimum scale is "image must always fully cover the crop circle": the
- * user can't zoom out far enough to expose blank space behind the crop.
- *
- * Output is `EXPORT_SIZE`-px JPEG with quality 0.9 (a couple dozen KB
- * typically — well under the server's 5 MiB cap).
+ * Pointermove writes transform directly to the DOM (no per-frame React
+ * re-render); React state only holds end-of-gesture snapshots. Minimum
+ * scale guarantees the image always covers the crop frame.
  */
 
 const EXPORT_SIZE = 512;
@@ -42,26 +28,12 @@ interface ImageDims {
 }
 
 export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
-  // Blob URL for the picked file. Created+revoked inside the SAME effect
-  // so StrictMode's setup → cleanup → setup cycle pairs them correctly:
-  // mount 1 creates URL_A; cleanup revokes URL_A; mount 2 creates URL_B
-  // and writes it to state, triggering a re-render that swaps the
-  // displayed `<img src>` from the dead URL_A to the live URL_B. The
-  // first attempt at this pairing put the URL in `useState(() => ...)`
-  // lazy init — that locks the URL in state for the component's lifetime,
-  // so when StrictMode's cleanup revoked it, the setup effect couldn't
-  // create a replacement (state was already set), and the displayed img
-  // permanently pointed at a revoked URL.
-  //
-  // Two other pitfalls this approach sidesteps:
-  //   - data URLs via FileReader are silently truncated by
-  //     iOS Safari/WKWebView (and iOS Firefox, which uses WKWebView)
-  //     beyond ~1-2 MB in `<img src>`. Phone photos at 5-15 MB
-  //     produced an empty crop frame. Blob URLs have no length limit.
-  //   - new Image() probes can mis-fire on mobile (decoded but with
-  //     naturalWidth=0 on iOS for some HEIC files); we let the
-  //     displayed `<img>` be the only loader and read dimensions from
-  //     its onLoad.
+  // Blob URL for the picked file. Create + revoke + setUrl all pair inside
+  // one effect so React StrictMode's setup → cleanup → setup cycle swaps
+  // the displayed `<img src>` from the revoked URL_A to a fresh URL_B
+  // instead of stranding the img on a dead URL. Data URLs (FileReader)
+  // can't substitute: iOS WebKit silently fails `<img src>` for data URLs
+  // larger than ~1-2 MB, which most phone photos exceed.
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     const u = URL.createObjectURL(file);
@@ -176,7 +148,6 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   // Track active pointers by pointerId; pinch when 2 are down.
   const pointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
   const gestureStartRef = useRef<{
-    pointers: Map<number, { x: number; y: number }>;
     centerX: number;
     centerY: number;
     distance: number;
@@ -186,27 +157,30 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
   } | null>(null);
 
   function snapshotGesture() {
-    const pts = Array.from(pointersRef.current.values());
-    if (pts.length === 0) {
+    const pts = pointersRef.current;
+    if (pts.size === 0) {
       gestureStartRef.current = null;
       return;
     }
     let cx = 0;
     let cy = 0;
-    for (const p of pts) {
+    let first: { x: number; y: number } | null = null;
+    let second: { x: number; y: number } | null = null;
+    for (const p of pts.values()) {
       cx += p.x;
       cy += p.y;
+      if (first === null) first = p;
+      else if (second === null) second = p;
     }
-    cx /= pts.length;
-    cy /= pts.length;
+    cx /= pts.size;
+    cy /= pts.size;
     let dist = 1;
-    if (pts.length >= 2) {
-      const dx = pts[0].x - pts[1].x;
-      const dy = pts[0].y - pts[1].y;
+    if (first && second) {
+      const dx = first.x - second.x;
+      const dy = first.y - second.y;
       dist = Math.max(1, Math.hypot(dx, dy));
     }
     gestureStartRef.current = {
-      pointers: new Map(pointersRef.current),
       centerX: cx,
       centerY: cy,
       distance: dist,
@@ -229,30 +203,36 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
     const start = gestureStartRef.current;
     if (!start || !imageDims) return;
 
-    const pts = Array.from(pointersRef.current.values());
+    // Direct iteration of the Map values avoids allocating an Array per
+    // pointermove (this runs at ~60Hz on touch). At most 2 pointers in
+    // practice — we capture the first two as we go for the pinch-distance
+    // math without a separate slice.
+    const pts = pointersRef.current;
     let cx = 0;
     let cy = 0;
-    for (const p of pts) {
+    let first: { x: number; y: number } | null = null;
+    let second: { x: number; y: number } | null = null;
+    for (const p of pts.values()) {
       cx += p.x;
       cy += p.y;
+      if (first === null) first = p;
+      else if (second === null) second = p;
     }
-    cx /= pts.length;
-    cy /= pts.length;
+    cx /= pts.size;
+    cy /= pts.size;
 
     let newScale = start.scale;
-    if (pts.length >= 2) {
-      const dx = pts[0].x - pts[1].x;
-      const dy = pts[0].y - pts[1].y;
+    if (first && second) {
+      const dx = first.x - second.x;
+      const dy = first.y - second.y;
       const dist = Math.max(1, Math.hypot(dx, dy));
       newScale = start.scale * (dist / start.distance);
     }
 
-    // Translate so the pinch midpoint stays put relative to the image.
-    // ox_new = ox_start + (cx_now - cx_start) + (centerX_relative_to_image
-    //   * (newScale - start.scale)). The "midpoint stays put" math:
-    //   pinch-midpoint in image-space = (centerX - frameCenterX - oxStart) / startScale
-    //   we want it to map to (centerX - frameCenterX - oxNew) / newScale
-    //   so oxNew = (centerX - frameCenterX) - newScale * imageX
+    // Pinch math: midpoint in image-space at gesture start =
+    // (cx_start - frameCenter - offsetStart) / scaleStart. Holding that
+    // image-space point under the current midpoint gives
+    // offsetNew = cx_now - frameCenter - scaleNew * imageMidpoint.
     const containerRect = containerRef.current?.getBoundingClientRect();
     if (!containerRect) return;
     const frameCenterX = containerRect.left + containerRect.width / 2;
@@ -361,16 +341,10 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
             onPointerCancel={handlePointerUp}
             onWheel={handleWheel}
           >
-            {/* Source image. Always rendered (when url is set) so the
-                browser loads it. Until onLoad reports natural dimensions,
-                the img is hidden 1×1px at top-left with opacity 0 — still
-                in the DOM, still loading. Once imageDims is set, the
-                inline width/height/margin/transform math takes over.
-                onError → loadError, but it doesn't unmount the img: a
-                src change (StrictMode mount 1 URL → mount 2 URL) will
-                trigger a fresh load attempt on the same img element, and
-                a successful onLoad both sets imageDims and clears
-                loadError. */}
+            {/* Pre-load: img stays in the DOM as a 1×1 hidden element so
+                a src change (StrictMode swaps the blob URL) triggers a
+                fresh load attempt rather than unmount/remount. onLoad
+                sets imageDims and clears any stale loadError. */}
             {url && (
               /* eslint-disable-next-line @next/next/no-img-element */
               <img
@@ -395,15 +369,9 @@ export default function ImageCropModal({ file, onCancel, onConfirm }: Props) {
                   top: '50%',
                   width: imageDims.width,
                   height: imageDims.height,
-                  // Tailwind's preflight applies `img { max-width: 100%; height: auto }`
-                  // globally, which would cap our explicit width at the container's
-                  // 370px before the transform downscales it — producing the
-                  // "image is visibly 1/N the expected width" rendering on
-                  // every browser, not just iOS. We need the img to lay out at
-                  // its natural pixel size so transform: scale() correctly
-                  // fits the crop frame. (height: auto loses to our inline
-                  // height anyway, so only max-width is actually load-bearing
-                  // here, but maxHeight: 'none' is harmless insurance.)
+                  // Override Tailwind preflight's `img { max-width: 100% }`
+                  // so the img lays out at its natural pixel size; transform:
+                  // scale() then fits it to the crop frame.
                   maxWidth: 'none',
                   maxHeight: 'none',
                   marginLeft: -imageDims.width / 2,

--- a/database/migrations/108_add_group_image_down.sql
+++ b/database/migrations/108_add_group_image_down.sql
@@ -1,0 +1,10 @@
+-- Rollback for 108_add_group_image_up.sql
+
+BEGIN;
+
+ALTER TABLE groups
+  DROP COLUMN IF EXISTS image_updated_at,
+  DROP COLUMN IF EXISTS image_mime_type,
+  DROP COLUMN IF EXISTS image_data;
+
+COMMIT;

--- a/database/migrations/108_add_group_image_up.sql
+++ b/database/migrations/108_add_group_image_up.sql
@@ -1,0 +1,26 @@
+-- Group avatar image upload.
+--
+-- The home list, group page header, and /info hero all currently render
+-- a participant-initials avatar (RespondentCircles). This migration adds
+-- optional image storage so a group can upload a custom circular avatar
+-- that replaces the initials graphic.
+--
+-- Storage: inline BYTEA on the `groups` row. The FE crops to a square
+-- before upload and the server stores the resulting JPEG/PNG bytes
+-- verbatim (no server-side resize today; the FE caps the export at
+-- ~512px). Inline storage keeps backups simple — pg_dump covers it
+-- automatically — and avoids a second storage surface.
+--
+-- `image_updated_at` doubles as the cache-buster: the FE constructs
+-- `/api/groups/by-route-id/<id>/image?v=<isoTimestamp>` so a freshly
+-- updated image invalidates browser + CDN caches without changing the
+-- group's identity.
+
+BEGIN;
+
+ALTER TABLE groups
+  ADD COLUMN image_data BYTEA,
+  ADD COLUMN image_mime_type TEXT,
+  ADD COLUMN image_updated_at TIMESTAMPTZ;
+
+COMMIT;

--- a/lib/api/_internal.ts
+++ b/lib/api/_internal.ts
@@ -209,6 +209,7 @@ export function toPoll(data: any): Poll {
     is_closed: data.is_closed ?? false,
     close_reason: data.close_reason ?? null,
     group_title: data.group_title ?? null,
+    group_image_updated_at: data.group_image_updated_at ?? null,
     context: data.context ?? null,
     details: data.details ?? null,
     title: data.title,

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -39,6 +39,7 @@ function toGroupSummary(data: any): GroupSummary {
     short_id: data.short_id ?? null,
     title: data.title ?? null,
     created_at: data.created_at,
+    image_updated_at: data.image_updated_at ?? null,
   };
 }
 
@@ -181,4 +182,78 @@ export async function apiUpdateGroupTitle(
   }
   invalidateAccessibleQuestions();
   return result;
+}
+
+/** Upload (or replace) a group's avatar image. Migration 108.
+ *
+ *  `imageBlob` is the FE-cropped square image — a JPEG or PNG Blob produced
+ *  by the cropper's canvas export. Encoded to base64 and POSTed as JSON
+ *  to match the rest of the API's content-type contract.
+ *
+ *  Invalidates every cached poll in the group (each carries
+ *  `group_image_updated_at`) plus the accessible-polls cache, so the next
+ *  read picks up the new timestamp + URL.
+ */
+export async function apiUploadGroupImage(
+  routeId: string,
+  imageBlob: Blob,
+): Promise<{ group_id: string; group_short_id: string | null; image_updated_at: string | null }> {
+  const mimeType = imageBlob.type || 'image/jpeg';
+  const arrayBuffer = await imageBlob.arrayBuffer();
+  const base64 = base64FromArrayBuffer(arrayBuffer);
+  const data = await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/image`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ image_base64: base64, mime_type: mimeType }),
+    },
+  );
+  const result = {
+    group_id: data.group_id as string,
+    group_short_id: (data.group_short_id ?? null) as string | null,
+    image_updated_at: (data.image_updated_at ?? null) as string | null,
+  };
+  invalidateGroupPolls(result.group_id);
+  return result;
+}
+
+/** Clear a group's avatar image (FE falls back to initials). Idempotent
+ *  server-side — safe to call even when no image is set. */
+export async function apiDeleteGroupImage(
+  routeId: string,
+): Promise<{ group_id: string; group_short_id: string | null }> {
+  const data = await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/image`,
+    { method: 'DELETE' },
+  );
+  const result = {
+    group_id: data.group_id as string,
+    group_short_id: (data.group_short_id ?? null) as string | null,
+  };
+  invalidateGroupPolls(result.group_id);
+  return result;
+}
+
+function invalidateGroupPolls(groupId: string) {
+  const accessible = getCachedAccessiblePolls() ?? [];
+  for (const mp of accessible) {
+    if (mp.group_id === groupId) invalidatePoll(mp.id);
+  }
+  invalidateAccessibleQuestions();
+}
+
+/** Encode an ArrayBuffer as base64. Chunked to avoid the `apply()`
+ *  call-stack limit on big buffers — handles the 5 MiB max-image-size
+ *  cap comfortably. */
+function base64FromArrayBuffer(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + CHUNK)),
+    );
+  }
+  return btoa(binary);
 }

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -44,6 +44,8 @@ export {
   apiGetGroupSummary,
   apiLeaveGroup,
   apiUpdateGroupTitle,
+  apiUploadGroupImage,
+  apiDeleteGroupImage,
 } from "./groups";
 
 export {

--- a/lib/groupRefresh.ts
+++ b/lib/groupRefresh.ts
@@ -107,6 +107,7 @@ function isPollContentEqual(a: Poll, b: Poll): boolean {
   if (a.prephase_deadline !== b.prephase_deadline) return false;
   if (a.prephase_deadline_minutes !== b.prephase_deadline_minutes) return false;
   if (a.group_title !== b.group_title) return false;
+  if (a.group_image_updated_at !== b.group_image_updated_at) return false;
   if (a.title !== b.title) return false;
   if (a.context !== b.context) return false;
   if (a.details !== b.details) return false;

--- a/lib/groupUtils.ts
+++ b/lib/groupUtils.ts
@@ -357,9 +357,8 @@ function buildGroupFromPolls(
   // Every poll in the group carries the same `group_image_updated_at`
   // (sourced server-side from `groups.image_updated_at` via JOIN). Read
   // off the latest poll for symmetry with the group_title source.
-  const groupRouteIdForImage = latestPoll.group_short_id ?? polls[0].group_id ?? null;
   const imageUrl = buildGroupImageUrl(
-    groupRouteIdForImage,
+    latestPoll.group_short_id ?? latestPoll.group_id ?? null,
     latestPoll.group_image_updated_at ?? null,
   );
 

--- a/lib/groupUtils.ts
+++ b/lib/groupUtils.ts
@@ -147,6 +147,25 @@ export interface Group {
   targetedPoll: Poll | null;
   /** Estimated count of anonymous respondents (max across polls). */
   anonymousRespondentCount: number;
+  /** Migration 108: URL of the group's uploaded avatar image, or null
+   *  when no custom image is set. When null, the FE falls back to the
+   *  initials-circles graphic (RespondentCircles). When set, the URL
+   *  includes a `?v=<timestamp>` cache-buster so the browser refetches
+   *  on every change. */
+  imageUrl: string | null;
+}
+
+/** Build the avatar image URL for a group from its route id + image-updated
+ *  timestamp. The endpoint is server-resolved to the group, so any of the
+ *  four route-id forms (groups.short_id, groups.id, polls.short_id, polls.id)
+ *  work. Returns null when no image is set on the group. */
+export function buildGroupImageUrl(
+  routeId: string | null | undefined,
+  imageUpdatedAt: string | null | undefined,
+): string | null {
+  if (!routeId || !imageUpdatedAt) return null;
+  const v = encodeURIComponent(imageUpdatedAt);
+  return `/api/groups/by-route-id/${encodeURIComponent(routeId)}/image?v=${v}`;
 }
 
 /** True iff the poll wrapper is open: not manually closed AND no
@@ -335,6 +354,15 @@ function buildGroupFromPolls(
 
   const targetedPoll = pickTargetedPoll(polls, votedQuestionIds, abstainedQuestionIds, now);
 
+  // Every poll in the group carries the same `group_image_updated_at`
+  // (sourced server-side from `groups.image_updated_at` via JOIN). Read
+  // off the latest poll for symmetry with the group_title source.
+  const groupRouteIdForImage = latestPoll.group_short_id ?? polls[0].group_id ?? null;
+  const imageUrl = buildGroupImageUrl(
+    groupRouteIdForImage,
+    latestPoll.group_image_updated_at ?? null,
+  );
+
   return {
     rootQuestionId: questions[0].id,
     rootPollId: polls[0].id,
@@ -357,6 +385,7 @@ function buildGroupFromPolls(
     latestPoll,
     targetedPoll,
     anonymousRespondentCount,
+    imageUrl,
   };
 }
 
@@ -390,6 +419,10 @@ export function buildEmptyGroup(summary: GroupSummary): Group {
     latestPoll: null,
     targetedPoll: null,
     anonymousRespondentCount: 0,
+    imageUrl: buildGroupImageUrl(
+      summary.short_id ?? summary.id,
+      summary.image_updated_at ?? null,
+    ),
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -133,6 +133,10 @@ export interface GroupSummary {
   short_id?: string | null;
   title?: string | null;
   created_at: string;
+  // Migration 108: ISO timestamp of when the group's avatar image was
+  // last set. Null when no custom image is set. Doubles as the cache-
+  // buster query param on `/api/groups/by-route-id/<id>/image`.
+  image_updated_at?: string | null;
 }
 
 // Poll wrapper. Mirrors PollResponse in server/models.py.
@@ -158,6 +162,11 @@ export interface Poll {
   // (single source of truth, one row per group). Every poll in the same
   // group receives the same value.
   group_title?: string | null;
+  // Migration 108: ISO timestamp of when the group's avatar image was
+  // last set/cleared. Null when no custom image is set. Every poll in
+  // the same group carries the same value (sourced from groups.image_updated_at
+  // via JOIN). Doubles as the cache-buster query param on the image URL.
+  group_image_updated_at?: string | null;
   context?: string | null;
   details?: string | null;
   title: string;

--- a/server/models.py
+++ b/server/models.py
@@ -319,6 +319,12 @@ class PollResponse(BaseModel):
     # mid-deploy races where a group row briefly exists without a short_id.
     group_id: str | None = None
     group_short_id: str | None = None
+    # Migration 108: ISO timestamp of when the group's avatar image was
+    # last set/cleared. Null when no custom image is set. Doubles as the
+    # cache-buster for `/api/groups/by-route-id/<id>/image?v=<timestamp>`
+    # — every poll in the group carries the same value, so the FE knows
+    # whether to render a fallback initials avatar or the uploaded image.
+    group_image_updated_at: str | None = None
     # Poll-level results-display + ranked-choice settings (migration 098).
     min_responses: int | None = None
     show_preliminary_results: bool = True

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -30,7 +30,11 @@ first.
 
 from __future__ import annotations
 
+import base64
+import binascii
+
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from database import get_db
@@ -52,12 +56,19 @@ class GroupSummary(BaseModel):
     yet. Surfaced by `POST /api/groups` (the empty-group create endpoint),
     `GET /api/groups/by-route-id/{id}/summary` (for the group page's
     direct-URL load when there are no visible polls), and the
-    `empty_groups` array on `POST /api/groups/mine`."""
+    `empty_groups` array on `POST /api/groups/mine`.
+
+    `image_updated_at` (migration 108) is the ISO timestamp of when the
+    group's avatar image was last set/cleared. Null when no custom image
+    is set. The FE constructs `/api/groups/by-route-id/<id>/image?v=<ts>`
+    using this value as the cache-buster.
+    """
 
     id: str
     short_id: str | None = None
     title: str | None = None
     created_at: str
+    image_updated_at: str | None = None
 
 
 class GroupPreviewResponse(BaseModel):
@@ -69,6 +80,33 @@ class GroupPreviewResponse(BaseModel):
 
     title: str
     description: str | None = None
+
+
+class GroupImageRequest(BaseModel):
+    """`POST /api/groups/{route_id}/image` body.
+
+    `image_base64` is the FE-cropped square image (JPEG or PNG) encoded as
+    base64 with no `data:` prefix. `mime_type` must be `image/jpeg` or
+    `image/png`. Max decoded size: `MAX_IMAGE_BYTES`. The FE crops to a
+    square + downscales to ~512px before sending, so the typical payload
+    is well under 100KB.
+    """
+
+    image_base64: str
+    mime_type: str
+
+
+class GroupImageResponse(BaseModel):
+    group_id: str
+    group_short_id: str | None = None
+    image_updated_at: str | None = None
+
+
+# 5 MiB — well above the FE-cropped ~100KB target but below anything
+# that would risk OOMing the 1GB droplet's API container even on a
+# pathological client.
+MAX_IMAGE_BYTES = 5 * 1024 * 1024
+_ALLOWED_IMAGE_MIME_TYPES = frozenset({"image/jpeg", "image/png"})
 
 
 class GroupTitleResponse(BaseModel):
@@ -158,7 +196,7 @@ def get_my_empty_groups(request: Request):
         return []
     with get_db() as conn:
         rows = conn.execute(
-            """SELECT g.id, g.short_id, g.title, g.created_at
+            """SELECT g.id, g.short_id, g.title, g.created_at, g.image_updated_at
                  FROM groups g
                  JOIN group_members m ON m.group_id = g.id
                 WHERE m.browser_id = %(bid)s
@@ -173,11 +211,13 @@ def get_my_empty_groups(request: Request):
 
 def _row_to_group_summary(row) -> GroupSummary:
     created_at = row.get("created_at")
+    image_updated_at = row.get("image_updated_at")
     return GroupSummary(
         id=str(row["id"]),
         short_id=row.get("short_id"),
         title=row.get("title"),
         created_at=created_at.isoformat() if created_at else "",
+        image_updated_at=image_updated_at.isoformat() if image_updated_at else None,
     )
 
 
@@ -196,7 +236,7 @@ def create_group(request: Request):
     with get_db() as conn:
         row = conn.execute(
             "INSERT INTO groups DEFAULT VALUES "
-            "RETURNING id, short_id, title, created_at"
+            "RETURNING id, short_id, title, created_at, image_updated_at"
         ).fetchone()
         grant_group_membership_inline(conn, str(row["id"]), browser_id)
         return _row_to_group_summary(row)
@@ -218,7 +258,7 @@ def get_group_summary(route_id: str):
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
         row = conn.execute(
-            "SELECT id, short_id, title, created_at "
+            "SELECT id, short_id, title, created_at, image_updated_at "
             "FROM groups WHERE id = %(id)s",
             {"id": group_id},
         ).fetchone()
@@ -392,6 +432,125 @@ def update_group_title(route_id: str, req: UpdateGroupTitleRequest):
         group_short_id=row.get("short_id"),
         title=row.get("title"),
     )
+
+
+@router.post("/{route_id}/image", response_model=GroupImageResponse)
+def upload_group_image(route_id: str, req: GroupImageRequest):
+    """Set the group's avatar image (migration 108).
+
+    Body: base64-encoded JPEG or PNG bytes (already square-cropped by the
+    FE — the server does NOT crop or resize). Replaces any previous image
+    on the group. Stamps `image_updated_at` so the FE knows to invalidate
+    its `/api/groups/by-route-id/<id>/image?v=<ts>` cache.
+
+    Anyone with the URL can change the group's image — same trust model
+    as `POST /api/groups/{route_id}/title`. No creator-secret check today.
+
+    `route_id` accepts the same four forms as `/by-route-id/{route_id}`:
+    `groups.short_id`, `groups.id`, `polls.short_id`, `polls.id`.
+    """
+    if req.mime_type not in _ALLOWED_IMAGE_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail="Image mime_type must be image/jpeg or image/png",
+        )
+    try:
+        image_bytes = base64.b64decode(req.image_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid base64 image data: {exc}"
+        ) from exc
+    if not image_bytes:
+        raise HTTPException(status_code=400, detail="Image is empty")
+    if len(image_bytes) > MAX_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Image exceeds {MAX_IMAGE_BYTES} bytes",
+        )
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        row = conn.execute(
+            """
+            UPDATE groups
+               SET image_data = %(data)s,
+                   image_mime_type = %(mime)s,
+                   image_updated_at = NOW()
+             WHERE id = %(id)s
+            RETURNING id, short_id, image_updated_at
+            """,
+            {"id": group_id, "data": image_bytes, "mime": req.mime_type},
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Group not found")
+    image_updated_at = row.get("image_updated_at")
+    return GroupImageResponse(
+        group_id=str(row["id"]),
+        group_short_id=row.get("short_id"),
+        image_updated_at=image_updated_at.isoformat() if image_updated_at else None,
+    )
+
+
+@router.delete("/{route_id}/image", response_model=GroupImageResponse)
+def delete_group_image(route_id: str):
+    """Clear the group's avatar image. Idempotent — a 200 is returned
+    even if no image was set, so the FE doesn't have to distinguish
+    "was set" from "wasn't set" to reset state. `image_updated_at` is
+    set to NULL so the FE falls back to the initials avatar."""
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        row = conn.execute(
+            """
+            UPDATE groups
+               SET image_data = NULL,
+                   image_mime_type = NULL,
+                   image_updated_at = NULL
+             WHERE id = %(id)s
+            RETURNING id, short_id, image_updated_at
+            """,
+            {"id": group_id},
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Group not found")
+    return GroupImageResponse(
+        group_id=str(row["id"]),
+        group_short_id=row.get("short_id"),
+        image_updated_at=None,
+    )
+
+
+@router.get("/by-route-id/{route_id}/image")
+def get_group_image(route_id: str):
+    """Serve the group's avatar image bytes with the stored MIME type.
+
+    Public — no membership / browser-id check. The URL itself is
+    unguessable (it requires the group's short_id or uuid), and the
+    image surface is intentionally narrow (just the avatar). Cached
+    via the FE's `?v=<image_updated_at>` query string; the response
+    sets `Cache-Control: public, max-age=31536000, immutable` so a
+    given URL never re-fetches once received (the next change bumps
+    the timestamp, producing a new URL).
+
+    Returns 404 when no image is set (FE renders fallback initials).
+    """
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        row = conn.execute(
+            "SELECT image_data, image_mime_type FROM groups WHERE id = %(id)s",
+            {"id": group_id},
+        ).fetchone()
+        if not row or not row.get("image_data"):
+            raise HTTPException(status_code=404, detail="Image not set")
+        return Response(
+            content=bytes(row["image_data"]),
+            media_type=row.get("image_mime_type") or "application/octet-stream",
+            headers={"Cache-Control": "public, max-age=31536000, immutable"},
+        )
 
 
 @router.delete("/{route_id}/membership", status_code=204)

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -51,7 +51,8 @@ router = APIRouter(prefix="/api/polls", tags=["polls"])
 _SELECT_POLLS_WITH_GROUP = (
     "SELECT polls.*, "
     "t.short_id AS group_short_id, "
-    "t.title AS group_title "
+    "t.title AS group_title, "
+    "t.image_updated_at AS group_image_updated_at "
     "FROM polls LEFT JOIN groups t ON polls.group_id = t.id"
 )
 
@@ -169,15 +170,18 @@ def _attach_group_fields(conn, row) -> dict:
     """
     out = dict(row)
     if out.get("group_id") and not (
-        out.get("group_short_id") and "group_title" in out
+        out.get("group_short_id")
+        and "group_title" in out
+        and "group_image_updated_at" in out
     ):
         t = conn.execute(
-            "SELECT short_id, title FROM groups WHERE id = %(id)s",
+            "SELECT short_id, title, image_updated_at FROM groups WHERE id = %(id)s",
             {"id": out["group_id"]},
         ).fetchone()
         if t:
             out.setdefault("group_short_id", t.get("short_id"))
             out.setdefault("group_title", t.get("title"))
+            out.setdefault("group_image_updated_at", t.get("image_updated_at"))
     return out
 
 
@@ -359,6 +363,7 @@ def _row_to_poll(
         is_closed=row.get("is_closed", False),
         close_reason=row.get("close_reason"),
         group_title=row.get("group_title"),
+        group_image_updated_at=_iso_or_none(row.get("group_image_updated_at")),
         context=row.get("context"),
         details=row.get("details"),
         title=_compute_display_title(row, question_rows),

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -16,6 +16,7 @@ rest.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -324,9 +325,15 @@ def polls_for_poll_ids(
 def group_ids_for_question_ids(conn, question_ids: list[str]) -> list[str]:
     """Resolve a list of question_ids to the set of group_ids that own them.
     Skips question_ids without a poll_id (post-Phase-4 there shouldn't be any)
-    and polls without a group_id (post-migration-100 there aren't any). Order
-    is unstable — the caller deduplicates."""
-    if not question_ids:
+    and polls without a group_id (post-migration-100 there aren't any).
+    Silently drops any non-UUID values from the caller's list before the query
+    — the FE's localStorage accessible-question list can pick up corrupted
+    entries (legacy bugs, manual edits) and one bad id used to 500 the whole
+    `/api/groups/mine` request, wedging the home page. Filtering here is
+    pragmatic resilience; the FE should also validate before sending.
+    Order is unstable — the caller deduplicates."""
+    valid_ids = [qid for qid in question_ids if _is_uuid_like(qid)]
+    if not valid_ids:
         return []
     rows = conn.execute(
         """SELECT DISTINCT mp.group_id
@@ -334,9 +341,19 @@ def group_ids_for_question_ids(conn, question_ids: list[str]) -> list[str]:
              JOIN polls mp ON p.poll_id = mp.id
             WHERE p.id = ANY(%(ids)s)
               AND mp.group_id IS NOT NULL""",
-        {"ids": question_ids},
+        {"ids": valid_ids},
     ).fetchall()
     return [str(r["group_id"]) for r in rows]
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _is_uuid_like(value: str) -> bool:
+    return isinstance(value, str) and bool(_UUID_RE.match(value))
 
 
 def poll_ids_for_group_ids(conn, group_ids: list[str]) -> list[str]:


### PR DESCRIPTION
## Summary

Groups can now have a custom uploaded image avatar that replaces the participant-initials graphic at every group-icon surface (home list, group page header, /info hero). The edit page hosts a circular drag/pinch crop modal; all changes stage locally and only commit on Save, with a "Discard changes?" confirmation guarding back navigation.

- Migration 108 adds `image_data BYTEA`, `image_mime_type TEXT`, `image_updated_at TIMESTAMPTZ` to `groups`. Bytes live in Postgres so pg_dump captures them and no second storage surface is needed.
- New endpoints: `POST/DELETE /api/groups/{route_id}/image` and `GET /api/groups/by-route-id/{route_id}/image` (immutable cache, `?v=<image_updated_at>` cache-buster). 5 MiB upload cap, JPEG/PNG only.
- `image_updated_at` flows through `PollResponse` via the existing `_SELECT_POLLS_WITH_GROUP` JOIN; `Poll.group_image_updated_at` lands on the FE and `Group.imageUrl` is derived in `lib/groupUtils.ts`.
- New `<GroupAvatar>` wraps `<RespondentCircles>` — renders the uploaded image when present, falls through to initials otherwise. Same outer dimensions either way, so swapping doesn't shift layout.
- New `<ImageCropModal>` handles drag + pinch zoom + canvas export at 512px / quality 0.9. Imperative pointer math (DOM transform written directly) avoids per-frame React re-renders during gestures.
- Edit-title flow rewritten to defer all image+title changes to local state and commit on Save; tapping back when changes are staged shows a red Discard confirmation.
- `/info` hero avatar bumped 50% (w-28 → w-[10.5rem]) and tightened: the page-template wrapper's `py-6` was retired to `pb-6` (the only real-content sub-routes in that bucket — /info and /edit-title — already manage their own paddingTop for fixed-header clearance, so `py-6` was duplicating 24px of top space).
- Server-side resilience: `group_ids_for_question_ids` now filters non-UUID values from the FE-supplied list before the SQL query, so one corrupt entry in `accessibleQuestionIds` localStorage can't 500 the entire `/api/groups/mine` request (which would render "An unexpected error occurred" on the home page).

### Pitfalls surfaced (now documented in CLAUDE.md)

1. **iOS WebKit silently fails `<img src="data:…">` for data URLs over ~1-2 MB.** Phone photos at 5-15 MB produce an empty crop frame. Blob URLs (no length limit) are the only working option for the displayed source.
2. **`useState(() => createObjectURL(file))` lazy init doesn't re-run on React StrictMode's mount→unmount→mount cycle.** State persists; only effects re-run. So the effect cleanup revoked URL_A but the displayed src kept pointing at it. Fix: pair createObjectURL + revokeObjectURL + `setUrl(...)` inside ONE useEffect.
3. **Tailwind preflight applies `img { max-width: 100% }` globally.** With inline `width: 1737px` set, max-width capped at the container's 370px BEFORE the transform: scale() ran, downscaling an already-clipped width. Visible on every browser, not just iOS — Playwright happened to pass because it only checked `width > 0`. Fix: explicit `maxWidth: 'none'` on the inline style.
4. **Don't allocate per-frame in pointermove.** Iterate the Map directly; don't `Array.from(...values())`.
5. **Dev-infra `_migrations` tracking is broken** (`:'fname'` psql variable substitution syntax error). Recovery: `destroy <branch>` + `upsert <branch>` to force a fresh DB.

## Test plan

- [x] Migration 108 applies cleanly (up + down).
- [x] Upload / GET / DELETE round-trip on the dev server (bytes match).
- [x] Avatar renders correctly empty (placeholder gray circle + camera badge) and with an image (circle-clipped + X badge top-right + camera badge bottom-right).
- [x] Group page header, /info hero, and home list all show the uploaded image.
- [x] iOS Firefox: pick + crop a photo, image appears behind crop circle, drag/pinch works.
- [x] Back from /edit-title with unsaved changes → discard confirmation shows; confirm leaves without committing, cancel stays.
- [x] Save uploads/deletes (per staging) + updates title (when changed) atomically, then navigates back.
- [x] Server-side UUID filter: malformed entries in `accessible_question_ids` return 200 with `[]` instead of 500.
- [ ] Production frontend deploys clean via Vercel.
- [ ] Production API deploys clean via the droplet auto-deploy + migration 108 applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqQoqigRLoNy69SEbaHrA5)_