### PR TITLE
Add diagnostic logging for Apple sign-in silent failure

### DIFF
--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -126,8 +126,15 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
     setError(null);
     setOAuthSubmitting("apple");
     try {
+      console.warn("[apple-signin] starting appleSignIn()");
       const idToken = await appleSignIn();
-      await apiSignInWithOAuth("apple", idToken);
+      console.warn(
+        `[apple-signin] got id_token (len=${idToken?.length ?? 0}); POSTing to /oauth/apple`,
+      );
+      const res = await apiSignInWithOAuth("apple", idToken);
+      console.warn(
+        `[apple-signin] POST succeeded; session_token len=${res.session_token?.length ?? 0} user.user_id=${res.user?.user_id ?? "(none)"} email=${res.user?.email ?? "(none)"} providers=${(res.user?.providers ?? []).join(",")}`,
+      );
       onClose();
     } catch (err) {
       // Apple rejects on user-cancel with various error shapes across
@@ -138,10 +145,21 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
       //     (Apple's ASAuthorizationError.canceled raw code).
       const message = err instanceof Error ? err.message : String(err);
       const rawError = (err as { error?: string })?.error;
-      if (
+      const isCancel =
         /popup_closed_by_user|user_cancelled|cancell?ed|error 1001/i.test(message) ||
-        (typeof rawError === "string" && /cancell?ed/i.test(rawError))
-      ) {
+        (typeof rawError === "string" && /cancell?ed/i.test(rawError));
+      // SignInModal swallows the error into a UI state setter, so
+      // without this the client log buffer was empty when sign-in
+      // silently failed. Forward every non-cancel error so the next
+      // failure leaves a trail.
+      if (!isCancel) {
+        const status = err instanceof ApiError ? err.status : undefined;
+        const name = err instanceof Error ? err.name : typeof err;
+        console.warn(
+          `[apple-signin] caught error: name=${name} status=${status} message=${message} rawError=${rawError ?? "(none)"}`,
+        );
+      }
+      if (isCancel) {
         setError(null);
       } else {
         setError(


### PR DESCRIPTION
## Summary
Diagnostic only — no behavior change.

Native iOS sign-in is still failing on `WhoeverWants Latest` after the RS256 fix landed:
- `POST /api/auth/oauth/apple` returns **200 OK** (verified in canary droplet logs)
- Next `GET /api/auth/me` returns **401** — bearer not attached, so either `saveSession` never ran or the token was lost
- FE shows "Couldn't sign you in with Apple. Try again in a moment."

The `SignInModal` catch block swallows the error into `setError(...)` without ever logging it, so the client-log buffer is empty even though the failure is reproducible. This patch adds four `console.warn` calls (which the canary tier's log forwarder DOES capture) along the Apple sign-in path:
1. Before `appleSignIn()` — confirms click handler fires
2. After `idToken` returns — confirms native plugin handed back a token
3. After `apiSignInWithOAuth` resolves — logs the response shape (catches a missing session_token, unexpected user object, etc.)
4. In the catch block — error name / status / message / rawError

## Test plan
- [ ] Merge → canary auto-deploys → iOS WebView picks up the new bundle on next page load
- [ ] User reopens TestFlight app, taps Apple Sign In, completes (or fails) the flow
- [ ] `curl "https://latest.whoeverwants.com/api/client-logs?search=apple-signin&limit=20"` returns the diagnostic trail
- [ ] Root-cause + ship a real fix; revert this PR (or trim to the catch-block log alone, which is generally useful)

https://claude.ai/code/session_019GMbgU2mNBRz8gPzagLANM

---
_Generated by [Claude Code](https://claude.ai/code/session_019GMbgU2mNBRz8gPzagLANM)_