### PR TITLE
Trigger iOS build automatically on GitHub Release publish

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -24,6 +24,16 @@ on:
       - 'package-lock.json'
       - '.github/workflows/ios-build.yml'
       - 'scripts/ios/**'
+  release:
+    # A non-draft / non-prerelease release publish always builds the prod
+    # bundle pinned to the release's tag, regardless of which files
+    # changed. This keeps the iOS prod build in lockstep with the
+    # GitHub Release that drives the rest of the prod deploy (Vercel + the
+    # prod droplet's API container both auto-deploy on release publish
+    # too; this trigger closes the loop for the native app). Prereleases
+    # are excluded — the `prod_only_on_real_release` guard on the job
+    # filters them out.
+    types: [published]
   workflow_dispatch:
     inputs:
       cap_env:
@@ -53,10 +63,14 @@ jobs:
   build:
     runs-on: [self-hosted, macos-mini]
     timeout-minutes: 45
+    # Skip prereleases — they wouldn't go to the production TestFlight
+    # track anyway, and the `published` event fires for them too.
+    if: github.event_name != 'release' || !github.event.release.prerelease
 
     env:
-      # Resolve CAP_ENV: manual dispatch input > branch-based default.
-      CAP_ENV: ${{ github.event.inputs.cap_env != '' && github.event.inputs.cap_env || (github.ref == 'refs/heads/main' && 'prod' || 'latest') }}
+      # Resolve CAP_ENV: manual dispatch input > release publish (always
+      # prod) > push to main (prod) > push to any other branch (latest).
+      CAP_ENV: ${{ github.event.inputs.cap_env != '' && github.event.inputs.cap_env || ((github.event_name == 'release' || github.ref == 'refs/heads/main') && 'prod' || 'latest') }}
       SCHEME: App
       PROJECT: ios/App/App.xcodeproj
       ARCHIVE_PATH: ${{ github.workspace }}/build/App.xcarchive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1828,6 +1828,7 @@ self-hosted Mac mini runner (labels: `self-hosted, macos-mini`). The workflow:
 
 Triggers:
 - Pushes to ANY branch that touch `capacitor.config.ts`, `ios/**`, `package.json`, `package-lock.json`, the workflow file, or `scripts/ios/**`. `main` builds the prod bundle (`com.whoeverwants.app`); every other branch builds the shared `latest` bundle (`com.whoeverwants.app.latest`). Concurrency is keyed on `github.ref` with `cancel-in-progress: true`, so rapid pushes to the same branch only run the latest commit.
+- **GitHub Release published** (non-draft, non-prerelease) → builds the prod bundle pinned to the release's tag. Keeps the iOS prod IPA in lockstep with the Vercel + droplet auto-deploys that already fire on the same event. Prereleases are filtered out by an `if:` guard on the job (the `published` action fires for prereleases too).
 - Manual via `workflow_dispatch` — inputs: `cap_env` (`latest|prod`), `cap_server_url` (explicit URL override), `skip_upload` (bool).
 
 ### Universal Links


### PR DESCRIPTION
## Summary
Adds `release: types: [published]` to the iOS build workflow so cutting a non-prerelease GitHub Release also fires the prod iOS build. Closes the auto-deploy loop: Vercel + the prod droplet's API container already redeploy on release publish (per the prod webhook → `Release published` flow). The iOS prod IPA now follows the same cycle instead of requiring a separate manual dispatch.

## Behavior matrix
| Event | CAP_ENV | Bundle | Notes |
|---|---|---|---|
| Push to `main` (existing) | prod | `com.whoeverwants.app` | unchanged |
| Push to any other branch (existing) | latest | `com.whoeverwants.app.latest` | unchanged |
| **Release published (new)** | prod | `com.whoeverwants.app` | builds at the release's tag |
| `workflow_dispatch` (existing) | input wins | per-input | unchanged |

## Guards
- Job-level `if: github.event_name != 'release' || !github.event.release.prerelease` — drops prereleases (the `published` action fires for them too).
- Drafts are excluded by `types: [published]` itself (drafts only fire `created`).
- `actions/checkout@v4` defaults to `github.ref` which is `refs/tags/<tag>` for release events — pins the build to the exact released commit, matching the droplet's `git checkout tags/<tag>` flow.

## Test plan
- [ ] Merge → no immediate change (no release in flight)
- [ ] Next time you cut a release, the `iOS Build & TestFlight` workflow auto-runs against the release's tag → builds + uploads `com.whoeverwants.app`
- [ ] Confirm the build appears in the prod TestFlight track within ~20 min of the release publish

https://claude.ai/code/session_019GMbgU2mNBRz8gPzagLANM

---
_Generated by [Claude Code](https://claude.ai/code/session_019GMbgU2mNBRz8gPzagLANM)_