### PR TITLE
Reduce top padding on group poll rectangles

### DIFF
--- a/app/g/[groupShortId]/GroupCardItem.tsx
+++ b/app/g/[groupShortId]/GroupCardItem.tsx
@@ -387,7 +387,7 @@ function GroupCardItemImpl(props: GroupCardItemProps) {
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchMove={handleTouchMove}
-        className={`pl-[0.9rem] pr-[0.65rem] pt-2.5 pb-1 cursor-pointer transition-colors select-none ${
+        className={`pl-[0.9rem] pr-[0.65rem] pt-2 pb-1 cursor-pointer transition-colors select-none ${
           isPressed
             ? "bg-blue-100 dark:bg-blue-900/40"
             : "bg-transparent"

--- a/app/g/[groupShortId]/GroupCardItem.tsx
+++ b/app/g/[groupShortId]/GroupCardItem.tsx
@@ -387,7 +387,7 @@ function GroupCardItemImpl(props: GroupCardItemProps) {
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchMove={handleTouchMove}
-        className={`pl-[0.9rem] pr-[0.65rem] pt-3 pb-1 cursor-pointer transition-colors select-none ${
+        className={`pl-[0.9rem] pr-[0.65rem] pt-2.5 pb-1 cursor-pointer transition-colors select-none ${
           isPressed
             ? "bg-blue-100 dark:bg-blue-900/40"
             : "bg-transparent"

--- a/app/g/[groupShortId]/GroupCardItem.tsx
+++ b/app/g/[groupShortId]/GroupCardItem.tsx
@@ -387,7 +387,7 @@ function GroupCardItemImpl(props: GroupCardItemProps) {
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchMove={handleTouchMove}
-        className={`pl-[0.9rem] pr-[0.65rem] pt-2 pb-1 cursor-pointer transition-colors select-none ${
+        className={`pl-[0.9rem] pr-[0.65rem] pt-1.5 pb-1 cursor-pointer transition-colors select-none ${
           isPressed
             ? "bg-blue-100 dark:bg-blue-900/40"
             : "bg-transparent"

--- a/app/g/[groupShortId]/GroupCardItem.tsx
+++ b/app/g/[groupShortId]/GroupCardItem.tsx
@@ -387,7 +387,7 @@ function GroupCardItemImpl(props: GroupCardItemProps) {
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchMove={handleTouchMove}
-        className={`pl-[0.9rem] pr-[0.65rem] pt-1.5 pb-1 cursor-pointer transition-colors select-none ${
+        className={`pl-[0.9rem] pr-[0.65rem] pt-[7px] pb-1 cursor-pointer transition-colors select-none ${
           isPressed
             ? "bg-blue-100 dark:bg-blue-900/40"
             : "bg-transparent"


### PR DESCRIPTION
## Summary
- Tightens each group-page poll rectangle's top padding from `pt-3` (12px) to `pt-[7px]` so the title sits closer to the divider above. Bottom padding (`pb-1`) unchanged.
- Touches one Tailwind class in `app/g/[groupShortId]/GroupCardItem.tsx`; no logic or layout structure changes.

## Test plan
- [ ] Visual: group page rows look noticeably tighter at the top edge without clipping the title baseline against the divider above.
- [ ] No regression in awaiting-state amber bar (`absolute inset-y-0 left-0`), pressed-state background, or any of the row's flex children.

https://claude.ai/code/session_01DB2NHqQaSLiCMcCAC5Lon6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB2NHqQaSLiCMcCAC5Lon6)_