### PR TITLE
Fix iOS TestFlight blank screens (repoint dev → latest, log forwarding on all tiers)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -130,12 +130,14 @@ jobs:
             URL="${{ github.event.inputs.cap_server_url }}"
           elif [[ "$CAP_ENV" == "prod" ]]; then
             URL=""  # capacitor.config.ts defaults to prod when unset
-          elif [[ -n "${{ github.event.head_commit.author.email }}" ]]; then
-            EMAIL="${{ github.event.head_commit.author.email }}"
-            SLUG=$(echo "$EMAIL" | tr '[:upper:]' '[:lower:]' | sed -e 's/@/-at-/g' -e 's/[^a-z0-9-]/-/g')
-            URL="https://$SLUG.dev.whoeverwants.com"
           else
-            URL=""  # No push email (workflow_dispatch without override) → fall through to prod
+            # Dev builds point at the canary "latest" tier (auto-deployed on
+            # every push to main). Per-author dev URLs no longer work: dev
+            # servers are per-branch now, so a per-author email slug doesn't
+            # resolve unless that same person happens to be pushing the
+            # currently-active branch. The latest tier is the stable "code
+            # is exactly what'll ship next" target for TestFlight diagnosis.
+            URL="https://latest.whoeverwants.com"
           fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           [[ -n "$URL" ]] && echo "WebView URL: $URL" || echo "WebView URL: (prod default)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -839,43 +839,52 @@ npm run debug:react question-123 revisit   # Debug vote retrieval
 
 ---
 
-## Client Log Forwarding (Dev Sites Only)
+## Client Log Forwarding
 
-On dev/debug sites (`*.dev.whoeverwants.com`, `localhost`), the browser automatically forwards all `console.log/warn/error/info/debug` output plus unhandled errors/rejections to the server via `POST /api/client-logs`. Logs are stored in an in-memory ring buffer (last 2000 entries) on the API server.
+The browser forwards `console.*` output and unhandled errors/rejections to the API server via `POST /api/client-logs`. The endpoint is an in-memory ring buffer (last 10000 entries on the API server) — no disk writes, no persistence across restarts.
 
-**This is NOT active on production** (whoeverwants.com).
+**Activation rules (`lib/clientLogForwarder.ts: isLogForwardingEnabled`):**
+- **Dev hosts** (`*.dev.whoeverwants.com`, `localhost`, `127.0.0.1`) — forward EVERYTHING (`log/warn/error/info/debug` + unhandled events). Low traffic; devs want full context.
+- **Canary + prod** (`latest.whoeverwants.com`, `whoeverwants.com`) — forward `warn/error` only + unhandled events. Verbose `log/info/debug` from a busy session would otherwise churn the ring buffer faster than diagnostic entries can be read (the level filter lives in `isHighVolumeHost()`). The primary reason this is enabled on prod is to capture WKWebView-specific JS errors from the iOS TestFlight app, which loads `whoeverwants.com` directly and has no other diagnostic channel (Safari Web Inspector requires a wired Mac).
 
 ### When the user reports an issue
 
-**IMMEDIATELY check client logs** in addition to server-side logs. This is the fastest way to see what the browser was doing when the error occurred. The dev server's FE proxies `/api/*` to its in-container API, so the public URL works directly:
+**IMMEDIATELY check client logs** in addition to server-side logs. The host you query matches the tier the user was on:
 
 ```bash
-# Read recent client logs (most recent first) — slug = your branch's dev slug
-curl -s "https://<slug>.dev.whoeverwants.com/api/client-logs?limit=100" | python3 -m json.tool
-
-# Filter by level (error, warn, log, info, debug)
+# Dev (branch's per-branch dev server, Mac-hosted)
 curl -s "https://<slug>.dev.whoeverwants.com/api/client-logs?level=error&limit=50" | python3 -m json.tool
 
-# Search for specific text in log messages
-curl -s "https://<slug>.dev.whoeverwants.com/api/client-logs?search=failed&limit=50" | python3 -m json.tool
+# Canary (auto-deployed on push to main)
+curl -s "https://latest.whoeverwants.com/api/client-logs?level=error&limit=50" | python3 -m json.tool
 
-# Clear logs (useful before reproducing an issue)
-curl -s -X DELETE "https://<slug>.dev.whoeverwants.com/api/client-logs"
+# Prod (deployed only on GitHub Release)
+curl -s "https://whoeverwants.com/api/client-logs?level=error&limit=50" | python3 -m json.tool
+
+# Other useful queries (same per-tier hosts):
+#   ?search=<text>            substring filter in messages
+#   ?since=<unix-timestamp>   only entries received after this time
+#   ?limit=N                  cap (default 200, most-recent-first)
+# DELETE clears the buffer (handy before reproducing)
 ```
 
 ### Diagnostic checklist when user reports a bug
 
-1. **Client logs**: `curl 'https://<slug>.dev.whoeverwants.com/api/client-logs?level=error&limit=50'`
-2. **Server logs**: `bash scripts/remote-mac.sh "docker exec whoeverwants-dev-<slug> tail -50 /repo/api.log"`
-3. **Full client log dump**: `curl 'https://<slug>.dev.whoeverwants.com/api/client-logs?limit=200'` (includes info/debug for context)
+1. **Client logs** on the matching tier (see above).
+2. **Server logs**:
+   - Dev: `bash scripts/remote-mac.sh "docker exec whoeverwants-dev-<slug> tail -50 /repo/api.log"`
+   - Canary: `bash scripts/remote-latest.sh "docker compose logs --tail 100" /root/whoeverwants`
+   - Prod: `bash scripts/remote.sh "docker compose logs --tail 100" /root/whoeverwants`
+3. **Full client log dump** (`?limit=200`) on dev for info/debug-level context (canary/prod return warn/error only).
 
 ### How it works
 
-- `lib/clientLogForwarder.ts` patches `console.*` methods on dev sites only
-- Logs are batched every 2 seconds and sent via `navigator.sendBeacon` (survives page unloads)
-- Each entry includes: level, message, timestamp, page URL, user agent, session ID
-- Ring buffer auto-evicts entries beyond 2000 (no disk writes, no persistence across API restarts)
-- The forwarder is installed once in `app/template.tsx` on mount
+- `lib/clientLogForwarder.ts` patches `console.*` methods at module load via `installClientLogForwarder()` (called once from `app/template.tsx`).
+- Levels patched are gated by `isHighVolumeHost()`: dev = all 5 methods; canary/prod = `warn` + `error` only.
+- Unhandled `error` and `unhandledrejection` are captured on every tier where forwarding is enabled (their `level` is hard-coded to `'error'`, so the prod filter doesn't drop them).
+- Logs are batched every 2s and sent via `navigator.sendBeacon` (survives page unloads); fetches with `keepalive: true` is the fallback.
+- Each entry includes: level, message, timestamp, page URL, user agent, session ID.
+- Ring buffer is 10000 entries (raised from 2000 when prod activation landed).
 
 ---
 
@@ -1614,7 +1623,7 @@ bridge into the remote WebView.
 A GitHub Actions workflow (`.github/workflows/ios-build.yml`) runs on a
 self-hosted Mac mini runner (labels: `self-hosted, macos-mini`). The workflow:
 
-1. Resolves `CAP_SERVER_URL` from the pusher's email (`<slug>.dev.whoeverwants.com`) or uses the prod default when `CAP_ENV=prod`.
+1. Resolves `CAP_SERVER_URL`: dev builds point at `https://latest.whoeverwants.com` (the canary tier, auto-deployed on every push to main); prod builds leave it unset and capacitor.config.ts's `PROD_URL` fallback (`https://whoeverwants.com`) wins. `workflow_dispatch` accepts a `cap_server_url` input that overrides both.
 2. Computes bundle ID + display name based on `CAP_ENV` and `github.actor`.
 3. Patches `ios/App/App.xcodeproj/project.pbxproj` with the bundle ID (automatic signing ignores the xcodebuild command-line override). Fails loudly if the sed doesn't match the expected occurrence count.
 4. Runs `npm ci` → `npx cap sync ios` → archives with `xcodebuild` → exports signed `.ipa` → uploads with `xcrun altool`. All signing uses App Store Connect API key auth (`-allowProvisioningUpdates -authenticationKey*`) — no Xcode GUI login needed.
@@ -1668,6 +1677,12 @@ See `docs/ios-setup.md` for the full one-time setup walkthrough.
 - **UIWindow's default `backgroundColor` is black, which leaks as a bottom-of-screen bar if the WebView's frame doesn't fully cover the window.** `CAPBridgeViewController.loadView()` is `final` and assigns `view = webView` — you can't restructure the view hierarchy. Defenses: (a) `AppDelegate.didFinishLaunchingWithOptions` sets `window?.backgroundColor = .systemBackground` (window is non-nil here for non-UIScene apps with `UIMainStoryboardFile` in Info.plist), (b) a `MainViewController: CAPBridgeViewController` subclass overrides `viewDidLoad` to set `view.backgroundColor = .systemBackground`. Use `.systemBackground` (not `.white`) so dark-mode users don't see white safe-area zones against a near-black page. Capacitor already writes `webView.backgroundColor` + `scrollView.backgroundColor` from `capacitor.config.ts` (CAPBridgeViewController.swift L308-310) — don't redo those in the subclass.
 - **Adding a new `.swift` file requires hand-patching `project.pbxproj`.** `npx cap sync ios` doesn't pick up new native files — it only syncs web assets and plugins. Xcode's GUI handles file-add via PBXBuildFile + PBXFileReference + group children entries, but the headless CI build has no GUI. For small additions (1–2 short classes), colocate inside `ios/App/App/AppDelegate.swift` which is already in the build phase. Reserve new files for non-trivial code where colocation hurts readability.
 - **Storyboard `customClass` references use the Xcode target name as `customModule`.** `<viewController customClass="MainViewController" customModule="App" customModuleProvider="target"/>` resolves to the `MainViewController` Swift class in the `App` target. Verify with `grep "name = " ios/App/App.xcodeproj/project.pbxproj` — the target name is the source of truth. Capacitor's default scaffold uses `customModule="Capacitor"` because the bridge VC ships from the Capacitor SPM package; subclasses defined in the app target need `customModule="App"` and the `customModuleProvider="target"` attribute.
+- **Per-author dev URLs are dead — dev iOS builds must target the canary tier.** An earlier version of `ios-build.yml` derived `CAP_SERVER_URL` from `head_commit.author.email` (`<slug>.dev.whoeverwants.com`). That worked under per-author dev servers but broke silently when dev servers became per-branch (the `<email-slug>` URL still resolves DNS-wise via the wildcard Caddy frontend, but returns HTTP 503 `upstream connect error` because no upstream container is registered for that slug). The WebView loads the 503, renders nothing visible, and the user sees a white screen (light mode) or black screen (dark mode — the `view.backgroundColor = .systemBackground` showing through). Fix in this repo's history: workflow now hardcodes `https://latest.whoeverwants.com` for dev. If a new tier appears that requires per-bundle URLs again, key on `github.ref` (branch name) NOT email.
+- **TestFlight blank-screen diagnostic workflow.** Symptom: app launches, shows a solid white or black screen (color = light/dark mode default from `view.backgroundColor = .systemBackground`), no content. Before reaching for Safari Web Inspector, run this triage:
+  1. Curl the URL the iOS build points at (`https://whoeverwants.com` for prod TestFlight, `https://latest.whoeverwants.com` for dev TestFlight). Verify it returns 200 with a valid `<title>` and `<meta name="build-id">`. A 503 / 5xx here is the bug (see the per-author-URL pitfall above for the dev case).
+  2. Open the same URL in iPhone Safari on the same device. If Safari renders fine but the WebView is blank, the bug is WebView-specific (CSS / JS / Capacitor bridge) — proceed to step 3. If Safari ALSO blanks, the bug is in the web bundle currently served by that tier.
+  3. Compare deployed `build-id` between tiers — `curl -s https://whoeverwants.com | grep -oE 'build-id" content="[^"]+"'` vs the same against `latest.whoeverwants.com`. If they diverge AND the prod tier is older AND prod TestFlight is the one failing, the most likely fix is "cut a release" to promote the newer (fixed) bundle to prod — no new iOS build needed since the WebView reloads its URL on each app open. (Pattern we hit: prod blank screen was an overlay-slide regression in commit `8a60ff0` already fixed in subsequent main commits but never released to prod because the two-tier deploy was set up after the regression and no release had been cut.)
+  4. Check client logs on the matching tier (`/api/client-logs?level=error&limit=50`) — the forwarder captures unhandled errors and prod-host `warn/error` console output. See the "Client Log Forwarding" section.
 
 ---
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,11 +1,12 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
 // The native WebView loads whichever URL wins this precedence chain:
-//   1. CAP_SERVER_URL — explicit override (CI sets this per-developer).
-//   2. Production site — the default fallback.
-// `CAP_ENV=dev` alone is no longer meaningful; the workflow translates
-// it into a real URL (e.g., <email-slug>.dev.whoeverwants.com) and
-// exports CAP_SERVER_URL before running `cap sync`.
+//   1. CAP_SERVER_URL — explicit override exported by the CI workflow.
+//   2. Production site (https://whoeverwants.com) — the default fallback.
+// The CI workflow (`.github/workflows/ios-build.yml`) sets CAP_SERVER_URL
+// to `https://latest.whoeverwants.com` for dev builds (the canary tier
+// auto-deployed on every push to main) and leaves it unset for prod
+// builds so the fallback kicks in.
 const PROD_URL = 'https://whoeverwants.com';
 const serverUrl = process.env.CAP_SERVER_URL || PROD_URL;
 

--- a/lib/clientLogForwarder.ts
+++ b/lib/clientLogForwarder.ts
@@ -39,6 +39,17 @@ function isLogForwardingEnabled(): boolean {
   );
 }
 
+// On canary + prod, only the warn/error stream + unhandled events get
+// forwarded. Verbose log/info/debug from a busy session would churn the
+// server's 10000-entry ring buffer fast and drown out the WKWebView errors
+// this is here to capture. Dev hosts forward everything (low traffic +
+// devs want full context).
+function isHighVolumeHost(): boolean {
+  if (typeof window === 'undefined') return false;
+  const host = window.location.hostname;
+  return host === 'latest.whoeverwants.com' || host === 'whoeverwants.com';
+}
+
 function getSessionId(): string {
   if (!sessionId) {
     sessionId = Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -115,7 +126,9 @@ export function installClientLogForwarder() {
 
   installed = true;
 
-  const levels = ['log', 'warn', 'error', 'info', 'debug'] as const;
+  const levels = isHighVolumeHost()
+    ? (['warn', 'error'] as const)
+    : (['log', 'warn', 'error', 'info', 'debug'] as const);
   for (const level of levels) {
     const original = console[level].bind(console);
     console[level] = (...args: unknown[]) => {

--- a/lib/clientLogForwarder.ts
+++ b/lib/clientLogForwarder.ts
@@ -2,8 +2,12 @@
  * Client-side log forwarder — intercepts console.{log,warn,error,info,debug}
  * and sends them to the server for Claude to read when debugging issues.
  *
- * Only active on dev/debug sites (*.dev.whoeverwants.com, localhost).
- * Does NOT activate on production (whoeverwants.com).
+ * Active on every site we ship to (dev / canary / production). The server
+ * stores logs in a 2000-entry ring buffer that auto-evicts; no persistence,
+ * no PII surface beyond what the user's console already shows. The prod-site
+ * activation exists primarily to capture WKWebView-specific JS errors from
+ * the iOS TestFlight app, which loads whoeverwants.com directly and has no
+ * other diagnostic channel (Safari Web Inspector requires a wired Mac).
  */
 
 const BATCH_INTERVAL_MS = 2000;
@@ -23,13 +27,15 @@ let flushTimer: ReturnType<typeof setTimeout> | null = null;
 let sessionId: string | null = null;
 let installed = false;
 
-function isDevSite(): boolean {
+function isLogForwardingEnabled(): boolean {
   if (typeof window === 'undefined') return false;
   const host = window.location.hostname;
   return (
     host === 'localhost' ||
     host === '127.0.0.1' ||
-    host.endsWith('.dev.whoeverwants.com')
+    host.endsWith('.dev.whoeverwants.com') ||
+    host === 'latest.whoeverwants.com' ||
+    host === 'whoeverwants.com'
   );
 }
 
@@ -105,7 +111,7 @@ function flush() {
  */
 export function installClientLogForwarder() {
   if (installed || typeof window === 'undefined') return;
-  if (!isDevSite()) return;
+  if (!isLogForwardingEnabled()) return;
 
   installed = true;
 

--- a/server/routers/client_logs.py
+++ b/server/routers/client_logs.py
@@ -1,4 +1,10 @@
-"""Client-side log collection endpoint (dev/debug only)."""
+"""Client-side log collection endpoint.
+
+In-memory ring buffer of the most recent console output forwarded from
+the browser via lib/clientLogForwarder.ts. Active on every tier we ship to
+(dev / canary / production) so iOS TestFlight WebView errors can be
+diagnosed without a wired-Mac Safari Web Inspector session.
+"""
 
 import logging
 import time

--- a/server/routers/client_logs.py
+++ b/server/routers/client_logs.py
@@ -18,8 +18,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/client-logs", tags=["client-logs"])
 
-# In-memory ring buffer: last 2000 log entries, auto-evicts oldest
-_LOG_BUFFER: deque[dict] = deque(maxlen=2000)
+# In-memory ring buffer: last 10000 log entries, auto-evicts oldest.
+# Raised from 2000 once log forwarding was enabled on prod/canary, where
+# concurrent users would otherwise churn the buffer faster than diagnostic
+# entries could be read. The clientLogForwarder on those tiers also filters
+# down to warn/error + unhandled events, so most of this headroom is for
+# bursty multi-user error scenarios rather than verbose console logging.
+_LOG_BUFFER: deque[dict] = deque(maxlen=10000)
 
 
 class ClientLogEntry(BaseModel):


### PR DESCRIPTION
## Summary

iOS TestFlight has been showing blank screens on both dev and production builds. Diagnosis + minimum fix below; details in the commits and the CLAUDE.md additions.

**Dev TestFlight (white screen):** the iOS workflow derived `CAP_SERVER_URL` from `head_commit.author.email` (`<slug>.dev.whoeverwants.com`). That worked when dev servers were per-author, but the dev-server architecture has shifted to per-branch — the per-author URL still resolves DNS-wise but returns HTTP 503 from Caddy with no upstream. WebView renders nothing → `view.backgroundColor = .systemBackground` shows through as white (light) / black (dark).

Repoint dev builds at `https://latest.whoeverwants.com` (the canary tier, auto-deployed on every push to main). It's a stable "exactly what'll ship next" target that survives without per-developer infrastructure.

**Prod TestFlight (black screen):** the prod build (#2, from May 9) loads `https://whoeverwants.com`. Safari on the same device renders that URL fine, so the issue is WKWebView-specific. Comparing `<meta name="build-id">`:

- `whoeverwants.com` → commit `8a60ff0` (#345 "Instant overlay-slide transitions")
- `latest.whoeverwants.com` → current main HEAD (`5213f62` at time of diagnosis)

The two-tier deploy setup landed AFTER `8a60ff0`, so no release has been cut since then. `whoeverwants.com` is stuck on the commit that introduced the overlay-slide work, and the very next commits on main (`#346`, `#347`, `#350`, `#351`) are explicit fixes to it. **A release cut from current main HEAD is the prod fix — no new iOS build needed**, since the WebView reloads its URL on each app open.

This PR doesn't perform the release; it only stages the supporting changes. After merge, cut a release from main HEAD to land the fix on `whoeverwants.com`.

**Client log forwarding extended to all tiers** so this class of issue is debuggable next time:
- Dev hosts (`*.dev.whoeverwants.com`, `localhost`) — keeps full `log/warn/error/info/debug` forwarding.
- Canary + prod (`latest.whoeverwants.com`, `whoeverwants.com`) — `warn/error` + unhandled events only. Per-simplify-review, filtering verbose console output on the high-traffic tiers keeps a busy session from churning the server's ring buffer before iOS WKWebView errors can be read. Buffer also bumped 2000 → 10000 entries.

## Changes

- `.github/workflows/ios-build.yml` — dev `CAP_SERVER_URL` → `https://latest.whoeverwants.com`; remove dead per-author email-slug branch.
- `lib/clientLogForwarder.ts` — extend allowlist; add `isHighVolumeHost()` level filter for canary/prod.
- `server/routers/client_logs.py` — ring buffer 2000 → 10000.
- `capacitor.config.ts` — update stale precedence-chain comment.
- `CLAUDE.md` — rewrite the Client Log Forwarding section for new contract; add iOS-section pitfalls (per-author URL is dead; TestFlight blank-screen diagnostic recipe).

## Test plan

- [ ] Dev iOS workflow auto-triggers on push (path filter matches `capacitor.config.ts` + `.github/workflows/ios-build.yml`); the resulting dev TestFlight build (`com.whoeverwants.app.dev.<github-actor>`) should load `https://latest.whoeverwants.com` and render correctly. ✅ Already confirmed live on TestFlight build 758 from a pre-rebase push of this branch.
- [ ] On merge to main: Vercel auto-deploys to `latest.whoeverwants.com`; existing dev TestFlight reopens load the merged bundle and continue working.
- [ ] After merge + release: `whoeverwants.com` updates to current main HEAD, existing prod TestFlight build #2 reopens load the fixed bundle. Verify by curling `https://whoeverwants.com` and confirming the `build-id` meta matches the release commit, then reopening the prod TestFlight app.
- [ ] If prod still blanks post-release: query `https://whoeverwants.com/api/client-logs?level=error&limit=50` to capture the WKWebView's JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGBef3seAXiVmVTJyJcni9)_