### PR TITLE
Require a saved name to create polls, vote, and create groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -669,6 +669,21 @@ uv lock                        # Regenerate lock file
 
 ---
 
+## Name-Required Policy
+
+The user's saved display name (`lib/userProfile.ts: getUserName/saveUserName`, localStorage key `whoeverwants_user_name`) is required for creating a poll, voting on a ballot, and creating a new group. Settings is the single edit surface.
+
+- **Shared validation lives in two mirrored files: `lib/nameValidation.ts` + `server/services/validation.py`.** Common-sense rules only: 1–50 chars after trim, no control chars (`\x00-\x1F\x7F`). Mirror constants in both files when changing.
+- **`<NameRequiredModal>` (`components/NameRequiredModal.tsx`) is the canonical "we need a name" surface.** Input + Save button; on save, calls `saveUserName(name)` then `onSubmit(name)`. Three callsites: `CreateGroupButtonHost` (home new group button), `CreateQuestionContent` (category bubble tap), `PollDetail` (every vote Submit path). Modal is z-`[70]` so it stacks above the create-poll bottom sheet (z-`[60]`) and the ConfirmationModal.
+- **No inline `<CompactNameField>` in ballots or the create-poll form.** Earlier iterations rendered "Your Name" inputs in the wrapper Submit sections of `app/g/[groupShortId]/p/[pollShortId]/page.tsx`, the create-poll modal bottom card, and each ballot's internal Submit (`QuestionBallot.tsx`, `RankingSection.tsx`, `QuestionBallot/TimeBallotSection.tsx`, `SuggestionVotingInterface.tsx`). They're all gone. Per-poll name overrides are not supported — your name is your name.
+- **Modal gates fire at the moment of the user-action click, not earlier.** Bubble tap → `handleBubbleClick(cat)` checks `isValidUserName(getUserName())`; if missing, stash `pendingBubbleCategory` + open modal; on save, `openModalFor(cat)`. Vote Submit click → `gateOnName(retry)` helper in `PollDetail`; if missing, stash a `pendingNameRetry: (() => void) | null` thunk + open modal; on save, replay the thunk. The thunk pattern keeps the union types from sprawling — each Submit site passes its own retry closure inline. Don't reach for a multi-variant `PendingAction` union; the thunk is cleaner.
+- **Server enforcement is the backstop, not the primary gate.** `validate_user_name` raises 400 in `POST /api/polls` (creator_name) and `POST /api/polls/{id}/votes` (voter_name). The FE's bubble/Submit modals are what produce a good UX; the server returns "is required" / "contains invalid characters" if the FE is bypassed. Mirror this pattern for any future "required identity field": always-on FE gate at action-click + server validator with matching rules.
+- **`CompactNameField.tsx`** still exists; it's only used on the settings page now. **Selects all on focus** so tapping into a pre-filled right-aligned field doesn't leave the caret at position 0 (where backspace is a no-op against the user's expectation — see the earlier bug). Tailwind's `text-right` + a pre-filled value is the trigger; any future right-aligned input wrapping a saved value should mirror the `.select()` on focus.
+- **Settings Save's disabled gate compares against `initialName`**, not against `name` truthiness. Tracking `initialName` (snapshot from `getUserName()` at mount; refreshed after each successful save) lets the rule "name changed → dirty → save enabled" cover the "user cleared a previously-saved name" case. Without this, the only-name-changed-to-empty case looked like "nothing dirty" and Save stayed disabled. Pattern applies to any other settings field whose meaningful state includes "cleared": track the initial value, compare on dirty-detection.
+- **API tests `conftest.py: create_poll` includes `"creator_name": "Test User"` by default** so existing tests don't have to know about the name-required rule. Anonymous-vote tests (passing `voter_name: null` or omitting it) were flipped to assert the server's 400 instead of the old 201. Future tests posting to `/api/polls` or `/api/polls/{id}/votes` need a non-empty name in the body.
+
+---
+
 ## CRITICAL RULES FOR AI ASSISTANTS
 
 The sections below contain mandatory rules. Follow them exactly.

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -668,8 +668,6 @@ export function CreateQuestionContent() {
     // Still editable — they can clear or change it freely.
     const inheritedForField = sharedDraftContext(drafts) ?? '';
     applyDraftToState(emptyDraft({ category: cat, forField: inheritedForField }));
-    // Refresh the creator name from localStorage so a name just set via
-    // NameRequiredModal flows into the submit payload.
     setCreatorName(getUserName() ?? "");
     setError(null);
     setIsModalOpen(true);
@@ -1318,9 +1316,7 @@ export function CreateQuestionContent() {
         recordQuestionCreation(sp.id, creatorSecret);
       }
 
-      if (creatorName.trim()) {
-        saveUserName(creatorName.trim());
-      }
+      saveUserName(creatorName);
       clearFormState();
       setIsSubmitted(false);
       isSubmittingRef.current = false;

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -12,13 +12,13 @@ import type { Poll, OptionsMetadata, Question } from "@/lib/types";
 import TypeFieldInput, { BUILT_IN_TYPES, FOR_FIELD_PLACEHOLDERS, getBuiltInType, isLocationLikeCategory } from "@/components/TypeFieldInput";
 import ModalPortal from "@/components/ModalPortal";
 import ConfirmationModal from "@/components/ConfirmationModal";
+import NameRequiredModal from "@/components/NameRequiredModal";
 import { useAppPrefetch } from "@/lib/prefetch";
 import { generateCreatorSecret, getCreatorSecret, recordQuestionCreation } from "@/lib/browserQuestionAccess";
 import { getUserName, saveUserName, getUserMinResponses, saveUserMinResponses } from "@/lib/userProfile";
 import { debugLog } from "@/lib/debugLogger";
 import OptionsInput from "@/components/OptionsInput";
 import CompactMinResponsesField from "@/components/CompactMinResponsesField";
-import CompactNameField from "@/components/CompactNameField";
 import SliderSwitch from "@/components/SliderSwitch";
 import { VOTING_CUTOFF_OPTIONS } from "@/components/VotingCutoffConditionsModal";
 import VotingCutoffField from "@/components/VotingCutoffField";
@@ -152,6 +152,10 @@ export function CreateQuestionContent() {
   const [drafts, setDrafts] = useState<QuestionDraft[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+  // When the user taps a category bubble but hasn't saved a name, stash
+  // the chosen category and open the NameRequiredModal. On save, retry
+  // `openModalFor` so the form lands with the right category.
+  const [pendingBubbleCategory, setPendingBubbleCategory] = useState<string | null>(null);
 
   const hasNoOptions = options.filter(o => o.trim()).length === 0;
   const isSuggestionMode = questionType === 'question' && category !== 'yes_no' && category !== 'time' && hasNoOptions;
@@ -664,9 +668,20 @@ export function CreateQuestionContent() {
     // Still editable — they can clear or change it freely.
     const inheritedForField = sharedDraftContext(drafts) ?? '';
     applyDraftToState(emptyDraft({ category: cat, forField: inheritedForField }));
+    // Refresh the creator name from localStorage so a name just set via
+    // NameRequiredModal flows into the submit payload.
+    setCreatorName(getUserName() ?? "");
     setError(null);
     setIsModalOpen(true);
   }, [applyDraftToState, drafts]);
+
+  const handleBubbleClick = useCallback((cat: string) => {
+    if (!isValidUserName(getUserName())) {
+      setPendingBubbleCategory(cat);
+      return;
+    }
+    openModalFor(cat);
+  }, [openModalFor]);
 
   // Read showDiscardConfirm via a ref inside the Escape handler so toggling
   // the inner confirm dialog doesn't tear down + rebuild the body-position
@@ -1561,7 +1576,7 @@ export function CreateQuestionContent() {
           <button
             key={entry.value}
             type="button"
-            onClick={() => openModalFor(entry.value)}
+            onClick={() => handleBubbleClick(entry.value)}
             disabled={isLoading}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-200 border border-blue-300 dark:border-blue-700 hover:bg-blue-200 dark:hover:bg-blue-900/60 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium select-none"
             aria-label={`Add ${entry.label} question`}
@@ -1624,7 +1639,7 @@ export function CreateQuestionContent() {
                 <button
                   type="button"
                   onClick={handleSubmitClick}
-                  disabled={isLoading || isSubmitted || !inlineFormHasDraftableContent || !isValidUserName(creatorName)}
+                  disabled={isLoading || isSubmitted || !inlineFormHasDraftableContent}
                   aria-label="Submit poll"
                   className="absolute right-2 top-2 w-11 h-11 flex items-center justify-center rounded-full bg-blue-500 text-white cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >
@@ -1856,11 +1871,6 @@ export function CreateQuestionContent() {
                       </div>
                     )}
 
-                    <CompactNameField
-                      name={creatorName}
-                      setName={setCreatorName}
-                      disabled={isLoading}
-                    />
                   </form>
                 </section>
 
@@ -1945,6 +1955,17 @@ export function CreateQuestionContent() {
         message="Discard this poll? Your changes will be lost."
         confirmText="Discard"
         confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
+      />
+
+      <NameRequiredModal
+        isOpen={!!pendingBubbleCategory}
+        message="Please enter your name to start a new poll."
+        onSubmit={() => {
+          const cat = pendingBubbleCategory;
+          setPendingBubbleCategory(null);
+          if (cat) openModalFor(cat);
+        }}
+        onCancel={() => setPendingBubbleCategory(null)}
       />
     </div>
   );

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -33,6 +33,7 @@ import { windowDurationMinutes, formatDurationLabel, formatDeadlineLabel, format
 import { getGroupHrefForPoll, resolveGroupRootRouteId } from "@/lib/groupUtils";
 import { enterAdvancesFocus } from "@/lib/formNavigation";
 import { haptic } from "@/lib/haptics";
+import { isValidUserName, validateUserName } from "@/lib/nameValidation";
 import * as questionBackTarget from "@/lib/questionBackTarget";
 import { cachePoll, getCachedGroupIdForQuestion, invalidatePoll, updateAccessiblePollsIfFresh } from "@/lib/questionCache";
 import {
@@ -1080,6 +1081,12 @@ export function CreateQuestionContent() {
       return;
     }
 
+    const nameCheck = validateUserName(creatorName);
+    if (!nameCheck.ok) {
+      setError(nameCheck.error);
+      return;
+    }
+
     // Auto-stage the inline form when it carries valid content. Lets the
     // user submit a single-question poll without first tapping "+ Question".
     // We compute the effective drafts list locally because setDrafts won't
@@ -1617,7 +1624,7 @@ export function CreateQuestionContent() {
                 <button
                   type="button"
                   onClick={handleSubmitClick}
-                  disabled={isLoading || isSubmitted || !inlineFormHasDraftableContent}
+                  disabled={isLoading || isSubmitted || !inlineFormHasDraftableContent || !isValidUserName(creatorName)}
                   aria-label="Submit poll"
                   className="absolute right-2 top-2 w-11 h-11 flex items-center justify-center rounded-full bg-blue-500 text-white cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >

--- a/app/g/[groupShortId]/p/[pollShortId]/page.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/page.tsx
@@ -71,7 +71,6 @@ import InitialBubble from "@/components/InitialBubble";
 import QuestionBallot, { type QuestionBallotHandle } from "@/components/QuestionBallot";
 import QuestionDetails from "@/components/QuestionDetails";
 import QuestionResultsDisplay from "@/components/QuestionResults";
-import CompactNameField from "@/components/CompactNameField";
 import VoterList from "@/components/VoterList";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import NameRequiredModal from "@/components/NameRequiredModal";
@@ -253,8 +252,6 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     voteChangeSubmitting,
     pendingPollChoices,
     setPendingPollChoices,
-    pollVoterNames,
-    setPollVoterName,
     pendingPollSubmit,
     setPendingPollSubmit,
     pollSubmitting,
@@ -527,11 +524,15 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     isCurrentUserName(poll.creator_name);
   const creatorImageUrl = creatorIsMe ? myUserImageUrl : null;
 
-  // Holds a yes/no tap that couldn't fire because the user hasn't saved a
-  // name yet. The NameRequiredModal retries via this when they save.
-  const [pendingYesNoTap, setPendingYesNoTap] = useState<
-    { questionId: string; newChoice: "yes" | "no" | "abstain" } | null
-  >(null);
+  // Submit actions paused because the user hasn't saved a name yet.
+  // NameRequiredModal collects the name and retries via `runPendingAction`.
+  type PendingSubmitAction =
+    | { kind: "yesNoTap"; questionId: string; newChoice: "yes" | "no" | "abstain" }
+    | { kind: "multi"; pollId: string }
+    | { kind: "single"; spId: string }
+    | { kind: "voteChange"; questionId: string; newChoice: "yes" | "no" | "abstain" };
+  const [pendingSubmitAction, setPendingSubmitAction] =
+    useState<PendingSubmitAction | null>(null);
 
   const dispatchYesNoTap = (
     questionId: string,
@@ -541,13 +542,60 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     // taps and edits route through the confirmation modal.
     if (!isMultiPoll && !userVoteMap.get(questionId)) {
       if (!isValidUserName(getUserName())) {
-        setPendingYesNoTap({ questionId, newChoice });
+        setPendingSubmitAction({ kind: "yesNoTap", questionId, newChoice });
         return;
       }
       void submitYesNoChoice(questionId, newChoice);
       return;
     }
     setPendingVoteChange({ questionId, newChoice });
+  };
+
+  const runMultiSubmit = (pollId: string) => {
+    const preparedNonYesNo: PreparedNonYesNoEntry[] = [];
+    let stagedCount = 0;
+    let hadValidationError = false;
+    for (const sp of subQuestions) {
+      if (sp.question_type === "yes_no") {
+        if (pendingPollChoices.has(sp.id)) stagedCount++;
+        continue;
+      }
+      const handle = subQuestionBallotRefs.get(sp.id);
+      if (!handle) continue;
+      const result = handle.prepareBatchVoteItem();
+      if ("skip" in result) continue;
+      if (!result.ok) {
+        hadValidationError = true;
+        continue;
+      }
+      preparedNonYesNo.push({
+        questionId: sp.id,
+        item: result.item,
+        commit: result.commit,
+        fail: result.fail,
+      });
+      stagedCount++;
+    }
+    if (hadValidationError) return;
+    if (stagedCount === 0) return;
+    setPendingPollSubmit({
+      pollId,
+      subQuestions,
+      stagedCount,
+      preparedNonYesNo,
+    });
+  };
+
+  const runPendingAction = (action: PendingSubmitAction) => {
+    if (action.kind === "yesNoTap") {
+      void submitYesNoChoice(action.questionId, action.newChoice);
+    } else if (action.kind === "multi") {
+      runMultiSubmit(action.pollId);
+    } else if (action.kind === "single") {
+      subQuestionBallotRefs.get(action.spId)?.triggerSubmit();
+    } else if (action.kind === "voteChange") {
+      void submitYesNoChoice(action.questionId, action.newChoice);
+    }
   };
 
   const shareUrl = useMemo(() => {
@@ -697,14 +745,7 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
                 partOfPollGroup={isMultiPoll}
                 wrapperHandlesSubmit={!!poll.id && wrapperOwnsSubmit}
                 externalVoterName={
-                  wrapperOwnsSubmit
-                    ? pollVoterNames.get(poll.id) ?? getUserName() ?? ""
-                    : undefined
-                }
-                setExternalVoterName={
-                  wrapperOwnsSubmit
-                    ? (name: string) => setPollVoterName(poll.id, name)
-                    : undefined
+                  wrapperOwnsSubmit ? getUserName() ?? "" : undefined
                 }
                 onWrapperSubmitStateChange={
                   wrapperOwnsSubmit ? handleWrapperSubmitStateChange : undefined
@@ -730,18 +771,8 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
           const hasStagedChange = hasYesNoStaged || hasNonYesNoReady;
           const submitting = pollSubmitting.has(pollId);
           const submitError = pollSubmitError.get(pollId);
-          const voterNameVal =
-            pollVoterNames.get(pollId) ?? getUserName() ?? "";
           return (
             <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-800">
-              <section className="mb-3 rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-                <CompactNameField
-                  name={voterNameVal}
-                  setName={(name: string) => setPollVoterName(pollId, name)}
-                  disabled={submitting}
-                  maxLength={30}
-                />
-              </section>
               {submitError && (
                 <div className="mb-3 p-2 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-300 rounded text-sm">
                   {submitError}
@@ -750,40 +781,13 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
               <button
                 type="button"
                 onClick={() => {
-                  const preparedNonYesNo: PreparedNonYesNoEntry[] = [];
-                  let stagedCount = 0;
-                  let hadValidationError = false;
-                  for (const sp of subQuestions) {
-                    if (sp.question_type === "yes_no") {
-                      if (pendingPollChoices.has(sp.id)) stagedCount++;
-                      continue;
-                    }
-                    const handle = subQuestionBallotRefs.get(sp.id);
-                    if (!handle) continue;
-                    const result = handle.prepareBatchVoteItem();
-                    if ("skip" in result) continue;
-                    if (!result.ok) {
-                      hadValidationError = true;
-                      continue;
-                    }
-                    preparedNonYesNo.push({
-                      questionId: sp.id,
-                      item: result.item,
-                      commit: result.commit,
-                      fail: result.fail,
-                    });
-                    stagedCount++;
+                  if (!isValidUserName(getUserName())) {
+                    setPendingSubmitAction({ kind: "multi", pollId });
+                    return;
                   }
-                  if (hadValidationError) return;
-                  if (stagedCount === 0) return;
-                  setPendingPollSubmit({
-                    pollId,
-                    subQuestions,
-                    stagedCount,
-                    preparedNonYesNo,
-                  });
+                  runMultiSubmit(pollId);
                 }}
-                disabled={submitting || !hasStagedChange || !isValidUserName(voterNameVal)}
+                disabled={submitting || !hasStagedChange}
                 className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
               >
                 {submitting ? "Submitting..." : "Submit Vote"}
@@ -799,23 +803,17 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
           const sp = subQuestions[0]!;
           const submitState = wrapperSubmitState.get(sp.id);
           if (!submitState?.visible) return null;
-          const voterNameVal =
-            pollVoterNames.get(pollId) ?? getUserName() ?? "";
           return (
             <div className="mt-3">
-              <section className="mb-3 rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-                <CompactNameField
-                  name={voterNameVal}
-                  setName={(name: string) => setPollVoterName(pollId, name)}
-                  maxLength={30}
-                />
-              </section>
               <button
                 type="button"
                 onClick={() => {
+                  if (!isValidUserName(getUserName())) {
+                    setPendingSubmitAction({ kind: "single", spId: sp.id });
+                    return;
+                  }
                   subQuestionBallotRefs.get(sp.id)?.triggerSubmit();
                 }}
-                disabled={!isValidUserName(voterNameVal)}
                 className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
               >
                 {submitState.label}
@@ -867,7 +865,16 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
             }
             cancelText="Cancel"
             confirmButtonClass="bg-blue-600 hover:bg-blue-700 text-white"
-            onConfirm={confirmVoteChange}
+            onConfirm={() => {
+              if (!pendingVoteChange) return;
+              const { questionId, newChoice } = pendingVoteChange;
+              if (!isValidUserName(getUserName())) {
+                setPendingSubmitAction({ kind: "voteChange", questionId, newChoice });
+                setPendingVoteChange(null);
+                return;
+              }
+              void confirmVoteChange();
+            }}
             onCancel={() => setPendingVoteChange(null)}
           />
         );
@@ -898,14 +905,14 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
       />
 
       <NameRequiredModal
-        isOpen={!!pendingYesNoTap}
+        isOpen={!!pendingSubmitAction}
         message="Please enter your name to submit your vote."
         onSubmit={() => {
-          const tap = pendingYesNoTap;
-          setPendingYesNoTap(null);
-          if (tap) void submitYesNoChoice(tap.questionId, tap.newChoice);
+          const action = pendingSubmitAction;
+          setPendingSubmitAction(null);
+          if (action) runPendingAction(action);
         }}
-        onCancel={() => setPendingYesNoTap(null)}
+        onCancel={() => setPendingSubmitAction(null)}
       />
     </>
   );

--- a/app/g/[groupShortId]/p/[pollShortId]/page.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/page.tsx
@@ -524,27 +524,22 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     isCurrentUserName(poll.creator_name);
   const creatorImageUrl = creatorIsMe ? myUserImageUrl : null;
 
-  // Submit actions paused because the user hasn't saved a name yet.
-  // NameRequiredModal collects the name and retries via `runPendingAction`.
-  type PendingSubmitAction =
-    | { kind: "yesNoTap"; questionId: string; newChoice: "yes" | "no" | "abstain" }
-    | { kind: "multi"; pollId: string }
-    | { kind: "single"; spId: string }
-    | { kind: "voteChange"; questionId: string; newChoice: "yes" | "no" | "abstain" };
-  const [pendingSubmitAction, setPendingSubmitAction] =
-    useState<PendingSubmitAction | null>(null);
+  // When a submit action fires without a saved name, the retry closure is
+  // stashed here and replayed after NameRequiredModal save.
+  const [pendingNameRetry, setPendingNameRetry] = useState<(() => void) | null>(null);
+
+  const gateOnName = (retry: () => void): boolean => {
+    if (isValidUserName(getUserName())) return true;
+    setPendingNameRetry(() => retry);
+    return false;
+  };
 
   const dispatchYesNoTap = (
     questionId: string,
     newChoice: "yes" | "no" | "abstain",
   ) => {
-    // First-time votes on single-question polls auto-submit; multi-poll
-    // taps and edits route through the confirmation modal.
     if (!isMultiPoll && !userVoteMap.get(questionId)) {
-      if (!isValidUserName(getUserName())) {
-        setPendingSubmitAction({ kind: "yesNoTap", questionId, newChoice });
-        return;
-      }
+      if (!gateOnName(() => void submitYesNoChoice(questionId, newChoice))) return;
       void submitYesNoChoice(questionId, newChoice);
       return;
     }
@@ -586,24 +581,14 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     });
   };
 
-  const runPendingAction = (action: PendingSubmitAction) => {
-    if (action.kind === "yesNoTap") {
-      void submitYesNoChoice(action.questionId, action.newChoice);
-    } else if (action.kind === "multi") {
-      runMultiSubmit(action.pollId);
-    } else if (action.kind === "single") {
-      subQuestionBallotRefs.get(action.spId)?.triggerSubmit();
-    } else if (action.kind === "voteChange") {
-      void submitYesNoChoice(action.questionId, action.newChoice);
-    }
-  };
-
   const shareUrl = useMemo(() => {
     if (typeof window === "undefined") return "";
     return `${window.location.origin}${getGroupHrefForPoll(poll)}`;
   }, [poll]);
 
   const pollTitle = subQuestions[0]?.title || poll.title;
+  // One localStorage read per render — passed into N sub-question QuestionBallots.
+  const savedUserName = getUserName() ?? "";
 
   return (
     <>
@@ -744,9 +729,7 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
                 isExpanded={true}
                 partOfPollGroup={isMultiPoll}
                 wrapperHandlesSubmit={!!poll.id && wrapperOwnsSubmit}
-                externalVoterName={
-                  wrapperOwnsSubmit ? getUserName() ?? "" : undefined
-                }
+                externalVoterName={wrapperOwnsSubmit ? savedUserName : undefined}
                 onWrapperSubmitStateChange={
                   wrapperOwnsSubmit ? handleWrapperSubmitStateChange : undefined
                 }
@@ -781,10 +764,7 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
               <button
                 type="button"
                 onClick={() => {
-                  if (!isValidUserName(getUserName())) {
-                    setPendingSubmitAction({ kind: "multi", pollId });
-                    return;
-                  }
+                  if (!gateOnName(() => runMultiSubmit(pollId))) return;
                   runMultiSubmit(pollId);
                 }}
                 disabled={submitting || !hasStagedChange}
@@ -808,11 +788,9 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
               <button
                 type="button"
                 onClick={() => {
-                  if (!isValidUserName(getUserName())) {
-                    setPendingSubmitAction({ kind: "single", spId: sp.id });
-                    return;
-                  }
-                  subQuestionBallotRefs.get(sp.id)?.triggerSubmit();
+                  const fire = () => subQuestionBallotRefs.get(sp.id)?.triggerSubmit();
+                  if (!gateOnName(fire)) return;
+                  fire();
                 }}
                 className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
               >
@@ -868,8 +846,8 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
             onConfirm={() => {
               if (!pendingVoteChange) return;
               const { questionId, newChoice } = pendingVoteChange;
-              if (!isValidUserName(getUserName())) {
-                setPendingSubmitAction({ kind: "voteChange", questionId, newChoice });
+              const fire = () => void submitYesNoChoice(questionId, newChoice);
+              if (!gateOnName(fire)) {
                 setPendingVoteChange(null);
                 return;
               }
@@ -905,14 +883,14 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
       />
 
       <NameRequiredModal
-        isOpen={!!pendingSubmitAction}
+        isOpen={!!pendingNameRetry}
         message="Please enter your name to submit your vote."
         onSubmit={() => {
-          const action = pendingSubmitAction;
-          setPendingSubmitAction(null);
-          if (action) runPendingAction(action);
+          const retry = pendingNameRetry;
+          setPendingNameRetry(null);
+          if (retry) retry();
         }}
-        onCancel={() => setPendingSubmitAction(null)}
+        onCancel={() => setPendingNameRetry(null)}
       />
     </>
   );

--- a/app/g/[groupShortId]/p/[pollShortId]/page.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/page.tsx
@@ -74,6 +74,8 @@ import QuestionResultsDisplay from "@/components/QuestionResults";
 import CompactNameField from "@/components/CompactNameField";
 import VoterList from "@/components/VoterList";
 import ConfirmationModal from "@/components/ConfirmationModal";
+import NameRequiredModal from "@/components/NameRequiredModal";
+import { isValidUserName } from "@/lib/nameValidation";
 import PollShareButton from "@/components/PollShareButton";
 import SimpleCountdown from "@/components/SimpleCountdown";
 import type { Poll, Question, QuestionResults } from "@/lib/types";
@@ -525,6 +527,12 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     isCurrentUserName(poll.creator_name);
   const creatorImageUrl = creatorIsMe ? myUserImageUrl : null;
 
+  // Holds a yes/no tap that couldn't fire because the user hasn't saved a
+  // name yet. The NameRequiredModal retries via this when they save.
+  const [pendingYesNoTap, setPendingYesNoTap] = useState<
+    { questionId: string; newChoice: "yes" | "no" | "abstain" } | null
+  >(null);
+
   const dispatchYesNoTap = (
     questionId: string,
     newChoice: "yes" | "no" | "abstain",
@@ -532,6 +540,10 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     // First-time votes on single-question polls auto-submit; multi-poll
     // taps and edits route through the confirmation modal.
     if (!isMultiPoll && !userVoteMap.get(questionId)) {
+      if (!isValidUserName(getUserName())) {
+        setPendingYesNoTap({ questionId, newChoice });
+        return;
+      }
       void submitYesNoChoice(questionId, newChoice);
       return;
     }
@@ -771,7 +783,7 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
                     preparedNonYesNo,
                   });
                 }}
-                disabled={submitting || !hasStagedChange}
+                disabled={submitting || !hasStagedChange || !isValidUserName(voterNameVal)}
                 className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
               >
                 {submitting ? "Submitting..." : "Submit Vote"}
@@ -803,6 +815,7 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
                 onClick={() => {
                   subQuestionBallotRefs.get(sp.id)?.triggerSubmit();
                 }}
+                disabled={!isValidUserName(voterNameVal)}
                 className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
               >
                 {submitState.label}
@@ -882,6 +895,17 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
           );
         }}
         onCancel={() => setPendingPollSubmit(null)}
+      />
+
+      <NameRequiredModal
+        isOpen={!!pendingYesNoTap}
+        message="Please enter your name to submit your vote."
+        onSubmit={() => {
+          const tap = pendingYesNoTap;
+          setPendingYesNoTap(null);
+          if (tap) void submitYesNoChoice(tap.questionId, tap.newChoice);
+        }}
+        onCancel={() => setPendingYesNoTap(null)}
       />
     </>
   );

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -58,6 +58,11 @@ export default function SettingsPage() {
   const router = useRouter();
   usePageReady(true);
   const [name, setName] = useState("");
+  // Snapshot of the saved name at mount, so the Save button can detect
+  // "user cleared their saved name" (name="" but savedName was non-empty)
+  // as a real change to commit — without this, clearing the name leaves
+  // Save disabled with nothing else dirty.
+  const [initialName, setInitialName] = useState("");
   const [locationInput, setLocationInput] = useState("");
   const [savedLocation, setSavedLocation] = useState<UserLocation | null>(null);
   const [theme, setTheme] = useState<ThemePreference>("system");
@@ -88,6 +93,7 @@ export default function SettingsPage() {
     const savedName = getUserName();
     if (savedName) {
       setName(savedName);
+      setInitialName(savedName);
     }
     const loc = getUserLocation();
     if (loc) {
@@ -212,6 +218,7 @@ export default function SettingsPage() {
 
     try {
       saveUserName(name);
+      setInitialName(name.trim());
 
       // Geocode location input if provided and different from saved
       if (locationInput.trim()) {
@@ -271,6 +278,7 @@ export default function SettingsPage() {
     clearUserName();
     clearUserLocation();
     setName("");
+    setInitialName("");
     setSavedLocation(null);
     setLocationInput("");
     // Also clear any uploaded profile image — "clear my settings" is
@@ -482,7 +490,7 @@ export default function SettingsPage() {
 
       <button
         onClick={handleSave}
-        disabled={isLoading || (!name.trim() && !locationInput.trim() && !hasPendingImageChange)}
+        disabled={isLoading || (name.trim() === initialName.trim() && !locationInput.trim() && !hasPendingImageChange)}
         className="w-full rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-base h-12 disabled:opacity-50 disabled:cursor-not-allowed mb-6"
       >
         {isLoading ? 'Saving...' : 'Save'}

--- a/components/CompactNameField.tsx
+++ b/components/CompactNameField.tsx
@@ -24,6 +24,13 @@ export default function CompactNameField({ name, setName, disabled = false, maxL
         value={name}
         onChange={(e) => setName(e.target.value)}
         onBlur={() => setName(name.trim())}
+        onFocus={(e) => {
+          // text-right inputs put the caret at position 0 when the user
+          // taps the empty left side of a pre-filled field — backspace
+          // there is a no-op and the user "can't delete". Selecting all
+          // on focus makes the next keystroke replace the value.
+          e.currentTarget.select();
+        }}
         onKeyDown={enterAdvancesFocus}
         disabled={disabled}
         maxLength={maxLength}

--- a/components/CreateGroupButtonHost.tsx
+++ b/components/CreateGroupButtonHost.tsx
@@ -37,6 +37,9 @@ import {
   HIDE_HOME_BACKDROP_EVENT,
 } from "@/lib/eventChannels";
 import { haptic } from "@/lib/haptics";
+import { getUserName } from "@/lib/userProfile";
+import { isValidUserName } from "@/lib/nameValidation";
+import NameRequiredModal from "@/components/NameRequiredModal";
 
 const IS_CAPACITOR_NATIVE =
   typeof window !== "undefined" && Capacitor.isNativePlatform();
@@ -47,6 +50,7 @@ export default function CreateGroupButtonHost(): React.ReactElement | null {
   const inFlight = useRef(false);
   const [mounted, setMounted] = useState(false);
   const [swipeBackActive, setSwipeBackActive] = useState(false);
+  const [nameModalOpen, setNameModalOpen] = useState(false);
 
   useEffect(() => {
     setMounted(true);
@@ -67,7 +71,7 @@ export default function CreateGroupButtonHost(): React.ReactElement | null {
   const isHome = pathname === "/";
   const visible = isHome || swipeBackActive;
 
-  const onClick = () => {
+  const startCreate = () => {
     if (inFlight.current) return;
     inFlight.current = true;
     haptic.medium();
@@ -87,7 +91,17 @@ export default function CreateGroupButtonHost(): React.ReactElement | null {
       });
   };
 
+  const onClick = () => {
+    if (inFlight.current) return;
+    if (!isValidUserName(getUserName())) {
+      setNameModalOpen(true);
+      return;
+    }
+    startCreate();
+  };
+
   return createPortal(
+    <>
     <button
       onClick={onClick}
       className="fixed z-50 h-12 px-[16.56px] rounded-full flex items-center justify-center gap-1.5 bg-blue-500 dark:bg-blue-600 active:bg-blue-600 dark:active:bg-blue-500 shadow-md shadow-black/20 cursor-pointer text-white font-normal"
@@ -115,7 +129,17 @@ export default function CreateGroupButtonHost(): React.ReactElement | null {
         +
       </span>
       <span className="text-lg leading-none">Group</span>
-    </button>,
+    </button>
+    <NameRequiredModal
+      isOpen={nameModalOpen}
+      message="Please enter your name to create a new group."
+      onSubmit={() => {
+        setNameModalOpen(false);
+        startCreate();
+      }}
+      onCancel={() => setNameModalOpen(false)}
+    />
+    </>,
     target,
   );
 }

--- a/components/NameRequiredModal.tsx
+++ b/components/NameRequiredModal.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import ModalPortal from "./ModalPortal";
+import { MAX_NAME_LENGTH, validateUserName } from "@/lib/nameValidation";
+import { saveUserName } from "@/lib/userProfile";
+
+interface NameRequiredModalProps {
+  isOpen: boolean;
+  // Called with the trimmed, validated name after `saveUserName` has run.
+  // Use this to retry the gated action (vote / create group / etc.).
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+  message?: string;
+  confirmText?: string;
+}
+
+export default function NameRequiredModal({
+  isOpen,
+  onSubmit,
+  onCancel,
+  message = "Please enter your name to continue.",
+  confirmText = "Save",
+}: NameRequiredModalProps) {
+  const [name, setName] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset + focus on open. Empty start: callers reach this modal precisely
+  // because no name was saved, so there's nothing to prefill.
+  useEffect(() => {
+    if (!isOpen) return;
+    setName("");
+    const id = window.setTimeout(() => inputRef.current?.focus(), 50);
+    return () => window.clearTimeout(id);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handle);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handle);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  const validation = validateUserName(name);
+  const canSubmit = validation.ok;
+  const errorText = name.length > 0 && !validation.ok ? validation.error : null;
+
+  const handleSubmit = () => {
+    const trimmed = name.trim();
+    if (!validateUserName(trimmed).ok) return;
+    saveUserName(trimmed);
+    onSubmit(trimmed);
+  };
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+        <div
+          className="absolute inset-0 bg-black/50 dark:bg-black/70"
+          onClick={onCancel}
+        />
+        <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full px-4 py-4">
+          <p className="text-gray-900 dark:text-white mb-3 text-base font-normal text-center">
+            {message}
+          </p>
+          <input
+            ref={inputRef}
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canSubmit) {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
+            maxLength={MAX_NAME_LENGTH}
+            placeholder="Your name"
+            className="w-full mb-3 px-3 py-2 text-base bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white focus:outline-none focus:border-blue-500 dark:focus:border-blue-400"
+          />
+          {errorText && (
+            <p className="mb-3 text-sm text-red-600 dark:text-red-400 text-center">
+              {errorText}
+            </p>
+          )}
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="px-6 py-2 rounded-lg transition-all active:scale-95 font-medium bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
+            >
+              {confirmText}
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/NameRequiredModal.tsx
+++ b/components/NameRequiredModal.tsx
@@ -25,8 +25,6 @@ export default function NameRequiredModal({
   const [name, setName] = useState("");
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // Reset + focus on open. Empty start: callers reach this modal precisely
-  // because no name was saved, so there's nothing to prefill.
   useEffect(() => {
     if (!isOpen) return;
     setName("");
@@ -34,10 +32,16 @@ export default function NameRequiredModal({
     return () => window.clearTimeout(id);
   }, [isOpen]);
 
+  // Stash `onCancel` in a ref so parent re-renders with a fresh closure don't
+  // tear down + rebuild the keydown listener + body-overflow lock mid-typing.
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  }, [onCancel]);
   useEffect(() => {
     if (!isOpen) return;
     const handle = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
+      if (e.key === "Escape") onCancelRef.current();
     };
     document.addEventListener("keydown", handle);
     document.body.style.overflow = "hidden";
@@ -45,7 +49,7 @@ export default function NameRequiredModal({
       document.removeEventListener("keydown", handle);
       document.body.style.overflow = "unset";
     };
-  }, [isOpen, onCancel]);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 

--- a/components/QuestionBallot.tsx
+++ b/components/QuestionBallot.tsx
@@ -20,6 +20,7 @@ import RankableOptions from "@/components/RankableOptions";
 import { isCreatedByThisBrowser, getCreatorSecret, recordQuestionCreation, storeSeenQuestionOptions, getSeenQuestionOptions } from "@/lib/browserQuestionAccess";
 import { hasQuestionData } from "@/lib/forgetQuestion";
 import { getUserName, saveUserName } from "@/lib/userProfile";
+import { isValidUserName } from "@/lib/nameValidation";
 import { usePageTitle } from "@/lib/usePageTitle";
 import QuestionDetails from "@/components/QuestionDetails";
 import SearchRadiusBubble from "@/components/SearchRadiusBubble";
@@ -1365,7 +1366,7 @@ const QuestionBallot = forwardRef<QuestionBallotHandle, QuestionBallotProps>(fun
 
                   <button
                     onClick={handleVoteClick}
-                    disabled={isSubmitting || (!yesNoChoice && !isAbstaining)}
+                    disabled={isSubmitting || (!yesNoChoice && !isAbstaining) || !isValidUserName(voterName)}
                     className="w-full py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
                   >
                     {isSubmitting ? 'Submitting...' : 'Submit Vote'}

--- a/components/QuestionBallot.tsx
+++ b/components/QuestionBallot.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef, useImperativeHandle, forwardRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useAppPrefetch } from "@/lib/prefetch";
-import CompactNameField from "@/components/CompactNameField";
 import QuestionResultsDisplay from "@/components/QuestionResults";
 import SuggestionVotingInterface from "@/components/SuggestionVotingInterface";
 import RankingSection from "@/components/RankingSection";
@@ -1360,13 +1359,9 @@ const QuestionBallot = forwardRef<QuestionBallotHandle, QuestionBallotProps>(fun
                     )}
                   </div>
 
-                  <section className="mb-4 rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-                    <CompactNameField name={voterName} setName={setVoterName} />
-                  </section>
-
                   <button
                     onClick={handleVoteClick}
-                    disabled={isSubmitting || (!yesNoChoice && !isAbstaining) || !isValidUserName(voterName)}
+                    disabled={isSubmitting || (!yesNoChoice && !isAbstaining)}
                     className="w-full py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
                   >
                     {isSubmitting ? 'Submitting...' : 'Submit Vote'}

--- a/components/QuestionBallot/TimeBallotSection.tsx
+++ b/components/QuestionBallot/TimeBallotSection.tsx
@@ -3,8 +3,6 @@
 import type { Dispatch, SetStateAction, ReactNode } from "react";
 import type { Question, QuestionResults, DayTimeWindow } from "@/lib/types";
 import AbstainButton from "@/components/AbstainButton";
-import CompactNameField from "@/components/CompactNameField";
-import { isValidUserName } from "@/lib/nameValidation";
 import TimeQuestionFields from "@/components/TimeQuestionFields";
 import TimeSlotBubbles from "@/components/TimeSlotBubbles";
 import { formatTimeSlot } from "@/lib/timeUtils";
@@ -210,14 +208,10 @@ export default function TimeBallotSection({
 
             {!wrapperHandlesSubmit && (
               <>
-                <section className="mb-4 rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-                  <CompactNameField name={voterName} setName={setVoterName} disabled={isSubmitting} maxLength={30} />
-                </section>
-
                 <button
                   type="button"
                   onClick={handleVoteClick}
-                  disabled={isSubmitting || (!isAbstaining && voterDayTimeWindows.filter(d => (d.windows ?? []).some(w => w.enabled !== false)).length === 0) || !isValidUserName(voterName)}
+                  disabled={isSubmitting || (!isAbstaining && voterDayTimeWindows.filter(d => (d.windows ?? []).some(w => w.enabled !== false)).length === 0)}
                   className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
                 >
                   {isSubmitting ? 'Submitting...' : 'Submit Availability'}
@@ -271,14 +265,10 @@ export default function TimeBallotSection({
 
             {!wrapperHandlesSubmit && (
               <>
-                <section className="mb-4 rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-                  <CompactNameField name={voterName} setName={setVoterName} disabled={isSubmitting} maxLength={30} />
-                </section>
-
                 <button
                   type="button"
                   onClick={handleVoteClick}
-                  disabled={isSubmitting || !isValidUserName(voterName)}
+                  disabled={isSubmitting}
                   className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
                 >
                   {isSubmitting ? 'Submitting...' : 'Submit Preferences'}

--- a/components/QuestionBallot/TimeBallotSection.tsx
+++ b/components/QuestionBallot/TimeBallotSection.tsx
@@ -4,6 +4,7 @@ import type { Dispatch, SetStateAction, ReactNode } from "react";
 import type { Question, QuestionResults, DayTimeWindow } from "@/lib/types";
 import AbstainButton from "@/components/AbstainButton";
 import CompactNameField from "@/components/CompactNameField";
+import { isValidUserName } from "@/lib/nameValidation";
 import TimeQuestionFields from "@/components/TimeQuestionFields";
 import TimeSlotBubbles from "@/components/TimeSlotBubbles";
 import { formatTimeSlot } from "@/lib/timeUtils";
@@ -216,7 +217,7 @@ export default function TimeBallotSection({
                 <button
                   type="button"
                   onClick={handleVoteClick}
-                  disabled={isSubmitting || (!isAbstaining && voterDayTimeWindows.filter(d => (d.windows ?? []).some(w => w.enabled !== false)).length === 0)}
+                  disabled={isSubmitting || (!isAbstaining && voterDayTimeWindows.filter(d => (d.windows ?? []).some(w => w.enabled !== false)).length === 0) || !isValidUserName(voterName)}
                   className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
                 >
                   {isSubmitting ? 'Submitting...' : 'Submit Availability'}
@@ -277,7 +278,7 @@ export default function TimeBallotSection({
                 <button
                   type="button"
                   onClick={handleVoteClick}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || !isValidUserName(voterName)}
                   className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100"
                 >
                   {isSubmitting ? 'Submitting...' : 'Submit Preferences'}

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -3,8 +3,6 @@
 import Countdown from "@/components/Countdown";
 import SimpleCountdown from "@/components/SimpleCountdown";
 import RankableOptions from "@/components/RankableOptions";
-import CompactNameField from "@/components/CompactNameField";
-import { isValidUserName } from "@/lib/nameValidation";
 import ReadOnlyTierCards from "@/components/ReadOnlyTierCards";
 import BinaryRankedChoiceBallot from "@/components/QuestionBallot/BinaryRankedChoiceBallot";
 import type { OptionsMetadata, QuestionResults } from "@/lib/types";
@@ -263,12 +261,9 @@ export default function RankingSection({
 
       {showBallot && !wrapperHandlesSubmit && (
         <>
-          <section className="mt-4 rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-            <CompactNameField name={voterName} setName={setVoterName} />
-          </section>
           <button
             onClick={handleVoteClick}
-            disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0) || !isValidUserName(voterName)}
+            disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0)}
             className="w-full mt-4 py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
           >
             {isSubmitting ? 'Submitting...' : 'Submit Vote'}

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -4,6 +4,7 @@ import Countdown from "@/components/Countdown";
 import SimpleCountdown from "@/components/SimpleCountdown";
 import RankableOptions from "@/components/RankableOptions";
 import CompactNameField from "@/components/CompactNameField";
+import { isValidUserName } from "@/lib/nameValidation";
 import ReadOnlyTierCards from "@/components/ReadOnlyTierCards";
 import BinaryRankedChoiceBallot from "@/components/QuestionBallot/BinaryRankedChoiceBallot";
 import type { OptionsMetadata, QuestionResults } from "@/lib/types";
@@ -267,7 +268,7 @@ export default function RankingSection({
           </section>
           <button
             onClick={handleVoteClick}
-            disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0)}
+            disabled={isSubmitting || (!isAbstaining && !justCancelledAbstain && rankedChoices.filter(choice => choice && choice.trim().length > 0).length === 0 && suggestionChoices.filter(c => c && c.trim().length > 0).length === 0) || !isValidUserName(voterName)}
             className="w-full mt-4 py-3 px-4 rounded-lg bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] active:bg-[#2a2a2a] dark:active:bg-[#e0e0e0] font-medium text-base transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:active:scale-100 flex items-center justify-center"
           >
             {isSubmitting ? 'Submitting...' : 'Submit Vote'}

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, Dispatch, SetStateAction } from "react";
 import OptionsInput, { type OptionsMetadata } from "@/components/OptionsInput";
 import SuggestionsList from "@/components/SuggestionsList";
 import CompactNameField from "@/components/CompactNameField";
+import { isValidUserName } from "@/lib/nameValidation";
 import OptionLabel from "@/components/OptionLabel";
 import SliderSwitch from "@/components/SliderSwitch";
 
@@ -311,7 +312,7 @@ export default function SuggestionVotingInterface({
           {/* Submit Button */}
           <button
             onClick={handleVoteClick}
-            disabled={isSubmitting}
+            disabled={isSubmitting || !isValidUserName(voterName)}
             className={`w-full py-3 px-4 rounded-lg font-medium transition-all duration-150 active:scale-95 disabled:cursor-not-allowed disabled:active:scale-100 ${
               suggestionChoices.length === 0 && !isSubmitting
                 ? 'bg-yellow-100 hover:bg-yellow-200 dark:bg-yellow-900 dark:hover:bg-yellow-800 active:bg-yellow-300 dark:active:bg-yellow-700 text-yellow-800 dark:text-yellow-200 border-2 border-yellow-300 dark:border-yellow-700'

--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect, Dispatch, SetStateAction } from "react";
 import OptionsInput, { type OptionsMetadata } from "@/components/OptionsInput";
 import SuggestionsList from "@/components/SuggestionsList";
-import CompactNameField from "@/components/CompactNameField";
-import { isValidUserName } from "@/lib/nameValidation";
 import OptionLabel from "@/components/OptionLabel";
 import SliderSwitch from "@/components/SliderSwitch";
 
@@ -305,14 +303,10 @@ export default function SuggestionVotingInterface({
 
       {!wrapperHandlesSubmit && (
         <>
-          <section className="mb-3 rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-            <CompactNameField name={voterName} setName={setVoterName} disabled={isSubmitting} />
-          </section>
-
           {/* Submit Button */}
           <button
             onClick={handleVoteClick}
-            disabled={isSubmitting || !isValidUserName(voterName)}
+            disabled={isSubmitting}
             className={`w-full py-3 px-4 rounded-lg font-medium transition-all duration-150 active:scale-95 disabled:cursor-not-allowed disabled:active:scale-100 ${
               suggestionChoices.length === 0 && !isSubmitting
                 ? 'bg-yellow-100 hover:bg-yellow-200 dark:bg-yellow-900 dark:hover:bg-yellow-800 active:bg-yellow-300 dark:active:bg-yellow-700 text-yellow-800 dark:text-yellow-200 border-2 border-yellow-300 dark:border-yellow-700'

--- a/lib/nameValidation.ts
+++ b/lib/nameValidation.ts
@@ -1,0 +1,30 @@
+// Shared username validation. The same rules feed every FE submit-button
+// gate and the server-side validator (see server/services/validation.py),
+// so changing one of the constants below means changing both sides.
+export const MIN_NAME_LENGTH = 1;
+export const MAX_NAME_LENGTH = 50;
+
+const CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
+
+export type NameValidation = { ok: true } | { ok: false; error: string };
+
+export function validateUserName(name: string | null | undefined): NameValidation {
+  if (name === null || name === undefined) {
+    return { ok: false, error: "Please enter your name" };
+  }
+  const trimmed = name.trim();
+  if (trimmed.length < MIN_NAME_LENGTH) {
+    return { ok: false, error: "Please enter your name" };
+  }
+  if (trimmed.length > MAX_NAME_LENGTH) {
+    return { ok: false, error: `Name must be ${MAX_NAME_LENGTH} characters or fewer` };
+  }
+  if (CONTROL_CHAR_RE.test(trimmed)) {
+    return { ok: false, error: "Name contains invalid characters" };
+  }
+  return { ok: true };
+}
+
+export function isValidUserName(name: string | null | undefined): boolean {
+  return validateUserName(name).ok;
+}

--- a/lib/useGroupVoting.ts
+++ b/lib/useGroupVoting.ts
@@ -80,16 +80,6 @@ export function useGroupVoting({
   const [pendingPollChoices, setPendingPollChoices] = useState<
     Map<string, YesNoChoice>
   >(() => new Map());
-  const [pollVoterNames, setPollVoterNames] = useState<Map<string, string>>(
-    () => new Map(),
-  );
-  // Same-value guard avoids no-op re-renders when both the all-yes_no Submit
-  // row and the wrapper Submit row write the identical name on each keystroke.
-  const setPollVoterName = useRef((id: string, name: string) => {
-    setPollVoterNames((prev) =>
-      prev.get(id) === name ? prev : new Map(prev).set(id, name),
-    );
-  }).current;
 
   const [pendingPollSubmit, setPendingPollSubmit] =
     useState<PendingPollSubmit | null>(null);
@@ -185,8 +175,7 @@ export function useGroupVoting({
         setPendingPollSubmit(null);
         return;
       }
-      const voterNameRaw = pollVoterNames.get(pollId) ?? getUserName() ?? "";
-      const voter_name = voterNameRaw.trim() || null;
+      const voter_name = (getUserName() ?? "").trim() || null;
       const returnedVotes = await apiSubmitPollVotes(pollId, {
         voter_name,
         items,
@@ -328,8 +317,6 @@ export function useGroupVoting({
     voteChangeSubmitting,
     pendingPollChoices,
     setPendingPollChoices,
-    pollVoterNames,
-    setPollVoterName,
     pendingPollSubmit,
     setPendingPollSubmit,
     pollSubmitting,

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -27,6 +27,7 @@ from models import (
 from services.groups import require_uuid
 from services.memberships import join_group, join_group_for_poll
 from services.push import fan_out_new_poll
+from services.validation import validate_user_name
 from services.questions import (
     _edit_vote_on_question,
     _finalize_suggestion_options,
@@ -431,6 +432,7 @@ def create_poll(
     req: CreatePollRequest, request: Request, background_tasks: BackgroundTasks
 ):
     _validate_request(req)
+    req.creator_name = validate_user_name(req.creator_name, field="Creator name")
 
     # questions.title is NOT NULL, so each question row needs a value even though
     # display goes through the poll's computed title.
@@ -725,6 +727,7 @@ def submit_poll_votes(poll_id: str, req: SubmitPollVotesRequest, request: Reques
     voter_name is poll-level: one voter, many question ballots.
     """
     require_uuid(poll_id, "poll_id")
+    req.voter_name = validate_user_name(req.voter_name, field="Voter name")
     now = datetime.now(timezone.utc)
 
     # Phase C.2: group join runs BEFORE the vote in its own transaction so

--- a/server/services/validation.py
+++ b/server/services/validation.py
@@ -1,0 +1,41 @@
+"""Shared request-body validators.
+
+Mirrors lib/nameValidation.ts on the FE — change these constants in
+lockstep with the FE module.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import HTTPException
+
+MIN_NAME_LENGTH = 1
+MAX_NAME_LENGTH = 50
+
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1F\x7F]")
+
+
+def validate_user_name(value: str | None, *, field: str = "name") -> str:
+    """Validate a display-name field. Returns the trimmed value; raises
+    HTTPException(400) on missing / out-of-range / control-char input.
+
+    Common-sense rules only — length and control-char exclusion. We don't
+    police case, emoji, punctuation, or charset since the name is a
+    user-controlled display string, never used for routing or auth.
+    """
+    if value is None:
+        raise HTTPException(status_code=400, detail=f"{field} is required")
+    trimmed = value.strip()
+    if len(trimmed) < MIN_NAME_LENGTH:
+        raise HTTPException(status_code=400, detail=f"{field} is required")
+    if len(trimmed) > MAX_NAME_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field} must be {MAX_NAME_LENGTH} characters or fewer",
+        )
+    if _CONTROL_CHAR_RE.search(trimmed):
+        raise HTTPException(
+            status_code=400, detail=f"{field} contains invalid characters"
+        )
+    return trimmed

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -52,6 +52,7 @@ def yes_no_question(**overrides) -> dict:
 def create_poll(client, creator_secret, *, browser_id=None, **kwargs) -> dict:
     payload = {
         "creator_secret": creator_secret,
+        "creator_name": "Test User",
         "questions": [yes_no_question()],
     }
     payload.update(kwargs)

--- a/server/tests/test_polls_api.py
+++ b/server/tests/test_polls_api.py
@@ -51,7 +51,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [_yes_no_question()],
             },
         )
@@ -68,7 +68,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "context": "Birthday",
                 "questions": [
                     _restaurant_question(),
@@ -105,7 +105,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "title": "What should we do tonight?",
                 "questions": [_yes_no_question()],
             },
@@ -121,7 +121,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "group_title": "Friday Night Plans",
                 "questions": [_yes_no_question()],
             },
@@ -132,10 +132,66 @@ class TestCreatePoll:
         # The override flows through to the computed display title too.
         assert data["title"] == "Friday Night Plans"
 
+    def test_rejects_missing_creator_name(self, client, creator_secret):
+        resp = client.post(
+            "/api/polls",
+            json={
+                "creator_secret": creator_secret,
+                "questions": [_yes_no_question()],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert "name" in resp.json()["detail"].lower()
+
+    def test_rejects_whitespace_creator_name(self, client, creator_secret):
+        resp = client.post(
+            "/api/polls",
+            json={
+                "creator_secret": creator_secret,
+                "creator_name": "   ",
+                "questions": [_yes_no_question()],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_rejects_overlong_creator_name(self, client, creator_secret):
+        resp = client.post(
+            "/api/polls",
+            json={
+                "creator_secret": creator_secret,
+                "creator_name": "A" * 51,
+                "questions": [_yes_no_question()],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_rejects_creator_name_with_control_char(self, client, creator_secret):
+        resp = client.post(
+            "/api/polls",
+            json={
+                "creator_secret": creator_secret,
+                "creator_name": "Bad\x07name",
+                "questions": [_yes_no_question()],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_creator_name_is_trimmed(self, client, creator_secret):
+        resp = client.post(
+            "/api/polls",
+            json={
+                "creator_secret": creator_secret,
+                "creator_name": "  Alice  ",
+                "questions": [_yes_no_question()],
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["creator_name"] == "Alice"
+
     def test_rejects_zero_questions(self, client, creator_secret):
         resp = client.post(
             "/api/polls",
-            json={"creator_secret": creator_secret, "questions": []},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "questions": []},
         )
         assert resp.status_code == 422  # pydantic min_length
 
@@ -143,7 +199,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [
                     {"question_type": "time", "category": "time"},
                     {"question_type": "time", "category": "time"},
@@ -159,7 +215,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [
                     _restaurant_question(),
                     _restaurant_question(),
@@ -175,7 +231,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [
                     _restaurant_question(context="Lunch"),
                     _restaurant_question(context="Dinner"),
@@ -191,7 +247,7 @@ class TestCreatePoll:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "response_deadline": "2030-01-01T12:00:00Z",
                 "prephase_deadline": "2030-01-02T12:00:00Z",
                 "questions": [_yes_no_question()],
@@ -206,7 +262,7 @@ class TestReadPoll:
         create = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [_yes_no_question()],
             },
         )
@@ -221,7 +277,7 @@ class TestReadPoll:
         create = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [_restaurant_question()],
             },
         )
@@ -245,7 +301,7 @@ class TestQuestionLinkage:
         create = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [
                     _yes_no_question(),
                     _restaurant_question(),
@@ -278,7 +334,7 @@ class TestGroupAddition:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [_yes_no_question()],
                 **kwargs,
             },
@@ -294,7 +350,7 @@ class TestGroupAddition:
         child = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "group_id": group_id,
                 "questions": [_yes_no_question()],
             },
@@ -311,7 +367,7 @@ class TestGroupAddition:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "group_id": bogus,
                 "questions": [_yes_no_question()],
             },
@@ -331,7 +387,7 @@ class TestGroupAddition:
         child = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "group_id": group_id,
                 "questions": [_yes_no_question()],
             },
@@ -352,7 +408,7 @@ class TestGroupAddition:
         child = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "group_id": group_id,
                 "group_title": "New Title",
                 "questions": [_yes_no_question()],
@@ -379,7 +435,7 @@ class TestGroupAddition:
         child = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "group_id": parent["group_id"],
                 "questions": [_yes_no_question()],
             },
@@ -449,7 +505,7 @@ class TestGroupId:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": [_yes_no_question()],
             },
         )
@@ -461,25 +517,25 @@ class TestGroupId:
     def test_two_root_polls_get_distinct_groups(self, client, creator_secret):
         a = client.post(
             "/api/polls",
-            json={"creator_secret": creator_secret, "questions": [_yes_no_question()]},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "questions": [_yes_no_question()]},
         )
         b = client.post(
             "/api/polls",
-            json={"creator_secret": creator_secret, "questions": [_yes_no_question()]},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "questions": [_yes_no_question()]},
         )
         assert self._group_id_for(a.json()["id"]) != self._group_id_for(b.json()["id"])
 
     def test_group_id_param_reuses_group(self, client, creator_secret):
         parent = client.post(
             "/api/polls",
-            json={"creator_secret": creator_secret, "questions": [_yes_no_question()]},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "questions": [_yes_no_question()]},
         )
         parent_group_id = self._group_id_for(parent.json()["id"])
 
         child = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "group_id": parent_group_id,
                 "questions": [_yes_no_question()],
             },
@@ -493,7 +549,7 @@ class TestGroupId:
         # assertion now that there's no chain walk.
         root = client.post(
             "/api/polls",
-            json={"creator_secret": creator_secret, "questions": [_yes_no_question()]},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "questions": [_yes_no_question()]},
         )
         root_group = self._group_id_for(root.json()["id"])
 
@@ -501,7 +557,7 @@ class TestGroupId:
             resp = client.post(
                 "/api/polls",
                 json={
-                    "creator_secret": creator_secret,
+                    "creator_secret": creator_secret, "creator_name": "Test User",
                     "group_id": root_group,
                     "questions": [_yes_no_question()],
                 },
@@ -517,7 +573,7 @@ class TestPollOperations:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "questions": questions or [_yes_no_question(), _restaurant_question()],
             },
         )
@@ -528,7 +584,7 @@ class TestPollOperations:
         multi = self._create_multi(client, creator_secret)
         resp = client.post(
             f"/api/polls/{multi['id']}/close",
-            json={"creator_secret": creator_secret, "close_reason": "manual"},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "close_reason": "manual"},
         )
         assert resp.status_code == 200, resp.text
         data = resp.json()
@@ -549,7 +605,7 @@ class TestPollOperations:
     def test_close_404_on_unknown_id(self, client, creator_secret):
         resp = client.post(
             f"/api/polls/{uuid.uuid4()}/close",
-            json={"creator_secret": creator_secret, "close_reason": "manual"},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "close_reason": "manual"},
         )
         assert resp.status_code == 404
 
@@ -557,7 +613,7 @@ class TestPollOperations:
         multi = self._create_multi(client, creator_secret)
         client.post(
             f"/api/polls/{multi['id']}/close",
-            json={"creator_secret": creator_secret, "close_reason": "manual"},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "close_reason": "manual"},
         )
         resp = client.post(
             f"/api/polls/{multi['id']}/reopen",
@@ -605,7 +661,7 @@ class TestPollOperations:
         )
         client.post(
             f"/api/polls/{multi['id']}/close",
-            json={"creator_secret": creator_secret, "close_reason": "manual"},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "close_reason": "manual"},
         )
         reopened = client.post(
             f"/api/polls/{multi['id']}/reopen",
@@ -645,7 +701,7 @@ class TestPollVoterAggregation:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "context": "Test",
                 "questions": [
                     _yes_no_question(context="A"),
@@ -676,30 +732,26 @@ class TestPollVoterAggregation:
         assert sorted(data["voter_names"]) == ["Alice", "Bob", "Carol"]
         assert data["anonymous_count"] == 0
 
-    def test_anonymous_count_is_max_per_question(self, client, creator_secret):
+    def test_anonymous_vote_rejected(self, client, creator_secret):
+        # Name-required policy: server rejects null/empty voter_name on
+        # POST /api/polls/<id>/votes. `anonymous_count` aggregation only
+        # ever populates from pre-policy legacy rows.
         multi = self._make_two_yes_no_multi(client, creator_secret)
-        sp_a, sp_b = multi["questions"]
-        # 3 anon on A, 2 anon on B → expect MAX = 3.
-        for _ in range(3):
-            self._vote(client, sp_a["id"], None, poll_id=multi["id"])
-        for _ in range(2):
-            self._vote(client, sp_b["id"], None, poll_id=multi["id"])
-        data = client.get(f"/api/polls/by-id/{multi['id']}").json()
-        assert data["voter_names"] == []
-        assert data["anonymous_count"] == 3
-
-    def test_mixed_named_and_anonymous(self, client, creator_secret):
-        multi = self._make_two_yes_no_multi(client, creator_secret)
-        sp_a, sp_b = multi["questions"]
-        self._vote(client, sp_a["id"], "Alice", poll_id=multi["id"])
-        self._vote(client, sp_b["id"], "Alice", poll_id=multi["id"])
-        self._vote(client, sp_a["id"], None, poll_id=multi["id"])
-        self._vote(client, sp_a["id"], None, poll_id=multi["id"])
-        self._vote(client, sp_b["id"], None, poll_id=multi["id"])
-        data = client.get(f"/api/polls/by-id/{multi['id']}").json()
-        assert data["voter_names"] == ["Alice"]
-        # max(2 anon on A, 1 anon on B) = 2
-        assert data["anonymous_count"] == 2
+        sp_a = multi["questions"][0]
+        resp = client.post(
+            f"/api/polls/{multi['id']}/votes",
+            json={
+                "voter_name": None,
+                "items": [
+                    {
+                        "question_id": sp_a["id"],
+                        "vote_type": "yes_no",
+                        "yes_no_choice": "yes",
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 400, resp.text
 
     def test_aggregation_returned_by_short_id_endpoint_too(self, client, creator_secret):
         multi = self._make_two_yes_no_multi(client, creator_secret)
@@ -715,7 +767,7 @@ class TestPollVoterAggregation:
         self._vote(client, sp_a["id"], "Alice", poll_id=multi["id"])
         closed = client.post(
             f"/api/polls/{multi['id']}/close",
-            json={"creator_secret": creator_secret, "close_reason": "manual"},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "close_reason": "manual"},
         ).json()
         assert closed["voter_names"] == ["Alice"]
 
@@ -739,7 +791,7 @@ class TestPollUnifiedVoting:
         resp = client.post(
             "/api/polls",
             json={
-                "creator_secret": creator_secret,
+                "creator_secret": creator_secret, "creator_name": "Test User",
                 "context": "Voting",
                 "questions": questions
                 or [_yes_no_question(context="A"), _yes_no_question(context="B")],
@@ -967,7 +1019,7 @@ class TestPollUnifiedVoting:
         multi = self._make_multi(client, creator_secret)
         client.post(
             f"/api/polls/{multi['id']}/close",
-            json={"creator_secret": creator_secret, "close_reason": "manual"},
+            json={"creator_secret": creator_secret, "creator_name": "Test User", "close_reason": "manual"},
         )
         sp_a = multi["questions"][0]
         resp = client.post(
@@ -994,7 +1046,9 @@ class TestPollUnifiedVoting:
         # Pydantic min_length=1 rejection.
         assert resp.status_code == 422
 
-    def test_anonymous_voter_name(self, client, creator_secret):
+    def test_voter_name_required(self, client, creator_secret):
+        # Name-required policy: server rejects omitted voter_name on
+        # POST /api/polls/<id>/votes.
         multi = self._make_multi(client, creator_secret)
         sp_a = multi["questions"][0]
         resp = client.post(
@@ -1009,6 +1063,4 @@ class TestPollUnifiedVoting:
                 ],
             },
         )
-        assert resp.status_code == 201
-        rows = resp.json()
-        assert rows[0]["voter_name"] is None
+        assert resp.status_code == 400, resp.text


### PR DESCRIPTION
## Summary

Make a saved display name a precondition for the three identity-bearing user actions: creating a poll, submitting a ballot, and creating a new group. The settings page stays the single edit surface; ballots and the create-poll form no longer carry inline "Your Name" fields.

- **Shared validation** in `lib/nameValidation.ts` + `server/services/validation.py` — 1–50 chars after trim, no control chars. Mirror constants on both sides.
- **`<NameRequiredModal>`** is the canonical gate. Three callsites:
  - Home `+ Group` button → modal opens if no name saved; on save, slides into the new empty group.
  - Category bubble on a group page → modal opens; on save, the create-poll form opens.
  - Every ballot Submit path (multi-question wrapper, single-question wrapper, yes/no tap-to-vote, yes/no tap-to-change confirm) → modal opens; on save, the original submit replays via a `pendingNameRetry: (() => void) | null` thunk.
- **Server enforcement** — `validate_user_name` returns 400 on missing / whitespace / overlong / control-char inputs on `POST /api/polls` (creator_name) and `POST /api/polls/{id}/votes` (voter_name).
- **`CompactNameField` still exists**, used only on the settings page. Now selects-all on focus so tapping into a pre-filled right-aligned field doesn't strand the caret at position 0.
- **Settings Save** now tracks an `initialName` snapshot, so clearing a previously-saved name counts as a real change (the only-name-changed-to-empty case no longer leaves Save disabled).
- New tests in `test_polls_api.py` cover the 400s; anonymous-vote tests inverted.

## Test plan

- [x] `POST /api/polls` with no `creator_name` / whitespace / control-char / 51-char → 400 with descriptive message
- [x] `POST /api/polls` with `"  Alice  "` → 201, `creator_name: "Alice"` (trimmed)
- [x] `POST /api/polls/<id>/votes` with no `voter_name` / whitespace → 400
- [x] `POST /api/polls/<id>/votes` with valid name → 201
- [x] Home `+ Group` tap with no saved name → name modal; on save, group create flow proceeds
- [x] Category bubble tap on `/g/<id>` with no saved name → name modal; on save, create-poll form opens with the name flowed in
- [x] Yes/No tap on a poll detail page with no saved name → name modal; on save, vote submits
- [x] Group page has no inline "Your Name" label; ballot page has no inline "Your Name" label
- [x] Settings: clear the name field → Save button stays enabled (was disabled before, the bug fix)
- [x] Settings: `CompactNameField` select-all on focus — tap a pre-filled field, press Backspace, value clears

https://claude.ai/code/session_01XUXrHjkWHEoVEReJYQRJxp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUXrHjkWHEoVEReJYQRJxp)_