### PR TITLE
Remove question count from group page top bar

### DIFF
--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -1632,11 +1632,6 @@ export function GroupContent({ groupId, initialExpandedQuestionId = null }: Grou
         participantNames={group.participantNames}
         anonymousCount={group.anonymousRespondentCount}
         imageUrl={group.imageUrl}
-        subtitle={
-          group.questions.length === 0
-            ? undefined
-            : `${group.questions.length} ${group.questions.length === 1 ? 'question' : 'questions'}`
-        }
         onTitleClick={() => slideToGroupInfo({ groupId })}
         rightSlot={<GroupShareButton routeId={groupId} title={group.title} />}
       />

--- a/components/GroupHeader.tsx
+++ b/components/GroupHeader.tsx
@@ -12,7 +12,6 @@ export interface GroupHeaderProps {
   /** Migration 108: when set, the header shows the uploaded image circle
    *  instead of the initials graphic. Null/undefined → initials fallback. */
   imageUrl?: string | null;
-  subtitle?: string;
   onTitleClick?: () => void;
   onBack?: () => void;
   rightSlot?: React.ReactNode;
@@ -47,7 +46,6 @@ export default function GroupHeader({
   participantNames,
   anonymousCount,
   imageUrl,
-  subtitle,
   onTitleClick,
   onBack,
   rightSlot,
@@ -57,14 +55,9 @@ export default function GroupHeader({
   const handleBack = onBack ?? (() => navigateWithTransition(router, '/', 'back'));
 
   const titleBlock = title ? (
-    <>
-      <h1 className="font-semibold text-lg text-gray-900 dark:text-white truncate">
-        {title}
-      </h1>
-      {subtitle && (
-        <p className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
-      )}
-    </>
+    <h1 className="font-semibold text-lg text-gray-900 dark:text-white truncate">
+      {title}
+    </h1>
   ) : null;
 
   const middleRightPad = hasRightSlot ? 'pr-2' : 'pr-4';


### PR DESCRIPTION
## Summary
- Drop the "N questions" subtitle from the group page's `GroupHeader`
- Remove the now-unused `subtitle` prop from `GroupHeader` (no other call sites used it)

## Test plan
- [ ] Visit a group page and confirm the top bar shows only the title + avatar + Share button (no "N questions" line)
- [ ] Confirm `/g/<id>/info` and `/g/<id>/edit-title` headers still render correctly

https://claude.ai/code/session_01XH9CVGsCNKPiVP8ZWSM3ed

---
_Generated by [Claude Code](https://claude.ai/code/session_01XH9CVGsCNKPiVP8ZWSM3ed)_