### PR TITLE
Move reference-location warning under the location selector

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1426,19 +1426,26 @@ export function CreateQuestionContent() {
   const questionFormBody = (
     <form onSubmit={(e) => { e.preventDefault(); e.stopPropagation(); }} className={`space-y-4${formHasContent ? ' border-t border-gray-200 dark:border-gray-700 py-3' : ''}`}>
       {isLocationLikeCategory(category) && (
-        <ReferenceLocationInput
-          latitude={refLatitude}
-          longitude={refLongitude}
-          label={refLocationLabel}
-          onLocationChange={(lat, lng, lbl) => {
-            setRefLatitude(lat);
-            setRefLongitude(lng);
-            setRefLocationLabel(lbl);
-          }}
-          searchRadius={searchRadius}
-          onSearchRadiusChange={setSearchRadius}
-          disabled={isLoading}
-        />
+        <div>
+          <ReferenceLocationInput
+            latitude={refLatitude}
+            longitude={refLongitude}
+            label={refLocationLabel}
+            onLocationChange={(lat, lng, lbl) => {
+              setRefLatitude(lat);
+              setRefLongitude(lng);
+              setRefLocationLabel(lbl);
+            }}
+            searchRadius={searchRadius}
+            onSearchRadiusChange={setSearchRadius}
+            disabled={isLoading}
+          />
+          {(refLatitude === undefined || refLongitude === undefined) && (
+            <p className="mt-2 text-sm text-orange-600 dark:text-orange-400">
+              Choose a reference location above to enable search.
+            </p>
+          )}
+        </div>
       )}
 
       {showTimeFields && (
@@ -1483,6 +1490,7 @@ export function CreateQuestionContent() {
           referenceLongitude={refLongitude}
           searchRadius={searchRadius}
           variant="compact"
+          hideReferenceLocationWarning
         />
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Move the "Choose a reference location above to enable search." warning from the separate Options card into the question-form card, placing it directly under `<ReferenceLocationInput>` with `mt-2` spacing.
- Suppress the duplicate copy inside `OptionsInput` at this callsite via the existing `hideReferenceLocationWarning` prop.

## Test plan
- [ ] Open `/g/` (or any group) → tap the 🍽️ Restaurant or 📍 Place bubble.
- [ ] If a saved reference location is already set, tap the blue location label to clear it.
- [ ] The orange warning appears directly under the `Near` selector in the top card, not in the Options card below.
- [ ] Setting any location hides the warning.

Demo: https://claude-fix-location-text-placement-1trkg.dev.whoeverwants.com/g/~1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRLhg8CrGNDkfbrUpdYcr7)_