### PR TITLE
Scale single-initial avatars 2x vs two-letter pairs

### DIFF
--- a/components/RespondentCircles.tsx
+++ b/components/RespondentCircles.tsx
@@ -74,7 +74,7 @@ export default function RespondentCircles({ names, anonymousCount, sizeClassName
         {circles.map((circle, i) => {
           const [cx, cy] = layout.centers[i];
           const r = layout.diameter / 2;
-          const fontSize = circle.label.length <= 1 ? r * 1.25 : circle.label.length <= 2 ? r : r * 0.8;
+          const fontSize = circle.label.length <= 1 ? r * 2 : circle.label.length <= 2 ? r : r * 0.8;
           return (
             <g key={i}>
               <circle cx={cx} cy={cy} r={r} fill={circle.fill} />


### PR DESCRIPTION
## Summary
- In `RespondentCircles`, a circle containing one initial now renders at font size `r * 2` instead of `r * 1.25`, so a solo initial is twice the size of a two-letter pair (which stays at `r`).

## Test plan
- [ ] Visit a group whose `/info` page shows a single-member hero avatar — confirm the initial fills more of the circle.
- [ ] Compare to a two-member group where each respondent circle shows one initial — single-member case should look noticeably larger relative to its circle.
- [ ] Spot-check a group with mixed avatars (some 1-letter, some 2-letter initials) — 2-letter pairs unchanged.

https://claude.ai/code/session_01LF7s54GEbJQNrrNh9qY5TZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF7s54GEbJQNrrNh9qY5TZ)_