### PR TITLE
Use poll's actual title for link previews, not category name

### DIFF
--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -324,9 +324,13 @@ def get_group_preview(route_id: str, p: str | None = None):
     them on visibility would 404 every share. Returning only title +
     description (no votes, no question contents) keeps this safe.
 
-    Title is the poll's auto-generated title; the `group_title`
-    override is deliberately ignored so a custom group name (often a
-    participant-name string) doesn't replace the poll's actual subject.
+    Title mirrors the in-app `_compute_display_title` (questions[0].title
+    when set — preserves user-typed yes_no prompts and the wrapper title
+    stamped at create time for any other category — falling back to the
+    auto-generated title from categories/contexts). The `group_title`
+    override is deliberately bypassed so a custom group name (often a
+    participant-name string like "Alice, Bob") doesn't replace the
+    poll's actual subject.
 
     Description: comma-joined options across the poll's questions; else
     the `details` (Notes) field; else null. Capped at 200 chars.
@@ -362,19 +366,26 @@ def get_group_preview(route_id: str, p: str | None = None):
             raise HTTPException(status_code=404, detail="Group not found")
 
         question_rows = conn.execute(
-            """SELECT category, question_type, details, options
+            """SELECT title, category, question_type, details, options
                  FROM questions
                 WHERE poll_id = %(pid)s
                 ORDER BY question_index NULLS LAST, created_at""",
             {"pid": str(target["id"])},
         ).fetchall()
 
-        categories = [_category_for_title(dict(q)) for q in question_rows]
-        contexts = [q.get("details") for q in question_rows]
-        title = (
-            generate_poll_title(categories, target.get("context"), contexts)
-            or "WhoeverWants"
-        )
+        primary_title = ""
+        if question_rows:
+            primary_title = (question_rows[0].get("title") or "").strip()
+
+        if primary_title:
+            title = primary_title
+        else:
+            categories = [_category_for_title(dict(q)) for q in question_rows]
+            contexts = [q.get("details") for q in question_rows]
+            title = (
+                generate_poll_title(categories, target.get("context"), contexts)
+                or "WhoeverWants"
+            )
 
         option_strs: list[str] = []
         seen: set[str] = set()

--- a/server/tests/test_groups_api.py
+++ b/server/tests/test_groups_api.py
@@ -191,6 +191,66 @@ class TestGroupByRouteId:
         assert polls[0]["questions"][0].get("results") is None
 
 
+class TestGroupPreview:
+    """The link-preview endpoint must surface the poll's REAL title (e.g.
+    a user-typed yes_no prompt) — not the generic category name. Earlier
+    the endpoint built the title purely from `generate_poll_title` using
+    categories/contexts, so a yes_no poll titled "Should we get pizza?"
+    rendered as "Yes/No?" in iMessage / Slack / Twitter previews."""
+
+    def test_yes_no_user_typed_title_is_used(
+        self, client, creator_secret, browser_id,
+    ):
+        poll = create_poll(
+            client,
+            creator_secret,
+            browser_id=browser_id,
+            title="Should we get pizza tonight?",
+        )
+        resp = client.get(f"/api/groups/by-route-id/{poll['short_id']}/preview")
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Should we get pizza tonight?"
+
+    def test_group_title_override_is_bypassed(
+        self, client, creator_secret, browser_id,
+    ):
+        """`groups.title` overrides are a group-name override (often a
+        participant-name string like "Alice, Bob") and would mislead a
+        link-preview consumer. The poll's actual subject must win."""
+        poll = create_poll(
+            client,
+            creator_secret,
+            browser_id=browser_id,
+            title="Should we get pizza tonight?",
+            group_title="Alice, Bob",
+        )
+        resp = client.get(f"/api/groups/by-route-id/{poll['short_id']}/preview")
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Should we get pizza tonight?"
+
+    def test_falls_back_to_auto_title_when_question_title_missing(
+        self, client, creator_secret, browser_id,
+    ):
+        """A poll created with no explicit title still gets an
+        auto-generated one stamped on `questions[0].title` at create time
+        (see `_resolve_question_title` in routers/polls.py). The preview
+        surfaces THAT — never reaches the inner `generate_poll_title`
+        fallback in normal flow. This test just confirms preview returns
+        SOMETHING reasonable when no title is supplied (i.e. the stamped
+        auto-title)."""
+        poll = create_poll(
+            client,
+            creator_secret,
+            browser_id=browser_id,
+        )
+        resp = client.get(f"/api/groups/by-route-id/{poll['short_id']}/preview")
+        assert resp.status_code == 200
+        title = resp.json()["title"]
+        # Auto-titled for a single yes_no question, but the only invariant
+        # we care about: not empty.
+        assert title
+
+
 class TestBrowserIdMiddleware:
     def test_response_carries_browser_id_header(self, client, creator_secret):
         """First-visit case: client sends no header; server mints + echoes one."""


### PR DESCRIPTION
The link-preview endpoint (`GET /api/groups/by-route-id/{id}/preview`)
called `generate_poll_title(categories, ...)` directly without reading
the user-typed title. A yes/no poll with a real prompt like "Pizza
tonight?" came back with "Yes/No?" — the category label — when shared
via iMessage / Slack / Twitter.

Mirror `_compute_display_title`'s logic: prefer `questions[0].title`
(the wrapper title stamped at create time), fall back to the auto-gen
only when missing. The `group_title` group-name override is still
intentionally bypassed so a custom name like "Alice, Bob" doesn't
replace the actual poll subject in a link preview.

https://claude.ai/code/session_019Lm7GjnjdWDiR3Z8Tmrrj4