### PR TITLE
Phase C: Apple + Google OAuth sign-in (web)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -945,10 +945,12 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Auth & Access Model
 
-> **Phase A + B shipped (migration 112).** User accounts via magic-link
-> email; OAuth (Apple, Google), passkey, group privacy, join requests,
-> invite links, and per-vote anonymity are scheduled phases on top.
-> Full plan + rationale in `docs/auth-access-model.md`.
+> **Phases A + B + C shipped.** A+B = identity foundation +
+> magic-link email sign-in (migration 112). C = "Sign in with Apple"
+> + "Sign in with Google" on web. Passkey (D), group privacy (E),
+> join requests (F), invite links (G), per-vote anonymity (H), and
+> Capacitor native OAuth (deferred follow-up to C) are still
+> scheduled. Full plan + rationale in `docs/auth-access-model.md`.
 
 **Identity tables (migration 112):**
 - `users(id)` — one row per real person.
@@ -1046,8 +1048,28 @@ contents directly; don't trust upsert completion alone. If migration
 doesn't appear, fire the upsert manually before debugging the
 migration content.
 
+**Phase C (Apple + Google OAuth on web) is wired through three layers:**
+
+1. **Server verifier (`server/services/oauth.py`).** `verify_google_id_token(id_token)` and `verify_apple_id_token(id_token)` validate the JWT against the provider's JWKS (signature + iss + aud + exp + required claims) and return an `OAuthIdentity{provider, provider_user_id, email, email_verified}`. Uses `PyJWKClient` (from the existing `pyjwt[crypto]` dep) — keys are fetched and cached per process; rotation is transparent. Algorithm is pinned per provider (`RS256` for Google, `ES256` for Apple) so a hostile token can't switch families. Email is only surfaced as the merge key when `email_verified` is true (Google sends boolean, Apple sends string "true" — both branches accepted; anything else → `email=None`, but the sub-based identity still resolves).
+2. **Server endpoints (`server/routers/auth.py`).** `POST /api/auth/oauth/google` and `POST /api/auth/oauth/apple` accept `{id_token}`, verify, then route through the shared `_sign_in_via_oauth` helper which calls `resolve_or_merge_user` → `link_browser_to_user` → `issue_session` (same three-step rhythm as magic-link verify). Returns the same `SessionResponse` shape so the FE doesn't branch by provider. `GET /api/auth/providers` reports `{email, google, apple}` capability booleans driven by `google_configured()` / `apple_configured()` — both gate the verify endpoints with 503 when the corresponding `*_AUDIENCES` env var is unset.
+3. **FE (`lib/oauth.ts` + `lib/api/auth.ts` + `components/SignInModal.tsx`).** SDK loaders for Google Identity Services + Apple JS are module-level memoized promises (concurrent modal opens share one fetch). Google renders its own branded button into a `ref`'d container via `google.accounts.id.renderButton` — required by their branding guidelines and the only way to get reliable popup-based credential delivery. Apple uses a custom-styled button that calls `AppleID.auth.signIn()`. `SignInModal` queries `apiGetAuthProviders()` on every open and hides each OAuth button when EITHER the client bundle (NEXT_PUBLIC_*_CLIENT_ID env var) OR the server tier (`*_AUDIENCES`) isn't configured — both must agree before the button surfaces.
+
+**Configuration: each provider needs matching env vars on BOTH sides.** Drop these into the API droplet's `.env.api` AND the Vercel project's environment variables to enable each button. Without them, the buttons hide silently:
+
+  * Google: `GOOGLE_OAUTH_CLIENT_IDS` (server, comma-separated to accept web + iOS audiences) + `NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID` (FE web client ID).
+  * Apple: `APPLE_OAUTH_AUDIENCES` (server, comma-separated for web Service ID + iOS bundle ID) + `NEXT_PUBLIC_APPLE_OAUTH_SERVICE_ID` (FE Service ID) + `NEXT_PUBLIC_APPLE_OAUTH_REDIRECT_URI` (optional; defaults to the current origin).
+
+**Cross-provider account merge "just works" via the shared verified-email lookup in `resolve_or_merge_user`.** A user who signed in with magic link first (email identity) and later signs in with Google using the same verified email lands on the SAME `user_id` — the second sign-in adds a `user_identities` row for `provider='google'` pointing at the existing user. `/api/auth/me` then reports `providers: ['email', 'google']`. Apple "Hide my email" relay addresses (`<token>@privaterelay.appleid.com`) are stable per (user, RP) and are treated identically to real emails for the merge — same address every time, so repeat sign-ins resolve.
+
+**Capacitor iOS web OAuth is intentionally hidden via `isWebOAuthAvailable()` (`Capacitor.isNativePlatform()` short-circuit).** Google explicitly blocks `accounts.google.com/gsi` in embedded WebViews per their "disallowed-user-agents" policy (would surface as a `403 disallowed_useragent` error mid-flow), and Apple's JS SDK doesn't render reliably inside WKWebView either. The buttons hide entirely on native iOS; only magic link is offered there. The follow-up Capacitor native PR will add `@capacitor-community/apple-sign-in` + a Google-Auth Capacitor plugin and use the same `/api/auth/oauth/{google,apple}` endpoints with native-flow-issued ID tokens.
+
+**Pitfall: PyJWT's `audience` accepts a list but `issuer` does NOT.** `jwt.decode(..., issuer='x')` only matches a single string; Google publishes tokens with both `'https://accounts.google.com'` AND `'accounts.google.com'` as the issuer over time. `services/oauth.py: _verify` therefore decodes WITHOUT an `issuer` arg and checks `claims['iss'] in tuple_of_acceptable_issuers` manually afterward. Mirror this pattern if a third OIDC provider arrives with multiple valid issuers.
+
+**Pitfall: testing OAuth without calling real providers.** `server/tests/test_oauth.py` monkey-patches `services.oauth._google_jwks_client` / `_apple_jwks_client` to return a fake `PyJWKClient` whose `get_signing_key_from_jwt` returns a locally-generated RSA (Google) / EC (Apple) public key. Tests then mint JWTs signed by the matching private key and drive every branch of the verifier (valid token, expired, wrong audience, wrong issuer, unverified email, repeat sign-in without email, cross-provider merge). The pattern is reusable for adding a third OIDC provider — generate the keypair once per module, patch the JWKS lookup, mint signed tokens locally.
+
+**Pitfall: stale OAuth env vars after .env.api edit require `docker compose up -d --force-recreate api`.** The `env_file:` in `docker-compose.yml` is read only on container creation. `restart` reuses the existing container's env. Symptom: `GET /api/auth/providers` keeps reporting `google: false` even though `GOOGLE_OAUTH_CLIENT_IDS` is in `.env.api` because the running process's `os.environ` doesn't see the new value. Same idiom as the APNS env-var rule (see Push Notifications section).
+
 **Open phases (see `docs/auth-access-model.md`):**
-- C: Sign in with Apple + Google (web + Capacitor).
 - D: Passkey (WebAuthn).
 - E: `groups.privacy` column, new groups default private, sign-in
   required for private creation.
@@ -1056,6 +1078,7 @@ migration content.
   target_poll_id.
 - H: per-vote anonymity flags (`votes.anonymous_to_peers`,
   `anonymous_to_creator`) + read-time filter audit.
+- C-follow-up: native Capacitor flows for Apple + Google on iOS.
 
 ---
 

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -2,20 +2,48 @@
 
 import { useEffect, useRef, useState } from "react";
 import ModalPortal from "./ModalPortal";
-import { apiRequestMagicLink } from "@/lib/api";
+import {
+  apiGetAuthProviders,
+  apiRequestMagicLink,
+  apiSignInWithApple,
+  apiSignInWithGoogle,
+} from "@/lib/api";
 import { ApiError } from "@/lib/api";
+import {
+  appleConfigured,
+  appleSignIn,
+  googleConfigured,
+  isWebOAuthAvailable,
+  renderGoogleButton,
+} from "@/lib/oauth";
 
 interface SignInModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
+function getThemePreference(): "light" | "dark" {
+  if (typeof document === "undefined") return "light";
+  // `data-theme` is stamped by the pre-hydration script in app/layout.tsx;
+  // if it's missing (system theme), fall back to media-query.
+  const explicit = document.documentElement.getAttribute("data-theme");
+  if (explicit === "dark") return "dark";
+  if (explicit === "light") return "light";
+  return window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
 /**
- * Phase B: magic-link sign-in modal. Single email field + Send button.
- * On send, hands off to the user's email — the magic link in the
- * inbox takes over (clicking it lands on `/auth/verify?token=...` and
- * issues the session there). This modal closes after a successful
- * request and shows a "check your email" toast in the settings page.
+ * Phase B + C: magic-link + OAuth sign-in modal.
+ *
+ * Magic-link is always available (the Resend fallback logs to stdout
+ * when API key isn't set, so dev still works); Google + Apple buttons
+ * render only when BOTH client-side env vars (NEXT_PUBLIC_*_CLIENT_ID)
+ * and server-side env vars (GOOGLE_OAUTH_CLIENT_IDS etc.) are
+ * configured. The capability discovery happens via
+ * `apiGetAuthProviders()` on mount.
  *
  * Stacks above the create-poll bottom sheet (z-60) and the
  * ConfirmationModal (z-70) via z-80, in case a future flow opens it
@@ -27,8 +55,111 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
   const [sent, setSent] = useState(false);
   const [emailConfigured, setEmailConfigured] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [serverProviders, setServerProviders] = useState<{
+    google: boolean;
+    apple: boolean;
+  } | null>(null);
+  const [oauthSubmitting, setOAuthSubmitting] = useState<
+    "google" | "apple" | null
+  >(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const googleButtonRef = useRef<HTMLDivElement>(null);
   const openedAtRef = useRef<number>(0);
+
+  // Resolve server-side provider capability once per modal open. The
+  // returned values are cached by the fetch layer's normal HTTP cache
+  // headers; we don't memoize at the module level because the API tier
+  // can change between page loads (PWA switching networks, dev tier
+  // gaining a new env var).
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    apiGetAuthProviders()
+      .then((p) => {
+        if (!cancelled) {
+          setServerProviders({ google: p.google, apple: p.apple });
+        }
+      })
+      .catch(() => {
+        // Network failure → assume neither OAuth provider is available
+        // on this tier, but keep the magic-link path visible.
+        if (!cancelled) setServerProviders({ google: false, apple: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  // Google's SDK renders its own branded button into a container we
+  // supply. Initialize it whenever the container mounts AND the server
+  // confirms Google is configured. The Promise resolves with the
+  // id_token on first successful sign-in; subsequent renders are no-ops
+  // (the SDK is initialized once).
+  useEffect(() => {
+    if (!isOpen || sent) return;
+    if (!isWebOAuthAvailable()) return;
+    if (!googleConfigured() || !serverProviders?.google) return;
+    const el = googleButtonRef.current;
+    if (!el) return;
+    let cancelled = false;
+    el.innerHTML = ""; // clean up any prior render before re-renders.
+    renderGoogleButton(el, getThemePreference())
+      .then(async (idToken) => {
+        if (cancelled) return;
+        setOAuthSubmitting("google");
+        setError(null);
+        try {
+          await apiSignInWithGoogle(idToken);
+          onClose();
+        } catch (err) {
+          setError(
+            err instanceof ApiError && err.status === 400
+              ? err.message || "Google sign-in failed."
+              : "Couldn't sign you in with Google. Try again in a moment."
+          );
+        } finally {
+          setOAuthSubmitting(null);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(
+          err instanceof Error ? err.message : "Google sign-in failed to load."
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, sent, serverProviders?.google, onClose]);
+
+  const handleAppleSignIn = async () => {
+    setError(null);
+    setOAuthSubmitting("apple");
+    try {
+      const idToken = await appleSignIn();
+      await apiSignInWithApple(idToken);
+      onClose();
+    } catch (err) {
+      // Apple's SDK throws with `error: 'popup_closed_by_user'` shape on
+      // cancel — treat as silent dismissal.
+      const message = err instanceof Error ? err.message : String(err);
+      if (
+        /popup_closed_by_user|user_cancelled|cancelled/i.test(message) ||
+        // SDK rejection on cancel sometimes has shape `{ error: 'popup_closed_by_user' }`.
+        (err as { error?: string })?.error?.includes?.("cancel")
+      ) {
+        setError(null);
+      } else {
+        setError(
+          err instanceof ApiError && err.status === 400
+            ? err.message || "Apple sign-in failed."
+            : "Couldn't sign you in with Apple. Try again in a moment."
+        );
+      }
+    } finally {
+      setOAuthSubmitting(null);
+    }
+  };
 
   // Suppress backdrop dismissal in the first 400ms after open so the
   // synthesized click after a long-press / tap that opened the modal
@@ -153,38 +284,96 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
               </button>
             </div>
           ) : (
-            <form onSubmit={handleSubmit}>
+            <>
               <h2 className="text-lg font-semibold mb-1">Sign in</h2>
               <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                We&apos;ll email you a one-tap sign-in link. No password
-                needed.
+                Pick a sign-in method. Your existing polls and groups stay
+                tied to this browser regardless.
               </p>
-              <input
-                ref={inputRef}
-                type="email"
-                inputMode="email"
-                autoComplete="email"
-                placeholder="you@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                onBlur={(e) => setEmail(e.target.value.trim())}
-                disabled={submitting}
-                maxLength={254}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white mb-3"
-              />
-              {error && (
-                <p className="text-sm text-red-600 dark:text-red-400 mb-3">
-                  {error}
-                </p>
-              )}
-              <button
-                type="submit"
-                disabled={submitting || !email.trim()}
-                className="w-full rounded-full bg-blue-600 hover:bg-blue-700 text-white h-11 font-medium disabled:opacity-50"
-              >
-                {submitting ? "Sending…" : "Send sign-in link"}
-              </button>
-            </form>
+
+              {/* OAuth buttons — only render when both the client bundle
+                  and the server tier have the provider configured. */}
+              {isWebOAuthAvailable() &&
+                serverProviders?.google &&
+                googleConfigured() && (
+                  <div className="mb-3">
+                    <div
+                      ref={googleButtonRef}
+                      className="flex justify-center min-h-[44px]"
+                      aria-label="Sign in with Google"
+                    />
+                  </div>
+                )}
+              {isWebOAuthAvailable() &&
+                serverProviders?.apple &&
+                appleConfigured() && (
+                  <button
+                    type="button"
+                    onClick={handleAppleSignIn}
+                    disabled={oauthSubmitting !== null}
+                    className="w-full mb-3 flex items-center justify-center gap-2 rounded-md h-11 font-medium bg-black text-white dark:bg-white dark:text-black disabled:opacity-50"
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      aria-hidden
+                    >
+                      <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+                    </svg>
+                    {oauthSubmitting === "apple"
+                      ? "Signing in…"
+                      : "Sign in with Apple"}
+                  </button>
+                )}
+
+              {/* "or" divider between OAuth and magic link, only when at
+                  least one OAuth button is visible. */}
+              {isWebOAuthAvailable() &&
+                ((serverProviders?.google && googleConfigured()) ||
+                  (serverProviders?.apple && appleConfigured())) && (
+                  <div className="flex items-center gap-3 my-4">
+                    <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      or
+                    </span>
+                    <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+                  </div>
+                )}
+
+              <form onSubmit={handleSubmit}>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Email me a sign-in link
+                </label>
+                <input
+                  ref={inputRef}
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  onBlur={(e) => setEmail(e.target.value.trim())}
+                  disabled={submitting || oauthSubmitting !== null}
+                  maxLength={254}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white mb-3"
+                />
+                {error && (
+                  <p className="text-sm text-red-600 dark:text-red-400 mb-3">
+                    {error}
+                  </p>
+                )}
+                <button
+                  type="submit"
+                  disabled={
+                    submitting || !email.trim() || oauthSubmitting !== null
+                  }
+                  className="w-full rounded-full bg-blue-600 hover:bg-blue-700 text-white h-11 font-medium disabled:opacity-50"
+                >
+                  {submitting ? "Sending…" : "Send sign-in link"}
+                </button>
+              </form>
+            </>
           )}
         </div>
       </div>

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -5,8 +5,8 @@ import ModalPortal from "./ModalPortal";
 import {
   apiGetAuthProviders,
   apiRequestMagicLink,
-  apiSignInWithApple,
-  apiSignInWithGoogle,
+  apiSignInWithOAuth,
+  type AuthProvidersResponse,
 } from "@/lib/api";
 import { ApiError } from "@/lib/api";
 import {
@@ -16,23 +16,11 @@ import {
   isWebOAuthAvailable,
   renderGoogleButton,
 } from "@/lib/oauth";
+import { resolveActiveTheme } from "@/lib/theme";
 
 interface SignInModalProps {
   isOpen: boolean;
   onClose: () => void;
-}
-
-function getThemePreference(): "light" | "dark" {
-  if (typeof document === "undefined") return "light";
-  // `data-theme` is stamped by the pre-hydration script in app/layout.tsx;
-  // if it's missing (system theme), fall back to media-query.
-  const explicit = document.documentElement.getAttribute("data-theme");
-  if (explicit === "dark") return "dark";
-  if (explicit === "light") return "light";
-  return window.matchMedia &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
 }
 
 /**
@@ -55,35 +43,37 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
   const [sent, setSent] = useState(false);
   const [emailConfigured, setEmailConfigured] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [serverProviders, setServerProviders] = useState<{
-    google: boolean;
-    apple: boolean;
-  } | null>(null);
+  const [serverProviders, setServerProviders] =
+    useState<AuthProvidersResponse | null>(null);
   const [oauthSubmitting, setOAuthSubmitting] = useState<
     "google" | "apple" | null
   >(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const googleButtonRef = useRef<HTMLDivElement>(null);
   const openedAtRef = useRef<number>(0);
+  // `onClose` may be a fresh closure on every parent render — read it
+  // through a ref so the Google-button effect doesn't tear down + re-
+  // initialize the GIS SDK every time the parent re-renders for an
+  // unrelated reason.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   // Resolve server-side provider capability once per modal open. The
-  // returned values are cached by the fetch layer's normal HTTP cache
-  // headers; we don't memoize at the module level because the API tier
-  // can change between page loads (PWA switching networks, dev tier
-  // gaining a new env var).
+  // fetch is module-memoized in `apiGetAuthProviders` so repeat opens
+  // only hit the network on the very first open per page lifetime.
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
     apiGetAuthProviders()
       .then((p) => {
-        if (!cancelled) {
-          setServerProviders({ google: p.google, apple: p.apple });
-        }
+        if (!cancelled) setServerProviders(p);
       })
       .catch(() => {
         // Network failure → assume neither OAuth provider is available
         // on this tier, but keep the magic-link path visible.
-        if (!cancelled) setServerProviders({ google: false, apple: false });
+        if (!cancelled) {
+          setServerProviders({ email: true, google: false, apple: false });
+        }
       });
     return () => {
       cancelled = true;
@@ -93,8 +83,7 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
   // Google's SDK renders its own branded button into a container we
   // supply. Initialize it whenever the container mounts AND the server
   // confirms Google is configured. The Promise resolves with the
-  // id_token on first successful sign-in; subsequent renders are no-ops
-  // (the SDK is initialized once).
+  // id_token on first successful sign-in.
   useEffect(() => {
     if (!isOpen || sent) return;
     if (!isWebOAuthAvailable()) return;
@@ -102,15 +91,15 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
     const el = googleButtonRef.current;
     if (!el) return;
     let cancelled = false;
-    el.innerHTML = ""; // clean up any prior render before re-renders.
-    renderGoogleButton(el, getThemePreference())
+    el.innerHTML = "";
+    renderGoogleButton(el, resolveActiveTheme())
       .then(async (idToken) => {
         if (cancelled) return;
         setOAuthSubmitting("google");
         setError(null);
         try {
-          await apiSignInWithGoogle(idToken);
-          onClose();
+          await apiSignInWithOAuth("google", idToken);
+          onCloseRef.current();
         } catch (err) {
           setError(
             err instanceof ApiError && err.status === 400
@@ -123,6 +112,9 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
       })
       .catch((err) => {
         if (cancelled) return;
+        // "Sign-in superseded" is raised when a re-render replaces the
+        // pending resolver — not user-visible; ignore silently.
+        if (err instanceof Error && err.message === "Sign-in superseded") return;
         setError(
           err instanceof Error ? err.message : "Google sign-in failed to load."
         );
@@ -130,23 +122,23 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
     return () => {
       cancelled = true;
     };
-  }, [isOpen, sent, serverProviders?.google, onClose]);
+  }, [isOpen, sent, serverProviders?.google]);
 
   const handleAppleSignIn = async () => {
     setError(null);
     setOAuthSubmitting("apple");
     try {
       const idToken = await appleSignIn();
-      await apiSignInWithApple(idToken);
+      await apiSignInWithOAuth("apple", idToken);
       onClose();
     } catch (err) {
-      // Apple's SDK throws with `error: 'popup_closed_by_user'` shape on
-      // cancel — treat as silent dismissal.
+      // Apple rejects on user-cancel with various error shapes across
+      // SDK versions — match defensively. Silent on cancel.
       const message = err instanceof Error ? err.message : String(err);
+      const rawError = (err as { error?: string })?.error;
       if (
         /popup_closed_by_user|user_cancelled|cancelled/i.test(message) ||
-        // SDK rejection on cancel sometimes has shape `{ error: 'popup_closed_by_user' }`.
-        (err as { error?: string })?.error?.includes?.("cancel")
+        (typeof rawError === "string" && rawError.includes("cancel"))
       ) {
         setError(null);
       } else {
@@ -229,6 +221,13 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
     onClose();
   };
 
+  const webOAuth = isWebOAuthAvailable();
+  const showGoogle =
+    webOAuth && !!serverProviders?.google && googleConfigured();
+  const showApple =
+    webOAuth && !!serverProviders?.apple && appleConfigured();
+  const showAnyOAuth = showGoogle || showApple;
+
   return (
     <ModalPortal>
       <div className="fixed inset-0 z-[80] flex items-center justify-center p-4">
@@ -291,55 +290,44 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
                 tied to this browser regardless.
               </p>
 
-              {/* OAuth buttons — only render when both the client bundle
-                  and the server tier have the provider configured. */}
-              {isWebOAuthAvailable() &&
-                serverProviders?.google &&
-                googleConfigured() && (
-                  <div className="mb-3">
-                    <div
-                      ref={googleButtonRef}
-                      className="flex justify-center min-h-[44px]"
-                      aria-label="Sign in with Google"
-                    />
-                  </div>
-                )}
-              {isWebOAuthAvailable() &&
-                serverProviders?.apple &&
-                appleConfigured() && (
-                  <button
-                    type="button"
-                    onClick={handleAppleSignIn}
-                    disabled={oauthSubmitting !== null}
-                    className="w-full mb-3 flex items-center justify-center gap-2 rounded-md h-11 font-medium bg-black text-white dark:bg-white dark:text-black disabled:opacity-50"
+              {showGoogle && (
+                <div className="mb-3">
+                  <div
+                    ref={googleButtonRef}
+                    className="flex justify-center min-h-[44px]"
+                    aria-label="Sign in with Google"
+                  />
+                </div>
+              )}
+              {showApple && (
+                <button
+                  type="button"
+                  onClick={handleAppleSignIn}
+                  disabled={oauthSubmitting !== null}
+                  className="w-full mb-3 flex items-center justify-center gap-2 rounded-md h-11 font-medium bg-black text-white dark:bg-white dark:text-black disabled:opacity-50"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden
                   >
-                    <svg
-                      className="w-4 h-4"
-                      viewBox="0 0 24 24"
-                      fill="currentColor"
-                      aria-hidden
-                    >
-                      <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
-                    </svg>
-                    {oauthSubmitting === "apple"
-                      ? "Signing in…"
-                      : "Sign in with Apple"}
-                  </button>
-                )}
-
-              {/* "or" divider between OAuth and magic link, only when at
-                  least one OAuth button is visible. */}
-              {isWebOAuthAvailable() &&
-                ((serverProviders?.google && googleConfigured()) ||
-                  (serverProviders?.apple && appleConfigured())) && (
-                  <div className="flex items-center gap-3 my-4">
-                    <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      or
-                    </span>
-                    <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
-                  </div>
-                )}
+                    <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+                  </svg>
+                  {oauthSubmitting === "apple"
+                    ? "Signing in…"
+                    : "Sign in with Apple"}
+                </button>
+              )}
+              {showAnyOAuth && (
+                <div className="flex items-center gap-3 my-4">
+                  <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    or
+                  </span>
+                  <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+                </div>
+              )}
 
               <form onSubmit={handleSubmit}>
                 <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -29,6 +29,12 @@ export interface SessionResponse {
   user: SessionUser;
 }
 
+export interface AuthProvidersResponse {
+  email: boolean;
+  google: boolean;
+  apple: boolean;
+}
+
 export async function apiRequestMagicLink(
   email: string,
 ): Promise<MagicLinkRequestResponse> {
@@ -83,4 +89,47 @@ export async function apiSignOut(): Promise<void> {
  *  `apiGetMe()` to refresh from the server. */
 export function getCurrentUser(): SessionUser | null {
   return getCachedSessionUser();
+}
+
+// ---------------------------------------------------------------------------
+// Phase C: Apple + Google OAuth sign-in
+// ---------------------------------------------------------------------------
+
+/** Verify a Google OIDC ID token (obtained client-side via the Google
+ *  Identity Services SDK) against the server. On success, the server
+ *  resolves the user via the (provider, sub) lookup or merges by
+ *  verified email, issues a session, and we persist it locally. */
+export async function apiSignInWithGoogle(
+  idToken: string,
+): Promise<SessionResponse> {
+  const res = await authFetch<SessionResponse>("/oauth/google", {
+    method: "POST",
+    body: JSON.stringify({ id_token: idToken }),
+  });
+  saveSession(res.session_token, res.user);
+  return res;
+}
+
+/** Same shape as `apiSignInWithGoogle` for Apple. The Apple flow only
+ *  carries the user's email on the first sign-in — repeat sign-ins
+ *  carry just `sub`, which the server matches against the existing
+ *  identity row. */
+export async function apiSignInWithApple(
+  idToken: string,
+): Promise<SessionResponse> {
+  const res = await authFetch<SessionResponse>("/oauth/apple", {
+    method: "POST",
+    body: JSON.stringify({ id_token: idToken }),
+  });
+  saveSession(res.session_token, res.user);
+  return res;
+}
+
+/** Capability discovery — which sign-in methods this API tier has
+ *  configured. Used by the SignInModal to hide OAuth buttons when the
+ *  server isn't wired up to verify them. Independent of client-side
+ *  configuration (NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID etc.); both must
+ *  be true for the button to function end-to-end. */
+export async function apiGetAuthProviders(): Promise<AuthProvidersResponse> {
+  return authFetch<AuthProvidersResponse>("/providers");
 }

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -91,18 +91,20 @@ export function getCurrentUser(): SessionUser | null {
   return getCachedSessionUser();
 }
 
-// ---------------------------------------------------------------------------
 // Phase C: Apple + Google OAuth sign-in
-// ---------------------------------------------------------------------------
 
-/** Verify a Google OIDC ID token (obtained client-side via the Google
- *  Identity Services SDK) against the server. On success, the server
- *  resolves the user via the (provider, sub) lookup or merges by
- *  verified email, issues a session, and we persist it locally. */
-export async function apiSignInWithGoogle(
+export type OAuthProvider = "google" | "apple";
+
+/** Verify an OAuth ID token (Google or Apple) against the server.
+ *  On success, the server resolves the user via the (provider, sub)
+ *  lookup or merges by verified email, issues a session, and we
+ *  persist it locally so `fetchWithBase` attaches the bearer token to
+ *  subsequent requests. */
+export async function apiSignInWithOAuth(
+  provider: OAuthProvider,
   idToken: string,
 ): Promise<SessionResponse> {
-  const res = await authFetch<SessionResponse>("/oauth/google", {
+  const res = await authFetch<SessionResponse>(`/oauth/${provider}`, {
     method: "POST",
     body: JSON.stringify({ id_token: idToken }),
   });
@@ -110,20 +112,10 @@ export async function apiSignInWithGoogle(
   return res;
 }
 
-/** Same shape as `apiSignInWithGoogle` for Apple. The Apple flow only
- *  carries the user's email on the first sign-in — repeat sign-ins
- *  carry just `sub`, which the server matches against the existing
- *  identity row. */
-export async function apiSignInWithApple(
-  idToken: string,
-): Promise<SessionResponse> {
-  const res = await authFetch<SessionResponse>("/oauth/apple", {
-    method: "POST",
-    body: JSON.stringify({ id_token: idToken }),
-  });
-  saveSession(res.session_token, res.user);
-  return res;
-}
+// Module-memoized providers lookup: the server's response is driven by
+// env vars and is stable for the page lifetime, so one fetch per page
+// load is enough. Concurrent callers share the in-flight promise.
+let providersPromise: Promise<AuthProvidersResponse> | null = null;
 
 /** Capability discovery — which sign-in methods this API tier has
  *  configured. Used by the SignInModal to hide OAuth buttons when the
@@ -131,5 +123,12 @@ export async function apiSignInWithApple(
  *  configuration (NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID etc.); both must
  *  be true for the button to function end-to-end. */
 export async function apiGetAuthProviders(): Promise<AuthProvidersResponse> {
-  return authFetch<AuthProvidersResponse>("/providers");
+  if (!providersPromise) {
+    providersPromise = authFetch<AuthProvidersResponse>("/providers").catch((err) => {
+      // Drop the cached failure so the next call can retry.
+      providersPromise = null;
+      throw err;
+    });
+  }
+  return providersPromise;
 }

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -75,8 +75,7 @@ export {
   apiVerifyMagicLink,
   apiGetMe,
   apiSignOut,
-  apiSignInWithGoogle,
-  apiSignInWithApple,
+  apiSignInWithOAuth,
   apiGetAuthProviders,
   getCurrentUser,
 } from "./auth";
@@ -84,4 +83,5 @@ export type {
   MagicLinkRequestResponse,
   SessionResponse,
   AuthProvidersResponse,
+  OAuthProvider,
 } from "./auth";

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -75,6 +75,13 @@ export {
   apiVerifyMagicLink,
   apiGetMe,
   apiSignOut,
+  apiSignInWithGoogle,
+  apiSignInWithApple,
+  apiGetAuthProviders,
   getCurrentUser,
 } from "./auth";
-export type { MagicLinkRequestResponse, SessionResponse } from "./auth";
+export type {
+  MagicLinkRequestResponse,
+  SessionResponse,
+  AuthProvidersResponse,
+} from "./auth";

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,0 +1,293 @@
+/**
+ * Phase C: web OAuth helpers for Apple + Google Sign In.
+ *
+ * Both providers ship browser SDKs that we lazy-load only when the
+ * sign-in modal opens — avoids paying the script-fetch cost on every
+ * page load. The flow on each side:
+ *   - User taps the provider's button in the modal.
+ *   - We load the provider's SDK script (idempotent — only fetches once
+ *     per page load).
+ *   - We trigger the provider's sign-in UI (popup or One Tap-style
+ *     overlay).
+ *   - The user grants consent; the provider hands us back an ID token.
+ *   - We POST the ID token to our server's verify endpoint (in
+ *     `lib/api/auth.ts`); the server validates the signature + claims
+ *     against the provider's JWKS and issues a session.
+ *
+ * Native Capacitor flows are intentionally out of scope for this phase
+ * — the iOS bundle hides the buttons via the `isNativePlatform` short-
+ * circuit and a follow-up PR will add `@capacitor-community/apple-sign-in`
+ * + `@codetrix-studio/capacitor-google-auth` for the native experience.
+ */
+
+import { Capacitor } from "@capacitor/core";
+
+const GOOGLE_GSI_SRC = "https://accounts.google.com/gsi/client";
+const APPLE_JS_SRC =
+  "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
+
+const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID || "";
+const APPLE_CLIENT_ID = process.env.NEXT_PUBLIC_APPLE_OAUTH_SERVICE_ID || "";
+
+// Module-level in-flight script loader promises so concurrent opens of
+// the sign-in modal (e.g. StrictMode double-mount in dev) don't fetch
+// the script twice. Lifetime is the page lifetime — the SDK is global.
+let googleScriptPromise: Promise<void> | null = null;
+let appleScriptPromise: Promise<void> | null = null;
+
+function loadScript(src: string, existingPromise: Promise<void> | null): Promise<void> {
+  if (existingPromise) return existingPromise;
+  return new Promise<void>((resolve, reject) => {
+    if (typeof document === "undefined") {
+      reject(new Error("Document is not available"));
+      return;
+    }
+    // The provider's SDK may already be on the page (e.g. from a
+    // previous mount). Reuse it.
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${src}"]`
+    );
+    if (existing) {
+      if (existing.dataset.loaded === "true") {
+        resolve();
+      } else {
+        existing.addEventListener("load", () => resolve(), { once: true });
+        existing.addEventListener(
+          "error",
+          () => reject(new Error(`Failed to load ${src}`)),
+          { once: true }
+        );
+      }
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener(
+      "load",
+      () => {
+        script.dataset.loaded = "true";
+        resolve();
+      },
+      { once: true }
+    );
+    script.addEventListener(
+      "error",
+      () => reject(new Error(`Failed to load ${src}`)),
+      { once: true }
+    );
+    document.head.appendChild(script);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Capability flags (read by the SignInModal to decide which buttons to show)
+// ---------------------------------------------------------------------------
+
+/** Whether Google Sign In is wired up on this client bundle. Independent
+ *  of the server-side `providers` endpoint — both must agree before the
+ *  button is functional. */
+export function googleConfigured(): boolean {
+  return !!GOOGLE_CLIENT_ID;
+}
+
+/** Same shape as `googleConfigured()` for Apple. */
+export function appleConfigured(): boolean {
+  return !!APPLE_CLIENT_ID;
+}
+
+/** Hide every OAuth button when running inside the Capacitor iOS
+ *  WebView — the native bundle will get plugin-driven flows in a follow-
+ *  up phase, and the web SDKs don't render correctly inside WKWebView
+ *  anyway (Google explicitly blocks `accounts.google.com/gsi` in
+ *  embedded WebViews per their disallowed-user-agents policy). */
+export function isWebOAuthAvailable(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (Capacitor.isNativePlatform()) return false;
+  } catch {
+    // Capacitor isn't available — that's the browser/PWA case, which
+    // is exactly when web OAuth IS available.
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Google
+// ---------------------------------------------------------------------------
+
+type GoogleCredentialResponse = { credential: string };
+
+interface GoogleAccountsIdentity {
+  initialize(config: {
+    client_id: string;
+    callback: (response: GoogleCredentialResponse) => void;
+    ux_mode?: "popup" | "redirect";
+    auto_select?: boolean;
+    cancel_on_tap_outside?: boolean;
+  }): void;
+  prompt(callback?: (notification: { isNotDisplayed?: () => boolean; isSkippedMoment?: () => boolean }) => void): void;
+  renderButton(
+    parent: HTMLElement,
+    options: {
+      type?: "standard" | "icon";
+      theme?: "outline" | "filled_blue" | "filled_black";
+      size?: "large" | "medium" | "small";
+      width?: number;
+      text?: "signin_with" | "signup_with" | "continue_with" | "signin";
+      shape?: "rectangular" | "pill" | "circle" | "square";
+      logo_alignment?: "left" | "center";
+    }
+  ): void;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: GoogleAccountsIdentity;
+      };
+    };
+    AppleID?: {
+      auth: {
+        init(config: {
+          clientId: string;
+          scope: string;
+          redirectURI: string;
+          state?: string;
+          usePopup?: boolean;
+        }): void;
+        signIn(): Promise<{
+          authorization: { id_token: string; code: string; state?: string };
+          user?: { name?: { firstName?: string; lastName?: string }; email?: string };
+        }>;
+      };
+    };
+  }
+}
+
+async function ensureGoogleSdk(): Promise<GoogleAccountsIdentity> {
+  if (!googleConfigured()) {
+    throw new Error("Google sign-in isn't configured on this client.");
+  }
+  googleScriptPromise = loadScript(GOOGLE_GSI_SRC, googleScriptPromise);
+  await googleScriptPromise;
+  if (!window.google?.accounts?.id) {
+    throw new Error("Google sign-in failed to initialize.");
+  }
+  return window.google.accounts.id;
+}
+
+/** Render the Google "Sign in with Google" button into a container.
+ *
+ *  The button itself is rendered by Google's SDK — required by their
+ *  branding guidelines for the official credential flow. We can't
+ *  substitute our own button without falling back to One Tap (which
+ *  is unreliable across browsers). Caller supplies the host element;
+ *  we initialize the SDK with our client_id and a callback that
+ *  resolves a Promise with the credential id_token.
+ *
+ *  Returns a Promise<string> that resolves with the id_token, or
+ *  rejects if the SDK fails to load. The Promise stays pending until
+ *  the user actually completes the flow (or never resolves if they
+ *  close the popup — caller times out or unmounts).
+ */
+export async function renderGoogleButton(
+  container: HTMLElement,
+  theme: "light" | "dark"
+): Promise<string> {
+  const sdk = await ensureGoogleSdk();
+  return new Promise<string>((resolve, reject) => {
+    let settled = false;
+    try {
+      sdk.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        ux_mode: "popup",
+        cancel_on_tap_outside: true,
+        callback: (response) => {
+          if (settled) return;
+          settled = true;
+          if (response?.credential) {
+            resolve(response.credential);
+          } else {
+            reject(new Error("Google didn't return a credential."));
+          }
+        },
+      });
+      sdk.renderButton(container, {
+        type: "standard",
+        theme: theme === "dark" ? "filled_black" : "outline",
+        size: "large",
+        text: "signin_with",
+        shape: "rectangular",
+        logo_alignment: "left",
+        // width: 280, // intentionally omitted; lets the button stretch.
+      });
+    } catch (err) {
+      if (!settled) {
+        settled = true;
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Apple
+// ---------------------------------------------------------------------------
+
+async function ensureAppleSdk() {
+  if (!appleConfigured()) {
+    throw new Error("Apple sign-in isn't configured on this client.");
+  }
+  appleScriptPromise = loadScript(APPLE_JS_SRC, appleScriptPromise);
+  await appleScriptPromise;
+  if (!window.AppleID?.auth) {
+    throw new Error("Apple sign-in failed to initialize.");
+  }
+  return window.AppleID.auth;
+}
+
+let appleInitialized = false;
+
+/** Trigger Apple's popup-based sign-in flow. Returns the id_token on
+ *  success, rejects on cancel or any other failure.
+ *
+ *  Apple requires:
+ *    - A Service ID (clientId here) registered in the Apple Developer
+ *      portal.
+ *    - The current origin's domain registered as a "Domain" on the
+ *      Service ID.
+ *    - A "Return URL" (redirectURI) also registered on the Service ID.
+ *      For `usePopup: true` the user is sent to this URL inside a popup
+ *      that posts the result back via postMessage — the URL just needs
+ *      to be reachable; we use the current origin's root.
+ *
+ *  `scope: 'email'` is the minimum we need to merge accounts on shared
+ *  email; `name` would also be sent but we don't surface display names
+ *  yet (Phase I).
+ */
+export async function appleSignIn(): Promise<string> {
+  const sdk = await ensureAppleSdk();
+  if (!appleInitialized) {
+    sdk.init({
+      clientId: APPLE_CLIENT_ID,
+      scope: "email",
+      // Apple requires the redirect URI to be HTTPS — the popup flow
+      // doesn't actually navigate the user there, but the SDK still
+      // validates the value.
+      redirectURI:
+        process.env.NEXT_PUBLIC_APPLE_OAUTH_REDIRECT_URI ||
+        (typeof window !== "undefined" ? window.location.origin : ""),
+      usePopup: true,
+    });
+    appleInitialized = true;
+  }
+  const result = await sdk.signIn();
+  const token = result?.authorization?.id_token;
+  if (!token) {
+    throw new Error("Apple didn't return an ID token.");
+  }
+  return token;
+}

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -179,6 +179,15 @@ async function ensureGoogleSdk(): Promise<GoogleAccountsIdentity> {
   return window.google.accounts.id;
 }
 
+// `sdk.initialize` overwrites Google's singleton callback every call,
+// so re-initializing per modal-open swaps the credential delivery to
+// the new Promise's resolver. Mirror Apple's one-shot init by routing
+// every callback through a mutable resolver that's reassigned before
+// each renderButton, with init itself called exactly once per page.
+let googleInitialized = false;
+let googleResolveRef: ((token: string) => void) | null = null;
+let googleRejectRef: ((err: Error) => void) | null = null;
+
 /** Render the Google "Sign in with Google" button into a container.
  *
  *  The button itself is rendered by Google's SDK — required by their
@@ -198,23 +207,32 @@ export async function renderGoogleButton(
   theme: "light" | "dark"
 ): Promise<string> {
   const sdk = await ensureGoogleSdk();
+  // Reject any previous still-pending promise so the new caller's
+  // resolver is the only one Google's callback delivers to.
+  googleRejectRef?.(new Error("Sign-in superseded"));
   return new Promise<string>((resolve, reject) => {
-    let settled = false;
+    googleResolveRef = resolve;
+    googleRejectRef = reject;
     try {
-      sdk.initialize({
-        client_id: GOOGLE_CLIENT_ID,
-        ux_mode: "popup",
-        cancel_on_tap_outside: true,
-        callback: (response) => {
-          if (settled) return;
-          settled = true;
-          if (response?.credential) {
-            resolve(response.credential);
-          } else {
-            reject(new Error("Google didn't return a credential."));
-          }
-        },
-      });
+      if (!googleInitialized) {
+        sdk.initialize({
+          client_id: GOOGLE_CLIENT_ID,
+          ux_mode: "popup",
+          cancel_on_tap_outside: true,
+          callback: (response) => {
+            const r = googleResolveRef;
+            const rej = googleRejectRef;
+            googleResolveRef = null;
+            googleRejectRef = null;
+            if (response?.credential) {
+              r?.(response.credential);
+            } else {
+              rej?.(new Error("Google didn't return a credential."));
+            }
+          },
+        });
+        googleInitialized = true;
+      }
       sdk.renderButton(container, {
         type: "standard",
         theme: theme === "dark" ? "filled_black" : "outline",
@@ -222,13 +240,11 @@ export async function renderGoogleButton(
         text: "signin_with",
         shape: "rectangular",
         logo_alignment: "left",
-        // width: 280, // intentionally omitted; lets the button stretch.
       });
     } catch (err) {
-      if (!settled) {
-        settled = true;
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
+      googleResolveRef = null;
+      googleRejectRef = null;
+      reject(err instanceof Error ? err : new Error(String(err)));
     }
   });
 }

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -30,3 +30,21 @@ export function applyTheme(theme: ThemePreference) {
     root.setAttribute("data-theme", theme);
   }
 }
+
+/** Resolve the user's currently-active theme to a concrete light/dark
+ *  value, accounting for explicit override (`data-theme` set by the
+ *  pre-hydration script in app/layout.tsx) and system preference
+ *  fallback. Used by themed third-party widgets (e.g. Google's Sign-In
+ *  button) that need an actual light/dark — not the user's stored
+ *  preference of "system". SSR-safe (returns "light" with no DOM). */
+export function resolveActiveTheme(): "light" | "dark" {
+  if (typeof document === "undefined") return "light";
+  const explicit = document.documentElement.getAttribute("data-theme");
+  if (explicit === "dark") return "dark";
+  if (explicit === "light") return "light";
+  return typeof window !== "undefined" &&
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -37,15 +37,14 @@ from middleware import (
     user_id_from_request as _user_id,
 )
 from services.auth import (
+    CompletedSignIn,
+    complete_sign_in,
     consume_magic_link,
     email_throttled,
     is_valid_email,
     issue_magic_link,
-    issue_session,
-    link_browser_to_user,
     load_user_profile,
     normalize_email,
-    resolve_or_merge_user,
     revoke_session,
     unlink_browser,
 )
@@ -210,6 +209,22 @@ def request_magic_link(req: MagicLinkRequestBody, request: Request):
     )
 
 
+def _signin_response(completed: CompletedSignIn) -> SessionResponse:
+    """Wrap `services.auth.CompletedSignIn` in the FE-facing response
+    shape. Every sign-in route — magic-link verify, OAuth providers,
+    eventual passkey — funnels through here so they don't drift."""
+    return SessionResponse(
+        session_token=completed.session.token,
+        expires_at=completed.session.expires_at,
+        user=UserSummary(
+            user_id=completed.profile.user_id,
+            email=completed.profile.email,
+            providers=completed.profile.providers,
+            created_at=completed.profile.created_at,
+        ),
+    )
+
+
 @router.post(
     "/magic-link/verify",
     response_model=SessionResponse,
@@ -221,9 +236,6 @@ def verify_magic_link(req: MagicLinkVerifyBody, request: Request):
     in by clicking the email on a different device than the one that
     requested the link links the CLICKING device, which matches user
     intent."""
-    browser_id = _browser_id(request)
-    user_agent = request.headers.get("user-agent")
-
     with get_db() as conn:
         consumed = consume_magic_link(conn, req.token)
         if not consumed:
@@ -231,35 +243,15 @@ def verify_magic_link(req: MagicLinkVerifyBody, request: Request):
                 status_code=400,
                 detail="Invalid or expired sign-in link",
             )
-
-        resolved = resolve_or_merge_user(
+        completed = complete_sign_in(
             conn,
             provider="email",
             provider_user_id=consumed.email,
             email=consumed.email,
+            browser_id=_browser_id(request),
+            user_agent=request.headers.get("user-agent"),
         )
-        link_browser_to_user(
-            conn, user_id=resolved.user_id, browser_id=browser_id
-        )
-        session = issue_session(
-            conn,
-            user_id=resolved.user_id,
-            browser_id=browser_id,
-            user_agent=user_agent,
-        )
-        profile = load_user_profile(conn, resolved.user_id)
-
-    assert profile is not None, "profile must exist immediately after issue"
-    return SessionResponse(
-        session_token=session.token,
-        expires_at=session.expires_at,
-        user=UserSummary(
-            user_id=profile.user_id,
-            email=profile.email,
-            providers=profile.providers,
-            created_at=profile.created_at,
-        ),
-    )
+    return _signin_response(completed)
 
 
 # ---------------------------------------------------------------------------
@@ -283,45 +275,37 @@ def verify_magic_link(req: MagicLinkVerifyBody, request: Request):
 # would be a 10-line addition here.
 
 
-def _sign_in_via_oauth(
-    request: Request,
+def _handle_oauth_signin(
     *,
-    provider: str,
-    provider_user_id: str,
-    email: str | None,
+    request: Request,
+    id_token: str,
+    provider_label: str,
+    configured: bool,
+    verify: callable,
 ) -> SessionResponse:
-    """Shared post-verify path: merge / mint user, link browser, issue
-    session, return profile. Identical for every OAuth provider."""
-    browser_id = _browser_id(request)
-    user_agent = request.headers.get("user-agent")
+    """Provider-agnostic OAuth handler. The verify endpoint passes its
+    provider-specific `configured()` flag + `verify(id_token)` function;
+    we handle the 503 / 400 / session-issuance rhythm uniformly. Adding
+    a third OIDC provider is one route handler + one row of imports."""
+    if not configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"{provider_label} sign-in isn't available on this server",
+        )
+    try:
+        identity = verify(id_token)
+    except OAuthVerificationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     with get_db() as conn:
-        resolved = resolve_or_merge_user(
+        completed = complete_sign_in(
             conn,
-            provider=provider,
-            provider_user_id=provider_user_id,
-            email=email,
+            provider=identity.provider,
+            provider_user_id=identity.provider_user_id,
+            email=identity.email,
+            browser_id=_browser_id(request),
+            user_agent=request.headers.get("user-agent"),
         )
-        link_browser_to_user(
-            conn, user_id=resolved.user_id, browser_id=browser_id
-        )
-        session = issue_session(
-            conn,
-            user_id=resolved.user_id,
-            browser_id=browser_id,
-            user_agent=user_agent,
-        )
-        profile = load_user_profile(conn, resolved.user_id)
-    assert profile is not None, "profile must exist immediately after issue"
-    return SessionResponse(
-        session_token=session.token,
-        expires_at=session.expires_at,
-        user=UserSummary(
-            user_id=profile.user_id,
-            email=profile.email,
-            providers=profile.providers,
-            created_at=profile.created_at,
-        ),
-    )
+    return _signin_response(completed)
 
 
 @router.post("/oauth/google", response_model=SessionResponse)
@@ -335,20 +319,12 @@ def sign_in_with_google(req: OAuthSignInBody, request: Request):
             (GOOGLE_OAUTH_CLIENT_IDS unset). FE should hide the button
             but a stale bundle that still tries it gets a clear 503.
     """
-    if not google_configured():
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Google sign-in isn't available on this server",
-        )
-    try:
-        identity = verify_google_id_token(req.id_token)
-    except OAuthVerificationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-    return _sign_in_via_oauth(
-        request,
-        provider=identity.provider,
-        provider_user_id=identity.provider_user_id,
-        email=identity.email,
+    return _handle_oauth_signin(
+        request=request,
+        id_token=req.id_token,
+        provider_label="Google",
+        configured=google_configured(),
+        verify=verify_google_id_token,
     )
 
 
@@ -366,20 +342,12 @@ def sign_in_with_apple(req: OAuthSignInBody, request: Request):
       - Token is ES256-signed (not RS256). The verifier pins the
         algorithm to keep a hostile token from switching families.
     """
-    if not apple_configured():
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Apple sign-in isn't available on this server",
-        )
-    try:
-        identity = verify_apple_id_token(req.id_token)
-    except OAuthVerificationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-    return _sign_in_via_oauth(
-        request,
-        provider=identity.provider,
-        provider_user_id=identity.provider_user_id,
-        email=identity.email,
+    return _handle_oauth_signin(
+        request=request,
+        id_token=req.id_token,
+        provider_label="Apple",
+        configured=apple_configured(),
+        verify=verify_apple_id_token,
     )
 
 

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -1,13 +1,18 @@
-"""Auth endpoints — Phase A (foundation) + Phase B (magic link).
+"""Auth endpoints — Phase A (foundation) + Phase B (magic link)
++ Phase C (Apple / Google OAuth).
 
 `POST /api/auth/magic-link/request`  start magic-link sign-in
 `POST /api/auth/magic-link/verify`   consume token, issue session
+`POST /api/auth/oauth/google`        verify Google ID token, issue session
+`POST /api/auth/oauth/apple`         verify Apple ID token, issue session
+`GET  /api/auth/providers`           list which sign-in methods are wired up
 `GET  /api/auth/me`                   resolve current session → user profile
 `POST /api/auth/sign-out`             revoke current session, unlink browser
 
-Phases C (Apple/Google OAuth) and D (Passkey) will add sibling routes
-that share `services/auth.py`'s `resolve_or_merge_user` +
-`issue_session` + `link_browser_to_user` helpers.
+Phase D (Passkey) will add a sibling route that shares
+`services/auth.py`'s `resolve_or_merge_user` + `issue_session` +
+`link_browser_to_user` helpers — the OAuth routes already follow that
+pattern.
 
 Identity resolution for the current request is done by
 `IdentityMiddleware` in `server/middleware.py` (sets
@@ -45,6 +50,13 @@ from services.auth import (
     unlink_browser,
 )
 from services.email import email_configured, send_magic_link
+from services.oauth import (
+    OAuthVerificationError,
+    apple_configured,
+    google_configured,
+    verify_apple_id_token,
+    verify_google_id_token,
+)
 
 log = logging.getLogger("auth")
 
@@ -85,6 +97,32 @@ class SessionResponse(BaseModel):
     session_token: str
     expires_at: datetime
     user: UserSummary
+
+
+class OAuthSignInBody(BaseModel):
+    """ID-token bearing payload from a successful OAuth flow on the FE.
+
+    Both Google and Apple use the same shape: a single `id_token` JWT
+    signed by the provider. The verifier in `services/oauth.py` checks
+    signature + issuer + audience + expiry against the provider's JWKS
+    and pulls `sub` (stable user id) + `email` (when present and
+    verified) from the claims. The FE never sends user-controlled
+    identity strings here — everything the server trusts comes from the
+    JWT itself.
+    """
+
+    id_token: str = Field(min_length=32, max_length=4096)
+
+
+class ProvidersResponse(BaseModel):
+    """Which sign-in providers this API tier has configured. The FE
+    hides OAuth buttons when the matching provider is unconfigured so
+    users don't tap an inert button. Email is always available (the
+    Resend fallback logs to stdout when RESEND_API_KEY is unset)."""
+
+    email: bool
+    google: bool
+    apple: bool
 
 
 # ---------------------------------------------------------------------------
@@ -221,6 +259,145 @@ def verify_magic_link(req: MagicLinkVerifyBody, request: Request):
             providers=profile.providers,
             created_at=profile.created_at,
         ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# OAuth (Apple + Google) — Phase C
+# ---------------------------------------------------------------------------
+#
+# Both endpoints share a flow:
+#   1. FE drives the provider's sign-in UI and obtains an ID token.
+#   2. FE POSTs the raw id_token here.
+#   3. `services/oauth.py` verifies the token against the provider's
+#      JWKS (signature + iss + aud + exp) and extracts the verified
+#      identity.
+#   4. `resolve_or_merge_user` keys the identity into our users table —
+#      either matching the existing (provider, sub) row OR merging by
+#      verified email across providers OR minting a new user.
+#   5. `link_browser_to_user` + `issue_session` issue the bearer token
+#      the FE stores for subsequent requests.
+#
+# The provider-specific logic lives in `services/oauth.py`; the router
+# is intentionally thin so adding a third OIDC provider (e.g. Microsoft)
+# would be a 10-line addition here.
+
+
+def _sign_in_via_oauth(
+    request: Request,
+    *,
+    provider: str,
+    provider_user_id: str,
+    email: str | None,
+) -> SessionResponse:
+    """Shared post-verify path: merge / mint user, link browser, issue
+    session, return profile. Identical for every OAuth provider."""
+    browser_id = _browser_id(request)
+    user_agent = request.headers.get("user-agent")
+    with get_db() as conn:
+        resolved = resolve_or_merge_user(
+            conn,
+            provider=provider,
+            provider_user_id=provider_user_id,
+            email=email,
+        )
+        link_browser_to_user(
+            conn, user_id=resolved.user_id, browser_id=browser_id
+        )
+        session = issue_session(
+            conn,
+            user_id=resolved.user_id,
+            browser_id=browser_id,
+            user_agent=user_agent,
+        )
+        profile = load_user_profile(conn, resolved.user_id)
+    assert profile is not None, "profile must exist immediately after issue"
+    return SessionResponse(
+        session_token=session.token,
+        expires_at=session.expires_at,
+        user=UserSummary(
+            user_id=profile.user_id,
+            email=profile.email,
+            providers=profile.providers,
+            created_at=profile.created_at,
+        ),
+    )
+
+
+@router.post("/oauth/google", response_model=SessionResponse)
+def sign_in_with_google(req: OAuthSignInBody, request: Request):
+    """Verify a Google OIDC ID token and issue a session.
+
+    Failure cases:
+      400 — token failed signature / issuer / audience / expiry checks,
+            or `sub` is missing. Message is user-safe.
+      503 — Google OAuth isn't configured on this API tier
+            (GOOGLE_OAUTH_CLIENT_IDS unset). FE should hide the button
+            but a stale bundle that still tries it gets a clear 503.
+    """
+    if not google_configured():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google sign-in isn't available on this server",
+        )
+    try:
+        identity = verify_google_id_token(req.id_token)
+    except OAuthVerificationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _sign_in_via_oauth(
+        request,
+        provider=identity.provider,
+        provider_user_id=identity.provider_user_id,
+        email=identity.email,
+    )
+
+
+@router.post("/oauth/apple", response_model=SessionResponse)
+def sign_in_with_apple(req: OAuthSignInBody, request: Request):
+    """Verify an Apple Sign In ID token and issue a session.
+
+    Apple's quirks vs Google:
+      - Email is sent on the FIRST sign-in only; subsequent sign-ins
+        carry just `sub`. We resolve via the (provider, sub) lookup
+        regardless of email presence, so repeat sign-ins still land on
+        the right user.
+      - "Hide my email" relays produce a stable per-(user, RP) proxy
+        address. Treated identically to a real email for merge purposes.
+      - Token is ES256-signed (not RS256). The verifier pins the
+        algorithm to keep a hostile token from switching families.
+    """
+    if not apple_configured():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Apple sign-in isn't available on this server",
+        )
+    try:
+        identity = verify_apple_id_token(req.id_token)
+    except OAuthVerificationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _sign_in_via_oauth(
+        request,
+        provider=identity.provider,
+        provider_user_id=identity.provider_user_id,
+        email=identity.email,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Providers (capability discovery)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/providers", response_model=ProvidersResponse)
+def get_providers():
+    """Report which sign-in methods this API tier supports. Read by the
+    FE on first paint of the sign-in modal so OAuth buttons can hide
+    when the provider isn't configured (avoids the user tapping an
+    inert button and seeing a 503)."""
+    return ProvidersResponse(
+        email=True,
+        google=google_configured(),
+        apple=apple_configured(),
     )
 
 

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -412,3 +412,55 @@ def load_user_profile(conn, user_id: str) -> UserProfile | None:
         providers=providers,
         created_at=user_row["created_at"],
     )
+
+
+# ---------------------------------------------------------------------------
+# Shared sign-in completion (magic-link + OAuth providers)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompletedSignIn:
+    """Result of `complete_sign_in`: a freshly-issued session + the user's
+    profile snapshot. Routers serialize this into their own response
+    models (SessionResponse / etc.) — keeping the data shape here lets
+    the magic-link and OAuth routes share one finalization rhythm."""
+
+    session: IssuedSession
+    profile: UserProfile
+
+
+def complete_sign_in(
+    conn,
+    *,
+    provider: str,
+    provider_user_id: str,
+    email: str | None,
+    browser_id: str | None,
+    user_agent: str | None,
+) -> CompletedSignIn:
+    """The four-step finalization shared by every sign-in provider:
+    `resolve_or_merge_user` → `link_browser_to_user` → `issue_session`
+    → `load_user_profile`. Magic-link verify, Google OAuth, and Apple
+    OAuth all hand off here; Phase D's passkey route will too.
+
+    `profile` is guaranteed non-None by construction — `resolve_or_merge_user`
+    inserted/found a row whose id we then pass to `load_user_profile` in
+    the same transaction.
+    """
+    resolved = resolve_or_merge_user(
+        conn,
+        provider=provider,
+        provider_user_id=provider_user_id,
+        email=email,
+    )
+    link_browser_to_user(conn, user_id=resolved.user_id, browser_id=browser_id)
+    session = issue_session(
+        conn,
+        user_id=resolved.user_id,
+        browser_id=browser_id,
+        user_agent=user_agent,
+    )
+    profile = load_user_profile(conn, resolved.user_id)
+    assert profile is not None, "profile must exist immediately after issue"
+    return CompletedSignIn(session=session, profile=profile)

--- a/server/services/oauth.py
+++ b/server/services/oauth.py
@@ -1,0 +1,227 @@
+"""OAuth ID-token verification for Phase C (Apple + Google sign-in).
+
+Apple and Google both issue OpenID Connect ID tokens — JWTs signed by the
+provider's private key, with claims that include a stable subject (`sub`),
+the user's email (when scope grants it), and a verified-email flag. The
+server verifies the signature against the provider's published JWKS (rotated
+public keys), validates the issuer / audience / expiry, and trusts the
+resulting claims as proof of identity.
+
+Both providers expose JWKS via standard endpoints; PyJWT's `PyJWKClient`
+caches the keys and handles rotation transparently. We pin the algorithms
+list to `RS256` (Google) / `ES256` (Apple) so a hostile token can't switch
+to a weaker family.
+
+`verify_google_id_token` and `verify_apple_id_token` are the public
+surface. Both return an `OAuthIdentity` describing the verified user, or
+raise `OAuthVerificationError` with a user-safe message on any failure.
+The verify endpoints in `routers/auth.py` convert that into a 400 with the
+message.
+
+Configuration via env vars on each API droplet:
+  GOOGLE_OAUTH_CLIENT_IDS  — comma-separated list of acceptable audiences
+                             (web client id + iOS client id, future
+                             Android client id, etc.). Tokens whose `aud`
+                             isn't in this list are rejected.
+  APPLE_OAUTH_AUDIENCES    — comma-separated list of acceptable audiences
+                             (web Service ID + iOS app bundle id).
+
+When the env var for a provider is unset, `<provider>_configured()`
+returns False and the verify endpoint 503s. This lets dev tiers run
+without OAuth configured and the FE flag the buttons as unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Iterable
+
+import jwt
+from jwt import InvalidTokenError, PyJWKClient
+
+log = logging.getLogger("oauth")
+
+
+# Audience configuration. Comma-separated so a single deployment can serve
+# multiple client IDs (web + iOS bundle). Stored as a tuple to keep ordering
+# stable across reads.
+def _split_audiences(value: str | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+_GOOGLE_AUDIENCES = _split_audiences(os.environ.get("GOOGLE_OAUTH_CLIENT_IDS"))
+_APPLE_AUDIENCES = _split_audiences(os.environ.get("APPLE_OAUTH_AUDIENCES"))
+
+# JWKS endpoints. These are well-known; PyJWKClient caches the fetched
+# keys (default TTL is generous) so we don't pay the network cost per
+# verify. Module-level instantiation is safe — the clients are
+# thread-safe.
+_GOOGLE_ISSUERS = ("https://accounts.google.com", "accounts.google.com")
+_GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+
+_APPLE_ISSUER = "https://appleid.apple.com"
+_APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+
+_google_jwks: PyJWKClient | None = None
+_apple_jwks: PyJWKClient | None = None
+
+
+def _google_jwks_client() -> PyJWKClient:
+    global _google_jwks
+    if _google_jwks is None:
+        _google_jwks = PyJWKClient(_GOOGLE_JWKS_URL, cache_keys=True)
+    return _google_jwks
+
+
+def _apple_jwks_client() -> PyJWKClient:
+    global _apple_jwks
+    if _apple_jwks is None:
+        _apple_jwks = PyJWKClient(_APPLE_JWKS_URL, cache_keys=True)
+    return _apple_jwks
+
+
+def google_configured() -> bool:
+    return bool(_GOOGLE_AUDIENCES)
+
+
+def apple_configured() -> bool:
+    return bool(_APPLE_AUDIENCES)
+
+
+class OAuthVerificationError(Exception):
+    """Raised when an ID token fails verification. Message is user-safe
+    (no raw provider error leaks)."""
+
+
+@dataclass(frozen=True)
+class OAuthIdentity:
+    provider: str  # 'google' | 'apple'
+    provider_user_id: str  # stable per-user 'sub' claim
+    email: str | None  # only set when present + verified
+    email_verified: bool
+
+
+def _verify(
+    *,
+    id_token: str,
+    jwks_client: PyJWKClient,
+    audiences: Iterable[str],
+    issuers: Iterable[str],
+    algorithms: Iterable[str],
+) -> dict:
+    """Common verify pipeline: signing key lookup + decode + claim
+    checks. Raises `OAuthVerificationError` with a user-safe message on
+    any failure (signature mismatch, expired, wrong issuer/audience,
+    malformed token). The provider-specific wrappers add the
+    `email_verified` rule on top."""
+    if not id_token or len(id_token) < 32:
+        raise OAuthVerificationError("Missing or malformed ID token")
+
+    audiences_tuple = tuple(audiences)
+    if not audiences_tuple:
+        raise OAuthVerificationError(
+            "OAuth provider not configured on this server"
+        )
+
+    try:
+        signing_key = jwks_client.get_signing_key_from_jwt(id_token).key
+    except Exception as exc:
+        log.warning("OAuth JWKS key lookup failed: %s", exc)
+        raise OAuthVerificationError("Could not verify sign-in token") from exc
+
+    try:
+        # `audience` accepts a list; `issuer` does not (PyJWT only
+        # checks against a single value). Check `iss` manually after
+        # decode if multiple issuers are valid.
+        claims = jwt.decode(
+            id_token,
+            signing_key,
+            algorithms=list(algorithms),
+            audience=list(audiences_tuple),
+            options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise OAuthVerificationError(
+            "Sign-in token has expired. Please try again."
+        ) from exc
+    except jwt.InvalidAudienceError as exc:
+        raise OAuthVerificationError(
+            "Sign-in token isn't for this application."
+        ) from exc
+    except InvalidTokenError as exc:
+        log.warning("OAuth token decode failed: %s", exc)
+        raise OAuthVerificationError("Invalid sign-in token") from exc
+
+    issuers_tuple = tuple(issuers)
+    if claims.get("iss") not in issuers_tuple:
+        raise OAuthVerificationError("Sign-in token has unexpected issuer.")
+
+    sub = claims.get("sub")
+    if not sub or not isinstance(sub, str):
+        raise OAuthVerificationError("Sign-in token is missing a subject id.")
+
+    return claims
+
+
+def verify_google_id_token(id_token: str) -> OAuthIdentity:
+    """Verify a Google OIDC ID token. Returns the identity.
+
+    Google sends `email_verified` as a boolean (sometimes as a string in
+    older flows — accept both). We only treat the email as the merge key
+    when it's verified; an unverified email can't be trusted to belong
+    to the sub.
+    """
+    claims = _verify(
+        id_token=id_token,
+        jwks_client=_google_jwks_client(),
+        audiences=_GOOGLE_AUDIENCES,
+        issuers=_GOOGLE_ISSUERS,
+        algorithms=("RS256",),
+    )
+    email = claims.get("email")
+    raw_verified = claims.get("email_verified")
+    # Google docs say this is a boolean; some flows return the string
+    # "true". Treat anything truthy except an explicit false-y value as
+    # verified.
+    email_verified = bool(raw_verified) and raw_verified not in (
+        "false",
+        "False",
+        False,
+    )
+    return OAuthIdentity(
+        provider="google",
+        provider_user_id=claims["sub"],
+        email=email if (email and email_verified) else None,
+        email_verified=email_verified,
+    )
+
+
+def verify_apple_id_token(id_token: str) -> OAuthIdentity:
+    """Verify an Apple Sign In ID token. Returns the identity.
+
+    Apple sends emails in the first sign-in only and may use the
+    "hide my email" proxy (`is_private_email: true`). Either form is
+    accepted as the merge key — the proxy address is stable per
+    (user, relying-party) and is the same email Apple uses for repeat
+    sign-ins. `email_verified` is sent as a string in Apple's tokens.
+    """
+    claims = _verify(
+        id_token=id_token,
+        jwks_client=_apple_jwks_client(),
+        audiences=_APPLE_AUDIENCES,
+        issuers=(_APPLE_ISSUER,),
+        algorithms=("ES256",),
+    )
+    email = claims.get("email")
+    raw_verified = claims.get("email_verified")
+    email_verified = raw_verified in (True, "true", "True")
+    return OAuthIdentity(
+        provider="apple",
+        provider_user_id=claims["sub"],
+        email=email if (email and email_verified) else None,
+        email_verified=email_verified,
+    )

--- a/server/tests/test_oauth.py
+++ b/server/tests/test_oauth.py
@@ -1,0 +1,502 @@
+"""Phase C: tests for the Apple / Google OAuth verify endpoints.
+
+Strategy: we can't call Google / Apple from CI, so the tests monkey-patch
+`services.oauth._google_jwks_client` / `_apple_jwks_client` to return a
+client whose JWKS contains a key pair we generate locally. Tests then
+issue tokens signed by our local private key — those pass signature
+verification, and we vary the claims (audience, issuer, expiry,
+email_verified) to drive every branch of the verifier.
+
+This keeps `services/oauth.py` faithfully exercised — the actual JWT
+decode + audience/issuer/expiry checks all run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+
+def _ensure_provider_config():
+    """Set env vars + reload the oauth module so module-level constants
+    pick them up. Tests rely on these being set BEFORE the module is
+    imported anywhere."""
+    os.environ.setdefault(
+        "GOOGLE_OAUTH_CLIENT_IDS",
+        "test-google-client-id.apps.googleusercontent.com",
+    )
+    os.environ.setdefault(
+        "APPLE_OAUTH_AUDIENCES",
+        "com.whoeverwants.app,com.whoeverwants.web",
+    )
+
+
+_ensure_provider_config()
+
+# Importing this BEFORE app/main forces the module-level audience tuples
+# in services.oauth to capture our test env vars rather than empty
+# defaults. importlib.reload would also work but this is simpler.
+import services.oauth as oauth_module  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from main import app  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Local signing key + fake JWKS client
+# ---------------------------------------------------------------------------
+
+
+class _FakeSigningKey:
+    """Mimics PyJWK.SigningKey enough for `signing_key.key` access in
+    services.oauth._verify."""
+
+    def __init__(self, public_key):
+        self.key = public_key
+
+
+class _FakeJWKSClient:
+    """Stand-in for PyJWKClient: any get_signing_key_from_jwt call
+    returns the single key we were constructed with. The verifier
+    doesn't actually care about `kid` matching — it just needs a public
+    key it can verify the signature against."""
+
+    def __init__(self, public_key):
+        self._public_key = public_key
+
+    def get_signing_key_from_jwt(self, _id_token):
+        return _FakeSigningKey(self._public_key)
+
+
+@pytest.fixture(scope="module")
+def google_keypair():
+    """RS256 keypair for signing fake Google tokens."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public = private.public_key()
+    return private, public
+
+
+@pytest.fixture(scope="module")
+def apple_keypair():
+    """ES256 keypair (P-256 curve) for signing fake Apple tokens."""
+    private = ec.generate_private_key(ec.SECP256R1())
+    public = private.public_key()
+    return private, public
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, google_keypair, apple_keypair):
+    """Swap the real PyJWKClient instances for our local fakes for every
+    test in this module. The verifier still does a real JWT decode +
+    claim check; only the JWKS fetch is short-circuited."""
+    _, google_pub = google_keypair
+    _, apple_pub = apple_keypair
+    monkeypatch.setattr(
+        oauth_module,
+        "_google_jwks_client",
+        lambda: _FakeJWKSClient(google_pub),
+    )
+    monkeypatch.setattr(
+        oauth_module,
+        "_apple_jwks_client",
+        lambda: _FakeJWKSClient(apple_pub),
+    )
+    # Override the module-level audience tuples in case other tests
+    # imported the module before _ensure_provider_config ran.
+    monkeypatch.setattr(
+        oauth_module,
+        "_GOOGLE_AUDIENCES",
+        ("test-google-client-id.apps.googleusercontent.com",),
+    )
+    monkeypatch.setattr(
+        oauth_module,
+        "_APPLE_AUDIENCES",
+        ("com.whoeverwants.app", "com.whoeverwants.web"),
+    )
+
+
+def _sign_google(
+    private_key,
+    *,
+    sub: str = "google-sub-12345",
+    audience: str = "test-google-client-id.apps.googleusercontent.com",
+    issuer: str = "https://accounts.google.com",
+    email: str | None = "user@example.com",
+    email_verified=True,
+    expires_in_seconds: int = 600,
+) -> str:
+    now = int(time.time())
+    payload = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": sub,
+        "iat": now,
+        "exp": now + expires_in_seconds,
+    }
+    if email is not None:
+        payload["email"] = email
+        payload["email_verified"] = email_verified
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+def _sign_apple(
+    private_key,
+    *,
+    sub: str = "apple-sub-67890",
+    audience: str = "com.whoeverwants.app",
+    issuer: str = "https://appleid.apple.com",
+    email: str | None = "user@privaterelay.appleid.com",
+    email_verified="true",
+    expires_in_seconds: int = 600,
+) -> str:
+    now = int(time.time())
+    payload = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": sub,
+        "iat": now,
+        "exp": now + expires_in_seconds,
+    }
+    if email is not None:
+        payload["email"] = email
+        payload["email_verified"] = email_verified
+    return jwt.encode(payload, private_key, algorithm="ES256")
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def browser_id():
+    return str(uuid.uuid4())
+
+
+def _bid_headers(bid: str | None) -> dict:
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+# ---------------------------------------------------------------------------
+# Pure verifier tests (services.oauth)
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleVerifier:
+    def test_valid_token_returns_identity(self, google_keypair):
+        private, _ = google_keypair
+        token = _sign_google(private)
+        identity = oauth_module.verify_google_id_token(token)
+        assert identity.provider == "google"
+        assert identity.provider_user_id == "google-sub-12345"
+        assert identity.email == "user@example.com"
+        assert identity.email_verified is True
+
+    def test_unverified_email_returns_none_email(self, google_keypair):
+        private, _ = google_keypair
+        token = _sign_google(private, email_verified=False)
+        identity = oauth_module.verify_google_id_token(token)
+        # Identity is still valid (sub is trusted), but email isn't
+        # surfaced as the merge key.
+        assert identity.provider_user_id == "google-sub-12345"
+        assert identity.email is None
+        assert identity.email_verified is False
+
+    def test_wrong_audience_rejected(self, google_keypair):
+        private, _ = google_keypair
+        token = _sign_google(private, audience="some-other-client-id")
+        with pytest.raises(oauth_module.OAuthVerificationError):
+            oauth_module.verify_google_id_token(token)
+
+    def test_wrong_issuer_rejected(self, google_keypair):
+        private, _ = google_keypair
+        token = _sign_google(private, issuer="https://attacker.example.com")
+        with pytest.raises(oauth_module.OAuthVerificationError):
+            oauth_module.verify_google_id_token(token)
+
+    def test_expired_token_rejected(self, google_keypair):
+        private, _ = google_keypair
+        token = _sign_google(private, expires_in_seconds=-60)
+        with pytest.raises(oauth_module.OAuthVerificationError):
+            oauth_module.verify_google_id_token(token)
+
+    def test_malformed_token_rejected(self):
+        with pytest.raises(oauth_module.OAuthVerificationError):
+            oauth_module.verify_google_id_token("not-a-real-token")
+
+
+class TestAppleVerifier:
+    def test_valid_token_returns_identity(self, apple_keypair):
+        private, _ = apple_keypair
+        token = _sign_apple(private)
+        identity = oauth_module.verify_apple_id_token(token)
+        assert identity.provider == "apple"
+        assert identity.provider_user_id == "apple-sub-67890"
+        assert identity.email == "user@privaterelay.appleid.com"
+        assert identity.email_verified is True
+
+    def test_accepts_string_true_email_verified(self, apple_keypair):
+        private, _ = apple_keypair
+        token = _sign_apple(private, email_verified="true")
+        identity = oauth_module.verify_apple_id_token(token)
+        assert identity.email_verified is True
+        assert identity.email == "user@privaterelay.appleid.com"
+
+    def test_accepts_alternate_audience(self, apple_keypair):
+        private, _ = apple_keypair
+        # Web Service ID is the second audience in our test config.
+        token = _sign_apple(private, audience="com.whoeverwants.web")
+        identity = oauth_module.verify_apple_id_token(token)
+        assert identity.provider_user_id == "apple-sub-67890"
+
+    def test_rejects_unknown_audience(self, apple_keypair):
+        private, _ = apple_keypair
+        token = _sign_apple(private, audience="com.attacker.app")
+        with pytest.raises(oauth_module.OAuthVerificationError):
+            oauth_module.verify_apple_id_token(token)
+
+    def test_repeat_sign_in_without_email(self, apple_keypair):
+        """Apple omits email on every sign-in after the first. The
+        verifier accepts that and surfaces None for email."""
+        private, _ = apple_keypair
+        token = _sign_apple(private, email=None)
+        identity = oauth_module.verify_apple_id_token(token)
+        assert identity.email is None
+        assert identity.provider_user_id == "apple-sub-67890"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests (POST /api/auth/oauth/{google,apple})
+# ---------------------------------------------------------------------------
+
+
+def _delete_user_for_sub(provider: str, sub: str) -> None:
+    """Clean up so the same sub across tests doesn't accumulate."""
+    import psycopg
+
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM users WHERE id IN ("
+                "  SELECT user_id FROM user_identities "
+                "  WHERE provider = %s AND provider_user_id = %s"
+                ")",
+                (provider, sub),
+            )
+        conn.commit()
+
+
+class TestGoogleOAuthEndpoint:
+    def test_valid_token_issues_session(
+        self, client, browser_id, google_keypair
+    ):
+        private, _ = google_keypair
+        sub = f"google-sub-{uuid.uuid4().hex[:12]}"
+        email = f"goog-{uuid.uuid4().hex[:8]}@example.com"
+        token = _sign_google(private, sub=sub, email=email)
+        try:
+            resp = client.post(
+                "/api/auth/oauth/google",
+                json={"id_token": token},
+                headers=_bid_headers(browser_id),
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["session_token"]
+            assert body["user"]["email"] == email.lower()
+            assert "google" in body["user"]["providers"]
+        finally:
+            _delete_user_for_sub("google", sub)
+
+    def test_invalid_token_400(self, client, browser_id):
+        resp = client.post(
+            "/api/auth/oauth/google",
+            json={"id_token": "x" * 200},  # passes Pydantic, fails decode
+            headers=_bid_headers(browser_id),
+        )
+        assert resp.status_code == 400
+
+    def test_repeat_sign_in_same_user(self, client, browser_id, google_keypair):
+        private, _ = google_keypair
+        sub = f"google-sub-{uuid.uuid4().hex[:12]}"
+        email = f"reuse-{uuid.uuid4().hex[:8]}@example.com"
+        try:
+            r1 = client.post(
+                "/api/auth/oauth/google",
+                json={"id_token": _sign_google(private, sub=sub, email=email)},
+                headers=_bid_headers(browser_id),
+            )
+            r2 = client.post(
+                "/api/auth/oauth/google",
+                json={"id_token": _sign_google(private, sub=sub, email=email)},
+                headers=_bid_headers(browser_id),
+            )
+            assert r1.status_code == 200 and r2.status_code == 200
+            assert r1.json()["user"]["user_id"] == r2.json()["user"]["user_id"]
+        finally:
+            _delete_user_for_sub("google", sub)
+
+
+class TestAppleOAuthEndpoint:
+    def test_valid_token_issues_session(self, client, browser_id, apple_keypair):
+        private, _ = apple_keypair
+        sub = f"apple-sub-{uuid.uuid4().hex[:12]}"
+        email = f"apple-{uuid.uuid4().hex[:8]}@example.com"
+        token = _sign_apple(private, sub=sub, email=email)
+        try:
+            resp = client.post(
+                "/api/auth/oauth/apple",
+                json={"id_token": token},
+                headers=_bid_headers(browser_id),
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert "apple" in body["user"]["providers"]
+        finally:
+            _delete_user_for_sub("apple", sub)
+
+    def test_repeat_sign_in_without_email_resolves_to_same_user(
+        self, client, browser_id, apple_keypair
+    ):
+        """Apple omits email after the first sign-in. The repeat call
+        should still resolve to the same user via the (provider, sub)
+        lookup."""
+        private, _ = apple_keypair
+        sub = f"apple-sub-{uuid.uuid4().hex[:12]}"
+        email = f"first-{uuid.uuid4().hex[:8]}@example.com"
+        try:
+            r1 = client.post(
+                "/api/auth/oauth/apple",
+                json={"id_token": _sign_apple(private, sub=sub, email=email)},
+                headers=_bid_headers(browser_id),
+            )
+            r2 = client.post(
+                "/api/auth/oauth/apple",
+                json={"id_token": _sign_apple(private, sub=sub, email=None)},
+                headers=_bid_headers(browser_id),
+            )
+            assert r1.status_code == 200 and r2.status_code == 200
+            assert r1.json()["user"]["user_id"] == r2.json()["user"]["user_id"]
+        finally:
+            _delete_user_for_sub("apple", sub)
+
+
+# ---------------------------------------------------------------------------
+# Cross-provider merge (account linking on shared verified email)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossProviderMerge:
+    def test_email_signin_then_google_signin_same_email_merges(
+        self, client, browser_id, google_keypair
+    ):
+        """A user who first signed in with magic link, then later signs
+        in with Google using the same verified email, should land on the
+        same user_id (one row in `users`, two rows in `user_identities`).
+        """
+        from services.auth import generate_token, hash_token, normalize_email
+        import psycopg
+
+        email = f"merge-{uuid.uuid4().hex[:8]}@example.com"
+        sub = f"google-sub-{uuid.uuid4().hex[:12]}"
+
+        # Step 1: magic-link sign-in.
+        ml_token = generate_token()
+        with psycopg.connect(TEST_DB_URL) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO magic_link_tokens
+                      (token_hash, email, browser_id, expires_at)
+                    VALUES
+                      (%s, %s, %s, NOW() + INTERVAL '15 minutes')
+                    """,
+                    (hash_token(ml_token), normalize_email(email), browser_id),
+                )
+            conn.commit()
+
+        try:
+            r1 = client.post(
+                "/api/auth/magic-link/verify",
+                json={"token": ml_token},
+                headers=_bid_headers(browser_id),
+            )
+            assert r1.status_code == 200
+            email_user_id = r1.json()["user"]["user_id"]
+
+            # Step 2: Google sign-in with the SAME verified email.
+            private, _ = google_keypair
+            google_token = _sign_google(private, sub=sub, email=email)
+            r2 = client.post(
+                "/api/auth/oauth/google",
+                json={"id_token": google_token},
+                headers=_bid_headers(browser_id),
+            )
+            assert r2.status_code == 200
+            assert r2.json()["user"]["user_id"] == email_user_id
+            assert set(r2.json()["user"]["providers"]) == {"email", "google"}
+        finally:
+            _delete_user_for_sub("google", sub)
+            with psycopg.connect(TEST_DB_URL) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "DELETE FROM users WHERE id IN ("
+                        "  SELECT user_id FROM user_identities WHERE email = %s"
+                        ")",
+                        (normalize_email(email),),
+                    )
+                conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Providers endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestProvidersEndpoint:
+    def test_reports_configured_providers(self, client):
+        resp = client.get("/api/auth/providers")
+        assert resp.status_code == 200
+        body = resp.json()
+        # In the test env both Google and Apple are configured via the
+        # module-level monkeypatch in `patch_jwks`.
+        assert body["email"] is True
+        assert body["google"] is True
+        assert body["apple"] is True
+
+
+# ---------------------------------------------------------------------------
+# 503 when provider is unconfigured
+# ---------------------------------------------------------------------------
+
+
+class TestUnconfiguredProvider:
+    def test_google_503_when_unconfigured(self, client, monkeypatch):
+        monkeypatch.setattr(oauth_module, "_GOOGLE_AUDIENCES", ())
+        resp = client.post(
+            "/api/auth/oauth/google",
+            json={"id_token": "x" * 200},
+        )
+        assert resp.status_code == 503
+
+    def test_apple_503_when_unconfigured(self, client, monkeypatch):
+        monkeypatch.setattr(oauth_module, "_APPLE_AUDIENCES", ())
+        resp = client.post(
+            "/api/auth/oauth/apple",
+            json={"id_token": "x" * 200},
+        )
+        assert resp.status_code == 503


### PR DESCRIPTION
## Summary

Adds "Sign in with Apple" and "Sign in with Google" to the existing magic-link sign-in flow (Phases A+B) on the **web** surface. Capacitor iOS native flows are deferred to a follow-up PR.

- **Server** (`server/services/oauth.py`): PyJWT-based ID-token verifier for both providers. Validates signature against the provider's JWKS, plus `iss` / `aud` / `exp` / required claims. RS256 pinned for Google, ES256 for Apple. `email_verified` parsed defensively (Google sends bool, Apple sends string).
- **Server endpoints** (`server/routers/auth.py`): `POST /api/auth/oauth/{google,apple}` + `GET /api/auth/providers`. Both OAuth handlers funnel through a new shared `_handle_oauth_signin` and the magic-link verify route now also funnels through a new `services/auth.py: complete_sign_in()` — single home for the `resolve_or_merge_user` → `link_browser_to_user` → `issue_session` → `load_user_profile` rhythm.
- **FE** (`lib/oauth.ts` + `components/SignInModal.tsx`): SDK loaders for Google Identity Services + Apple JS, lazy-loaded on demand. Google's branded button is rendered into a `ref`'d div (Google branding requirement); Apple uses a custom-styled button triggering `AppleID.auth.signIn()`. Buttons hide when EITHER the client bundle (`NEXT_PUBLIC_*_CLIENT_ID`) OR the server (`*_AUDIENCES`) is unconfigured. Capacitor iOS hides every OAuth button (Google explicitly blocks WebView sign-in; Apple JS doesn't render reliably there).
- **Tests** (`server/tests/test_oauth.py`): 20 new tests covering every branch of the verifier + endpoints + cross-provider account merge. Generate ephemeral RSA/ECDSA keypairs locally, mint signed JWTs, swap `PyJWKClient` for a fake — exercises the real `jwt.decode` path without calling Google/Apple. All 42 auth tests (20 new + 22 existing magic-link) pass.

**Cross-provider merge is automatic.** A user who signed in with magic-link, then signs in with Google using the same verified email, lands on the same `user_id` via the existing `resolve_or_merge_user` email lookup. `/api/auth/me` reports `providers: ['email', 'google']`. Apple "Hide my email" relays are stable per (user, RP), so they merge cleanly too.

## Configuration

Each provider requires matching env vars on BOTH server tier and Vercel project:

| Provider | Server (`.env.api`) | FE (`NEXT_PUBLIC_*`) |
|---|---|---|
| Google | `GOOGLE_OAUTH_CLIENT_IDS` (comma-sep for web + iOS audiences) | `NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID` (web client ID) |
| Apple | `APPLE_OAUTH_AUDIENCES` (comma-sep for Service ID + iOS bundle) | `NEXT_PUBLIC_APPLE_OAUTH_SERVICE_ID` (Service ID) + `NEXT_PUBLIC_APPLE_OAUTH_REDIRECT_URI` (optional) |

Neither is set on dev tiers — buttons hide silently and `/api/auth/providers` reports `{google: false, apple: false}`. After editing `.env.api`, restart with `docker compose up -d --force-recreate api` (env_file is read on container creation only).

## Test plan

- [x] All 20 OAuth tests pass against dev tier DB
- [x] Existing 22 magic-link tests still pass through the refactored `complete_sign_in` helper
- [x] `tsc --noEmit` clean
- [x] `npm run lint` no new warnings/errors in changed files
- [x] `POST /api/auth/oauth/google` returns 503 on unconfigured dev tier
- [x] `POST /api/auth/oauth/apple` returns 503 on unconfigured dev tier
- [x] Magic-link flow still issues sessions end-to-end (regression check on the shared `complete_sign_in` refactor)
- [x] SignInModal renders correctly (no OAuth buttons, only magic-link) when providers unconfigured
- [ ] Production validation requires real Google/Apple client IDs — out of scope for this PR

## Out of scope (follow-up phases)

- Native Capacitor iOS OAuth flows (Apple Sign In + Google Auth Capacitor plugins).
- Phase D: Passkey / WebAuthn.
- Phase E+: group privacy, join requests, invite links, per-vote anonymity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWdxivAM1y4o53g59jaB5Q)_