### PR TITLE
Shrink single-initial labels by 20% in RespondentCircles

### DIFF
--- a/components/RespondentCircles.tsx
+++ b/components/RespondentCircles.tsx
@@ -74,7 +74,7 @@ export default function RespondentCircles({ names, anonymousCount, sizeClassName
         {circles.map((circle, i) => {
           const [cx, cy] = layout.centers[i];
           const r = layout.diameter / 2;
-          const fontSize = circle.label.length <= 1 ? r * 2 : circle.label.length <= 2 ? r : r * 0.8;
+          const fontSize = circle.label.length <= 1 ? r * 1.6 : circle.label.length <= 2 ? r : r * 0.8;
           return (
             <g key={i}>
               <circle cx={cx} cy={cy} r={r} fill={circle.fill} />


### PR DESCRIPTION
## Summary
- Dropped the single-character initial font-size multiplier in `RespondentCircles` from `r * 2` to `r * 1.6` (a 20% reduction).
- Two-initial and overflow-badge cases are unchanged.

## Test plan
- [ ] Visual check on group cards, home list, group header, and /info hero that single-initial bubbles render with a smaller glyph than before.
- [ ] Two-initial bubbles unchanged.

https://claude.ai/code/session_01FXJtNkZgkBDSeA4BaEtQp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXJtNkZgkBDSeA4BaEtQp8)_