### PR TITLE
Drop "Results will show when the question closes" banner on open time ballots

### DIFF
--- a/components/QuestionResults.tsx
+++ b/components/QuestionResults.tsx
@@ -246,13 +246,7 @@ function TimeResults({ results, isQuestionClosed }: { results: QuestionResults; 
   const slotsByDay = useMemo(() => groupSlotsByDay(options), [options]);
 
   if (!isQuestionClosed) {
-    return (
-      <div className="text-center py-3">
-        <div className="text-gray-600 dark:text-gray-400 text-sm">
-          Results will show when the question closes
-        </div>
-      </div>
-    );
+    return null;
   }
 
   if (options.length === 0) {


### PR DESCRIPTION
## Summary
- `TimeResults` rendered a "Results will show when the question closes" banner whenever it was mounted with `isQuestionClosed=false`, which includes every render during ballot fill-out and vote edit (the banner came through `QuestionBallot`'s `preliminaryResultsBlock` for time questions).
- Return `null` in that branch so open time ballots stay free of the banner; closed-question results render unchanged.

## Test plan
- [ ] Open a time question (availability or preferences phase) and confirm no "Results will show when the question closes" banner appears.
- [ ] Edit a submitted time vote and confirm the same.
- [ ] Close a time question and confirm the results UI still renders.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jav9ah3YukM5PAAtU35wXD)_