### PR TITLE
Show context-aware cutoff label on poll creation form

### DIFF
--- a/app/create-poll/createPollHelpers.ts
+++ b/app/create-poll/createPollHelpers.ts
@@ -96,6 +96,18 @@ export function anyDraftUsesPrephase(drafts: QuestionDraft[]): boolean {
   return drafts.some(d => draftDbQuestionType(d) === 'time' || draftIsSuggestionMode(d));
 }
 
+/** True when at least one draft is a time question. */
+export function anyDraftIsTime(drafts: QuestionDraft[]): boolean {
+  return drafts.some(d => draftDbQuestionType(d) === 'time');
+}
+
+/** True when at least one draft is in suggestion mode (ranked_choice with no
+ *  options yet). Distinct from `anyDraftIsTime` so the cutoff label can pick
+ *  the correct phrasing per poll composition. */
+export function anyDraftHasSuggestion(drafts: QuestionDraft[]): boolean {
+  return drafts.some(d => draftIsSuggestionMode(d));
+}
+
 /** True when at least one draft is a ranked_choice question — these are
  *  the only ones for which "min responses to show preliminary results" is
  *  meaningful (yes/no shows results immediately, time questions don't have

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -56,6 +56,8 @@ import {
   draftDbQuestionType,
   draftToQuestionParams,
   anyDraftUsesPrephase,
+  anyDraftIsTime,
+  anyDraftHasSuggestion,
   anyDraftIsRankedChoice,
   sharedDraftContext,
   synthesizePlaceholderPoll,
@@ -430,10 +432,16 @@ export function CreateQuestionContent() {
   // category='custom', no options) which would otherwise look like
   // "suggestion mode" and wrongly surface the prephase fields after
   // every staged draft.
-  const inlineFormUsesPrephase = isModalOpen && (
-    isSuggestionMode || questionType === 'time' || category === 'time'
-  );
-  const pollHasPrephase = anyDraftUsesPrephase(drafts) || inlineFormUsesPrephase;
+  const inlineFormHasTime = isModalOpen && (questionType === 'time' || category === 'time');
+  const inlineFormHasSuggestion = isModalOpen && isSuggestionMode;
+  const pollHasTime = anyDraftIsTime(drafts) || inlineFormHasTime;
+  const pollHasSuggestion = anyDraftHasSuggestion(drafts) || inlineFormHasSuggestion;
+  const pollHasPrephase = pollHasTime || pollHasSuggestion;
+  const cutoffLabel = pollHasTime && pollHasSuggestion
+    ? "Suggestion/Availability Cutoff"
+    : pollHasTime
+      ? "Availability Cutoff"
+      : "Suggestion Cutoff";
 
   // Migration 098: poll-level results-display + ranked-choice settings.
   // The min-responses + show-results pair is meaningful iff the poll
@@ -1350,7 +1358,7 @@ export function CreateQuestionContent() {
   const suggestionCutoffField = (
     <div>
       <label className="flex items-center justify-between gap-3 h-12 cursor-pointer">
-        <span className="text-base font-normal">Suggestion/Availability Cutoff</span>
+        <span className="text-base font-normal">{cutoffLabel}</span>
         <span className="relative inline-flex">
           <span className="text-base font-normal text-gray-500 dark:text-gray-500 text-right">
             {(() => {


### PR DESCRIPTION
## Summary
- Display "Suggestion Cutoff" for non-time polls and "Availability Cutoff" for time-only polls
- Keep the combined "Suggestion/Availability Cutoff" label only when the poll mixes both kinds
- Split the previous `inlineFormUsesPrephase` flag into time/suggestion components so the label tracks the in-progress draft as well as staged drafts

## Test plan
- [ ] Open the create-poll modal with a Time bubble → label reads "Availability Cutoff"
- [ ] Open with Restaurant/Movie/etc. (suggestion mode) → label reads "Suggestion Cutoff"
- [ ] Stage a Time draft, then add a Restaurant draft → label reads "Suggestion/Availability Cutoff"
- [ ] Yes/No only polls don't surface the cutoff field at all (unchanged)

https://claude.ai/code/session_015RwfGuiMLCK74JD6jdxkEz

---
_Generated by [Claude Code](https://claude.ai/code/session_015RwfGuiMLCK74JD6jdxkEz)_