### PR TITLE
Boost iOS Capacitor FAB bottom gap by 75%

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -14,6 +14,9 @@ import { isUuidLike, isGroupRootView } from '@/lib/questionId';
 import { apiCreateGroup } from '@/lib/api';
 import { GROUP_ID_ATTR } from '@/lib/groupDomMarkers';
 import { HOME_SELECTION_MODE_CHANGE_EVENT, type HomeSelectionModeChangeDetail } from '@/lib/eventChannels';
+import { Capacitor } from '@capacitor/core';
+
+const IS_CAPACITOR_NATIVE = typeof window !== 'undefined' && Capacitor.isNativePlatform();
 
 // `CreateQuestionContent` (the bubble-bar + create-poll-modal owner) is
 // mounted in `app/layout.tsx` via `<PersistentCreatePollHost />` so it
@@ -70,7 +73,7 @@ function CreateGroupButton({ router }: { router: ReturnType<typeof useRouter> })
       className="fixed z-50 h-12 px-3 rounded-full flex items-center justify-center gap-1.5 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-normal"
       style={{
         right: 'max(1.5rem, env(safe-area-inset-right, 0px))',
-        bottom: '1rem',
+        bottom: IS_CAPACITOR_NATIVE ? '1.75rem' : '1rem',
       }}
       aria-label="Create new group"
     >


### PR DESCRIPTION
## Summary
- In the native Capacitor app the home page's floating "+ Group" FAB sits visibly closer to the screen edge than in the web/PWA, where the layout viewport sits well above the physical bottom (per the existing "iOS PWA layout viewport vs physical screen" note in `CLAUDE.md`).
- Detect Capacitor via `Capacitor.isNativePlatform()` (the typed `@capacitor/core` export, already a dep) at module scope, and raise the FAB's `bottom` from `1rem` to `1.75rem` only when running natively. Web/PWA spacing is unchanged.

## Test plan
- [ ] Web (Safari / Chrome): home page renders FAB at the same `1rem` offset as before.
- [ ] PWA standalone (add-to-home-screen iPhone): FAB offset unchanged from web.
- [ ] iOS Capacitor TestFlight build: FAB clears the home-indicator zone with the new larger gap.

https://claude.ai/code/session_01KA13K7UVvANBLEwpyuTaRr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KA13K7UVvANBLEwpyuTaRr)_