### PR TITLE
Remove "create a question and share the link" placeholder

### DIFF
--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -5,7 +5,7 @@ import { flushSync, createPortal } from "react-dom";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { Question } from "@/lib/types";
 import { getMyGroups } from "@/lib/simpleQuestionQueries";
-import { buildEmptyGroup, buildGroupFromPollDown, buildGroupSyncFromCache, buildPollMap, EMPTY_GROUP_HINT, findChainRoot, isPendingPollId, POLL_QUERY_PARAM } from "@/lib/groupUtils";
+import { buildEmptyGroup, buildGroupFromPollDown, buildGroupSyncFromCache, buildPollMap, findChainRoot, isPendingPollId, POLL_QUERY_PARAM } from "@/lib/groupUtils";
 // POLL_QUERY_PARAM is still used by `GroupPageInner` to redirect legacy
 // `?p=<pollShort>` URLs to the new `/g/<group>/p/<pollShort>` route.
 import { mergePollListPreservingIdentity, mergeQuestionResultsMap } from "@/lib/groupRefresh";
@@ -1691,11 +1691,6 @@ export function GroupContent({ groupId, overlayCardsOffset }: GroupContentProps)
             );
           })}
 
-        {group?.isEmpty && (
-          <p className="px-4 pt-6 pb-4 text-base text-gray-700 dark:text-gray-300 text-center">
-            {EMPTY_GROUP_HINT}
-          </p>
-        )}
         <div id={DRAFT_POLL_PORTAL_ID} />
       </div>
 

--- a/app/g/page.tsx
+++ b/app/g/page.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams, useRouter } from "next/navigation";
 import { useEffect, Suspense } from "react";
 import { apiGetQuestionById, apiGetPollById } from "@/lib/api";
-import { EMPTY_GROUP_HINT, getGroupHrefForPoll } from "@/lib/groupUtils";
+import { getGroupHrefForPoll } from "@/lib/groupUtils";
 import { usePageReady } from "@/lib/usePageReady";
 import { useMeasuredHeight } from "@/lib/useMeasuredHeight";
 import GroupHeader from "@/components/GroupHeader";
@@ -87,10 +87,7 @@ export function EmptyPlaceholder({ inOverlay = false }: { inOverlay?: boolean } 
           portal — mismatched padding made the bubbles rewrap on
           handoff. */}
       <div style={{ paddingTop: `calc(${headerHeight}px + 1.5rem)` }}>
-        <p className="px-4 text-base text-gray-700 dark:text-gray-300 text-center">
-          {EMPTY_GROUP_HINT}
-        </p>
-        <div id={DRAFT_POLL_PORTAL_ID} className="mt-4" />
+        <div id={DRAFT_POLL_PORTAL_ID} />
       </div>
     </>
   );

--- a/lib/groupUtils.ts
+++ b/lib/groupUtils.ts
@@ -27,10 +27,6 @@ import { API_ORIGIN } from './api/_internal';
  *  out the current user. */
 export const EMPTY_GROUP_TITLE = 'New Group';
 
-/** Hint rendered above the bubble bar on empty groups (both the home
- *  new group button's slide overlay and the real `/g/<short_id>` route show this). */
-export const EMPTY_GROUP_HINT = 'Create a question and then share the link!';
-
 /** Trimmed + case-insensitive name equality. Collapses different casings
  *  of the same name so the viewer doesn't appear twice in respondent
  *  lists when a sibling poll's `voter_names` carries a variant spelling. */


### PR DESCRIPTION
Drops the empty-group hint text from both surfaces that rendered it
(the `/g/` placeholder and the in-group empty state) and removes the
now-unused `EMPTY_GROUP_HINT` constant.

https://claude.ai/code/session_01WpZJJ6zEfrv4erS95aySsZ