### PR TITLE
Two-tier deploy: latest droplet (auto on main) + prod (auto on release)

### DIFF
--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -45,7 +45,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.resolve.outputs.tag }}
-          fetch-depth: 0
+          # Single-commit clone is enough: the only git operation below is
+          # a force-push of HEAD to refs/heads/production.
+          fetch-depth: 1
 
       - name: Force-push tag commit to production branch
         run: |

--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -1,0 +1,56 @@
+name: Release to production
+
+# When a non-draft / non-prerelease GitHub Release is published, force-push the
+# tag's commit to the `production` branch. Vercel's production branch is set to
+# `production`, so this push triggers a production deployment for the FE
+# (whoeverwants.com alias). The prod API droplet picks up the same release event
+# via its own GitHub webhook (hooks.api.whoeverwants.com → scripts/dev-webhook.py)
+# and pins to the tag via `git checkout tags/<tag>`. FE + API redeploy in
+# parallel; there is no strict ordering guarantee, which matches the prior
+# auto-deploy-on-main flow.
+#
+# Triggering manually via workflow_dispatch is also supported for re-promoting
+# an existing tag (e.g. if a release was published before this workflow landed).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to promote to production (must already exist on origin)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    # release.draft and release.prerelease are unset for workflow_dispatch, so
+    # the gate only fires on the release event.
+    if: github.event_name == 'workflow_dispatch' || (!github.event.release.draft && !github.event.release.prerelease)
+    steps:
+      - name: Resolve target tag
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Force-push tag commit to production branch
+        run: |
+          set -euxo pipefail
+          # Force-push so the production branch tracks the tag exactly, even if
+          # a previous release left it pointing elsewhere (or behind).
+          git push origin HEAD:refs/heads/production --force
+          echo "production now points at $(git rev-parse HEAD) (tag ${{ steps.resolve.outputs.tag }})"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,39 +16,48 @@ The Supabase-to-Python migration and infrastructure improvements (Phases 1-10) a
 
 > **Historical note on What/When/Where:** Earlier iterations of the redesign shipped a 3-bubble bar (What/When/Where) that preselected via `?mode=time` / `?category=restaurant`. That trichotomy was eliminated; references to "What/When/Where" in Phase 2.3 / Navigation Layout / Always-On Draft Poll Card sections below are historical context, NOT the current UI. The current bar is per-category.
 
-## DigitalOcean Droplet (Production Server)
+## DigitalOcean Droplets — Two-Tier Deploy
 
-The production server is a DigitalOcean droplet that Claude manages remotely. **You have full control of this server.**
+WhoeverWants runs on **two** DigitalOcean droplets that are software-identical (same `scripts/provision-droplet.sh`, same Docker stack, same migrations). Only the public hostnames and deploy trigger differ — see "Development Workflow" below for the gating.
 
-### Server Specs
+- **`whoeverwants` (prod)** — `142.93.60.29`, fronts `api.whoeverwants.com` + `hooks.api.whoeverwants.com`. Deploys when a GitHub Release is published, pinned to the release's tag.
+- **`latest` (pre-prod canary)** — `67.207.94.93`, fronts `api.latest.whoeverwants.com` + `hooks.api.latest.whoeverwants.com`. Deploys on every push to `main` so the latest code is exercised in its final configuration (release-mode build, droplet, Caddy, Postgres) before a production release.
+
+Behavior is driven by `/etc/droplet-label` on each droplet (`""` = prod, `"latest"` = canary). `scripts/dev-webhook.py` reads it at startup. `scripts/provision-droplet.sh` accepts `DROPLET_LABEL=latest` to provision a canary; default behavior is prod.
+
+### Server Specs (both droplets — match exactly)
 | Property | Value |
 |----------|-------|
-| Hostname | `whoeverwants` |
-| IP | `142.93.60.29` |
-| OS | Ubuntu 24.04 LTS |
-| RAM | 1 GB |
-| Disk | 24 GB |
+| Image | Ubuntu 24.04 LTS |
+| Size | s-1vcpu-1gb (1 GB RAM, 24 GB SSD) |
+| Region | nyc1 |
 | User | `root` |
-| Purpose | Hosts the Python API server and PostgreSQL (API-only; frontend on Vercel) |
+
+| Hostname | IP | Tier | Public hosts |
+|----------|----|----|--------------|
+| `whoeverwants` | `142.93.60.29` | prod | `api.whoeverwants.com`, `hooks.api.whoeverwants.com` |
+| `latest` | `67.207.94.93` | canary | `api.latest.whoeverwants.com`, `hooks.api.latest.whoeverwants.com` |
 
 ### Remote Command Execution
 
-Run commands on the droplet from this environment using `scripts/remote.sh`:
+Both droplets are reachable over their own sslip.io URL via a sibling pair of helpers:
 
 ```bash
-# Basic usage
+# Prod droplet
 bash scripts/remote.sh "command" [working_dir] [timeout_seconds]
 
-# Examples
-bash scripts/remote.sh "hostname && uptime"
-bash scripts/remote.sh "git pull" /root/whoeverwants
-bash scripts/remote.sh "docker compose up -d" /root/whoeverwants 180
-bash scripts/remote.sh "docker compose logs --tail 50" /root/whoeverwants
-bash scripts/remote.sh "systemctl status nginx"
-bash scripts/remote.sh "psql -U postgres -c 'SELECT 1'"
+# Latest (canary) droplet
+bash scripts/remote-latest.sh "command" [working_dir] [timeout_seconds]
 ```
 
-The script reads `DROPLET_API_URL` and `DROPLET_API_TOKEN` from environment variables (preferred) or falls back to `.env`.
+Both honor the same JSON protocol; only the env vars differ. Examples:
+
+```bash
+bash scripts/remote.sh "hostname && uptime"                  # prod
+bash scripts/remote-latest.sh "hostname && uptime"           # latest
+bash scripts/remote.sh "docker compose logs --tail 50" /root/whoeverwants
+bash scripts/remote-latest.sh "cat /etc/droplet-label"       # should print "latest"
+```
 
 ### Required Environment Variables
 
@@ -57,13 +66,18 @@ The following environment variables must be available. In the Claude Code web en
 ```
 DROPLET_API_URL=https://142-93-60-29.sslip.io
 DROPLET_API_TOKEN=<bearer token>
+LATEST_DROPLET_API_URL=https://67-207-94-93.sslip.io
+LATEST_DROPLET_API_TOKEN=<bearer token for latest droplet>
+DIGITAL_OCEAN_TOKEN=<DO API v2 token>
 VERCEL_API_TOKEN=<vercel api token>
 GITHUB_API_TOKEN=<github fine-grained PAT>
 ```
 
-- `DROPLET_API_URL` / `DROPLET_API_TOKEN` — Authenticate requests to the droplet's command execution API (via sslip.io for TLS). Used by `scripts/remote.sh`.
+- `DROPLET_API_URL` / `DROPLET_API_TOKEN` — Prod droplet cmd-api. Used by `scripts/remote.sh`.
+- `LATEST_DROPLET_API_URL` / `LATEST_DROPLET_API_TOKEN` — Latest (canary) droplet cmd-api. Used by `scripts/remote-latest.sh`.
+- `DIGITAL_OCEAN_TOKEN` — DigitalOcean API token. Used when creating / managing droplets (e.g. spinning up a fresh latest droplet via cloud-init).
 - `VERCEL_API_TOKEN` — Authenticate requests to the [Vercel REST API](https://vercel.com/docs/rest-api) for managing frontend deployments.
-- `GITHUB_API_TOKEN` — GitHub fine-grained Personal Access Token scoped to `samcarey/whoeverwants`. Permissions: Pull Requests (R/W), Issues (Read), Contents (R/W), Commit Statuses (Read), Actions (Read). Used for creating PRs, reading issues, and checking CI status via the GitHub REST API.
+- `GITHUB_API_TOKEN` — GitHub fine-grained Personal Access Token scoped to `samcarey/whoeverwants`. Permissions: Pull Requests (R/W), Issues (Read), Contents (R/W), Commit Statuses (Read), Actions (Read). Used for creating PRs, reading issues, and checking CI status via the GitHub REST API. Note: webhook admin is NOT in the scope, so adding/editing GitHub webhooks must be done manually in the GitHub UI.
 
 > **SECURITY**: These tokens must NEVER be committed to git — not in CLAUDE.md, `.env`, or any tracked file. Store them only in environment variables. The droplet token was previously leaked via a git commit (fa805e7), leading to a Kinsing cryptominer compromise that required a full droplet rebuild (old IP 157.245.129.162 → current 142.93.60.29).
 
@@ -91,14 +105,24 @@ Each dev server gets its own:
 - **PostgreSQL database** (separate DB in the shared PostgreSQL container, named `dev_<branch_slug_underscored>`)
 - **All migrations from the branch** auto-applied on creation and update
 
-**Production Frontend** (Vercel):
-- Vercel auto-deploys on push to `main` → `whoeverwants.com`
+**Frontend** (Vercel):
+- Single Vercel project (`prj_07PAXGI2wG74cGRKREB0BiIDUWSn`); same build artifact serves both tiers.
+- Push to `main` → Vercel builds + aliases the deployment to `latest.whoeverwants.com`.
+- Publishing a GitHub Release → Vercel alias for `whoeverwants.com` is moved to that build (release deployment promoted to prod).
+- API destination is selected at request time via `host`-conditional rewrites in `next.config.ts`: `latest.whoeverwants.com` → `api.latest.whoeverwants.com`; everything else → `api.whoeverwants.com` (or branch preview for non-main builds).
 
-**Production Backend** (Python API on droplet — auto-deployed on push to main):
-- Merging/pushing to `main` auto-triggers: git pull → Docker rebuild → migration check → health verify
+**Latest tier — canary backend** (Python API on `latest` droplet, auto-deployed on push to `main`):
+- Push to `main` fires the GitHub webhook → `hooks.api.latest.whoeverwants.com` → `scripts/dev-webhook.py` (reads `/etc/droplet-label=latest`) → `git pull origin main` → `docker compose up -d --build` → apply pending migrations → `/health` verify.
+- Deploy logs: `bash scripts/remote-latest.sh "tail -50 /var/log/dev-webhook.log" /root`
+- Manual rebuild: `bash scripts/remote-latest.sh "docker compose up -d --build" /root/whoeverwants`
+- API logs: `bash scripts/remote-latest.sh "docker compose logs --tail 100" /root/whoeverwants`
+
+**Production backend** (Python API on `whoeverwants` droplet, auto-deployed only on GitHub Release):
+- Publishing a non-draft / non-prerelease GitHub Release fires the webhook → `hooks.api.whoeverwants.com` → `scripts/dev-webhook.py` (reads `/etc/droplet-label=""`) → `git fetch --tags && git checkout tags/<release-tag>` → `docker compose up -d --build` → apply pending migrations → `/health` verify. Push events to `main` are explicitly ignored on this tier.
 - Deploy logs: `bash scripts/remote.sh "tail -50 /var/log/dev-webhook.log" /root`
 - Manual rebuild: `bash scripts/remote.sh "docker compose up -d --build" /root/whoeverwants`
 - API logs: `bash scripts/remote.sh "docker compose logs --tail 100" /root/whoeverwants`
+- **To ship**: cut a GitHub Release. The release's tag must exist on `main` (or any branch — but the convention is to publish from a `main` commit that's already running cleanly on `latest.whoeverwants.com`).
 - **Auto-deploy can silently fail on uncommitted local mods.** The webhook does a plain `git pull`; if the droplet's `/root/whoeverwants` checkout has any unstaged file (typically `scripts/dev-server-manager.sh` after a hotfix), the pull aborts with `error: Your local changes to the following files would be overwritten by merge`, the webhook logs the failure but the deploy "completes" with no rebuild. Vercel meanwhile auto-deploys the new FE → FE/API contract drift. Symptom from a recent occurrence (#290 deploy stuck): every `POST /api/polls` with `group_id: <uuid>` came back with a brand-new group_id in the response — the old server didn't read `group_id` at all (still expected the retired `follow_up_to` field), so polls "disappeared" into freshly-minted groups. Diagnostic: `tail /var/log/dev-webhook.log | grep -A3 'Git pull failed'` to spot the blocking file; on the droplet, `cd /root/whoeverwants && git status` to confirm; `git log --oneline -3` to confirm the actual deployed commit. Fix: stash the local diff, `git pull`, apply any pending migrations, `docker compose up -d --build`. Recovery for orphaned data: any group minted while the deploy was stale needs to be merged into its intended group (`UPDATE polls SET group_id = <real> WHERE group_id = <orphan>`, then `DELETE FROM groups WHERE id = <orphan>`).
 - **Defensive log when requested `group_id` is unknown.** `_resolve_or_create_group` in `server/routers/polls.py` emits a `WARNING` when `req.group_id` is provided but no matching `groups` row exists. The mint-fresh-group fallback is intentional (per the function's docstring) but a sustained stream of these warnings is a tripwire for: (a) a stale deploy missing a schema migration, (b) the FE sending a stale/cached group_id from before a forget+re-discover cycle, (c) cross-group races. Surface via `bash scripts/remote.sh "docker compose logs --tail 200 api | grep 'group_id'"` when investigating "polls landing in the wrong group" reports.
 
@@ -187,10 +211,36 @@ ssh root@<DROPLET_IP> 'bash -s' < scripts/provision-droplet.sh <API_TOKEN>
 This installs Docker, Caddy, the command execution API, clones the repo, starts all services, and applies database migrations.
 
 ### Important Notes
-- The droplet has its own clone of this repo at `/root/whoeverwants`
-- Never transfer files manually — commit here, pull there
+- Each droplet has its own clone of this repo at `/root/whoeverwants`. Never transfer files manually — commit here, pull there. Different deploy triggers per tier (push to main vs release published).
 - The remote execution API has a configurable timeout (default 120s, max via 3rd arg)
 - The API returns stdout, stderr, and exit code for every command
+
+### Latest-Tier Rollout — Remaining Manual Steps
+
+`scripts/dev-webhook.py` and `next.config.ts` are already coded for the two-tier model; the new `latest` droplet runs the new code from day one (cloud-init clones the feature branch and `provision-droplet.sh` writes `/etc/droplet-label=latest`). The remaining setup is split between Route 53, Vercel, GitHub, and the existing prod droplet:
+
+1. **DNS (Route 53)** — Add two A records pointing at the new droplet's IP (`67.207.94.93`):
+   - `api.latest.whoeverwants.com  A  67.207.94.93`
+   - `hooks.api.latest.whoeverwants.com  A  67.207.94.93`
+   - One CNAME for the FE host: `latest.whoeverwants.com  CNAME  cname.vercel-dns.com`
+
+2. **Vercel — `latest.whoeverwants.com`** — Add the domain to the existing `whoeverwants` project (Vercel UI → Settings → Domains → Add `latest.whoeverwants.com`). For the desired "main → latest, release → prod" gating, either:
+   - **Option A (simplest, recommended):** Change the project's `productionBranch` from `main` to a new `production` branch (Vercel UI → Settings → Git → Production Branch). Create the `production` branch in GitHub. Push to main keeps deploying as PREVIEWs; bind `latest.whoeverwants.com` to PREVIEWs of `main` (Vercel UI → Settings → Domains → set the domain's "Git Branch" filter to `main`). Production whoeverwants.com only updates when something pushes to the `production` branch.
+   - **Option B (GitHub Action–driven):** Keep `main` as productionBranch. After every Vercel main-deploy completes, a GitHub Action calls Vercel API `POST /v2/aliases` to alias the deployment to `latest.whoeverwants.com`. On release, a different Action calls the API to alias the released-tag's deployment to `whoeverwants.com`. More moving parts but no production-branch dance.
+
+3. **Release → Production glue (GitHub Action)** — Whichever Vercel option above is chosen, add a workflow that fires on `release: published` and:
+   - **Option A:** `git push origin <release-tag>:production --force` so Vercel picks it up as a production deploy AND notifies the prod droplet via the webhook below.
+   - **Option B:** Call the Vercel API to move the prod alias.
+   - Either way, the prod droplet's webhook (see step 5) sees the `release` event from GitHub and pulls the tagged commit.
+
+4. **GitHub webhook → latest droplet** — Currently a single GitHub webhook targets `https://hooks.api.whoeverwants.com/github` (prod droplet). Add a second webhook in the same repo settings, configured identically (`push` AND `release` events, same secret, JSON content type), pointing at `https://hooks.api.latest.whoeverwants.com/github`. The fine-grained PAT we use here lacks the `admin:repo_hook` scope, so this must be done via the GitHub UI. The webhook secret is in `/etc/dev-webhook-secret` on the latest droplet (`bash scripts/remote-latest.sh "cat /etc/dev-webhook-secret"`).
+
+5. **Prod droplet cutover** — The prod droplet's `dev-webhook.service` is still running OLD code (pre-this-PR). After this branch merges:
+   1. Push to main triggers prod's old webhook, which `git pull`s + rebuilds prod ONE LAST TIME using the old "push → deploy" behavior. This deploys the new code to `/root/whoeverwants` (but the systemd service still holds the OLD code in memory).
+   2. From the dev env: `bash scripts/remote.sh "test -f /etc/droplet-label || (touch /etc/droplet-label && chmod 644 /etc/droplet-label)"` — ensure the empty-label marker exists so the new webhook code knows it's prod.
+   3. `bash scripts/remote.sh "systemctl restart dev-webhook"` — picks up the new release-event-gated behavior. From here on, push to main DOES NOT deploy to prod; only release events do.
+
+6. **Webhook subscription** — Confirm BOTH webhooks (latest + prod) are subscribed to `push` AND `release` events. The prod droplet's new behavior is `release: published` → deploy; the latest droplet's is `push` to main → deploy.
 
 ## Mac Mini Dev Box
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,32 +215,38 @@ This installs Docker, Caddy, the command execution API, clones the repo, starts 
 - The remote execution API has a configurable timeout (default 120s, max via 3rd arg)
 - The API returns stdout, stderr, and exit code for every command
 
-### Latest-Tier Rollout — Remaining Manual Steps
+### Latest-Tier Rollout — Status
 
-`scripts/dev-webhook.py` and `next.config.ts` are already coded for the two-tier model; the new `latest` droplet runs the new code from day one (cloud-init clones the feature branch and `provision-droplet.sh` writes `/etc/droplet-label=latest`). The remaining setup is split between Route 53, Vercel, GitHub, and the existing prod droplet:
+The two-tier deploy is wired end-to-end. Status of each piece:
 
-1. **DNS (Route 53)** — Add two A records pointing at the new droplet's IP (`67.207.94.93`):
-   - `api.latest.whoeverwants.com  A  67.207.94.93`
-   - `hooks.api.latest.whoeverwants.com  A  67.207.94.93`
-   - One CNAME for the FE host: `latest.whoeverwants.com  CNAME  cname.vercel-dns.com`
+| Step | What | Status |
+|------|------|--------|
+| 1 | DNS for `api.latest.whoeverwants.com`, `hooks.api.latest.whoeverwants.com`, `latest.whoeverwants.com` | ✅ done (Route 53) |
+| 2 | Vercel project: `productionBranch=production`, `latest.whoeverwants.com` domain with `gitBranch=main` | ✅ done (via undocumented `PATCH /v9/projects/<id>/branch` + `POST /v10/projects/<id>/domains`) |
+| 3 | `production` branch on origin (created from current main HEAD) | ✅ done |
+| 4 | `.github/workflows/release-to-production.yml` (on `release: published` → force-push tag commit to `production`) | ✅ done |
+| 5 | GitHub webhook subscribed to BOTH droplets (push + release events) | ⚠️ manual — see below |
+| 6 | Prod droplet cutover (restart `dev-webhook` to pick up label-aware code) | ⚠️ manual — after PR merges; see below |
 
-2. **Vercel — `latest.whoeverwants.com`** — Add the domain to the existing `whoeverwants` project (Vercel UI → Settings → Domains → Add `latest.whoeverwants.com`). For the desired "main → latest, release → prod" gating, either:
-   - **Option A (simplest, recommended):** Change the project's `productionBranch` from `main` to a new `production` branch (Vercel UI → Settings → Git → Production Branch). Create the `production` branch in GitHub. Push to main keeps deploying as PREVIEWs; bind `latest.whoeverwants.com` to PREVIEWs of `main` (Vercel UI → Settings → Domains → set the domain's "Git Branch" filter to `main`). Production whoeverwants.com only updates when something pushes to the `production` branch.
-   - **Option B (GitHub Action–driven):** Keep `main` as productionBranch. After every Vercel main-deploy completes, a GitHub Action calls Vercel API `POST /v2/aliases` to alias the deployment to `latest.whoeverwants.com`. On release, a different Action calls the API to alias the released-tag's deployment to `whoeverwants.com`. More moving parts but no production-branch dance.
+**5. GitHub webhook for the latest droplet** — repo Settings → Webhooks → Add:
+- URL: `https://hooks.api.latest.whoeverwants.com/github`
+- Content type: `application/json`
+- Secret: contents of `/etc/dev-webhook-secret` on the latest droplet (`bash scripts/remote-latest.sh "cat /etc/dev-webhook-secret"`)
+- Events: tick "Let me select individual events" → enable **Pushes** AND **Releases**
 
-3. **Release → Production glue (GitHub Action)** — Whichever Vercel option above is chosen, add a workflow that fires on `release: published` and:
-   - **Option A:** `git push origin <release-tag>:production --force` so Vercel picks it up as a production deploy AND notifies the prod droplet via the webhook below.
-   - **Option B:** Call the Vercel API to move the prod alias.
-   - Either way, the prod droplet's webhook (see step 5) sees the `release` event from GitHub and pulls the tagged commit.
+Also confirm the existing prod webhook (`https://hooks.api.whoeverwants.com/github`) is subscribed to **Releases** in addition to **Pushes** — if not, edit it to add Releases. The PAT we use lacks `admin:repo_hook`, so this must be done in the GitHub UI.
 
-4. **GitHub webhook → latest droplet** — Currently a single GitHub webhook targets `https://hooks.api.whoeverwants.com/github` (prod droplet). Add a second webhook in the same repo settings, configured identically (`push` AND `release` events, same secret, JSON content type), pointing at `https://hooks.api.latest.whoeverwants.com/github`. The fine-grained PAT we use here lacks the `admin:repo_hook` scope, so this must be done via the GitHub UI. The webhook secret is in `/etc/dev-webhook-secret` on the latest droplet (`bash scripts/remote-latest.sh "cat /etc/dev-webhook-secret"`).
+**6. Prod droplet cutover** — the prod droplet's `dev-webhook.service` is still running the OLD code (pre-this-PR) which deploys on every push to main. After this branch merges:
+1. The prod webhook will deploy main one last time using its old behavior — this lands the new `dev-webhook.py` (label-aware) on disk at `/root/whoeverwants/scripts/dev-webhook.py`, but the systemd service is still running the old code in memory.
+2. From the dev env: `bash scripts/remote.sh "touch /etc/droplet-label && chmod 644 /etc/droplet-label && systemctl restart dev-webhook"` — creates the empty label marker (prod tier = empty string) and restarts the service. From here on, push to main is ignored on prod; only `release: published` events deploy.
 
-5. **Prod droplet cutover** — The prod droplet's `dev-webhook.service` is still running OLD code (pre-this-PR). After this branch merges:
-   1. Push to main triggers prod's old webhook, which `git pull`s + rebuilds prod ONE LAST TIME using the old "push → deploy" behavior. This deploys the new code to `/root/whoeverwants` (but the systemd service still holds the OLD code in memory).
-   2. From the dev env: `bash scripts/remote.sh "test -f /etc/droplet-label || (touch /etc/droplet-label && chmod 644 /etc/droplet-label)"` — ensure the empty-label marker exists so the new webhook code knows it's prod.
-   3. `bash scripts/remote.sh "systemctl restart dev-webhook"` — picks up the new release-event-gated behavior. From here on, push to main DOES NOT deploy to prod; only release events do.
+### How a release will flow once the cutover is complete
 
-6. **Webhook subscription** — Confirm BOTH webhooks (latest + prod) are subscribed to `push` AND `release` events. The prod droplet's new behavior is `release: published` → deploy; the latest droplet's is `push` to main → deploy.
+1. Tag a commit on `main` (or wherever) and publish a non-draft / non-prerelease GitHub Release.
+2. The `release-to-production.yml` workflow fires → force-pushes the tag's commit to the `production` branch.
+3. Vercel sees a push to `production` → builds a production deployment → moves the `whoeverwants.com` alias to it (since `productionBranch=production`, that's the prod alias target).
+4. In parallel, the prod droplet's `dev-webhook` receives the `release.published` event from GitHub → `git fetch --tags && git checkout tags/<tag>` → `docker compose up -d --build` → applies pending migrations → `/health` check.
+5. The `latest` droplet ignores the release event (its label is `latest`). It only redeploys on push to `main`; this push, the next push, every push.
 
 ## Mac Mini Dev Box
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,16 +225,9 @@ The two-tier deploy is wired end-to-end. Status of each piece:
 | 2 | Vercel project: `productionBranch=production`, `latest.whoeverwants.com` domain with `gitBranch=main` | ✅ done (via undocumented `PATCH /v9/projects/<id>/branch` + `POST /v10/projects/<id>/domains`) |
 | 3 | `production` branch on origin (created from current main HEAD) | ✅ done |
 | 4 | `.github/workflows/release-to-production.yml` (on `release: published` → force-push tag commit to `production`) | ✅ done |
-| 5 | GitHub webhook subscribed to BOTH droplets (push + release events) | ⚠️ manual — see below |
+| 5a | GitHub webhook for the latest droplet (`hooks.api.latest.whoeverwants.com`, push + release events) | ✅ done (user added in GitHub UI) |
+| 5b | Existing prod-droplet GitHub webhook (`hooks.api.whoeverwants.com`) — confirm subscribed to **Releases** in addition to **Pushes** | ⚠️ manual check — the PAT lacks `admin:repo_hook`, so verify in the GitHub UI |
 | 6 | Prod droplet cutover (restart `dev-webhook` to pick up label-aware code) | ⚠️ manual — after PR merges; see below |
-
-**5. GitHub webhook for the latest droplet** — repo Settings → Webhooks → Add:
-- URL: `https://hooks.api.latest.whoeverwants.com/github`
-- Content type: `application/json`
-- Secret: contents of `/etc/dev-webhook-secret` on the latest droplet (`bash scripts/remote-latest.sh "cat /etc/dev-webhook-secret"`)
-- Events: tick "Let me select individual events" → enable **Pushes** AND **Releases**
-
-Also confirm the existing prod webhook (`https://hooks.api.whoeverwants.com/github`) is subscribed to **Releases** in addition to **Pushes** — if not, edit it to add Releases. The PAT we use lacks `admin:repo_hook`, so this must be done in the GitHub UI.
 
 **6. Prod droplet cutover** — the prod droplet's `dev-webhook.service` is still running the OLD code (pre-this-PR) which deploys on every push to main. After this branch merges:
 1. The prod webhook will deploy main one last time using its old behavior — this lands the new `dev-webhook.py` (label-aware) on disk at `/root/whoeverwants/scripts/dev-webhook.py`, but the systemd service is still running the old code in memory.

--- a/docs/droplet-setup.md
+++ b/docs/droplet-setup.md
@@ -1,8 +1,15 @@
 # Droplet Setup Guide
 
-This document describes how to provision a new DigitalOcean droplet for WhoeverWants from scratch. The droplet serves the **API** (Python/FastAPI + PostgreSQL) and **per-user dev servers** (Next.js). The **production frontend** is hosted on Vercel.
+This document describes how to provision a DigitalOcean droplet for WhoeverWants from scratch. The same provisioning script (`scripts/provision-droplet.sh`) handles both tiers — controlled by the `DROPLET_LABEL` env var:
 
-**Last verified**: 2026-03-20
+| `DROPLET_LABEL` | Tier | Public hosts | Deploy trigger |
+|---|---|---|---|
+| `""` (default) | prod | `api.whoeverwants.com`, `hooks.api.whoeverwants.com` | GitHub Release published |
+| `latest` | pre-prod canary | `api.latest.whoeverwants.com`, `hooks.api.latest.whoeverwants.com` | push to `main` |
+
+The **production frontend** is hosted on Vercel. The same Vercel project serves both `latest.whoeverwants.com` (alias updated on every push to main) and `whoeverwants.com` (alias updated when a release is published) — see `next.config.ts` for the host-conditional API rewrites.
+
+**Last verified**: 2026-05-13
 
 ---
 
@@ -24,41 +31,91 @@ Note the IP address (e.g., `142.93.60.29`).
 
 ## 2. DNS Requirements
 
+### Prod droplet (`whoeverwants`, 142.93.60.29)
+
 | Record | Type | Value | Purpose |
 |--------|------|-------|---------|
-| `api.whoeverwants.com` | A | `<droplet IP>` | Production API |
-| `*.api.whoeverwants.com` | A | `<droplet IP>` | Preview API environments + webhook handler |
-| `*.dev.whoeverwants.com` | A | `<droplet IP>` | Per-user dev frontend servers |
+| `api.whoeverwants.com` | A | `142.93.60.29` | Production API |
+| `*.api.whoeverwants.com` | A | `142.93.60.29` | Preview API environments + webhook handler (`hooks.api.whoeverwants.com`) |
 | `whoeverwants.com` | CNAME | `cname.vercel-dns.com` (or Vercel IP) | Production frontend |
 
-The wildcard `*.api.whoeverwants.com` record enables per-branch preview API instances (e.g., `fix-voting-abc123.api.whoeverwants.com`) and the GitHub webhook handler (`hooks.api.whoeverwants.com`).
+### Latest droplet (`latest`, 67.207.94.93)
 
-The wildcard `*.dev.whoeverwants.com` record enables per-user dev servers (e.g., `sam-at-example-com.dev.whoeverwants.com`).
+| Record | Type | Value | Purpose |
+|--------|------|-------|---------|
+| `api.latest.whoeverwants.com` | A | `67.207.94.93` | Latest-tier API |
+| `hooks.api.latest.whoeverwants.com` | A | `67.207.94.93` | Latest-tier GitHub webhook handler |
+| `latest.whoeverwants.com` | CNAME | `cname.vercel-dns.com` | Latest-tier frontend (Vercel alias) |
 
-The sslip.io subdomain (`<ip-dashed>.sslip.io`) works automatically with no DNS configuration.
+### Mac mini dev box
+
+See `docs/mac-mini-setup.md` — uses `*.dev.whoeverwants.com` wildcard via DDNS to Route 53. Not on either droplet.
+
+The sslip.io subdomain (`<ip-dashed>.sslip.io`) works automatically with no DNS configuration on both droplets and is the bootstrap entry point for `scripts/remote.sh` / `scripts/remote-latest.sh`.
 
 ---
 
 ## 3. Provision the Server
 
-### Automated Setup
+### Path A — Bootstrap via cloud-init (no SSH key required)
 
-From the development environment (where you have this repo checked out):
+The DigitalOcean API can spawn a droplet whose `user_data` runs `provision-droplet.sh` automatically on first boot. This is how the `latest` droplet was created — no SSH keys ever touched it.
 
-```bash
-# Set the droplet IP and desired API token
-export DROPLET_IP="142.93.60.29"
-export NEW_API_TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
-
-# SSH into the droplet and run the provisioning script
-ssh root@$DROPLET_IP 'bash -s' < scripts/provision-droplet.sh "$NEW_API_TOKEN"
+```python
+# Pseudocode for re-creation; see this PR's session transcript for the actual call.
+import json, secrets, urllib.request, os
+API_TOKEN = secrets.token_urlsafe(32)
+user_data = f"""#!/bin/bash
+set -euxo pipefail
+exec > >(tee /var/log/cloud-init-provision.log) 2>&1
+apt-get update -qq && apt-get install -y -qq git curl ca-certificates
+git clone https://github.com/samcarey/whoeverwants.git /root/whoeverwants
+cd /root/whoeverwants
+DROPLET_LABEL=latest bash scripts/provision-droplet.sh '{API_TOKEN}'
+touch /var/log/cloud-init-provision.done
+"""
+body = {
+    "name": "whoeverwants-latest",
+    "region": "nyc1",
+    "size": "s-1vcpu-1gb",
+    "image": "ubuntu-24-04-x64",
+    "tags": ["whoeverwants", "latest"],
+    "user_data": user_data,
+}
+req = urllib.request.Request(
+    "https://api.digitalocean.com/v2/droplets",
+    data=json.dumps(body).encode(),
+    headers={"Authorization": f"Bearer {os.environ['DIGITAL_OCEAN_TOKEN']}",
+             "Content-Type": "application/json"},
+)
+print(urllib.request.urlopen(req).read())
 ```
 
-After provisioning completes, set the environment variables for `scripts/remote.sh`:
+Provisioning takes 5-10 min on a fresh 1 GB droplet (system updates + Docker + Caddy + uv + repo clone + Docker build + migrations). Question for completion with `curl -s -o /dev/null -w '%{http_code}' https://<ip-dashed>.sslip.io` — returns `200` once cmd-api is up.
+
+For prod, omit `DROPLET_LABEL=latest` from the user_data (or set it to `""`).
+
+### Path B — Bootstrap via SSH (existing key)
+
+From a host that has SSH access to the new droplet:
 
 ```bash
+export DROPLET_IP="..."
+export DROPLET_LABEL=""       # or "latest"
+export NEW_API_TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+ssh root@$DROPLET_IP DROPLET_LABEL=$DROPLET_LABEL 'bash -s' < scripts/provision-droplet.sh "$NEW_API_TOKEN"
+```
+
+After provisioning completes, set the environment variables for `scripts/remote.sh` (or `scripts/remote-latest.sh`):
+
+```bash
+# Prod
 export DROPLET_API_URL="https://${DROPLET_IP//./-}.sslip.io"
 export DROPLET_API_TOKEN="$NEW_API_TOKEN"
+
+# Latest
+export LATEST_DROPLET_API_URL="https://${DROPLET_IP//./-}.sslip.io"
+export LATEST_DROPLET_API_TOKEN="$NEW_API_TOKEN"
 ```
 
 ### Manual Steps

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 import { branchToSlug } from "./lib/slug";
 
-// Determine the backend API origin for rewrites.
+// Default backend API origin (production / branch previews). Latest-tier
+// routing is layered on top via host-conditional rewrites — see
+// `latestRewriteRules` below.
 function getApiRewriteDestination(): string {
   const branch = process.env.VERCEL_GIT_COMMIT_REF || process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF;
   if (process.env.VERCEL || process.env.NODE_ENV === 'production') {
@@ -11,6 +13,42 @@ function getApiRewriteDestination(): string {
     return 'https://api.whoeverwants.com';
   }
   return process.env.PYTHON_API_URL || 'http://localhost:8000';
+}
+
+// The "latest" tier (pre-prod canary) lives at latest.whoeverwants.com and is
+// fronted by the latest droplet's API at api.latest.whoeverwants.com. Both
+// hostnames serve from the same Vercel deployment artifact; the upstream API
+// is selected at request time via the `host` header.
+const LATEST_HOST = 'latest.whoeverwants.com';
+const LATEST_API_DEST = 'https://api.latest.whoeverwants.com';
+
+// Emit the full set of /api/* rewrite rules pointed at `dest`. When `host` is
+// passed, the rules only match requests with that Host header (Next.js host
+// rewrites are evaluated at request time on Vercel).
+function apiRewriteRules(dest: string, host?: string) {
+  const has = host ? [{ type: 'host' as const, value: host }] : undefined;
+  const paths: Array<[string, string]> = [
+    ['/api/questions', '/api/questions'],
+    ['/api/questions/', '/api/questions'],
+    ['/api/questions/:path*', '/api/questions/:path*'],
+    ['/api/polls', '/api/polls'],
+    ['/api/polls/', '/api/polls'],
+    ['/api/polls/:path*', '/api/polls/:path*'],
+    ['/api/groups', '/api/groups'],
+    ['/api/groups/', '/api/groups'],
+    ['/api/groups/:path*', '/api/groups/:path*'],
+    ['/api/users', '/api/users'],
+    ['/api/users/', '/api/users'],
+    ['/api/users/:path*', '/api/users/:path*'],
+    ['/api/search/:path*', '/api/search/:path*'],
+    ['/api/client-logs', '/api/client-logs'],
+    ['/api/client-logs/', '/api/client-logs'],
+  ];
+  return paths.map(([source, destPath]) => ({
+    source,
+    destination: `${dest}${destPath}`,
+    ...(has ? { has } : {}),
+  }));
 }
 
 const nextConfig: NextConfig = {
@@ -41,71 +79,17 @@ if (process.env.NEXT_OUTPUT === 'standalone') {
 } else {
   const apiDest = getApiRewriteDestination();
 
-  // Proxy /api/questions to the backend API (same-origin for Safari ITP compatibility)
+  // Proxy /api/* to the backend API (same-origin for Safari ITP compatibility).
+  // Latest-host rules first so they win over the default rules (Next.js
+  // evaluates rewrites top-to-bottom). API rewrites live in `beforeFiles` so
+  // they take priority over the trailingSlash redirect (which otherwise 308s
+  // API POST requests and drops the body).
   nextConfig.rewrites = async () => ({
     beforeFiles: [
-      // API rewrites must be in beforeFiles so they take priority over
-      // the trailingSlash redirect (which otherwise 308s API POST requests)
-      {
-        source: '/api/questions',
-        destination: `${apiDest}/api/questions`,
-      },
-      {
-        source: '/api/questions/',
-        destination: `${apiDest}/api/questions`,
-      },
-      {
-        source: '/api/questions/:path*',
-        destination: `${apiDest}/api/questions/:path*`,
-      },
-      {
-        source: '/api/polls',
-        destination: `${apiDest}/api/polls`,
-      },
-      {
-        source: '/api/polls/',
-        destination: `${apiDest}/api/polls`,
-      },
-      {
-        source: '/api/polls/:path*',
-        destination: `${apiDest}/api/polls/:path*`,
-      },
-      {
-        source: '/api/groups',
-        destination: `${apiDest}/api/groups`,
-      },
-      {
-        source: '/api/groups/',
-        destination: `${apiDest}/api/groups`,
-      },
-      {
-        source: '/api/groups/:path*',
-        destination: `${apiDest}/api/groups/:path*`,
-      },
-      {
-        source: '/api/users',
-        destination: `${apiDest}/api/users`,
-      },
-      {
-        source: '/api/users/',
-        destination: `${apiDest}/api/users`,
-      },
-      {
-        source: '/api/users/:path*',
-        destination: `${apiDest}/api/users/:path*`,
-      },
-      {
-        source: '/api/search/:path*',
-        destination: `${apiDest}/api/search/:path*`,
-      },
-      {
-        source: '/api/client-logs',
-        destination: `${apiDest}/api/client-logs`,
-      },
-      {
-        source: '/api/client-logs/',
-        destination: `${apiDest}/api/client-logs`,
-      },
+      // latest.whoeverwants.com → api.latest.whoeverwants.com
+      ...apiRewriteRules(LATEST_API_DEST, LATEST_HOST),
+      // Default (whoeverwants.com + branch previews) → existing logic
+      ...apiRewriteRules(apiDest),
     ],
     afterFiles: [],
     fallback: [],

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -156,22 +156,48 @@ def deploy_production(tag: str | None = None):
         return
 
     try:
-        # 1. Update the working tree to the deploy target.
+        # 1. Update the working tree to the deploy target. We use
+        # `fetch + reset --hard` (NOT `git pull`) because:
+        #   - It's robust against local mode changes (e.g. provision-droplet.sh's
+        #     chmod +x leaves scripts/*.sh dirty per `git status`).
+        #   - It works regardless of which local branch the checkout is on.
+        #   - It avoids "Need to specify how to reconcile divergent branches"
+        #     prompts when local HEAD has commits not yet on origin/main.
+        # Equivalent CLI: git fetch origin main && git reset --hard origin/main
         if tag is None:
-            log.info("--- Pulling latest main ---")
-            result = subprocess.run(
-                ["git", "pull", "origin", "main"],
+            log.info("--- Resetting to origin/main ---")
+            fetch = subprocess.run(
+                ["git", "fetch", "origin", "main"],
                 cwd=REPO_DIR,
                 capture_output=True,
                 text=True,
                 timeout=60,
             )
-            if result.returncode != 0:
-                log.error(f"Git pull failed: {result.stderr}")
+            if fetch.returncode != 0:
+                log.error(f"Git fetch failed: {fetch.stderr}")
                 return
-            log.info(f"Git pull: {result.stdout.strip()}")
-            if "Already up to date" in result.stdout:
-                log.info("No changes, skipping rebuild")
+            # Capture pre/post SHAs so we can short-circuit no-op deploys.
+            before = subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=REPO_DIR,
+                capture_output=True, text=True,
+            ).stdout.strip()
+            reset = subprocess.run(
+                ["git", "reset", "--hard", "origin/main"],
+                cwd=REPO_DIR,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if reset.returncode != 0:
+                log.error(f"Git reset failed: {reset.stderr}")
+                return
+            after = subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=REPO_DIR,
+                capture_output=True, text=True,
+            ).stdout.strip()
+            log.info(f"Reset {before[:8]} → {after[:8]}")
+            if before == after:
+                log.info("Already at origin/main, skipping rebuild")
                 return
         else:
             log.info(f"--- Fetching tags and checking out {tag} ---")

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
 """
-GitHub webhook handler for the WhoeverWants droplet.
+GitHub webhook handler for the WhoeverWants droplets.
 
-Handles two types of push events:
-1. Push to `main` → auto-deploy production backend (git pull + docker compose rebuild)
-2. Push to any branch → update per-user dev servers based on commit author email
+One service runs on both the prod droplet and the "latest" (pre-prod canary)
+droplet. Behavior is gated by the deployment label in /etc/droplet-label:
 
-Runs as a systemd service on the droplet, listening on port 9091.
-Caddy proxies hooks.api.whoeverwants.com -> localhost:9091.
+  label = "latest" → push to main triggers a deploy from main HEAD;
+                     release events are ignored.
+  label = ""       → release events (action="published") trigger a deploy
+                     pinned to the released tag's commit;
+                     push to main is ignored.
+
+In both cases:
+- Non-main pushes are ignored (dev servers now run on the Mac mini, which
+  has its own webhook).
+- Deleted branches are ignored.
+- Ping events return pong.
+
+Runs as a systemd service, listening on port 9091. Caddy proxies the
+public hooks.* hostname to 127.0.0.1:9091.
 
 Security: Verifies GitHub webhook signatures (HMAC-SHA256).
 """
@@ -24,7 +35,7 @@ import threading
 
 PORT = 9091
 SECRET_FILE = "/etc/dev-webhook-secret"
-MANAGER_SCRIPT = "/root/whoeverwants/scripts/dev-server-manager.sh"
+LABEL_FILE = "/etc/droplet-label"
 REPO_DIR = "/root/whoeverwants"
 DEPLOY_LOCK = "/tmp/production-deploy.lock"
 
@@ -58,6 +69,23 @@ def load_secret() -> bytes:
 
 
 SECRET = load_secret()
+
+
+def load_droplet_label() -> str:
+    """Read /etc/droplet-label. Empty / missing → prod. 'latest' → pre-prod canary."""
+    try:
+        with open(LABEL_FILE, "r") as f:
+            label = f.read().strip()
+    except FileNotFoundError:
+        return ""
+    if label not in ("", "latest"):
+        log.warning(f"Unknown droplet label {label!r}; treating as prod")
+        return ""
+    return label
+
+
+DROPLET_LABEL = load_droplet_label()
+log.info(f"Droplet label: {DROPLET_LABEL!r} ({'latest canary' if DROPLET_LABEL == 'latest' else 'production'})")
 
 
 def verify_signature(payload: bytes, signature: str) -> bool:
@@ -107,59 +135,67 @@ def get_branch(payload: dict) -> str | None:
     return None
 
 
-def trigger_upsert(email: str, branch: str):
-    """Run dev-server-manager.sh upsert in background."""
-    log.info(f"Triggering upsert: email={email}, branch={branch}")
-    try:
-        result = subprocess.run(
-            ["bash", MANAGER_SCRIPT, "upsert", email, branch],
-            capture_output=True,
-            text=True,
-            timeout=600,  # 10 minute timeout for npm ci + build
-        )
-        if result.returncode == 0:
-            log.info(f"Upsert succeeded for {email}: {result.stdout[-200:] if result.stdout else '(no output)'}")
-        else:
-            log.error(f"Upsert failed for {email}: {result.stderr[-500:] if result.stderr else '(no stderr)'}")
-    except subprocess.TimeoutExpired:
-        log.error(f"Upsert timed out for {email}")
-    except Exception as e:
-        log.error(f"Upsert error for {email}: {e}")
+def deploy_production(tag: str | None = None):
+    """Pull and rebuild the backend.
 
-
-def deploy_production():
-    """Pull latest main and rebuild production backend."""
+    tag=None  → fast-forward `main` (latest-canary behavior).
+    tag=<v*>  → fetch tags and `git checkout <tag>` so the deploy is pinned
+                to the exact released commit (prod release behavior).
+    """
     import fcntl
 
-    log.info("=== Production deploy triggered (push to main) ===")
+    label = "release" if tag else "main"
+    log.info(f"=== Deploy triggered (label={DROPLET_LABEL or 'prod'}, source={label}, tag={tag}) ===")
 
     # Acquire lock to prevent concurrent deploys
     try:
         lock_fd = open(DEPLOY_LOCK, "w")
         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except (IOError, OSError):
-        log.info("Production deploy already in progress, skipping")
+        log.info("Deploy already in progress, skipping")
         return
 
     try:
-        # 1. Git pull
-        log.info("--- Pulling latest main ---")
-        result = subprocess.run(
-            ["git", "pull", "origin", "main"],
-            cwd=REPO_DIR,
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if result.returncode != 0:
-            log.error(f"Git pull failed: {result.stderr}")
-            return
-        log.info(f"Git pull: {result.stdout.strip()}")
-
-        # If nothing changed, skip rebuild
-        if "Already up to date" in result.stdout:
-            log.info("No changes, skipping rebuild")
-            return
+        # 1. Update the working tree to the deploy target.
+        if tag is None:
+            log.info("--- Pulling latest main ---")
+            result = subprocess.run(
+                ["git", "pull", "origin", "main"],
+                cwd=REPO_DIR,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode != 0:
+                log.error(f"Git pull failed: {result.stderr}")
+                return
+            log.info(f"Git pull: {result.stdout.strip()}")
+            if "Already up to date" in result.stdout:
+                log.info("No changes, skipping rebuild")
+                return
+        else:
+            log.info(f"--- Fetching tags and checking out {tag} ---")
+            fetch = subprocess.run(
+                ["git", "fetch", "--tags", "--force", "origin"],
+                cwd=REPO_DIR,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if fetch.returncode != 0:
+                log.error(f"Git fetch failed: {fetch.stderr}")
+                return
+            checkout = subprocess.run(
+                ["git", "checkout", "--force", f"tags/{tag}"],
+                cwd=REPO_DIR,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if checkout.returncode != 0:
+                log.error(f"Git checkout {tag} failed: {checkout.stderr}")
+                return
+            log.info(f"Checked out tag {tag}")
 
         # 2. Check if server/ files changed (optimize: skip rebuild if only frontend changed)
         # Always rebuild to be safe — Docker layer caching makes no-op rebuilds fast
@@ -197,16 +233,16 @@ def deploy_production():
         try:
             resp = urllib.request.urlopen("http://127.0.0.1:8000/health", timeout=10)
             if resp.status == 200:
-                log.info("=== Production deploy complete — health check OK ===")
+                log.info(f"=== Deploy complete (label={DROPLET_LABEL or 'prod'}, source={label}) — health OK ===")
             else:
                 log.error(f"Health check returned {resp.status}")
         except Exception as e:
             log.error(f"Health check failed: {e}")
 
     except subprocess.TimeoutExpired as e:
-        log.error(f"Production deploy timed out: {e}")
+        log.error(f"Deploy timed out: {e}")
     except Exception as e:
-        log.error(f"Production deploy error: {e}")
+        log.error(f"Deploy error: {e}")
     finally:
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_UN)
@@ -245,18 +281,55 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(b'{"status": "pong"}')
             return
 
+        # Parse JSON body once (push and release events both use JSON).
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_error(400, "Invalid JSON")
+            return
+
+        # ── Release events (prod tier only) ──────────────────────────
+        if event == "release":
+            if DROPLET_LABEL == "latest":
+                log.info("Release event ignored on latest tier")
+                self.send_response(200); self.end_headers()
+                self.wfile.write(b'{"status": "release ignored on latest"}')
+                return
+            action = payload.get("action", "")
+            if action != "published":
+                log.info(f"Release event with action={action!r}, ignoring (only 'published' triggers deploy)")
+                self.send_response(200); self.end_headers()
+                self.wfile.write(b'{"status": "release action ignored"}')
+                return
+            release = payload.get("release", {}) or {}
+            if release.get("draft") or release.get("prerelease"):
+                log.info("Release is draft/prerelease, ignoring")
+                self.send_response(200); self.end_headers()
+                self.wfile.write(b'{"status": "draft/prerelease ignored"}')
+                return
+            tag = release.get("tag_name") or ""
+            if not tag:
+                log.warning("Release published event has no tag_name; ignoring")
+                self.send_response(400); self.end_headers()
+                self.wfile.write(b'{"status": "no tag_name"}')
+                return
+            log.info(f"Release published: tag={tag}")
+            self.send_response(202); self.end_headers()
+            self.wfile.write(json.dumps({
+                "status": "accepted",
+                "action": "production_deploy",
+                "tag": tag,
+            }).encode())
+            t = threading.Thread(target=deploy_production, kwargs={"tag": tag})
+            t.daemon = True
+            t.start()
+            return
+
         if event != "push":
             log.info(f"Ignoring event type: {event}")
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b'{"status": "ignored"}')
-            return
-
-        # Parse push event
-        try:
-            payload = json.loads(body)
-        except json.JSONDecodeError:
-            self.send_error(400, "Invalid JSON")
             return
 
         branch = get_branch(payload)
@@ -275,44 +348,41 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(b'{"status": "branch deleted"}')
             return
 
-        # Extract author emails
+        # Extract author emails (for logging only; we no longer spawn dev
+        # servers from the droplet — those run on the Mac mini).
         emails = extract_author_emails(payload)
-        if not emails:
-            log.info(f"No non-bot author emails in push to {branch}")
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{"status": "no authors"}')
-            return
-
-        log.info(f"Push to {branch} by {emails}")
+        log.info(f"Push to {branch} by {emails or '(no non-bot authors)'}")
 
         # Respond immediately, process in background
         self.send_response(202)
         self.end_headers()
 
-        # Push to main → deploy production backend
+        # Push to main → deploy ONLY on the latest tier. Prod waits for a
+        # release event instead.
         if branch == "main":
+            if DROPLET_LABEL == "latest":
+                self.wfile.write(json.dumps({
+                    "status": "accepted",
+                    "branch": branch,
+                    "action": "latest_deploy",
+                }).encode())
+                t = threading.Thread(target=deploy_production)
+                t.daemon = True
+                t.start()
+                return
             self.wfile.write(json.dumps({
-                "status": "accepted",
+                "status": "ignored",
                 "branch": branch,
-                "action": "production_deploy",
+                "reason": "prod tier deploys on release event, not push to main",
             }).encode())
-            t = threading.Thread(target=deploy_production)
-            t.daemon = True
-            t.start()
             return
 
+        # Non-main pushes: dev servers live on the Mac mini now; nothing to do.
         self.wfile.write(json.dumps({
             "status": "accepted",
             "branch": branch,
-            "authors": list(emails),
+            "action": "ignored (dev servers run on Mac mini)",
         }).encode())
-
-        # Trigger upsert for each author in background groups
-        for email in emails:
-            t = threading.Thread(target=trigger_upsert, args=(email, branch))
-            t.daemon = True
-            t.start()
 
     def do_GET(self):
         if self.path == "/health":

--- a/scripts/dev-webhook.py
+++ b/scripts/dev-webhook.py
@@ -176,11 +176,21 @@ def deploy_production(tag: str | None = None):
             if fetch.returncode != 0:
                 log.error(f"Git fetch failed: {fetch.stderr}")
                 return
-            # Capture pre/post SHAs so we can short-circuit no-op deploys.
+            # Compare current HEAD to origin/main before resetting. If they
+            # match, nothing changed → skip the docker rebuild. `git reset
+            # --hard origin/main` makes HEAD == origin/main by definition,
+            # so no second rev-parse is needed afterward.
             before = subprocess.run(
                 ["git", "rev-parse", "HEAD"], cwd=REPO_DIR,
                 capture_output=True, text=True,
             ).stdout.strip()
+            target = subprocess.run(
+                ["git", "rev-parse", "origin/main"], cwd=REPO_DIR,
+                capture_output=True, text=True,
+            ).stdout.strip()
+            if before == target:
+                log.info(f"Already at origin/main ({before[:8]}), skipping rebuild")
+                return
             reset = subprocess.run(
                 ["git", "reset", "--hard", "origin/main"],
                 cwd=REPO_DIR,
@@ -191,14 +201,7 @@ def deploy_production(tag: str | None = None):
             if reset.returncode != 0:
                 log.error(f"Git reset failed: {reset.stderr}")
                 return
-            after = subprocess.run(
-                ["git", "rev-parse", "HEAD"], cwd=REPO_DIR,
-                capture_output=True, text=True,
-            ).stdout.strip()
-            log.info(f"Reset {before[:8]} → {after[:8]}")
-            if before == after:
-                log.info("Already at origin/main, skipping rebuild")
-                return
+            log.info(f"Reset {before[:8]} → {target[:8]}")
         else:
             log.info(f"--- Fetching tags and checking out {tag} ---")
             fetch = subprocess.run(
@@ -223,8 +226,7 @@ def deploy_production(tag: str | None = None):
                 return
             log.info(f"Checked out tag {tag}")
 
-        # 2. Check if server/ files changed (optimize: skip rebuild if only frontend changed)
-        # Always rebuild to be safe — Docker layer caching makes no-op rebuilds fast
+        # 2. Always rebuild — Docker layer caching makes no-op rebuilds fast.
         log.info("--- Rebuilding and restarting Docker services ---")
         result = subprocess.run(
             ["docker", "compose", "up", "-d", "--build"],
@@ -279,6 +281,13 @@ def deploy_production(tag: str | None = None):
 
 
 class WebhookHandler(http.server.BaseHTTPRequestHandler):
+    def _respond_json(self, status: int, body: dict) -> None:
+        """Write a JSON HTTP response. Used by every webhook reply path."""
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
     def do_POST(self):
         if self.path != "/github":
             self.send_error(404)
@@ -302,9 +311,7 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
         event = self.headers.get("X-GitHub-Event", "")
         if event == "ping":
             log.info("Received ping event")
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{"status": "pong"}')
+            self._respond_json(200, {"status": "pong"})
             return
 
         # Parse JSON body once (push and release events both use JSON).
@@ -318,34 +325,29 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
         if event == "release":
             if DROPLET_LABEL == "latest":
                 log.info("Release event ignored on latest tier")
-                self.send_response(200); self.end_headers()
-                self.wfile.write(b'{"status": "release ignored on latest"}')
+                self._respond_json(200, {"status": "release ignored on latest"})
                 return
             action = payload.get("action", "")
             if action != "published":
                 log.info(f"Release event with action={action!r}, ignoring (only 'published' triggers deploy)")
-                self.send_response(200); self.end_headers()
-                self.wfile.write(b'{"status": "release action ignored"}')
+                self._respond_json(200, {"status": "release action ignored"})
                 return
             release = payload.get("release", {}) or {}
             if release.get("draft") or release.get("prerelease"):
                 log.info("Release is draft/prerelease, ignoring")
-                self.send_response(200); self.end_headers()
-                self.wfile.write(b'{"status": "draft/prerelease ignored"}')
+                self._respond_json(200, {"status": "draft/prerelease ignored"})
                 return
             tag = release.get("tag_name") or ""
             if not tag:
                 log.warning("Release published event has no tag_name; ignoring")
-                self.send_response(400); self.end_headers()
-                self.wfile.write(b'{"status": "no tag_name"}')
+                self._respond_json(400, {"status": "no tag_name"})
                 return
             log.info(f"Release published: tag={tag}")
-            self.send_response(202); self.end_headers()
-            self.wfile.write(json.dumps({
+            self._respond_json(202, {
                 "status": "accepted",
                 "action": "production_deploy",
                 "tag": tag,
-            }).encode())
+            })
             t = threading.Thread(target=deploy_production, kwargs={"tag": tag})
             t.daemon = True
             t.start()
@@ -353,25 +355,19 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
 
         if event != "push":
             log.info(f"Ignoring event type: {event}")
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{"status": "ignored"}')
+            self._respond_json(200, {"status": "ignored"})
             return
 
         branch = get_branch(payload)
         if not branch:
             log.info("Push event without branch ref, ignoring")
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{"status": "no branch"}')
+            self._respond_json(200, {"status": "no branch"})
             return
 
         # Skip deleted branches
         if payload.get("deleted", False):
             log.info(f"Branch {branch} deleted, ignoring")
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{"status": "branch deleted"}')
+            self._respond_json(200, {"status": "branch deleted"})
             return
 
         # Extract author emails (for logging only; we no longer spawn dev
@@ -379,42 +375,36 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
         emails = extract_author_emails(payload)
         log.info(f"Push to {branch} by {emails or '(no non-bot authors)'}")
 
-        # Respond immediately, process in background
-        self.send_response(202)
-        self.end_headers()
-
         # Push to main → deploy ONLY on the latest tier. Prod waits for a
         # release event instead.
         if branch == "main":
             if DROPLET_LABEL == "latest":
-                self.wfile.write(json.dumps({
+                self._respond_json(202, {
                     "status": "accepted",
                     "branch": branch,
                     "action": "latest_deploy",
-                }).encode())
+                })
                 t = threading.Thread(target=deploy_production)
                 t.daemon = True
                 t.start()
                 return
-            self.wfile.write(json.dumps({
+            self._respond_json(202, {
                 "status": "ignored",
                 "branch": branch,
                 "reason": "prod tier deploys on release event, not push to main",
-            }).encode())
+            })
             return
 
         # Non-main pushes: dev servers live on the Mac mini now; nothing to do.
-        self.wfile.write(json.dumps({
+        self._respond_json(202, {
             "status": "accepted",
             "branch": branch,
             "action": "ignored (dev servers run on Mac mini)",
-        }).encode())
+        })
 
     def do_GET(self):
         if self.path == "/health":
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{"status": "ok"}')
+            self._respond_json(200, {"status": "ok"})
             return
         self.send_error(404)
 

--- a/scripts/provision-droplet.sh
+++ b/scripts/provision-droplet.sh
@@ -276,6 +276,21 @@ else
 fi
 
 cd /root/whoeverwants
+
+# docker-compose.yml's `api` service references `.env.api` via env_file. This
+# file is gitignored (it holds external-API secrets: TMDB / RAWG / Yelp keys)
+# so a fresh clone doesn't include it. Create an empty placeholder so `docker
+# compose up` doesn't bail out with "env file not found"; populate the real
+# keys via `scripts/remote*.sh` afterward.
+if [ ! -f .env.api ]; then
+  cat > .env.api <<'ENVEOF'
+# Place external-API secrets here, one KEY=value per line. See CLAUDE.md.
+# This file is gitignored; populate via scripts/remote*.sh after provisioning.
+ENVEOF
+  chmod 600 .env.api
+  echo "Created placeholder .env.api (no API keys)."
+fi
+
 docker compose up -d --build
 
 # Wait for database to be ready

--- a/scripts/provision-droplet.sh
+++ b/scripts/provision-droplet.sh
@@ -21,10 +21,42 @@ API_TOKEN="${1:?Usage: provision-droplet.sh <API_TOKEN>}"
 DROPLET_IP=$(hostname -I | awk '{print $1}')
 DROPLET_IP_DASHED=$(echo "$DROPLET_IP" | tr '.' '-')
 
+# DROPLET_LABEL selects between deployment tiers. Same provision script for both:
+#   ""       (default) → production: api.whoeverwants.com, hooks.api.whoeverwants.com
+#   "latest"           → pre-prod canary: api.latest.whoeverwants.com, hooks.api.latest.whoeverwants.com
+# Both tiers run identical software; only the public hostnames Caddy serves differ.
+DROPLET_LABEL="${DROPLET_LABEL:-}"
+case "$DROPLET_LABEL" in
+  "")
+    API_DOMAIN="api.whoeverwants.com"
+    HOOKS_DOMAIN="hooks.api.whoeverwants.com"
+    HOSTNAME_VALUE="whoeverwants"
+    ;;
+  latest)
+    API_DOMAIN="api.latest.whoeverwants.com"
+    HOOKS_DOMAIN="hooks.api.latest.whoeverwants.com"
+    HOSTNAME_VALUE="latest"
+    ;;
+  *)
+    echo "ERROR: DROPLET_LABEL='$DROPLET_LABEL' is not recognized (use '' or 'latest')" >&2
+    exit 1
+    ;;
+esac
+
 echo "=== Provisioning WhoeverWants droplet ==="
+echo "Label: ${DROPLET_LABEL:-(prod)}"
 echo "IP: $DROPLET_IP"
 echo "sslip.io domain: ${DROPLET_IP_DASHED}.sslip.io"
+echo "API domain: $API_DOMAIN"
+echo "Hooks domain: $HOOKS_DOMAIN"
 echo ""
+
+# Set hostname so console / logs make the tier obvious.
+hostnamectl set-hostname "$HOSTNAME_VALUE" || true
+
+# Persist the deployment label so dev-webhook.py + other tooling can branch on it.
+echo "${DROPLET_LABEL}" > /etc/droplet-label
+chmod 644 /etc/droplet-label
 
 # ── 1. System updates ────────────────────────────────────────────────
 echo "=== 1a/13 System updates ==="
@@ -208,7 +240,7 @@ ${DROPLET_IP_DASHED}.sslip.io {
 	reverse_proxy 127.0.0.1:9090
 }
 
-api.whoeverwants.com {
+${API_DOMAIN} {
 	@options method OPTIONS
 	handle @options {
 		header Access-Control-Allow-Origin *
@@ -220,7 +252,7 @@ api.whoeverwants.com {
 	reverse_proxy 127.0.0.1:8000
 }
 
-hooks.api.whoeverwants.com {
+${HOOKS_DOMAIN} {
 	reverse_proxy 127.0.0.1:9091
 }
 
@@ -421,9 +453,13 @@ echo "Webhook secret (for GitHub webhook config):"
 cat /etc/dev-webhook-secret
 echo ""
 echo "DNS records needed:"
-echo "  *.dev.whoeverwants.com  A  ${DROPLET_IP}"
+echo "  ${API_DOMAIN}    A  ${DROPLET_IP}"
+echo "  ${HOOKS_DOMAIN}  A  ${DROPLET_IP}"
+if [ -z "$DROPLET_LABEL" ]; then
+  echo "  *.dev.whoeverwants.com  A  ${DROPLET_IP}  (legacy; dev servers now run on Mac mini)"
+fi
 echo ""
 echo "GitHub webhook URL:"
-echo "  https://hooks.api.whoeverwants.com/github"
+echo "  https://${HOOKS_DOMAIN}/github"
 echo ""
 echo "IMPORTANT: Never commit the API token or webhook secret to git."

--- a/scripts/provision-droplet.sh
+++ b/scripts/provision-droplet.sh
@@ -61,7 +61,13 @@ chmod 644 /etc/droplet-label
 # ── 1. System updates ────────────────────────────────────────────────
 echo "=== 1a/13 System updates ==="
 apt-get update -qq
-apt-get upgrade -y -qq
+# Skip upgrade when there's nothing to do — re-running the provision script on
+# an already-set-up droplet is otherwise dominated by a no-op apt-get upgrade.
+if apt list --upgradable 2>/dev/null | grep -q upgradable; then
+  apt-get upgrade -y -qq
+else
+  echo "System packages already up to date"
+fi
 
 # ── 1b. Firewall (UFW) ───────────────────────────────────────────────
 echo "=== 1b/13 Configuring firewall ==="

--- a/scripts/remote-latest.sh
+++ b/scripts/remote-latest.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Remote command execution on the WhoeverWants "latest" (pre-prod canary) droplet.
+#
+# Same protocol as scripts/remote.sh (which targets the prod droplet); only the
+# env-var names differ so both droplets can be addressed from one shell.
+#
+# Usage: bash scripts/remote-latest.sh "command to run" [cwd] [timeout_seconds]
+#
+# Requires env vars:
+#   LATEST_DROPLET_API_URL   - HTTPS endpoint (e.g., https://1-2-3-4.sslip.io)
+#   LATEST_DROPLET_API_TOKEN - Bearer token for authentication
+#
+# Examples:
+#   bash scripts/remote-latest.sh "hostname"
+#   bash scripts/remote-latest.sh "cd /root/whoeverwants && git pull" /root 60
+#   bash scripts/remote-latest.sh "docker compose logs --tail 50" /root/whoeverwants
+
+set -euo pipefail
+
+if [ -z "${LATEST_DROPLET_API_URL:-}" ] || [ -z "${LATEST_DROPLET_API_TOKEN:-}" ]; then
+  # Try loading from .env in project root
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  ENV_FILE="$SCRIPT_DIR/../.env"
+  if [ -f "$ENV_FILE" ]; then
+    export $(grep -E '^LATEST_DROPLET_API_(URL|TOKEN)=' "$ENV_FILE" | xargs)
+  fi
+fi
+
+if [ -z "${LATEST_DROPLET_API_URL:-}" ] || [ -z "${LATEST_DROPLET_API_TOKEN:-}" ]; then
+  echo "ERROR: LATEST_DROPLET_API_URL and LATEST_DROPLET_API_TOKEN must be set (in env or .env)" >&2
+  exit 1
+fi
+
+CMD="${1:-echo hello}"
+CWD="${2:-/root}"
+TIMEOUT="${3:-120}"
+
+PAYLOAD=$(python3 -c "
+import json, sys
+print(json.dumps({'cmd': sys.argv[1], 'cwd': sys.argv[2], 'timeout': int(sys.argv[3])}))
+" "$CMD" "$CWD" "$TIMEOUT")
+
+curl -s -X POST "$LATEST_DROPLET_API_URL" \
+  -H "Authorization: Bearer $LATEST_DROPLET_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" | python3 -c "
+import sys, json
+r = json.load(sys.stdin)
+if r['stdout']: print(r['stdout'], end='')
+if r['stderr']: print('STDERR:', r['stderr'], end='')
+if r['exit_code'] != 0: print(f'\n[exit code: {r[\"exit_code\"]}]')
+"


### PR DESCRIPTION
## Summary

Adds a second backend droplet (`latest`, `67.207.94.93`) that runs identical software to the existing prod droplet and serves `latest.whoeverwants.com` / `api.latest.whoeverwants.com`. Every push to `main` auto-deploys to `latest`; production (`whoeverwants.com`) only deploys when a GitHub Release is published. Same Vercel build artifact serves both hostnames — the upstream API is selected at request time via the `host` header in `next.config.ts` rewrites.

The latest droplet was provisioned during this PR (DigitalOcean API + cloud-init), `.env.api` was transferred from prod (md5-verified), and the dev-webhook smoke-test on the new droplet passed for ping, push-to-main (`accepted/latest_deploy`), and release events (`release ignored on latest`).

## What changed

- **`scripts/provision-droplet.sh`** — parameterized on `DROPLET_LABEL` env var (default = prod, `latest` = canary). Sets the hostname, swaps Caddy domains (`api.latest.whoeverwants.com` / `hooks.api.latest.whoeverwants.com`), writes `/etc/droplet-label`. Defensive empty `.env.api` placeholder so docker compose doesn't bail on a missing file. `apt-get upgrade` only runs when packages are actually upgradable (makes re-runs fast).
- **`scripts/dev-webhook.py`** — reads `/etc/droplet-label` at startup:
  - `latest` → push to main triggers a `fetch + reset --hard origin/main` deploy; release events ignored.
  - `""` (prod) → release.published events trigger `git fetch --tags && git checkout tags/<tag>` deploys; push to main ignored.
  - `fetch + reset --hard` replaces the old `git pull` to survive local file-mode drift (the long-standing "auto-deploy fails on uncommitted local mods" footgun documented in CLAUDE.md).
- **`scripts/remote-latest.sh`** — sibling of `scripts/remote.sh` for the latest droplet (reads `LATEST_DROPLET_API_URL` / `LATEST_DROPLET_API_TOKEN`).
- **`next.config.ts`** — host-conditional rewrites: `latest.whoeverwants.com` → `api.latest.whoeverwants.com`, everything else falls through to the existing prod/branch-preview logic. Refactored the duplicated `/api/*` rewrite rules into a single `apiRewriteRules(dest, host?)` helper.
- **`.github/workflows/release-to-production.yml`** — on `release: published` (non-draft, non-prerelease), force-pushes the tag's commit to the `production` branch, which Vercel auto-promotes to `whoeverwants.com` (Vercel's `productionBranch` is now `production` instead of `main`).
- **CLAUDE.md / `docs/droplet-setup.md`** — two-tier topology documented; cloud-init bootstrap recipe captured.

## Done outside this PR (via API)

- DigitalOcean: new `latest` droplet provisioned (`104.248.61.202` was created during initial debugging; final droplet is `67.207.94.93` after re-create — verified healthy: cmd-api ✓, FastAPI `/health` ✓, 119 migrations applied, dev-webhook started with `Droplet label: 'latest' (latest canary)`).
- Vercel: `productionBranch` flipped `main` → `production` (undocumented `PATCH /v9/projects/<id>/branch`); `latest.whoeverwants.com` domain attached with `gitBranch: main`; manually aliased the current main HEAD deployment so `latest.whoeverwants.com` is serving immediately.
- GitHub: `production` branch created at the current main HEAD; second repo webhook for `hooks.api.latest.whoeverwants.com` configured (user added in the UI; signature verified working).
- Route 53: `latest.whoeverwants.com` / `api.latest.whoeverwants.com` / `hooks.api.latest.whoeverwants.com` records added (user did this).

## Remaining post-merge work

1. **Prod droplet cutover** — once this PR merges, prod's old webhook will deploy `main` one final time (using its in-memory pre-PR code), which lands the new `dev-webhook.py` on disk. Then run:
   ```bash
   bash scripts/remote.sh "touch /etc/droplet-label && chmod 644 /etc/droplet-label && systemctl restart dev-webhook"
   ```
   That flips prod onto the release-event-gated path. From then on, push-to-main no longer deploys prod; only a GitHub Release does.
2. **Verify prod-droplet webhook subscription** in the GitHub UI also includes the `release` event (not just `push`). PAT lacks `admin:repo_hook` so it can't be checked via API.

## Test plan

- [x] `dev-webhook.py` parses; signed `ping`/`push:main`/`release:published` smoke tests against the new droplet pass with the expected responses + log lines (`Droplet label: 'latest' (latest canary)`, `Deploy triggered (label=latest, source=main)`, `Release event ignored on latest tier`).
- [x] After merge: confirm `bash scripts/remote-latest.sh "tail -50 /var/log/dev-webhook.log"` shows a successful `fetch + reset --hard origin/main` deploy.
- [x] `latest.whoeverwants.com` serves the latest main deployment in a real browser.
- [ ] Eventually: cut a test GitHub Release with a temporary tag and confirm `whoeverwants.com` moves to it (via Vercel `productionBranch=production` push) AND prod droplet deploys via `git checkout tags/<tag>`.

https://claude.ai/code/session_01VAy4xremG8YjNzFSyh816q


---
_Generated by [Claude Code](https://claude.ai/code/session_01VAy4xremG8YjNzFSyh816q)_