### PR TITLE
Reuse create-poll options card pattern for ballot suggestions input

### DIFF
--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -269,13 +269,14 @@ export default function SuggestionVotingInterface({
           </div>
         )}
 
-        {/* Add new suggestions using shared component — mirrors the
-            options card on the create-poll form: external left-justified
-            label above a rounded card hosting the compact OptionsInput. */}
+        {/* Mirrors the options card on the create-poll form. Card shade
+            is bg-gray-50 (not bg-white as in create-poll) because the
+            ballot context sits on the page bg, not a sheet backdrop —
+            see CLAUDE.md's "Always-Visible Name Field" section. */}
         <div className={filteredExistingSuggestions.length > 0 ? "mt-3" : ""}>
-          <label className="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1 px-1">
+          <h5 className="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1 px-1">
             Suggestions
-          </label>
+          </h5>
           <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
             <OptionsInput
               options={newSuggestions}
@@ -292,7 +293,6 @@ export default function SuggestionVotingInterface({
             />
           </section>
         </div>
-
 
         {voteError && (
           <div className="mt-3 p-3 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-sm">

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -269,21 +269,28 @@ export default function SuggestionVotingInterface({
           </div>
         )}
 
-        {/* Add new suggestions using shared component */}
-        <div className={filteredExistingSuggestions.length > 0 ? "mt-3 pt-3 border-t border-gray-200 dark:border-gray-600" : ""}>
-          <OptionsInput
-            options={newSuggestions}
-            setOptions={setNewSuggestions}
-            isLoading={isSubmitting}
-            label={isEditingVote ? "Add new suggestions:" : "Add new suggestions:"}
-            category={question.category || 'custom'}
-            optionsMetadata={suggestionMetadata}
-            onMetadataChange={onSuggestionMetadataChange}
-            referenceLatitude={question.reference_latitude}
-            referenceLongitude={question.reference_longitude}
-            searchRadius={searchRadius}
-            hideReferenceLocationWarning
-          />
+        {/* Add new suggestions using shared component — mirrors the
+            options card on the create-poll form: external left-justified
+            label above a rounded card hosting the compact OptionsInput. */}
+        <div className={filteredExistingSuggestions.length > 0 ? "mt-3" : ""}>
+          <label className="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1 px-1">
+            Suggestions
+          </label>
+          <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
+            <OptionsInput
+              options={newSuggestions}
+              setOptions={setNewSuggestions}
+              isLoading={isSubmitting}
+              category={question.category || 'custom'}
+              optionsMetadata={suggestionMetadata}
+              onMetadataChange={onSuggestionMetadataChange}
+              referenceLatitude={question.reference_latitude}
+              referenceLongitude={question.reference_longitude}
+              searchRadius={searchRadius}
+              variant="compact"
+              hideReferenceLocationWarning
+            />
+          </section>
         </div>
 
 


### PR DESCRIPTION
## Summary

Wraps the new-suggestions `OptionsInput` in the ballot's `SuggestionVotingInterface` in the same rounded-3xl card structure as the create-poll page's options card, with an external left-justified `Suggestions` heading and `variant="compact"` rows so spacing/dividers match.

- Card shade is `bg-gray-50 dark:bg-gray-800` (not the `bg-white` create-poll uses) per CLAUDE.md's parent-context-shade rule — the ballot sits on the page bg, not a sheet backdrop.
- Heading is `<h5>` to match the existing-suggestions heading in the same file (line 234) and avoid a `<label>`-without-`htmlFor` a11y miss.
- Drops the old `border-t` separator since the new card boundary provides its own visual separation.

## Test plan

- [x] Open a ranked-choice poll in the suggestion phase on the dev server and confirm the new card matches the create-poll options card visually
- [x] Verify the existing-suggestions block above still renders with its own header + checkboxes
- [x] Confirm the "Your Name" sub-card immediately below is unaffected (same shape + shade)
- [ ] Edit-vote flow still shows the same suggestion-input card
- [ ] Categories that use autocomplete (Restaurant, Place, Movie, etc.) still render the autocomplete input inside the new card

Demo: https://claude-reuse-options-card-suggestions-aqec9.dev.whoeverwants.com/g/~1?p=1

https://claude.ai/code/session_01Gi1DcYpfTEAgJfp56ceB7r

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi1DcYpfTEAgJfp56ceB7r)_