### PR TITLE
Mirror received client logs to stdout for cross-worker visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -888,7 +888,7 @@ npm run debug:react question-123 revisit   # Debug vote retrieval
 
 ## Client Log Forwarding
 
-The browser forwards `console.*` output and unhandled errors/rejections to the API server via `POST /api/client-logs`. The endpoint is an in-memory ring buffer (last 10000 entries on the API server) — no disk writes, no persistence across restarts.
+The browser forwards `console.*` output and unhandled errors/rejections to the API server via `POST /api/client-logs`. The endpoint is an in-memory ring buffer (last 10000 entries on the API server) — no disk writes, no persistence across restarts. **The ring buffer is per-uvicorn-worker**, and the canary/prod containers run with `--workers 2`. A POST landing on worker B's buffer is invisible to a GET that hits worker A's buffer — both endpoints route through the same Caddy → uvicorn socket but the kernel dispatches connections across workers via accept-balancing, so the worker for each request is non-deterministic from the caller's POV. To work around this, `receive_client_logs` ALSO mirrors every received entry to stdout via `logger.warning("[client-log] ...")`; tail `docker compose logs api | grep '\[client-log\]'` for the cross-worker source of truth when the `/api/client-logs` GET returns suspiciously-empty. (The buffer is still useful for the FE itself when running in-process polls, and as a fallback when log volume is high enough that grepping the docker stdout becomes painful.)
 
 **Activation rules (`lib/clientLogForwarder.ts: isLogForwardingEnabled`):**
 - **Dev hosts** (`*.dev.whoeverwants.com`, `localhost`, `127.0.0.1`) — forward EVERYTHING (`log/warn/error/info/debug` + unhandled events). Low traffic; devs want full context.

--- a/server/routers/client_logs.py
+++ b/server/routers/client_logs.py
@@ -55,6 +55,19 @@ async def receive_client_logs(batch: ClientLogBatch, request: Request):
             "clientIp": client_ip,
             "receivedAt": time.time(),
         })
+        # Mirror every received entry to stdout so `docker compose logs api`
+        # captures the trail regardless of which uvicorn worker the POST
+        # landed on. The in-memory _LOG_BUFFER is per-worker, so the
+        # /api/client-logs GET endpoint can return empty even right after
+        # a successful POST when the GET hits a different worker; the
+        # docker logs are the cross-worker source of truth.
+        logger.warning(
+            "[client-log] level=%s session=%s ua=%s msg=%s",
+            entry.level,
+            batch.sessionId or "(none)",
+            (entry.userAgent or "")[:60],
+            entry.message,
+        )
     return {"status": "ok", "accepted": len(batch.logs)}
 
 


### PR DESCRIPTION
## Summary
The `/api/client-logs` in-memory ring buffer is **per-uvicorn-worker**, and the canary/prod containers run with `--workers 2`. A POST landing on worker B's buffer is invisible to a GET that hits worker A's buffer — the kernel dispatches connections across workers via accept-balancing, so the worker for each request is non-deterministic from the caller's POV.

This was masking the Apple Sign In diagnostic data: `POST /api/client-logs` was landing in the access log (after PR #437's sendBeacon→fetch fix), but every GET I did kept returning `total: 0`. I verified the multi-worker root cause by checking `/proc` inside the container.

## Fix
`receive_client_logs` now also writes each received entry to stdout via `logger.warning("[client-log] ...")`. The container's docker stdout (`docker compose logs api | grep '\[client-log\]'`) becomes the cross-worker source of truth for client log entries. The in-memory buffer stays as-is (still useful for in-process polls + as a fallback when grep volume is high).

CLAUDE.md updated with the multi-worker pitfall and the docker-logs workflow.

## Verify
- [ ] Merge → canary auto-deploys
- [ ] Force-quit + reopen iOS TestFlight, go to Settings → Sign in → tap Apple → complete or fail
- [ ] `bash scripts/remote-latest.sh "docker compose logs --tail 100 api | grep '\[client-log\]'"` returns the trail (regardless of which worker the POST hit)

https://claude.ai/code/session_019GMbgU2mNBRz8gPzagLANM

---
_Generated by [Claude Code](https://claude.ai/code/session_019GMbgU2mNBRz8gPzagLANM)_