### PR TITLE
Replace `<title>` placeholder with grey-italic hint in new-poll form

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1633,16 +1633,16 @@ export function CreateQuestionContent() {
                   breathing room above the sheet edge that the bubbles
                   have above the screen edge. */}
               <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 pb-[4.5rem] space-y-3">
-                <div className="text-center px-2 pt-1 break-words min-h-[1.75rem] flex items-center justify-center">
+                <div className="text-center px-2 pt-1 break-words h-7 flex items-center justify-center">
                   {title.trim() ? (
                     <span
-                      className="text-xl font-bold text-blue-600 dark:text-blue-400"
+                      className="text-xl font-bold leading-7 text-blue-600 dark:text-blue-400"
                       style={{ fontFamily: "'M PLUS 1 Code', monospace" }}
                     >
                       {title.trim()}
                     </span>
                   ) : (
-                    <span className="text-[0.9375rem] italic text-gray-500 dark:text-gray-400">
+                    <span className="text-[0.9375rem] leading-7 italic text-gray-500 dark:text-gray-400">
                       Enter a Category, Context, and/or Options
                     </span>
                   )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1634,12 +1634,21 @@ export function CreateQuestionContent() {
                   have above the screen edge. */}
               <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 pb-[4.5rem] space-y-3">
                 <div className="text-center px-2 pt-1 break-words">
-                  <span
-                    className="text-xl font-bold text-blue-600 dark:text-blue-400"
-                    style={{ fontFamily: "'M PLUS 1 Code', monospace" }}
-                  >
-                    {title.trim() || "‹title›"}
-                  </span>
+                  {title.trim() ? (
+                    <span
+                      className="text-xl font-bold text-blue-600 dark:text-blue-400"
+                      style={{ fontFamily: "'M PLUS 1 Code', monospace" }}
+                    >
+                      {title.trim()}
+                    </span>
+                  ) : (
+                    <span
+                      className="text-xl italic text-gray-500 dark:text-gray-400"
+                      style={{ fontFamily: "'M PLUS 1 Code', monospace" }}
+                    >
+                      Enter a Category, Context, and/or Options
+                    </span>
+                  )}
                 </div>
 
                 {/* Top card: question form. Simple fields (Category, Context,

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1642,7 +1642,7 @@ export function CreateQuestionContent() {
                       {title.trim()}
                     </span>
                   ) : (
-                    <span className="text-[0.625rem] italic text-gray-500 dark:text-gray-400">
+                    <span className="text-[0.9375rem] italic text-gray-500 dark:text-gray-400">
                       Enter a Category, Context, and/or Options
                     </span>
                   )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1642,10 +1642,7 @@ export function CreateQuestionContent() {
                       {title.trim()}
                     </span>
                   ) : (
-                    <span
-                      className="text-xl italic text-gray-500 dark:text-gray-400"
-                      style={{ fontFamily: "'M PLUS 1 Code', monospace" }}
-                    >
+                    <span className="text-[0.625rem] italic text-gray-500 dark:text-gray-400">
                       Enter a Category, Context, and/or Options
                     </span>
                   )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -1633,7 +1633,7 @@ export function CreateQuestionContent() {
                   breathing room above the sheet edge that the bubbles
                   have above the screen edge. */}
               <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 pb-[4.5rem] space-y-3">
-                <div className="text-center px-2 pt-1 break-words">
+                <div className="text-center px-2 pt-1 break-words min-h-[1.75rem] flex items-center justify-center">
                   {title.trim() ? (
                     <span
                       className="text-xl font-bold text-blue-600 dark:text-blue-400"


### PR DESCRIPTION
## Summary
- Swap the bracketed `‹title›` placeholder in the new-poll sheet for grey-italic hint copy ("Enter a Category, Context, and/or Options") in the app's default sans font at 15px, so the empty state reads as guidance rather than a placeholder slot.
- Pin the title-row container to fixed `h-7` and force `leading-7` on both spans so swapping between the placeholder and the bold-blue M PLUS 1 Code title can't grow the line box past 28px — the card below stays put on first type.

## Test plan
- [ ] Tap the home "+" FAB → empty placeholder mounts → tap any category bubble → modal opens showing the grey-italic hint above the top card.
- [ ] Tap the Category dropdown and pick Restaurant → real bold-blue title appears in the same vertical slot; the question/settings cards below do not shift.
- [ ] Clear the title (or pick a category that doesn't auto-title yet) → hint reappears.


---
_Generated by [Claude Code](https://claude.ai/code/session_016NxjUEd5LUBhfBQqzKR99N)_