### PR TITLE
Phase F + G auth: join requests + invite links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -945,16 +945,22 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Auth & Access Model
 
-> **Phases A + B + C + D shipped.** A+B = identity foundation +
+> **Phases A + B + C + D + E + F shipped.** A+B = identity foundation +
 > magic-link email sign-in (migration 112). C = "Sign in with Apple"
 > + "Sign in with Google" on web, plus native Apple Sign In on
 > Capacitor iOS via `@capgo/capacitor-social-login`. D = passkey
 > (WebAuthn) registration + sign-in (migration 113), with anonymous
 > registration supported so a user can create an account directly
-> from a passkey. Group privacy (E), join requests (F), invite links
-> (G), per-vote anonymity (H), and native Google on iOS (deferred
-> sub-follow-up to C — needs per-bundle iOS client IDs + URL-scheme
-> patching) are still scheduled. Full plan + rationale in
+> from a passkey. E = group privacy (migration 114) — new groups
+> default private; visibility filter gates `/by-route-id` 404s for
+> non-members; creator-only privacy toggle on /info. F = group join
+> requests (migration 115) — signed-in non-members request access
+> via the /info-not-found page, creators approve/deny from a /info
+> "Pending requests" section, push notification fans out to every
+> browser the creator's signed in on. Invite links (G), per-vote
+> anonymity (H), and native Google on iOS (deferred sub-follow-up to
+> C — needs per-bundle iOS client IDs + URL-scheme patching) are
+> still scheduled. Full plan + rationale in
 > `docs/auth-access-model.md`.
 
 **Cross-browser visibility for signed-in users.** Every read that
@@ -1299,9 +1305,7 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
 **Open phases (see `docs/auth-access-model.md`):**
 - D: Passkey (WebAuthn). **Shipped.**
 - E: `groups.privacy` column, new groups default private. **Shipped.**
-- F: `group_join_requests` + push notification to creator. Closes
-  the signed-in sharing loop; the privacy-toggle escape hatch is
-  the bridge until then.
+- F: `group_join_requests` + push notification to creator. **Shipped.**
 - G: `group_invites` with single + multi-use modes and optional
   target_poll_id.
 - H: per-vote anonymity flags (`votes.anonymous_to_peers`,
@@ -1310,6 +1314,89 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
   creator_user_id can be set after-the-fact, enabling
   privacy-flip on grandfathered groups.
 - C-follow-up: native Google Sign In on iOS (Apple native shipped; Google needs per-bundle iOS client IDs + reversed-URL-scheme registration).
+
+**Phase F (group join requests) shipped in migration 115.** Adds
+`group_join_requests(id, group_id, requester_user_id, message,
+status, requested_at, decided_at, decided_by_user_id)` with status
+in `('pending', 'approved', 'denied', 'cancelled')`. A partial
+unique index on `(group_id, requester_user_id) WHERE
+status = 'pending'` enforces "one open request per (group, user)"
+without blocking re-requests after a denial. Three endpoints in
+`routers/groups.py`:
+  * `POST /api/groups/<route_id>/join-requests` (body `{message?}`)
+    — signed-in caller. Returns 200 + status discriminator
+    (`pending` | `already_pending` | `already_member`). 401
+    anonymous, 404 unknown group. Idempotent via the partial
+    unique index — second call doesn't re-fire the creator push.
+  * `GET /api/groups/<route_id>/join-requests` — creator-only.
+    Returns pending oldest first, with `requester_email` joined
+    in (NULL for passkey-only requesters). 401/403/404.
+  * `POST /api/groups/<route_id>/join-requests/<id>/decide` (body
+    `{action: 'approve' | 'deny'}`) — creator-only. Approve writes
+    a `group_members` row keyed on the requester's
+    earliest-linked `user_browsers.browser_id` (one row is enough
+    — `load_user_visibility`'s user-aware lookup expands to every
+    linked browser). Deny just walks the status. Returns 200 on
+    transition, 404 on cross-group / already-decided / unknown
+    request_id. The route_id + request_id pairing is enforced
+    server-side: a creator of group A can't decide on a request
+    that belongs to group B even with a guessed request_id.
+
+`services/join_requests.py` is the single home for the three
+operations (`create_join_request`, `list_pending_requests`,
+`decide_request`) + the membership-or-creator short-circuit. The
+membership write on approve uses the same `ON CONFLICT (group_id,
+browser_id) DO NOTHING` pattern as the auto-join paths so an
+existing membership row keeps its original `joined_at` watermark.
+
+Push fan-out: `services/push.py: fan_out_join_request(group_id,
+creator_user_id, payload)`. Walks `user_browsers WHERE user_id =
+creator_user_id` (NOT group_members) — the creator might have
+requested notifications on Device A and be looking at Device B
+when the request lands. Gated on the per-group `notify_new_poll`
+pref so muting a group still mutes join-request noise. Shares
+`_dispatch_pushes` with `fan_out_new_poll` (the send + record-
+outcomes loop is identical) — extracted on this PR so adding a
+third event type doesn't fork the loop.
+
+FE: `apiCreateGroupJoinRequest`, `apiListGroupJoinRequests`,
+`apiDecideGroupJoinRequest` in `lib/api/groups.ts`. The /info page
+mounts `<JoinRequestsSection groupId enabled />` when the viewer is
+the recorded creator (gated on `session.user_id ===
+group.creatorUserId`); the section renders nothing on an empty
+pending list. The `<GroupNotFound>` 404 page accepts an optional
+`routeId` prop — when signed in AND `routeId` is set, it surfaces
+a "Request to join" button that POSTs to the join-request endpoint
+and shows a "Request sent" / "Group not found" result. Anonymous
+viewers on the same page get a "Sign in to request access" CTA
+that opens `SignInModal`; signing in fires
+`SESSION_CHANGED_EVENT` and the button surfaces without remount.
+
+**Pitfall: requester-email surfaces are NULL for passkey-only
+accounts.** Phase D permits accounts with no email at all
+(`user_identities` carries only a passkey row). The
+`requester_email` field on `GroupJoinRequest` / the list endpoint
+returns null in that case; UI fallback is the literal string
+"Passkey user". When adding new identity-bearing surfaces, mirror
+this fallback rather than coercing the email to a placeholder
+server-side — the null is the truth.
+
+**Pitfall: the "Request to join" CTA only goes on group-level 404s,
+not poll-level 404s.** `/g/<group>/p/<poll>` 404s pass through
+`app/g/[groupShortId]/p/[pollShortId]/page.tsx`'s own "Poll Not
+Found" branch, which is intentionally kept distinct — the user
+might not need access to the whole group, they might just have a
+dead poll URL. If a future request adds "request access to a
+specific poll" semantics, that page is the place to mirror the
+join-request CTA.
+
+**Pitfall: my-emails normalization mismatch.** The server
+normalizes emails to lowercase + trimmed via `normalize_email`
+before persisting + comparing. Tests that mint an email and then
+assert against `requester_email` from a response must also
+normalize the expected value — or use a lowercase email to start.
+The `_sign_in` test helper in `test_join_requests.py` returns the
+normalized form for this reason.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -945,10 +945,10 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Auth & Access Model
 
-> **Phases A + B + C + D + E + F shipped.** A+B = identity foundation +
-> magic-link email sign-in (migration 112). C = "Sign in with Apple"
-> + "Sign in with Google" on web, plus native Apple Sign In on
-> Capacitor iOS via `@capgo/capacitor-social-login`. D = passkey
+> **Phases A + B + C + D + E + F + G shipped.** A+B = identity
+> foundation + magic-link email sign-in (migration 112). C = "Sign in
+> with Apple" + "Sign in with Google" on web, plus native Apple Sign
+> In on Capacitor iOS via `@capgo/capacitor-social-login`. D = passkey
 > (WebAuthn) registration + sign-in (migration 113), with anonymous
 > registration supported so a user can create an account directly
 > from a passkey. E = group privacy (migration 114) — new groups
@@ -957,10 +957,13 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 > requests (migration 115) — signed-in non-members request access
 > via the /info-not-found page, creators approve/deny from a /info
 > "Pending requests" section, push notification fans out to every
-> browser the creator's signed in on. Invite links (G), per-vote
-> anonymity (H), and native Google on iOS (deferred sub-follow-up to
-> C — needs per-bundle iOS client IDs + URL-scheme patching) are
-> still scheduled. Full plan + rationale in
+> browser the creator's signed in on. G = invite links (migration
+> 116) — creators mint shareable URLs (`/invite/<token>`); raw token
+> + URL surfaced once at create time and persisted as sha256 hash;
+> signed-in viewers auto-redeem on landing, anonymous viewers get a
+> sign-in CTA. Per-vote anonymity (H) and native Google on iOS
+> (deferred sub-follow-up to C — needs per-bundle iOS client IDs +
+> URL-scheme patching) are still scheduled. Full plan + rationale in
 > `docs/auth-access-model.md`.
 
 **Cross-browser visibility for signed-in users.** Every read that
@@ -1307,7 +1310,7 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
 - E: `groups.privacy` column, new groups default private. **Shipped.**
 - F: `group_join_requests` + push notification to creator. **Shipped.**
 - G: `group_invites` with single + multi-use modes and optional
-  target_poll_id.
+  target_poll_id. **Shipped.**
 - H: per-vote anonymity flags (`votes.anonymous_to_peers`,
   `anonymous_to_creator`) + read-time filter audit.
 - I (partial): "claim an anonymous-created group" so legacy
@@ -1397,6 +1400,112 @@ assert against `requester_email` from a response must also
 normalize the expected value — or use a lowercase email to start.
 The `_sign_in` test helper in `test_join_requests.py` returns the
 normalized form for this reason.
+
+**Phase G (group invite links) shipped in migration 116.** Adds
+`group_invites(id, token_hash, group_id, created_by_user_id, mode,
+target_poll_id, max_uses, use_count, expires_at, revoked_at,
+created_at)` with a unique constraint on `token_hash`. Same
+hash-only-storage pattern as `sessions` and `magic_link_tokens`:
+the raw token is returned exactly once at create time and embedded
+in the shareable URL; the server keeps only `sha256(token)`. A DB
+leak doesn't yield usable invites.
+
+Four endpoints across two routers:
+  * `POST /api/groups/<route_id>/invites` (body: `{mode,
+    max_uses?, target_poll_id?, expires_in_hours?}`) — creator-only.
+    `mode='single'` forces `max_uses=1` server-side regardless of
+    the body (the client's value is normalized, not rejected, so
+    fewer edge cases surface in the UI). Cross-group
+    `target_poll_id`s are silently downgraded to NULL — falling
+    back to "land on group root" is friendlier than 400'ing on
+    stale poll selection.
+  * `GET /api/groups/<route_id>/invites` — creator-only. Lists
+    active invites (not revoked, not expired, has remaining uses).
+    Token + url are omitted from list responses — those are one-shot
+    at create time. FE shows "Link only shown when first created"
+    for previously-existing invites.
+  * `DELETE /api/groups/<route_id>/invites/<invite_id>` —
+    creator-only. Returns 204 on revoke, 404 when already revoked
+    or not owned. The `created_by_user_id` check is folded into the
+    UPDATE's WHERE clause so ownership + status transition happen
+    atomically.
+  * `POST /api/auth/invites/<token>/redeem` (lives on the auth
+    router because the URL the joiner clicked has no route_id —
+    just a raw token). Requires user_id (401 anonymous). 404 on
+    invalid / expired / revoked / fully-used. Atomic conditional
+    UPDATE on `use_count < max_uses` serializes redemptions at
+    row-lock granularity — whoever wins the lock increments,
+    whoever loses sees the predicate fail. Already-member redemptions
+    roll back the use_count bump so a member re-clicking the URL
+    doesn't consume an invite use. Returns short_ids pre-resolved
+    so the FE builds the redirect URL without a second round-trip.
+
+`services/invites.py` is the single home for `issue_invite`,
+`list_active_invites`, `revoke_invite`, `redeem_invite`. The shared
+FE-origin allowlist was lifted out of `routers/auth.py` into
+`services/fe_origin.py: resolve_fe_origin` so both magic-link and
+invite-URL minting use the same allowlist. When adding a new tier
+or external embed that needs to appear in user-bound URLs, extend
+`_ALLOWED_ORIGIN_PATTERNS` there.
+
+FE: `apiCreateGroupInvite` / `apiListGroupInvites` /
+`apiRevokeGroupInvite` in `lib/api/groups.ts` + `apiRedeemInvite`
+in `lib/api/auth.ts`. `<InviteLinksSection>` mounts on /info next
+to `<JoinRequestsSection>` (both gated on the same
+`viewerIsCreator` derived from `session.user_id ===
+group.creatorUserId`). The freshly-minted invite is the ONLY row
+where a Copy button surfaces — `freshUrls` state holds
+`{inviteId: rawUrl}` for that session only; refresh or navigate
+away and the URL is gone, matching the server's
+hash-only-storage. `/invite/<token>/page.tsx` is the redemption
+landing page: anonymous viewers see "Sign in to continue" + the
+existing `SignInModal`; signed-in viewers auto-redeem on mount via
+`SESSION_CHANGED_EVENT`-driven re-fire and `router.replace` to the
+destination URL (`/g/<group>` or `/g/<group>/p/<poll>` when the
+invite carries a target_poll_id).
+
+The template's fallback header gate now skips `/invite/<token>`
+(`isInvitePage` flag in `app/template.tsx`) — the redemption page
+renders its own full-screen UI; the template's empty top bar would
+just be visual noise above it.
+
+**Pitfall: invite list endpoint deliberately omits raw tokens.**
+The list shape returns `token: null` / `url: null` for every row
+because the only place the raw token exists post-creation is in
+the URL the creator copied at create time. Don't add a "view
+invite link" affordance — it would require either storing the raw
+token (defeating the hash-only-storage model) or accepting that
+re-viewing a link means minting a new invite anyway. The FE's
+"Link only shown when first created" copy is the intentional
+trade-off.
+
+**Pitfall: redeem's use_count rollback is not transactional with
+the membership write.** The redeem-then-rollback sequence for
+already-member callers does the UPDATE → SELECT membership →
+UPDATE -1 in three statements; a concurrent redeem from a
+different user between statements 1 and 3 could theoretically see
+the bumped count temporarily. In practice (a) the bump+rollback
+happens in the same DB connection within one request,
+(b) the visibility-affecting decision (already-member or not) is
+final by the time the second UPDATE runs, and (c) a transient
+use_count flicker is benign — the FE never sees it because the
+list endpoint runs in a separate request later. If the
+already-member-rollback pattern ever expands to side effects that
+care about correctness (e.g. a webhook), refactor to a single
+conditional UPDATE that doesn't bump in the first place when the
+caller is already a member.
+
+**Pitfall: invite URLs are origin-derived, not hardcoded.** The
+`POST /api/groups/<route>/invites` response's `url` field uses
+`services/fe_origin.resolve_fe_origin(request)` — same allowlist
+as magic-link URLs. A request hitting the API with no recognized
+`Origin` header falls back to `FE_DEFAULT_ORIGIN` (default
+`https://whoeverwants.com`). For dev tiers the FE sends an
+Origin like `https://<slug>.dev.whoeverwants.com` which IS on the
+allowlist, so the URL embedded in the response matches what the
+creator sees in their browser bar. If you add a new
+`branch.api.whoeverwants.com`-style API host that takes a
+different FE origin, extend the allowlist.
 
 ---
 

--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -46,6 +46,7 @@ import { haptic } from "@/lib/haptics";
 import { PENDING_ACTION_COPY, type PendingActionKind } from "./groupActionCopy";
 import { GroupCardItem, ROW_DIVIDER_CLASS, type GroupCardGroup } from "./GroupCardItem";
 import BubbleBarPanel, { PANEL_HEIGHT_VAR, PANEL_OFFSET_VAR } from "@/components/BubbleBarPanel";
+import { GroupNotFound as GroupNotFoundFallback } from "@/components/GroupLoadState";
 
 import type { Group } from "@/lib/groupUtils";
 
@@ -1706,20 +1707,11 @@ export function GroupContent({ groupId, overlayCardsOffset }: GroupContentProps)
   }
 
   if (error || !group) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Group Not Found</h2>
-          <p className="text-gray-600 dark:text-gray-400 mb-4">This group may not exist or you don&apos;t have access.</p>
-          <button
-            onClick={() => router.push('/')}
-            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
-          >
-            Go Home
-          </button>
-        </div>
-      </div>
-    );
+    // Phase F: GroupNotFoundFallback surfaces the "Request to join"
+    // CTA for signed-in non-members of private groups. Passing
+    // routeId from `groupId` (the URL path id) lets it POST against
+    // the correct group on tap.
+    return <GroupNotFoundFallback routeId={groupId} />;
   }
 
   return (
@@ -2256,20 +2248,10 @@ function GroupPageInner() {
   }, [pollParam, rootPoll, groupShortId, router]);
 
   if (error) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Group Not Found</h2>
-          <p className="text-gray-600 dark:text-gray-400 mb-4">This group may have been removed or the link is incorrect.</p>
-          <button
-            onClick={() => router.push("/")}
-            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
-          >
-            Go Home
-          </button>
-        </div>
-      </div>
-    );
+    // Phase F: same join-request affordance as the GroupContent error
+    // branch above. `groupShortId` here is the URL path id from
+    // useParams() — handed to GroupNotFoundFallback as `routeId`.
+    return <GroupNotFoundFallback routeId={groupShortId} />;
   }
 
   if (!rootPoll && !isEmptyGroup) {

--- a/app/g/[groupShortId]/edit-title/page.tsx
+++ b/app/g/[groupShortId]/edit-title/page.tsx
@@ -251,7 +251,7 @@ export function GroupEditTitleView({ groupId }: { groupId: string }) {
   const { group, loading, error } = useGroup(groupId);
 
   if (loading) return <GroupLoading />;
-  if (error || !group) return <GroupNotFound />;
+  if (error || !group) return <GroupNotFound routeId={groupId} />;
   return <Editor group={group} groupId={groupId} />;
 }
 

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -10,6 +10,7 @@ import GroupShareButton from "@/components/GroupShareButton";
 import GroupPrivacySection from "@/components/GroupPrivacySection";
 import HeaderPortal from "@/components/HeaderPortal";
 import InitialBubble from "@/components/InitialBubble";
+import InviteLinksSection from "@/components/InviteLinksSection";
 import JoinRequestsSection from "@/components/JoinRequestsSection";
 import NotificationSettingsCard from "@/components/NotificationSettingsCard";
 import { GroupLoading, GroupNotFound } from "@/components/GroupLoadState";
@@ -129,6 +130,8 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         <GroupPrivacySection group={group} groupId={groupId} />
 
         <JoinRequestsSection groupId={groupId} enabled={viewerIsCreator} />
+
+        <InviteLinksSection groupId={groupId} enabled={viewerIsCreator} />
 
         <NotificationSettingsCard groupRouteId={groupId} className="mt-[0.96rem]" />
 

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { hasAppHistory } from "@/lib/viewTransitions";
 import { slideToGroupRoot, slideToGroupEditTitle } from "@/lib/slideOverlay";
@@ -10,10 +10,16 @@ import GroupShareButton from "@/components/GroupShareButton";
 import GroupPrivacySection from "@/components/GroupPrivacySection";
 import HeaderPortal from "@/components/HeaderPortal";
 import InitialBubble from "@/components/InitialBubble";
+import JoinRequestsSection from "@/components/JoinRequestsSection";
 import NotificationSettingsCard from "@/components/NotificationSettingsCard";
 import { GroupLoading, GroupNotFound } from "@/components/GroupLoadState";
 import { getUserName, isCurrentUserName } from "@/lib/userProfile";
 import { useMyUserImageUrl } from "@/lib/useMyUserImageUrl";
+import {
+  getCachedSessionUser,
+  SESSION_CHANGED_EVENT,
+  type SessionUser,
+} from "@/lib/session";
 
 /** Prop-driven inner view. Exposed so the slide overlay can render this
  *  view directly without going through useParams() (the overlay mounts
@@ -22,12 +28,25 @@ export function GroupInfoView({ groupId }: { groupId: string }) {
   const { group, loading, error } = useGroup(groupId);
 
   if (loading) return <GroupLoading />;
-  if (error || !group) return <GroupNotFound />;
+  if (error || !group) return <GroupNotFound routeId={groupId} />;
   return <Info group={group} groupId={groupId} />;
 }
 
 function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; groupId: string }) {
   const myUserImageUrl = useMyUserImageUrl();
+  // Mirror GroupPrivacySection's session-tracking pattern: seed from
+  // the localStorage-cached profile on mount, then subscribe to live
+  // session changes so the JoinRequestsSection mounts/unmounts the
+  // moment the viewer signs in or out without a remount of the page.
+  const [session, setSession] = useState<SessionUser | null>(null);
+  useEffect(() => {
+    setSession(getCachedSessionUser());
+    const update = () => setSession(getCachedSessionUser());
+    window.addEventListener(SESSION_CHANGED_EVENT, update);
+    return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
+  }, []);
+  const viewerIsCreator =
+    !!session && !!group.creatorUserId && session.user_id === group.creatorUserId;
 
   const goBack = () => {
     // Slide overlay: mount the group root above the current page and slide
@@ -108,6 +127,8 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         </div>
 
         <GroupPrivacySection group={group} groupId={groupId} />
+
+        <JoinRequestsSection groupId={groupId} enabled={viewerIsCreator} />
 
         <NotificationSettingsCard groupRouteId={groupId} className="mt-[0.96rem]" />
 

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -1,0 +1,177 @@
+/**
+ * Phase G: invite redemption landing page (`/invite/<token>`).
+ *
+ * The URL minted by `POST /api/groups/<id>/invites` resolves here.
+ * Flow:
+ *   1. Page mounts → reads `token` from URL params.
+ *   2. If anonymous → show "Sign in to join this group" + SignInModal.
+ *      Signing in fires SESSION_CHANGED_EVENT → effect re-fires →
+ *      auto-redeem.
+ *   3. If signed in → POST /api/auth/invites/<token>/redeem.
+ *      - 200 → router.replace to `/g/<group_short_id>` (or
+ *        `/g/<group_short_id>/p/<poll_short_id>` when the invite has
+ *        a target_poll_id).
+ *      - 404 → "This invite link is invalid or expired."
+ *      - 401 (token expired mid-tap) → silently re-trigger sign-in.
+ *
+ * We deliberately don't surface group info BEFORE redemption (no
+ * "preview the group title" call). Phase E's privacy rule says
+ * private groups shouldn't leak metadata to non-members; the invite
+ * URL is the leak channel that DOES leak (intentionally), but only
+ * the title — and we'd rather just navigate the user into the group
+ * after they redeem than surface a "preview, click again to redeem"
+ * step.
+ */
+
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+import {
+  ApiError,
+  apiRedeemInvite,
+  type InviteRedeemResult,
+} from "@/lib/api";
+import SignInModal from "@/components/SignInModal";
+import { GroupLoading } from "@/components/GroupLoadState";
+import {
+  getCachedSessionUser,
+  SESSION_CHANGED_EVENT,
+  type SessionUser,
+} from "@/lib/session";
+
+function buildDestinationUrl(result: InviteRedeemResult): string {
+  const groupRoute = result.group_short_id || result.group_id;
+  if (result.target_poll_short_id) {
+    return `/g/${groupRoute}/p/${result.target_poll_short_id}`;
+  }
+  return `/g/${groupRoute}`;
+}
+
+function InviteRedeemView({ token }: { token: string }) {
+  const router = useRouter();
+  const [session, setSession] = useState<SessionUser | null>(null);
+  const [phase, setPhase] = useState<
+    "loading" | "anonymous" | "redeeming" | "error"
+  >("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [signInOpen, setSignInOpen] = useState(false);
+
+  // Track the latest session via the same pattern other surfaces use
+  // — initial read on mount + SESSION_CHANGED_EVENT subscription so
+  // signing in via the modal triggers redemption without a remount.
+  useEffect(() => {
+    setSession(getCachedSessionUser());
+    const update = () => setSession(getCachedSessionUser());
+    window.addEventListener(SESSION_CHANGED_EVENT, update);
+    return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
+  }, []);
+
+  // Auto-redeem whenever we have a session. Re-fires on session
+  // changes (so the post-sign-in flow lands here). Closes the
+  // SignInModal too — once the user signs in, the modal's purpose is
+  // done and the redemption flow takes over.
+  useEffect(() => {
+    if (!session) {
+      setPhase("anonymous");
+      return;
+    }
+    setPhase("redeeming");
+    setSignInOpen(false);
+    setErrorMessage(null);
+    let cancelled = false;
+    apiRedeemInvite(token)
+      .then((result) => {
+        if (cancelled) return;
+        router.replace(buildDestinationUrl(result));
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof ApiError && e.status === 401) {
+          // Session expired between the cache read and the POST. The
+          // fetch wrapper has already cleared local session state, so
+          // SESSION_CHANGED_EVENT fires and this effect re-runs into
+          // the anonymous branch — which surfaces the sign-in CTA.
+          setPhase("anonymous");
+          return;
+        }
+        const msg =
+          e instanceof ApiError && e.status === 404
+            ? "This invite link is invalid or expired."
+            : e instanceof ApiError
+            ? e.message
+            : "Could not redeem invite. Please try again.";
+        setErrorMessage(msg);
+        setPhase("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [session, token, router]);
+
+  if (phase === "loading" || phase === "redeeming") {
+    return <GroupLoading label="Joining group..." />;
+  }
+
+  if (phase === "error") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-sm px-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            Couldn&apos;t redeem invite
+          </h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            {errorMessage ?? "This invite link is invalid or expired."}
+          </p>
+          <button
+            onClick={() => router.replace("/")}
+            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+          >
+            Go Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Anonymous branch
+  return (
+    <>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-sm px-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            You&apos;ve been invited
+          </h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            Sign in to join the group.
+          </p>
+          <button
+            onClick={() => setSignInOpen(true)}
+            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+          >
+            Sign in to continue
+          </button>
+        </div>
+      </div>
+      <SignInModal
+        isOpen={signInOpen}
+        onClose={() => setSignInOpen(false)}
+      />
+    </>
+  );
+}
+
+function InviteRedeemInner() {
+  const params = useParams();
+  const token = params.token as string;
+  return <InviteRedeemView token={token} />;
+}
+
+export default function InviteRedeemPage() {
+  return (
+    <Suspense fallback={<GroupLoading label="Joining group..." />}>
+      <InviteRedeemInner />
+    </Suspense>
+  );
+}

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -133,6 +133,10 @@ function TemplateInner({ children }: AppTemplateProps) {
   // of the new group button + padding treatment via isGroupRootView.
   const isGroupLikePage = isGroupRootView(pathname);
   const isSettingsPage = pathname === '/settings' || pathname === '/settings/';
+  // Phase G: /invite/<token> is a redemption landing page that renders
+  // its own full-screen redirect-or-sign-in UI. The template's
+  // fallback header would just sit above it as empty chrome.
+  const isInvitePage = pathname.startsWith('/invite/');
 
   // The draft poll card on every group-like page hosts the inline question
   // form (category/for fields + question fields) plus the staged-questions
@@ -143,8 +147,8 @@ function TemplateInner({ children }: AppTemplateProps) {
 
   return (
     <>
-      {/* Fallback header for pages without a page-specific header (not group, settings, home, or create-modal). */}
-      {!isGroupFamilyPage && !isSettingsPage && pathname !== '/' && (
+      {/* Fallback header for pages without a page-specific header (not group, settings, home, invite redemption, or create-modal). */}
+      {!isGroupFamilyPage && !isSettingsPage && !isInvitePage && pathname !== '/' && (
         <div className="sticky top-0 z-30 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700"
              style={{ paddingTop: 'env(safe-area-inset-top)' }}>
           <div className="relative flex items-start justify-between pt-2 pb-2 pl-2 pr-2.5">

--- a/components/GroupLoadState.tsx
+++ b/components/GroupLoadState.tsx
@@ -1,6 +1,19 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+
+import {
+  ApiError,
+  apiCreateGroupJoinRequest,
+} from "@/lib/api";
+import SignInModal from "@/components/SignInModal";
+import { haptic } from "@/lib/haptics";
+import {
+  getCachedSessionUser,
+  SESSION_CHANGED_EVENT,
+  type SessionUser,
+} from "@/lib/session";
 
 export function GroupLoading({ label = "Loading group..." }: { label?: string }) {
   return (
@@ -16,20 +29,154 @@ export function GroupLoading({ label = "Loading group..." }: { label?: string })
   );
 }
 
-export function GroupNotFound() {
+/**
+ * Phase F: when `routeId` is provided AND the viewer is signed in,
+ * surface a "Request to join" affordance below the standard "Go Home"
+ * fallback. The button POSTs to `/api/groups/<routeId>/join-requests`
+ * — which works regardless of whether this is a private-group 404
+ * (the actual case it's meant to handle) or just a wrong URL (it'll
+ * 404 too, surfaced as a clean error message).
+ *
+ * Why on the 404 page and not on a private group's hidden landing
+ * page: per Phase E, /by-route-id 404s strangers on private groups
+ * with no leak of title/avatar. So the 404 page IS the only surface a
+ * signed-in non-member ever reaches when given a private group's URL.
+ * We don't try to look up the group here — that would be the leak.
+ *
+ * UX states:
+ *   * Anonymous viewer → only the "Go Home" button (signing in alone
+ *     isn't a meaningful CTA — they need a private group URL first).
+ *   * Signed-in viewer → "Request to join" button below "Go Home".
+ *     Tap → POST → on success show "Request sent. The group's creator
+ *     will be notified."; on 404 show "Group not found."; on 401
+ *     (token expired mid-tap) show a re-sign-in nudge.
+ */
+export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
   const router = useRouter();
+  const [session, setSession] = useState<SessionUser | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [status, setStatus] = useState<
+    | { kind: "idle" }
+    | { kind: "sent"; message: string }
+    | { kind: "error"; message: string }
+  >({ kind: "idle" });
+  const [signInOpen, setSignInOpen] = useState(false);
+
+  // Same session-tracking pattern as GroupPrivacySection — seed from
+  // the localStorage cache then subscribe to live changes so the
+  // "Request to join" button surfaces the moment the user signs in
+  // via the modal below.
+  useEffect(() => {
+    setSession(getCachedSessionUser());
+    const update = () => setSession(getCachedSessionUser());
+    window.addEventListener(SESSION_CHANGED_EVENT, update);
+    return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
+  }, []);
+
+  const requestAccess = () => {
+    if (!routeId || submitting) return;
+    haptic.medium();
+    setSubmitting(true);
+    setStatus({ kind: "idle" });
+    apiCreateGroupJoinRequest(routeId, null)
+      .then((result) => {
+        if (result.status === "already_member") {
+          setStatus({
+            kind: "sent",
+            message: "You're already in this group. Go home to find it.",
+          });
+        } else if (result.status === "already_pending") {
+          setStatus({
+            kind: "sent",
+            message: "You've already requested access. The creator will see it.",
+          });
+        } else {
+          setStatus({
+            kind: "sent",
+            message: "Request sent. The group's creator will be notified.",
+          });
+        }
+      })
+      .catch((e) => {
+        const msg =
+          e instanceof ApiError && e.status === 404
+            ? "Group not found. Check the link."
+            : e instanceof ApiError && e.status === 401
+            ? "Session expired. Sign in again."
+            : e instanceof ApiError
+            ? e.message
+            : "Could not send request";
+        setStatus({ kind: "error", message: msg });
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  // The "Request to join" CTA only renders when we have a routeId to
+  // request against AND the viewer is signed in. Anonymous viewers
+  // get a quieter "Sign in to request access" nudge that opens the
+  // SignInModal — once they sign in, the SESSION_CHANGED_EVENT fires
+  // and this component re-renders with the actual Request button.
+  const canRequest = !!routeId && !!session;
+  const showSignInNudge = !!routeId && !session;
+  const requestSent = status.kind === "sent";
+
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Group Not Found</h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-4">This group may not exist or you don&apos;t have access.</p>
-        <button
-          onClick={() => router.push("/")}
-          className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
-        >
-          Go Home
-        </button>
+    <>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-sm px-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Group Not Found</h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            This group may not exist or you don&apos;t have access.
+          </p>
+          <button
+            onClick={() => router.push("/")}
+            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+          >
+            Go Home
+          </button>
+          {canRequest && !requestSent && (
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={requestAccess}
+                disabled={submitting}
+                className="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-900 dark:text-white font-medium rounded-lg transition-colors disabled:opacity-50"
+              >
+                {submitting ? "Sending…" : "Request to join"}
+              </button>
+            </div>
+          )}
+          {showSignInNudge && (
+            <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+              <button
+                type="button"
+                onClick={() => setSignInOpen(true)}
+                className="text-blue-600 dark:text-blue-400 hover:underline active:opacity-70"
+              >
+                Sign in
+              </button>
+              {" to request access."}
+            </p>
+          )}
+          {status.kind === "sent" && (
+            <p
+              className="mt-4 text-sm text-green-700 dark:text-green-400"
+              role="status"
+            >
+              {status.message}
+            </p>
+          )}
+          {status.kind === "error" && (
+            <p
+              className="mt-4 text-sm text-red-600 dark:text-red-400"
+              role="status"
+            >
+              {status.message}
+            </p>
+          )}
+        </div>
       </div>
-    </div>
+      <SignInModal isOpen={signInOpen} onClose={() => setSignInOpen(false)} />
+    </>
   );
 }

--- a/components/InviteLinksSection.tsx
+++ b/components/InviteLinksSection.tsx
@@ -1,0 +1,262 @@
+/**
+ * Phase G (group invite links) — creator-side invite management
+ * section on /info.
+ *
+ * Two UI surfaces:
+ *   1. List of active invites with per-row Copy + Revoke buttons.
+ *      "Active" = not revoked, not expired, has remaining uses. The
+ *      server filters this set; the FE just renders.
+ *   2. "Create new invite link" button. v1 mints a multi-use,
+ *      unlimited, no-expiry invite with no target poll — the simplest
+ *      shape. Future iterations can layer a modal for mode / expiry /
+ *      target controls without changing the API contract.
+ *
+ * Only mounted when the viewer is the recorded creator (the parent
+ * /info page gates this via the same session + creator_user_id check
+ * as `GroupPrivacySection`'s toggle + `JoinRequestsSection`).
+ *
+ * Token + URL display:
+ *   - The list endpoint NEVER returns raw tokens — they're one-shot
+ *     at create time. So an invite row from list mode shows
+ *     "Active link" + use_count + Revoke; no Copy button (we don't
+ *     have the URL to copy).
+ *   - The newly-minted invite from `apiCreateGroupInvite` DOES carry
+ *     `url` + `token`. We prepend it to the list and surface a Copy
+ *     button for THAT row only. After page refresh / unmount, the
+ *     URL is lost (matches the security model — server didn't keep
+ *     it either).
+ *
+ * Empty active list (and no freshly-minted row) → just shows the
+ * "Create new invite link" button; no "no invites yet" placeholder.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  ApiError,
+  apiCreateGroupInvite,
+  apiListGroupInvites,
+  apiRevokeGroupInvite,
+} from "@/lib/api";
+import type { GroupInvite } from "@/lib/api";
+import { haptic } from "@/lib/haptics";
+
+interface Props {
+  groupId: string;
+  /** When false, the section renders nothing (used to gate on the
+   *  creator check at the parent level). */
+  enabled: boolean;
+  className?: string;
+}
+
+export default function InviteLinksSection({
+  groupId,
+  enabled,
+  className = "mt-6",
+}: Props) {
+  // `invites` is the server's view (no tokens). `freshUrls` is a
+  // per-id Map of "this invite was minted in THIS browser session, so
+  // we still have its raw URL". The merger below the JSX overlays
+  // them so freshly-minted rows show a Copy button while
+  // previously-existing rows don't.
+  const [invites, setInvites] = useState<GroupInvite[] | null>(null);
+  const [freshUrls, setFreshUrls] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [revokingIds, setRevokingIds] = useState<Set<string>>(new Set());
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setInvites(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiListGroupInvites(groupId)
+      .then((data) => {
+        if (cancelled) return;
+        setInvites(data);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof ApiError && (e.status === 403 || e.status === 404)) {
+          setInvites([]);
+          return;
+        }
+        setError(
+          e instanceof ApiError ? e.message : "Failed to load invites",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId, enabled]);
+
+  const createInvite = () => {
+    if (creating) return;
+    haptic.medium();
+    setCreating(true);
+    setError(null);
+    // v1 defaults: multi-use, unlimited, no expiry, no target poll.
+    // The modal-driven configuration UI is a follow-up.
+    apiCreateGroupInvite(groupId, { mode: "multi" })
+      .then((invite) => {
+        setInvites((prev) => (prev ? [invite, ...prev] : [invite]));
+        if (invite.url) {
+          setFreshUrls((prev) => ({ ...prev, [invite.id]: invite.url! }));
+        }
+      })
+      .catch((e) => {
+        setError(
+          e instanceof ApiError ? e.message : "Failed to create invite",
+        );
+      })
+      .finally(() => setCreating(false));
+  };
+
+  const revokeInvite = (invite: GroupInvite) => {
+    if (revokingIds.has(invite.id)) return;
+    haptic.medium();
+    setRevokingIds((prev) => {
+      const next = new Set(prev);
+      next.add(invite.id);
+      return next;
+    });
+    setError(null);
+    // Optimistically drop the row.
+    setInvites((prev) =>
+      prev ? prev.filter((i) => i.id !== invite.id) : prev,
+    );
+    setFreshUrls((prev) => {
+      if (!(invite.id in prev)) return prev;
+      const next = { ...prev };
+      delete next[invite.id];
+      return next;
+    });
+    apiRevokeGroupInvite(groupId, invite.id)
+      .catch((e) => {
+        setInvites((prev) => (prev ? [invite, ...prev] : prev));
+        setError(
+          e instanceof ApiError ? e.message : "Failed to revoke invite",
+        );
+      })
+      .finally(() => {
+        setRevokingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(invite.id);
+          return next;
+        });
+      });
+  };
+
+  const copyUrl = async (invite: GroupInvite, url: string) => {
+    haptic.light();
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedId(invite.id);
+      // Clear the "Copied!" indicator after a short delay so the
+      // user can tell repeated taps registered.
+      window.setTimeout(() => {
+        setCopiedId((prev) => (prev === invite.id ? null : prev));
+      }, 1800);
+    } catch {
+      // Last-resort fallback if Clipboard API is unavailable
+      // (older WebViews, permissions blocked, etc.).
+      window.prompt("Copy this URL:", url);
+    }
+  };
+
+  if (!enabled || loading) return null;
+
+  // Always render the create button when the section is enabled —
+  // empty list is the common starting state.
+  const list = invites ?? [];
+
+  return (
+    <section className={className}>
+      <h2 className="px-1 mb-2 text-sm font-semibold text-gray-500 dark:text-gray-400">
+        Invite links
+      </h2>
+      {error && (
+        <p
+          className="px-1 mb-2 text-xs text-red-600 dark:text-red-400"
+          role="status"
+        >
+          {error}
+        </p>
+      )}
+      {list.length > 0 && (
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden mb-3">
+          <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+            {list.map((invite) => {
+              const url = freshUrls[invite.id];
+              const revoking = revokingIds.has(invite.id);
+              const usageLabel =
+                invite.max_uses != null
+                  ? `${invite.use_count}/${invite.max_uses} used`
+                  : `${invite.use_count} used`;
+              const modeLabel =
+                invite.mode === "single" ? "Single use" : "Multi-use";
+              return (
+                <li key={invite.id} className="px-4 py-3 flex flex-col gap-2">
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-gray-900 dark:text-white">
+                      {modeLabel} · {usageLabel}
+                    </span>
+                    {url && (
+                      <span className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 break-all">
+                        {url}
+                      </span>
+                    )}
+                    {!url && (
+                      <span className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                        Link only shown when first created.
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {url && (
+                      <button
+                        type="button"
+                        onClick={() => copyUrl(invite, url)}
+                        className="flex-1 h-10 rounded-full bg-blue-600 hover:bg-blue-700 active:scale-95 text-white text-sm font-medium transition-transform"
+                        aria-label="Copy invite link"
+                      >
+                        {copiedId === invite.id ? "Copied!" : "Copy link"}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => revokeInvite(invite)}
+                      disabled={revoking}
+                      className="flex-1 h-10 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 active:scale-95 text-gray-800 dark:text-gray-200 text-sm font-medium disabled:opacity-50 transition-transform"
+                      aria-label="Revoke invite"
+                    >
+                      Revoke
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={createInvite}
+        disabled={creating}
+        className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 active:scale-95 text-white text-sm font-medium rounded-full disabled:opacity-50 transition-transform"
+      >
+        {creating ? "Creating…" : "Create invite link"}
+      </button>
+    </section>
+  );
+}

--- a/components/JoinRequestsSection.tsx
+++ b/components/JoinRequestsSection.tsx
@@ -1,0 +1,194 @@
+/**
+ * Phase F (group join requests) — creator-side pending list on /info.
+ *
+ * Renders the group's pending join requests with Approve / Deny
+ * buttons per row. Only mounted when the caller is the group's
+ * recorded `creator_user_id` (the parent /info page gates this via
+ * the same session + creator_user_id check as
+ * `GroupPrivacySection`'s toggle).
+ *
+ * Empty pending list → renders nothing at all (no chrome, no "no
+ * pending requests" placeholder). The section's whole purpose is to
+ * surface actionable items; rendering an empty card every time the
+ * creator opens /info would be visual noise.
+ *
+ * Action flow:
+ *   1. Tap Approve / Deny → optimistic remove from the local list +
+ *      haptic feedback.
+ *   2. Fire `apiDecideGroupJoinRequest`.
+ *   3. On success, leave the row removed. On failure, restore + show
+ *      a transient error message above the section.
+ *
+ * Requester identity display:
+ *   - Email when available (most users — magic-link sign-in always
+ *     records one, OAuth merges via verified email).
+ *   - "Passkey user" fallback for Phase D no-email accounts.
+ *   - Message (if any) renders below the identity line in lighter
+ *     text. Long messages truncate to 3 lines with an expandable
+ *     "more" link (deferred — for v1, line-clamp-3 is enough).
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  ApiError,
+  apiDecideGroupJoinRequest,
+  apiListGroupJoinRequests,
+} from "@/lib/api";
+import type { GroupJoinRequest } from "@/lib/api";
+import { haptic } from "@/lib/haptics";
+
+interface Props {
+  groupId: string;
+  /** When true, the section refetches its list. Driver: parent calls
+   *  this after the SignInModal flips from signed-out to signed-in.
+   *  Falsy → don't fetch; the section renders nothing. */
+  enabled: boolean;
+  className?: string;
+}
+
+export default function JoinRequestsSection({
+  groupId,
+  enabled,
+  className = "mt-6",
+}: Props) {
+  const [requests, setRequests] = useState<GroupJoinRequest[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Track per-request "deciding" state so a slow network doesn't let
+  // the user double-tap and fire two decide POSTs.
+  const [decidingIds, setDecidingIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!enabled) {
+      setRequests(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiListGroupJoinRequests(groupId)
+      .then((data) => {
+        if (cancelled) return;
+        setRequests(data);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        // 403 / 404 here just means the caller isn't the creator or
+        // the route is unresolvable — both fall through to "render
+        // nothing", which the empty-list branch already handles. Log
+        // anything else as an explicit error.
+        if (e instanceof ApiError && (e.status === 403 || e.status === 404)) {
+          setRequests([]);
+          return;
+        }
+        setError(
+          e instanceof ApiError ? e.message : "Failed to load join requests",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId, enabled]);
+
+  const decide = (request: GroupJoinRequest, action: "approve" | "deny") => {
+    if (decidingIds.has(request.id)) return;
+    haptic.medium();
+    setDecidingIds((prev) => {
+      const next = new Set(prev);
+      next.add(request.id);
+      return next;
+    });
+    setError(null);
+    // Optimistically drop the row — the decided-on row will be gone
+    // from the server's pending list on next reload anyway.
+    setRequests((prev) =>
+      prev ? prev.filter((r) => r.id !== request.id) : prev,
+    );
+    apiDecideGroupJoinRequest(groupId, request.id, action)
+      .catch((e) => {
+        // Roll the row back so the creator can retry.
+        setRequests((prev) => (prev ? [request, ...prev] : prev));
+        setError(
+          e instanceof ApiError ? e.message : "Failed to decide request",
+        );
+      })
+      .finally(() => {
+        setDecidingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(request.id);
+          return next;
+        });
+      });
+  };
+
+  // Render nothing during initial load (no need to show a spinner for a
+  // section that's blank when empty), when not enabled, or when there
+  // are no pending requests. The only visible states are "has
+  // requests" and "had a load error".
+  if (!enabled || loading || !requests) return null;
+  if (requests.length === 0 && !error) return null;
+
+  return (
+    <section className={className}>
+      <h2 className="px-1 mb-2 text-sm font-semibold text-gray-500 dark:text-gray-400">
+        Pending requests
+      </h2>
+      {error && (
+        <p
+          className="px-1 mb-2 text-xs text-red-600 dark:text-red-400"
+          role="status"
+        >
+          {error}
+        </p>
+      )}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden">
+        <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+          {requests.map((r) => {
+            const deciding = decidingIds.has(r.id);
+            const identity = r.requester_email ?? "Passkey user";
+            return (
+              <li key={r.id} className="px-4 py-3 flex flex-col gap-2">
+                <div className="flex flex-col min-w-0">
+                  <span className="text-gray-900 dark:text-white break-words">
+                    {identity}
+                  </span>
+                  {r.message && (
+                    <span className="mt-0.5 text-sm text-gray-600 dark:text-gray-400 break-words whitespace-pre-wrap">
+                      {r.message}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => decide(r, "approve")}
+                    disabled={deciding}
+                    className="flex-1 h-10 rounded-full bg-green-600 hover:bg-green-700 active:scale-95 text-white text-sm font-medium disabled:opacity-50 transition-transform"
+                    aria-label={`Approve request from ${identity}`}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => decide(r, "deny")}
+                    disabled={deciding}
+                    className="flex-1 h-10 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 active:scale-95 text-gray-800 dark:text-gray-200 text-sm font-medium disabled:opacity-50 transition-transform"
+                    aria-label={`Deny request from ${identity}`}
+                  >
+                    Deny
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/database/migrations/115_group_join_requests_down.sql
+++ b/database/migrations/115_group_join_requests_down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP INDEX IF EXISTS group_join_requests_requester_idx;
+DROP INDEX IF EXISTS group_join_requests_group_status_idx;
+DROP INDEX IF EXISTS group_join_requests_pending_unique;
+DROP TABLE IF EXISTS group_join_requests;
+
+COMMIT;

--- a/database/migrations/115_group_join_requests_up.sql
+++ b/database/migrations/115_group_join_requests_up.sql
@@ -1,0 +1,66 @@
+-- Phase F of the auth & access model (see docs/auth-access-model.md).
+-- Adds `group_join_requests` so signed-in non-members of a private group
+-- can request access, and the creator can approve or deny. Phase E's
+-- "private = members-only" rule otherwise leaves no path into a private
+-- group except via an invite link (Phase G).
+--
+-- One pending request per (group, requester) — enforced by a partial
+-- unique index so the same user can re-request after a denial without a
+-- dedupe error. Status walks 'pending' → 'approved' | 'denied' |
+-- 'cancelled'; only `pending` rows occupy the unique slot.
+--
+-- `requester_user_id` is NOT NULL: only signed-in users can request.
+-- Anonymous browsers can't request because there's no durable identity
+-- to approve against (an anonymous request approved on Browser A would
+-- be useless if the user wipes localStorage on Browser B and never
+-- re-signed in). The endpoint enforces this; the FK + NOT NULL is the
+-- backstop.
+--
+-- `message` is the optional "Hi, it's Alice from work" the requester
+-- adds so the creator knows who's asking. NULL when blank.
+--
+-- ON DELETE behavior:
+--   * `group_id` → CASCADE: deleting a group drops every pending and
+--     historical request for it. There's no value to surface them
+--     elsewhere; the data is gone with the group.
+--   * `requester_user_id` → CASCADE: deleting a user (Phase I) drops
+--     their requests; the creator has no remaining context to act on.
+--   * `decided_by_user_id` → SET NULL: deleting the creator should NOT
+--     blow away the historical record of approved/denied decisions;
+--     the rows remain with `decided_by_user_id IS NULL` as
+--     "decision by [deleted user]".
+
+BEGIN;
+
+CREATE TABLE group_join_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    requester_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    message TEXT,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'approved', 'denied', 'cancelled')),
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    decided_at TIMESTAMPTZ,
+    decided_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Partial unique: only ONE pending request per (group, requester). A
+-- denied or approved row doesn't occupy the slot, so the user can
+-- re-request after a denial (or self-cancel and try again).
+CREATE UNIQUE INDEX group_join_requests_pending_unique
+    ON group_join_requests (group_id, requester_user_id)
+    WHERE status = 'pending';
+
+-- Creator-side "list pending for my group" lookup goes through
+-- (group_id, status) — pending list, sorted by requested_at. Covered by
+-- this index without scanning historical rows.
+CREATE INDEX group_join_requests_group_status_idx
+    ON group_join_requests (group_id, status, requested_at);
+
+-- Requester-side "my pending requests" lookup (Phase F.future may
+-- surface this as a "you have N pending requests" badge on the home
+-- page). Cheap to maintain; rare to query without it.
+CREATE INDEX group_join_requests_requester_idx
+    ON group_join_requests (requester_user_id, status);
+
+COMMIT;

--- a/database/migrations/116_group_invites_down.sql
+++ b/database/migrations/116_group_invites_down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS group_invites_group_id_idx;
+DROP TABLE IF EXISTS group_invites;
+
+COMMIT;

--- a/database/migrations/116_group_invites_up.sql
+++ b/database/migrations/116_group_invites_up.sql
@@ -1,0 +1,62 @@
+-- Phase G of the auth & access model (see docs/auth-access-model.md).
+-- Adds `group_invites` so creators can mint shareable links that grant
+-- private-group membership on redemption. Complements Phase F join
+-- requests: invites are creator-initiated, push (creator → joiner);
+-- join requests are joiner-initiated, pull (joiner → creator approves).
+--
+-- Storage shape mirrors `sessions` and `magic_link_tokens`: server
+-- stores only `sha256(token)` (token_hash). The raw token is returned
+-- exactly once at create time and embedded in the shareable URL — a DB
+-- leak doesn't yield usable invite tokens.
+--
+-- Mode: 'single' = max_uses=1 enforced server-side; 'multi' = max_uses
+-- can be NULL (unlimited) or any positive int. The check constraint
+-- accepts both — the create endpoint normalizes max_uses to 1 for
+-- 'single' regardless of what the client sent.
+--
+-- `target_poll_id` is the optional "land on this poll after joining"
+-- pointer. ON DELETE SET NULL so deleting a poll doesn't blow away
+-- the invite — the redirect just falls back to the group root.
+--
+-- `expires_at` is nullable (no expiry by default). `revoked_at` is the
+-- creator's "kill this link" stamp; NULL means active. Both are
+-- checked at redeem time; an invite is REDEEMABLE iff
+-- (revoked_at IS NULL) AND (expires_at IS NULL OR expires_at > NOW())
+-- AND (max_uses IS NULL OR use_count < max_uses).
+--
+-- ON DELETE behavior:
+--   * `group_id` → CASCADE: deleting a group drops every invite for it.
+--   * `created_by_user_id` → CASCADE: deleting a user drops their
+--     issued invites. They're not redeemable anyway after the FK row
+--     vanishes, so no value in preserving them.
+--   * `target_poll_id` → SET NULL: deleting a poll falls back to the
+--     group-root redirect on redeem.
+
+BEGIN;
+
+CREATE TABLE group_invites (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash TEXT NOT NULL UNIQUE,
+    group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    created_by_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    mode TEXT NOT NULL CHECK (mode IN ('single', 'multi')),
+    target_poll_id UUID REFERENCES polls(id) ON DELETE SET NULL,
+    max_uses INTEGER CHECK (max_uses IS NULL OR max_uses > 0),
+    use_count INTEGER NOT NULL DEFAULT 0,
+    expires_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Creator-side "list my group's invites" — pulls all rows for one
+-- group_id, sorted by created_at. Active-only filter happens in
+-- application code (compound predicate over revoked_at + expires_at
+-- + max_uses isn't worth a partial index for the expected row counts).
+CREATE INDEX group_invites_group_id_idx
+    ON group_invites (group_id, created_at DESC);
+
+-- Redeem path: hash the inbound raw token, look up by token_hash.
+-- The UNIQUE constraint already provides the index, but the explicit
+-- name makes the lookup intent visible in EXPLAIN output.
+
+COMMIT;

--- a/docs/auth-access-model.md
+++ b/docs/auth-access-model.md
@@ -142,17 +142,46 @@ group_invites
   created_at
 ```
 
-**Request flow** (Phase F):
+**Request flow** (Phase F — shipped):
 - `POST /api/groups/<route_id>/join-requests` body: `{message?}`. Requires
-  user_id. 409 if a pending request already exists.
-- Push notification fan-out to creator's `push_subscriptions` (same infra as
-  new-poll notifications, gated on the creator's per-group pref defaulting
-  ON for own groups).
-- `GET /api/groups/<route_id>/join-requests` — creator-only.
+  user_id (401 anonymous). Returns 200 with a status discriminator so
+  the FE doesn't have to branch on HTTP code:
+  * `status='already_member'` — caller is already a member or the
+    recorded creator. No row inserted, no push fired.
+  * `status='pending'` — fresh request inserted (HTTP still 200 for
+    consistency, but the FE shows "request sent").
+  * `status='already_pending'` — existing pending row returned as-is
+    (no overwrite of the prior message, no second push fire).
+  Idempotency comes from the partial unique index on (group_id,
+  requester_user_id) WHERE status='pending'. The
+  doc's original "409 on duplicate" rule was retired in favor of this
+  status-in-body design: simpler FE handling, and the existing-row
+  payload lets the FE surface "your request was sent N hours ago"
+  if a future iteration adds that affordance.
+- Push notification fan-out to the creator's `push_subscriptions`,
+  derived from `user_browsers WHERE user_id = creator` so the
+  creator gets notified on EVERY browser they're signed in on (not
+  just the one that received the request — they might have requested
+  notifications on Device A and be looking at Device B when the
+  request lands). Gated on the existing per-group `notify_new_poll`
+  pref (default ON, missing-row-is-on) — Phase F reuses the new-poll
+  pref as the single "I want to hear about this group" signal. Phase
+  I can add a dedicated `notify_join_request` column if join-request
+  volume needs to be muted independently.
+- `GET /api/groups/<route_id>/join-requests` — creator-only (401
+  anonymous, 403 non-creator, 403 group-with-no-creator). Returns
+  pending requests oldest first, with `requester_email` joined from
+  `user_identities` (NULL for passkey-only requesters).
 - `POST /api/groups/<route_id>/join-requests/<id>/decide` body:
-  `{action: 'approve'|'deny'}`. Approve → INSERT group_members. Deny →
-  mark denied. Requester gets no notification on deny (avoids "why
-  rejected" follow-ups).
+  `{action: 'approve'|'deny'}`. Approve → INSERT group_members keyed
+  on the requester's earliest-linked browser_id (per
+  `user_browsers`). `load_user_visibility`'s user_browsers walk
+  expands the single row to every device they're signed in on, so
+  one INSERT suffices. Deny → mark denied. Requester gets no
+  notification on deny (avoids "why rejected" follow-ups). The
+  request_id is scoped to (group_id, request_id) — a creator of
+  group A can't decide on a request in group B even with a guessed
+  request_id (returns 404 instead).
 
 **Invite flow** (Phase G):
 - `POST /api/groups/<route_id>/invites` body:
@@ -209,7 +238,7 @@ the original session for the rationale.
 | C | OAuth (Apple, Google) | web + Capacitor flows, ID-token verify, account merge on shared email | A |
 | D | Passkey | WebAuthn server + browser; iOS native plugin | A; can ship after E/F if flaky |
 | E | Group privacy | `groups.privacy`, `groups.creator_user_id`, visibility filter, sign-in nudge | A, B |
-| F | Join requests | `group_join_requests` table, request/approve/deny, push notification | E |
+| F | Join requests (shipped) | `group_join_requests` table (migration 115), request/approve/deny endpoints, push notification fan-out to creator's `user_browsers`, /info "Pending requests" creator section, "Request to join" CTA on signed-in 404 page | E |
 | G | Invite links | `group_invites` table, create/redeem/revoke, target-poll on join | E |
 | H | Per-vote anonymity | anonymity flags on votes, read-time filter everywhere, audit test | A |
 | I | Polish | account settings (linked identities, **add recovery email to passkey-only account**, sign out, delete), retire `creator_secret` | A–H |

--- a/docs/auth-access-model.md
+++ b/docs/auth-access-model.md
@@ -183,16 +183,40 @@ group_invites
   group A can't decide on a request in group B even with a guessed
   request_id (returns 404 instead).
 
-**Invite flow** (Phase G):
+**Invite flow** (Phase G — shipped):
 - `POST /api/groups/<route_id>/invites` body:
-  `{mode, max_uses?, target_poll_id?, expires_in_hours?}`. Returns
-  `{token, url}`. Token is the raw value, only ever returned once.
-- `POST /api/auth/invites/<token>/redeem` — requires user_id; writes
-  `group_members` if not already a member, bumps use_count, returns
-  `{group_id, target_poll_id}` for FE redirect.
-- `DELETE /api/groups/<route_id>/invites/<id>` — revoke.
-- FE `/g/<id>/info` adds an "Invite link" section listing active invites
-  (with use counts) + a "Create invite link" button.
+  `{mode, max_uses?, target_poll_id?, expires_in_hours?}`. Creator-only.
+  Returns the full `InviteResponse` shape including raw `token` + a
+  host-derived `url`, returned EXACTLY ONCE. The server stores
+  sha256(token) only. `mode='single'` normalizes max_uses=1; cross-group
+  `target_poll_id`s are silently downgraded to NULL rather than 400'd.
+- `POST /api/auth/invites/<token>/redeem` — requires user_id. Atomic
+  conditional UPDATE bumps `use_count` only if the invite is
+  redeemable (not revoked, not expired, has remaining uses).
+  Writes `group_members` keyed on the requester's earliest-linked
+  browser_id (same pattern as Phase F approve). Returns
+  `{group_id, group_short_id, target_poll_id, target_poll_short_id,
+  already_member}` — short_ids pre-resolved so the FE doesn't need a
+  second round-trip to build the redirect URL. Already-member
+  redemptions roll back the use_count bump so a member re-clicking
+  the URL doesn't consume an invite use.
+- `GET /api/groups/<route_id>/invites` — creator-only. Lists active
+  invites (not revoked, not expired, has remaining uses). Omits raw
+  `token` / `url` from list responses — those are one-shot at create.
+- `DELETE /api/groups/<route_id>/invites/<id>` — creator-only revoke.
+  Idempotent: 204 on success, 404 if already revoked or not owned.
+- FE `/g/<id>/info` mounts `<InviteLinksSection>` (creator-only) with
+  a "Create invite link" button and a list of active invites (with
+  per-row Copy + Revoke). Copy is shown only on the freshly-minted
+  row in the current session — the list endpoint doesn't return raw
+  tokens, so previously-existing invites display "Link only shown
+  when first created" with a Revoke button. v1 minted invites are
+  multi-use, unlimited, no expiry; mode/max_uses/expires UI is a
+  follow-up.
+- FE `/invite/<token>` is the redemption landing page. Anonymous
+  viewers see a "Sign in to continue" CTA; signed-in viewers
+  auto-redeem on mount and `router.replace` to the destination
+  group / poll URL.
 
 ## Per-vote anonymity
 
@@ -239,7 +263,7 @@ the original session for the rationale.
 | D | Passkey | WebAuthn server + browser; iOS native plugin | A; can ship after E/F if flaky |
 | E | Group privacy | `groups.privacy`, `groups.creator_user_id`, visibility filter, sign-in nudge | A, B |
 | F | Join requests (shipped) | `group_join_requests` table (migration 115), request/approve/deny endpoints, push notification fan-out to creator's `user_browsers`, /info "Pending requests" creator section, "Request to join" CTA on signed-in 404 page | E |
-| G | Invite links | `group_invites` table, create/redeem/revoke, target-poll on join | E |
+| G | Invite links (shipped) | `group_invites` table (migration 116), creator-side create/list/revoke endpoints, anonymous-allowed `/invite/<token>` landing page that auto-redeems for signed-in viewers, `InviteLinksSection` on /info | E |
 | H | Per-vote anonymity | anonymity flags on votes, read-time filter everywhere, audit test | A |
 | I | Polish | account settings (linked identities, **add recovery email to passkey-only account**, sign out, delete), retire `creator_secret` | A–H |
 

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -254,3 +254,35 @@ export async function apiRenamePasskey(
     },
   );
 }
+
+/** Phase G: invite redemption.
+ *
+ *  Lives on /auth (not /groups) because the URL the joiner clicked
+ *  carries only a raw token — no route_id. The redeem endpoint
+ *  resolves the group from the token's stored group_id and writes a
+ *  `group_members` row for the requester's earliest-linked browser.
+ *
+ *  Throws `ApiError` on 401 (anonymous) and 404 (invalid / expired /
+ *  revoked / fully-used). The caller is responsible for surfacing
+ *  status-specific messages to the user (the FE's invite page does).
+ *
+ *  `already_member: true` is NOT an error — it means the user was
+ *  already a member (possibly approved via Phase F earlier), and
+ *  use_count was NOT bumped. The FE can still redirect into the
+ *  group but skip any "welcome!" toast. */
+export interface InviteRedeemResult {
+  group_id: string;
+  group_short_id: string | null;
+  target_poll_id: string | null;
+  target_poll_short_id: string | null;
+  already_member: boolean;
+}
+
+export async function apiRedeemInvite(
+  token: string,
+): Promise<InviteRedeemResult> {
+  return authFetch<InviteRedeemResult>(
+    `/invites/${encodeURIComponent(token)}/redeem`,
+    { method: "POST" },
+  );
+}

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -332,6 +332,83 @@ export async function apiUpdateGroupPrivacy(
   return result;
 }
 
+/**
+ * Phase F: join-request helpers.
+ *
+ * Three operations:
+ *   * `apiCreateGroupJoinRequest(routeId, message)` — signed-in
+ *     non-member requests access. Returns the request summary + a
+ *     status enum ('pending' | 'already_pending' | 'already_member')
+ *     so callers can differentiate UX states.
+ *   * `apiListGroupJoinRequests(routeId)` — creator-only list of
+ *     pending requests for their group.
+ *   * `apiDecideGroupJoinRequest(routeId, requestId, action)` —
+ *     creator approves or denies a pending request. Action 'approve'
+ *     writes a `group_members` row server-side; the approved user sees
+ *     the group on next refresh.
+ *
+ * All three throw `ApiError` on non-2xx (401 = signed out, 403 = not
+ * the creator, 404 = unknown group / already-decided request, etc.).
+ */
+
+export interface GroupJoinRequest {
+  id: string;
+  group_id: string;
+  requester_user_id: string;
+  requester_email: string | null;
+  message: string | null;
+  requested_at: string;
+}
+
+export interface CreateGroupJoinRequestResult {
+  status: 'pending' | 'already_pending' | 'already_member';
+  request: GroupJoinRequest | null;
+}
+
+export async function apiCreateGroupJoinRequest(
+  routeId: string,
+  message: string | null,
+): Promise<CreateGroupJoinRequestResult> {
+  const data = await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/join-requests`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ message: message ?? null }),
+    },
+  );
+  return {
+    status: data.status,
+    request: data.request ?? null,
+  };
+}
+
+export async function apiListGroupJoinRequests(
+  routeId: string,
+): Promise<GroupJoinRequest[]> {
+  const data = await groupFetch<any[]>(
+    `/${encodeURIComponent(routeId)}/join-requests`,
+  );
+  return Array.isArray(data) ? data : [];
+}
+
+export async function apiDecideGroupJoinRequest(
+  routeId: string,
+  requestId: string,
+  action: 'approve' | 'deny',
+): Promise<{ request_id: string; status: 'approved' | 'denied' }> {
+  const data = await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/join-requests/${encodeURIComponent(requestId)}/decide`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ action }),
+    },
+  );
+  return {
+    request_id: data.request_id,
+    status: data.status,
+  };
+}
+
 /** Encode an ArrayBuffer as base64. Chunked to avoid the `apply()`
  *  call-stack limit on big buffers — handles the 5 MiB max-image-size
  *  cap comfortably. */

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -409,6 +409,87 @@ export async function apiDecideGroupJoinRequest(
   };
 }
 
+/**
+ * Phase G: invite-link helpers.
+ *
+ * Three creator-side operations + one redeem (which lives on the
+ * `auth` namespace because the URL the joiner clicked has no
+ * route_id, only a raw token):
+ *   * `apiCreateGroupInvite(routeId, options)` — mint a new invite.
+ *     The response includes the raw `token` + a host-derived `url`
+ *     exactly ONCE; lose it and the creator has to mint again.
+ *   * `apiListGroupInvites(routeId)` — active invites for a group,
+ *     creator-only.
+ *   * `apiRevokeGroupInvite(routeId, inviteId)` — mark an invite
+ *     revoked.
+ *   * `apiRedeemInvite(token)` is exported from `lib/api/auth.ts`.
+ *
+ * The list endpoint deliberately omits `token` and `url` (one-shot at
+ * create time) — a lost URL means a new invite, not a "view the link
+ * again" affordance.
+ */
+
+export interface GroupInvite {
+  id: string;
+  group_id: string;
+  mode: 'single' | 'multi';
+  target_poll_id: string | null;
+  max_uses: number | null;
+  use_count: number;
+  expires_at: string | null;
+  created_at: string;
+  /** Populated only on the create-response shape, NEVER on list. */
+  token?: string | null;
+  /** Populated only on the create-response shape, NEVER on list. */
+  url?: string | null;
+}
+
+export interface CreateGroupInviteOptions {
+  mode?: 'single' | 'multi';
+  max_uses?: number | null;
+  target_poll_id?: string | null;
+  expires_in_hours?: number | null;
+}
+
+export async function apiCreateGroupInvite(
+  routeId: string,
+  options: CreateGroupInviteOptions = {},
+): Promise<GroupInvite> {
+  const body = {
+    mode: options.mode ?? 'multi',
+    max_uses: options.max_uses ?? null,
+    target_poll_id: options.target_poll_id ?? null,
+    expires_in_hours: options.expires_in_hours ?? null,
+  };
+  const data = await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/invites`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    },
+  );
+  return data as GroupInvite;
+}
+
+export async function apiListGroupInvites(
+  routeId: string,
+): Promise<GroupInvite[]> {
+  const data = await groupFetch<any[]>(
+    `/${encodeURIComponent(routeId)}/invites`,
+  );
+  return Array.isArray(data) ? (data as GroupInvite[]) : [];
+}
+
+export async function apiRevokeGroupInvite(
+  routeId: string,
+  inviteId: string,
+): Promise<void> {
+  await groupFetch(
+    `/${encodeURIComponent(routeId)}/invites/${encodeURIComponent(inviteId)}`,
+    { method: 'DELETE' },
+  );
+}
+
 /** Encode an ArrayBuffer as base64. Chunked to avoid the `apply()`
  *  call-stack limit on big buffers — handles the 5 MiB max-image-size
  *  cap comfortably. */

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -47,6 +47,13 @@ export {
   apiUpdateGroupPrivacy,
   apiUploadGroupImage,
   apiDeleteGroupImage,
+  apiCreateGroupJoinRequest,
+  apiListGroupJoinRequests,
+  apiDecideGroupJoinRequest,
+} from "./groups";
+export type {
+  GroupJoinRequest,
+  CreateGroupJoinRequestResult,
 } from "./groups";
 
 export {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -50,10 +50,15 @@ export {
   apiCreateGroupJoinRequest,
   apiListGroupJoinRequests,
   apiDecideGroupJoinRequest,
+  apiCreateGroupInvite,
+  apiListGroupInvites,
+  apiRevokeGroupInvite,
 } from "./groups";
 export type {
   GroupJoinRequest,
   CreateGroupJoinRequestResult,
+  GroupInvite,
+  CreateGroupInviteOptions,
 } from "./groups";
 
 export {
@@ -92,6 +97,7 @@ export {
   apiListPasskeys,
   apiDeletePasskey,
   apiRenamePasskey,
+  apiRedeemInvite,
   getCurrentUser,
 } from "./auth";
 export type {
@@ -102,4 +108,5 @@ export type {
   PasskeySummary,
   PasskeyListResponse,
   PasskeyRegistrationResult,
+  InviteRedeemResult,
 } from "./auth";

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -157,21 +157,13 @@ class ProvidersResponse(BaseModel):
 # Origin doesn't end up in the email body (otherwise users would click
 # links to attacker-controlled domains).
 
-_ALLOWED_ORIGIN_PATTERNS = [
-    re.compile(r"^https://whoeverwants\.com$"),
-    re.compile(r"^https://latest\.whoeverwants\.com$"),
-    re.compile(r"^https://[a-z0-9-]+\.dev\.whoeverwants\.com$"),
-    re.compile(r"^http://localhost:\d+$"),
-    re.compile(r"^http://127\.0\.0\.1:\d+$"),
-]
-_DEFAULT_FE_ORIGIN = os.environ.get("FE_DEFAULT_ORIGIN", "https://whoeverwants.com")
-
-
+# `services.fe_origin.resolve_fe_origin` is the canonical FE origin
+# allowlist now — same logic, shared across magic-link + invite URL
+# minting. Kept as a thin alias here so existing call sites in this
+# router keep working without a churnful rename.
 def _resolve_fe_origin(request: Request) -> str:
-    origin = request.headers.get("origin")
-    if origin and any(p.match(origin) for p in _ALLOWED_ORIGIN_PATTERNS):
-        return origin
-    return _DEFAULT_FE_ORIGIN
+    from services.fe_origin import resolve_fe_origin as _resolve
+    return _resolve(request)
 
 
 def _resolve_rp_id(request: Request) -> str:
@@ -830,3 +822,70 @@ def rename_user_passkey(
     if not ok:
         raise HTTPException(status_code=404, detail="Passkey not found")
     return {"credential_id": credential_id, "name": req.name.strip()[:120] or None}
+
+
+# ---------------------------------------------------------------------------
+# Phase G: invite redemption
+# ---------------------------------------------------------------------------
+#
+# Lives on /api/auth (not /api/groups/<route>/invites/<token>/redeem)
+# because the redeem flow is keyed solely on the raw token — there's
+# no group route_id in the URL the joiner clicked. The token + the
+# session token are the two inputs; the group falls out of the lookup.
+
+
+class InviteRedeemResponse(BaseModel):
+    """Result of `POST /api/auth/invites/{token}/redeem`. The FE uses
+    `group_short_id` (preferred) or `group_id` (fallback) to build the
+    redirect URL; when `target_poll_short_id` is set, the redirect goes
+    deep into the poll detail page. `already_member` lets the FE
+    differentiate "you just joined" toast vs "you were already here"
+    no-op so it doesn't double-show a welcome flow."""
+
+    group_id: str
+    group_short_id: str | None
+    target_poll_id: str | None
+    target_poll_short_id: str | None
+    already_member: bool
+
+
+@router.post(
+    "/invites/{token}/redeem",
+    response_model=InviteRedeemResponse,
+)
+def redeem_group_invite(token: str, request: Request):
+    """Phase G: consume an invite token + write membership.
+
+    Requires user_id (401 anonymous). Returns 404 on invalid /
+    expired / revoked / fully-used tokens — indistinguishable to the
+    caller (no leak about WHY redemption failed).
+
+    Already-a-member callers get a 200 with `already_member=true`
+    instead of an error. Same row count after their click as before
+    — they can re-share an invite they previously redeemed without
+    surprises.
+    """
+    # Local import: services/invites.py uses services/auth.py's
+    # hash_token; eager import here is fine but the deferred form
+    # keeps router imports tidy.
+    from services.invites import redeem_invite
+
+    user_id = _user_id(request)
+    if not user_id:
+        raise HTTPException(
+            status_code=401, detail="Sign in to redeem invites"
+        )
+
+    with get_db() as conn:
+        result = redeem_invite(conn, token, user_id)
+    if result is None:
+        raise HTTPException(
+            status_code=404, detail="Invite invalid or expired"
+        )
+    return InviteRedeemResponse(
+        group_id=result.group_id,
+        group_short_id=result.group_short_id,
+        target_poll_id=result.target_poll_id,
+        target_poll_short_id=result.target_poll_short_id,
+        already_member=result.already_member,
+    )

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import base64
 import binascii
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
@@ -43,6 +43,12 @@ from middleware import (
     user_id_from_request as _user_id,
 )
 from models import PollResponse, UpdateGroupTitleRequest
+from services.join_requests import (
+    create_join_request,
+    decide_request,
+    is_member_or_creator,
+    list_pending_requests,
+)
 from services.memberships import leave_group as _leave_group_row
 from services.groups import (
     filter_visible_polls,
@@ -54,6 +60,7 @@ from services.groups import (
     polls_for_poll_ids,
     resolve_group_id_from_route_id,
 )
+from services.push import fan_out_join_request
 
 
 class GroupSummary(BaseModel):
@@ -779,3 +786,335 @@ def leave_group(route_id: str, request: Request):
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
         _leave_group_row(conn, group_id, browser_id, user_id=user_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase F: join requests
+# ---------------------------------------------------------------------------
+#
+# Signed-in non-members of a private group can request access. The creator
+# (`groups.creator_user_id`) approves or denies. On approve, the requester
+# gets a `group_members` row keyed on one of their linked browsers — and
+# `load_user_visibility`'s user_browsers walk makes the group visible on
+# every device they're signed in on.
+#
+# Anonymous browsers can't request (no durable identity to approve).
+#
+# Existence-leak surface: a signed-in non-member POSTing /join-requests
+# learns whether the route resolves (201 vs 404). That's the same leak
+# the existing /by-route-id surfaces (which 404s strangers on private
+# groups today), so no new channel.
+
+
+class JoinRequestCreate(BaseModel):
+    """Body for `POST /api/groups/{route_id}/join-requests`. `message`
+    is optional — the requester can include a brief "hi, it's Alice
+    from work" so the creator has context. Empty / whitespace-only
+    becomes NULL."""
+
+    message: str | None = None
+
+
+class JoinRequestSummaryResponse(BaseModel):
+    """Per-request shape returned to the creator (list endpoint) and
+    echoed by the create endpoint. `requester_email` is NULL for
+    passkey-only users (Phase D registration permits no-email accounts)
+    — the FE renders a "Passkey user" fallback."""
+
+    id: str
+    group_id: str
+    requester_user_id: str
+    requester_email: str | None
+    message: str | None
+    requested_at: str
+
+
+class JoinRequestCreateResponse(BaseModel):
+    """`status` walks 'pending' (newly created) | 'already_pending'
+    (re-request while one's still open) | 'already_member' (signed-in
+    creator or member POSTed, so no row was inserted). The FE collapses
+    'pending' and 'already_pending' into "request sent" — the distinction
+    is preserved here for observability."""
+
+    status: str  # 'pending' | 'already_pending' | 'already_member'
+    request: JoinRequestSummaryResponse | None = None
+
+
+class JoinRequestDecideBody(BaseModel):
+    """`action` is 'approve' or 'deny'. The route's `decided_at` is set
+    server-side; the creator can't backdate."""
+
+    action: str  # 'approve' | 'deny'
+
+
+class JoinRequestDecideResponse(BaseModel):
+    request_id: str
+    status: str  # 'approved' | 'denied'
+
+
+def _summary_to_response(s, fallback_email: str | None = None) -> JoinRequestSummaryResponse:
+    return JoinRequestSummaryResponse(
+        id=s.id,
+        group_id=s.group_id,
+        requester_user_id=s.requester_user_id,
+        requester_email=s.requester_email if s.requester_email is not None else fallback_email,
+        message=s.message,
+        requested_at=s.requested_at.isoformat() if s.requested_at else "",
+    )
+
+
+@router.post(
+    "/{route_id}/join-requests",
+    response_model=JoinRequestCreateResponse,
+)
+def create_group_join_request(
+    route_id: str,
+    body: JoinRequestCreate,
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
+    """Phase F: signed-in non-member requests access to a (typically
+    private) group. Returns:
+
+      * 401 — not signed in. Anonymous browsers can't request because
+        there's no durable identity to approve.
+      * 404 — route doesn't resolve to any group.
+      * 200 + status='already_member' — caller is already a member or
+        the group's recorded creator. No row written, no push fired.
+      * 201 + status='pending' — fresh request inserted.
+      * 200 + status='already_pending' — an open request already
+        existed; the row is returned but no second push fires.
+
+    Push notification to the creator (when `creator_user_id` is
+    recorded) is dispatched via BackgroundTasks AFTER the response is
+    serialized, mirroring the new-poll fan-out pattern. Anonymous-
+    created / pre-Phase-E groups have no recorded creator and no push
+    is fired — the request still records, so a future "claim group"
+    Phase I action can surface the backlog.
+    """
+    user_id = _user_id(request)
+    if not user_id:
+        raise HTTPException(
+            status_code=401, detail="Sign in to request access"
+        )
+
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+
+        # Already-member / creator short-circuit. We return 200 (not 201)
+        # so the FE can show "you're already in this group" instead of
+        # "request sent". The row in group_members might be keyed on a
+        # different browser_id than the current one — that's fine, the
+        # user_browsers walk makes it visible on this device too.
+        if is_member_or_creator(conn, group_id, user_id):
+            return JoinRequestCreateResponse(
+                status="already_member", request=None
+            )
+
+        # Snapshot existence BEFORE the create so we know whether this
+        # call inserted a new row or returned an existing pending one.
+        # The partial-unique-index conflict path makes create_join_request
+        # idempotent; the SELECT distinguishes the two cases for the
+        # response status + the push-fire decision.
+        existing = conn.execute(
+            """
+            SELECT 1 FROM group_join_requests
+             WHERE group_id = %(g)s::uuid
+               AND requester_user_id = %(u)s::uuid
+               AND status = 'pending'
+             LIMIT 1
+            """,
+            {"g": group_id, "u": user_id},
+        ).fetchone()
+        is_new = existing is None
+
+        summary = create_join_request(conn, group_id, user_id, body.message)
+
+        # Fetch the requester's email for the response shape (the helper
+        # doesn't join — it's used for both create and list, but only
+        # list joins on user_identities). Inline lookup is cheaper than
+        # adding another helper.
+        email_row = conn.execute(
+            """
+            SELECT email FROM user_identities
+             WHERE user_id = %(u)s::uuid AND email IS NOT NULL
+             ORDER BY created_at DESC LIMIT 1
+            """,
+            {"u": user_id},
+        ).fetchone()
+        requester_email = email_row["email"] if email_row else None
+
+        # Read the creator for the push fan-out. Anonymous-created
+        # groups have NULL creator_user_id; skip the push in that case.
+        meta = get_group_metadata(conn, group_id)
+        creator_user_id = meta["creator_user_id"] if meta else None
+        group_short_id_row = conn.execute(
+            "SELECT short_id FROM groups WHERE id = %(g)s::uuid",
+            {"g": group_id},
+        ).fetchone()
+        group_short_id = (
+            group_short_id_row.get("short_id") if group_short_id_row else None
+        )
+
+    # Fire-and-forget push fan-out. Runs only on a brand-new request;
+    # a repeat-ping for an already-pending request would just noise the
+    # creator on every "polite re-request" tap.
+    if is_new and creator_user_id:
+        route_for_url = group_short_id or group_id
+        # Subject line is intentionally generic so passkey-only requesters
+        # (no email) don't surface as a literal "null wants to join".
+        # The /info page has full details once the creator taps in.
+        body_text = (
+            f"{requester_email} wants to join"
+            if requester_email
+            else "Someone wants to join your group"
+        )
+        background_tasks.add_task(
+            fan_out_join_request,
+            group_id,
+            creator_user_id,
+            {
+                "title": "Join request",
+                "body": body_text,
+                "url": f"/g/{route_for_url}/info",
+                "group_id": route_for_url,
+                "tag": f"join-request-{summary.id}",
+            },
+        )
+
+    return JoinRequestCreateResponse(
+        status="pending" if is_new else "already_pending",
+        request=_summary_to_response(summary, fallback_email=requester_email),
+    )
+
+
+@router.get(
+    "/{route_id}/join-requests",
+    response_model=list[JoinRequestSummaryResponse],
+)
+def list_group_join_requests(route_id: str, request: Request):
+    """Phase F: list pending requests for a group. Creator-only.
+
+    Authorization: must be signed in AND match the group's recorded
+    `creator_user_id`. Anonymous-created / pre-Phase-E groups have
+    NULL creator and can't have a creator viewer either, so they 403
+    here for everyone — the join-request system simply isn't available
+    on those groups.
+
+    404 on route resolution failure; 401 when not signed in; 403 when
+    signed in but not the creator (distinguishes "not your group" from
+    "no such group" — same convention as the privacy toggle).
+    """
+    user_id = _user_id(request)
+    if not user_id:
+        raise HTTPException(
+            status_code=401, detail="Sign in to view join requests"
+        )
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        meta = get_group_metadata(conn, group_id)
+        if not meta or not meta["creator_user_id"]:
+            raise HTTPException(
+                status_code=403,
+                detail="Group has no recorded creator",
+            )
+        if meta["creator_user_id"] != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Only the group's creator can view join requests",
+            )
+        summaries = list_pending_requests(conn, group_id)
+    return [_summary_to_response(s) for s in summaries]
+
+
+@router.post(
+    "/{route_id}/join-requests/{request_id}/decide",
+    response_model=JoinRequestDecideResponse,
+)
+def decide_group_join_request(
+    route_id: str,
+    request_id: str,
+    body: JoinRequestDecideBody,
+    request: Request,
+):
+    """Phase F: creator approves or denies a pending request.
+
+    On approve: writes a `group_members` row for the requester's
+    earliest-linked browser_id (per `user_browsers`). The walk in
+    `load_user_visibility` expands that to every device the requester
+    is signed in on, so they see the group immediately on the next
+    refresh — no per-device approval needed.
+
+    On deny: the row's status walks to 'denied'. The requester gets no
+    notification (per `docs/auth-access-model.md`: "Requester gets no
+    notification on deny — avoids 'why rejected' follow-ups"). They
+    can re-request, since the partial unique index only blocks
+    pending duplicates.
+
+    Idempotent: a second decide on the same request returns 404 (the
+    row's no longer pending). Distinguishing 'already_decided' from
+    'never_existed' isn't worth a separate status code — both states
+    have the same "do nothing else" implication for the caller.
+    """
+    if body.action not in ("approve", "deny"):
+        raise HTTPException(
+            status_code=400, detail="action must be 'approve' or 'deny'"
+        )
+    user_id = _user_id(request)
+    if not user_id:
+        raise HTTPException(
+            status_code=401, detail="Sign in to decide join requests"
+        )
+    decision = "approved" if body.action == "approve" else "denied"
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        meta = get_group_metadata(conn, group_id)
+        if not meta or not meta["creator_user_id"]:
+            raise HTTPException(
+                status_code=403, detail="Group has no recorded creator"
+            )
+        if meta["creator_user_id"] != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Only the group's creator can decide join requests",
+            )
+        # Existence + group-scoping guard: the route-id MUST match the
+        # request's group_id. Without this, a creator of group A could
+        # decide on a request that belongs to group B by guessing
+        # request_ids (the join-request table is indexed but not
+        # secret). Tying decision authority to (group_id, request_id)
+        # together closes the cross-group manipulation channel.
+        ownership = conn.execute(
+            """
+            SELECT 1 FROM group_join_requests
+             WHERE id = %(r)s::uuid
+               AND group_id = %(g)s::uuid
+               AND status = 'pending'
+             LIMIT 1
+            """,
+            {"r": request_id, "g": group_id},
+        ).fetchone()
+        if not ownership:
+            raise HTTPException(
+                status_code=404,
+                detail="Request not found or already decided",
+            )
+        decided = decide_request(conn, request_id, decision, user_id)
+    if not decided:
+        # decide_request returns None only on race (a second click
+        # flipped the row between our SELECT and UPDATE). Treat the
+        # same as "already decided".
+        raise HTTPException(
+            status_code=404,
+            detail="Request not found or already decided",
+        )
+    return JoinRequestDecideResponse(
+        request_id=decided.request_id,
+        status=decided.status,
+    )

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -43,6 +43,13 @@ from middleware import (
     user_id_from_request as _user_id,
 )
 from models import PollResponse, UpdateGroupTitleRequest
+from services.invites import (
+    IssuedInvite,
+    InviteSummary,
+    issue_invite,
+    list_active_invites,
+    revoke_invite,
+)
 from services.join_requests import (
     create_join_request,
     decide_request,
@@ -1118,3 +1125,231 @@ def decide_group_join_request(
         request_id=decided.request_id,
         status=decided.status,
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase G: invite links
+# ---------------------------------------------------------------------------
+#
+# Creator-owned shareable URLs that grant private-group membership on
+# redemption. Complements Phase F join requests: invites are
+# creator-initiated (push from creator → joiner); join requests are
+# joiner-initiated (pull from joiner → creator approves).
+#
+# Storage: `services/invites.py` persists sha256(token) only. The raw
+# token is returned ONCE at create time and embedded in the shareable
+# URL. The redeem endpoint hashes the inbound raw token and matches.
+#
+# Authorization: create / list / revoke are creator-only (signed-in
+# AND `creator_user_id` matches the session). Redeem (in `routers/auth.py`)
+# requires signed-in but ANY user can redeem.
+
+
+class CreateInviteRequest(BaseModel):
+    """Body for `POST /api/groups/{route_id}/invites`.
+
+    `mode='single'` forces max_uses=1 server-side; `mode='multi'`
+    accepts an optional max_uses (NULL = unlimited).
+
+    `target_poll_id` is the optional auto-scroll target: the FE
+    redirects to `/g/<group>/p/<poll_short>` instead of `/g/<group>`
+    after redemption. Must be a poll in the same group; the server
+    silently drops cross-group target_poll_ids (returns NULL).
+
+    `expires_in_hours` is the time-to-live knob. NULL = never expires
+    (creator must revoke explicitly).
+    """
+
+    mode: str  # 'single' | 'multi'
+    max_uses: int | None = None
+    target_poll_id: str | None = None
+    expires_in_hours: int | None = None
+
+
+class InviteResponse(BaseModel):
+    """Shape returned by create + list. `token` and `url` are populated
+    ONLY on create (they're the one-time raw-token reveal); list
+    omits them since the creator already received the URL at create
+    time."""
+
+    id: str
+    group_id: str
+    mode: str
+    target_poll_id: str | None
+    max_uses: int | None
+    use_count: int
+    expires_at: str | None
+    created_at: str
+    token: str | None = None
+    url: str | None = None
+
+
+def _summary_to_invite_response(s) -> InviteResponse:
+    """List-side conversion. No token/url since list doesn't reveal."""
+    return InviteResponse(
+        id=s.id,
+        group_id=s.group_id,
+        mode=s.mode,
+        target_poll_id=s.target_poll_id,
+        max_uses=s.max_uses,
+        use_count=s.use_count,
+        expires_at=s.expires_at.isoformat() if s.expires_at else None,
+        created_at=s.created_at.isoformat() if s.created_at else "",
+    )
+
+
+def _issued_to_invite_response(
+    issued: IssuedInvite, url: str
+) -> InviteResponse:
+    """Create-side conversion. Carries the raw token + the FE-host-
+    derived shareable URL — both surfaced exactly once."""
+    return InviteResponse(
+        id=issued.id,
+        group_id=issued.group_id,
+        mode=issued.mode,
+        target_poll_id=issued.target_poll_id,
+        max_uses=issued.max_uses,
+        use_count=issued.use_count,
+        expires_at=issued.expires_at.isoformat() if issued.expires_at else None,
+        created_at=issued.created_at.isoformat(),
+        token=issued.token,
+        url=url,
+    )
+
+
+def _require_creator(conn, group_id: str, user_id: str | None) -> None:
+    """Raise 401/403 unless the caller is signed in AND matches the
+    group's recorded `creator_user_id`. Shared 3-way authorization
+    gate for every invite-management endpoint."""
+    if not user_id:
+        raise HTTPException(
+            status_code=401, detail="Sign in to manage invites"
+        )
+    meta = get_group_metadata(conn, group_id)
+    if not meta or not meta["creator_user_id"]:
+        raise HTTPException(
+            status_code=403, detail="Group has no recorded creator"
+        )
+    if meta["creator_user_id"] != user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the group's creator can manage invites",
+        )
+
+
+@router.post(
+    "/{route_id}/invites",
+    response_model=InviteResponse,
+    status_code=201,
+)
+def create_group_invite(
+    route_id: str,
+    body: CreateInviteRequest,
+    request: Request,
+):
+    """Phase G: mint a new invite link. Creator-only.
+
+    The response is the ONLY time the raw token + URL are returned —
+    sha256(token) is what hits the DB. If the creator loses the URL,
+    they have to mint a new invite.
+    """
+    from services.fe_origin import resolve_fe_origin
+
+    user_id = _user_id(request)
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        _require_creator(conn, group_id, user_id)
+
+        if body.mode not in ("single", "multi"):
+            raise HTTPException(
+                status_code=400, detail="mode must be 'single' or 'multi'"
+            )
+        if body.max_uses is not None and body.max_uses <= 0:
+            raise HTTPException(
+                status_code=400, detail="max_uses must be positive"
+            )
+        if body.expires_in_hours is not None and body.expires_in_hours <= 0:
+            raise HTTPException(
+                status_code=400, detail="expires_in_hours must be positive"
+            )
+
+        # Cross-group target_poll_id silently downgraded to NULL — a
+        # 400 would force the FE to handle "stale poll selection" as a
+        # distinct error path; falling back to "land on the group
+        # root" is more forgiving and matches what target_poll_id
+        # being NULL means at redeem time anyway.
+        target_poll_id: str | None = None
+        if body.target_poll_id:
+            poll_row = conn.execute(
+                """SELECT id FROM polls
+                    WHERE id = %(p)s::uuid AND group_id = %(g)s::uuid""",
+                {"p": body.target_poll_id, "g": group_id},
+            ).fetchone()
+            if poll_row:
+                target_poll_id = str(poll_row["id"])
+
+        issued = issue_invite(
+            conn,
+            group_id=group_id,
+            created_by_user_id=user_id,
+            mode=body.mode,
+            target_poll_id=target_poll_id,
+            max_uses=body.max_uses,
+            expires_in_hours=body.expires_in_hours,
+        )
+
+    # URL build runs OUTSIDE the get_db() block; no DB roundtrip
+    # needed. The token is embedded in the path; the FE's
+    # `/invite/[token]/page.tsx` resolves on receipt.
+    origin = resolve_fe_origin(request)
+    url = f"{origin}/invite/{issued.token}"
+    return _issued_to_invite_response(issued, url)
+
+
+@router.get(
+    "/{route_id}/invites",
+    response_model=list[InviteResponse],
+)
+def list_group_invites(route_id: str, request: Request):
+    """Phase G: list a group's active invites. Creator-only.
+
+    "Active" = not revoked, not expired, has remaining uses. Revoked
+    or fully-used invites are excluded — the UI doesn't need them.
+    """
+    user_id = _user_id(request)
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        _require_creator(conn, group_id, user_id)
+        summaries = list_active_invites(conn, group_id)
+    return [_summary_to_invite_response(s) for s in summaries]
+
+
+@router.delete(
+    "/{route_id}/invites/{invite_id}",
+    status_code=204,
+)
+def revoke_group_invite(
+    route_id: str, invite_id: str, request: Request
+):
+    """Phase G: revoke an active invite. Creator-only.
+
+    Returns 204 on successful revoke. 404 when the invite doesn't
+    exist OR isn't owned by the caller OR was already revoked —
+    indistinguishable to the caller, no information leak about
+    invites belonging to other creators.
+    """
+    user_id = _user_id(request)
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        _require_creator(conn, group_id, user_id)
+        ok = revoke_invite(conn, invite_id, user_id)
+    if not ok:
+        raise HTTPException(
+            status_code=404, detail="Invite not found or already revoked"
+        )

--- a/server/services/fe_origin.py
+++ b/server/services/fe_origin.py
@@ -1,0 +1,52 @@
+"""FE origin resolution for any server-side URL minting (magic links,
+invite links, password-reset emails, etc.).
+
+Reads the `Origin` request header (set by every major browser on
+cross-origin fetches) and validates it against an allowlist. Falls
+back to `FE_DEFAULT_ORIGIN` env var (default `https://whoeverwants.com`)
+when the Origin header is absent or unmatched.
+
+Without this allowlist, a hostile Origin header could trick the server
+into embedding attacker-controlled hostnames in shareable URLs
+(magic-link emails, invite URLs) — recipients would click through to
+the attacker's site. The allowlist enforces "we'll only embed our own
+hosts in user-bound URLs".
+
+When adding a new host (e.g. an additional preview tier or external
+embed), extend `_ALLOWED_ORIGIN_PATTERNS` here — it's the single
+allowlist for the whole API.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from fastapi import Request
+
+
+_ALLOWED_ORIGIN_PATTERNS = [
+    re.compile(r"^https://whoeverwants\.com$"),
+    re.compile(r"^https://latest\.whoeverwants\.com$"),
+    re.compile(r"^https://[a-z0-9-]+\.dev\.whoeverwants\.com$"),
+    re.compile(r"^http://localhost:\d+$"),
+    re.compile(r"^http://127\.0\.0\.1:\d+$"),
+]
+
+_DEFAULT_FE_ORIGIN = os.environ.get(
+    "FE_DEFAULT_ORIGIN", "https://whoeverwants.com"
+)
+
+
+def resolve_fe_origin(request: Request) -> str:
+    """Pick the FE origin to embed in URLs for this request.
+
+    Returns the request's `Origin` header when it matches a known
+    pattern; otherwise the configured default. The result is always a
+    URL prefix without a trailing slash, suitable for concatenation
+    with a path like `/invite/<token>` or `/auth/verify?token=...`.
+    """
+    origin = request.headers.get("origin")
+    if origin and any(p.match(origin) for p in _ALLOWED_ORIGIN_PATTERNS):
+        return origin
+    return _DEFAULT_FE_ORIGIN

--- a/server/services/invites.py
+++ b/server/services/invites.py
@@ -1,0 +1,348 @@
+"""Phase G (group invites) — server-side helpers.
+
+Four operations:
+  * `issue_invite(conn, ...)` mints a raw token + persists its sha256
+    hash + metadata. Returns the raw token to the caller exactly once.
+  * `list_active_invites(conn, group_id)` returns non-revoked,
+    non-expired invites with use_count info, sorted newest first.
+  * `redeem_invite(conn, token, user_id)` walks the redemption
+    transaction: validates the token + use_count + expiry + revoked
+    state, bumps use_count, writes a `group_members` row for the
+    requester's earliest-linked browser_id, returns the resolved
+    group_id + target poll info for the FE redirect.
+  * `revoke_invite(conn, invite_id, by_user_id)` stamps `revoked_at`
+    on a creator-owned invite. Idempotent.
+
+Token storage mirrors sessions + magic-link tokens: raw value returned
+ONLY at create time, sha256 hash persisted. The raw token never sits in
+the DB at rest.
+
+Redemption is gated on user_id (signed-in only). Anonymous browsers
+can't redeem because there's no durable identity to write membership
+against — the same reasoning as Phase F join requests.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from services.auth import generate_token, hash_token
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IssuedInvite:
+    """Result of `issue_invite`. `token` is the raw value — returned
+    ONCE at create time and embedded in the shareable URL. Server
+    stores only `token_hash`; if the creator loses the URL, they have
+    to mint a new invite."""
+
+    id: str
+    token: str
+    group_id: str
+    mode: str
+    target_poll_id: str | None
+    max_uses: int | None
+    use_count: int
+    expires_at: datetime | None
+    created_at: datetime
+
+
+@dataclass
+class InviteSummary:
+    """Creator-facing view of an active invite (no raw token — that's
+    one-shot at create time). The FE builds the shareable URL on the
+    server side via the `url` field on the create response;
+    list-endpoint entries don't carry one because the creator already
+    has the URL from the create call. `use_count` + `max_uses` drive
+    the "3/5 uses" display."""
+
+    id: str
+    group_id: str
+    mode: str
+    target_poll_id: str | None
+    max_uses: int | None
+    use_count: int
+    expires_at: datetime | None
+    created_at: datetime
+
+
+@dataclass
+class RedeemResult:
+    """Result of `redeem_invite`. `group_short_id` and
+    `target_poll_short_id` are pre-resolved so the FE doesn't need a
+    second round-trip to build the redirect URL. `already_member` is
+    True when redemption was a no-op because membership existed before
+    the redeem call — use_count is NOT bumped in that case (a member
+    re-clicking the URL shouldn't consume an invite use)."""
+
+    group_id: str
+    group_short_id: str | None
+    target_poll_id: str | None
+    target_poll_short_id: str | None
+    already_member: bool
+
+
+def issue_invite(
+    conn,
+    *,
+    group_id: str,
+    created_by_user_id: str,
+    mode: str,
+    target_poll_id: str | None = None,
+    max_uses: int | None = None,
+    expires_in_hours: int | None = None,
+) -> IssuedInvite:
+    """Mint a new invite. Caller is responsible for authorization
+    (creator-only at the router layer).
+
+    `mode='single'` forces `max_uses=1` regardless of what was passed
+    (the client's request is normalized rather than rejected — fewer
+    edge cases to surface in the UI).
+    `mode='multi'` accepts max_uses NULL (unlimited) or any positive
+    int.
+
+    `expires_in_hours` is the client's "expire after N hours" knob;
+    NULL = never expires (the creator must revoke explicitly).
+    """
+    if mode not in ("single", "multi"):
+        raise ValueError(f"invalid mode: {mode!r}")
+    if mode == "single":
+        max_uses = 1
+    elif max_uses is not None and max_uses <= 0:
+        raise ValueError("max_uses must be positive")
+    expires_at: datetime | None = None
+    if expires_in_hours is not None:
+        if expires_in_hours <= 0:
+            raise ValueError("expires_in_hours must be positive")
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            hours=expires_in_hours
+        )
+
+    raw_token = generate_token()
+    row = conn.execute(
+        """
+        INSERT INTO group_invites (
+            token_hash, group_id, created_by_user_id, mode,
+            target_poll_id, max_uses, expires_at
+        )
+        VALUES (
+            %(h)s, %(g)s::uuid, %(u)s::uuid, %(m)s,
+            %(p)s, %(mx)s, %(e)s
+        )
+        RETURNING id, group_id, mode, target_poll_id, max_uses,
+                  use_count, expires_at, created_at
+        """,
+        {
+            "h": hash_token(raw_token),
+            "g": group_id,
+            "u": created_by_user_id,
+            "m": mode,
+            "p": target_poll_id,
+            "mx": max_uses,
+            "e": expires_at,
+        },
+    ).fetchone()
+    return IssuedInvite(
+        id=str(row["id"]),
+        token=raw_token,
+        group_id=str(row["group_id"]),
+        mode=row["mode"],
+        target_poll_id=(
+            str(row["target_poll_id"]) if row.get("target_poll_id") else None
+        ),
+        max_uses=row.get("max_uses"),
+        use_count=row["use_count"],
+        expires_at=row.get("expires_at"),
+        created_at=row["created_at"],
+    )
+
+
+def list_active_invites(conn, group_id: str) -> list[InviteSummary]:
+    """List a group's active (non-revoked, non-expired, not-fully-used)
+    invites, newest first. The compound active-predicate matches the
+    redeem-time check in `redeem_invite` so the list and the actual
+    redeemable set don't diverge."""
+    rows = conn.execute(
+        """
+        SELECT id, group_id, mode, target_poll_id, max_uses,
+               use_count, expires_at, created_at
+          FROM group_invites
+         WHERE group_id = %(g)s::uuid
+           AND revoked_at IS NULL
+           AND (expires_at IS NULL OR expires_at > NOW())
+           AND (max_uses IS NULL OR use_count < max_uses)
+         ORDER BY created_at DESC
+        """,
+        {"g": group_id},
+    ).fetchall()
+    return [
+        InviteSummary(
+            id=str(r["id"]),
+            group_id=str(r["group_id"]),
+            mode=r["mode"],
+            target_poll_id=(
+                str(r["target_poll_id"]) if r.get("target_poll_id") else None
+            ),
+            max_uses=r.get("max_uses"),
+            use_count=r["use_count"],
+            expires_at=r.get("expires_at"),
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+
+
+def revoke_invite(conn, invite_id: str, by_user_id: str) -> bool:
+    """Mark a creator-owned invite as revoked. Returns True iff the
+    UPDATE affected a row (i.e. the invite existed, was owned by
+    `by_user_id`, and wasn't already revoked).
+
+    The `created_by_user_id` check in the WHERE clause is the
+    authorization gate. A non-creator hitting the revoke endpoint
+    surfaces as a no-op (False return → 404 at the router). We don't
+    need a separate ownership lookup because the UPDATE's predicate
+    enforces it atomically.
+    """
+    row = conn.execute(
+        """
+        UPDATE group_invites
+           SET revoked_at = NOW()
+         WHERE id = %(i)s::uuid
+           AND created_by_user_id = %(u)s::uuid
+           AND revoked_at IS NULL
+        RETURNING id
+        """,
+        {"i": invite_id, "u": by_user_id},
+    ).fetchone()
+    return row is not None
+
+
+def redeem_invite(
+    conn,
+    token: str,
+    user_id: str,
+) -> RedeemResult | None:
+    """Validate + consume an invite. Returns the resolved group +
+    target poll info for the FE redirect. Returns None when the token
+    is invalid, expired, revoked, or fully used — the router 404s in
+    all those cases so we don't leak which specific reason failed.
+
+    Atomic increment is the load-bearing piece. Two simultaneous
+    redemptions race on `use_count < max_uses` if we do read-then-write;
+    the UPDATE with the predicate in the WHERE clause + RETURNING
+    serializes them at row-lock granularity. Whoever wins the lock
+    increments; whoever loses sees `use_count = max_uses` on retry and
+    fails the predicate.
+
+    Already-member short-circuit: if the requester is already a member
+    (via any of their linked browsers) we don't bump use_count — a
+    member re-clicking the share URL shouldn't consume a use. Same
+    rationale as Phase F's `is_member_or_creator` skip.
+    """
+    if not token:
+        return None
+
+    # Atomic conditional UPDATE: only bump if redeemable. RETURNING
+    # tells us whether the lock + predicate succeeded.
+    invite = conn.execute(
+        """
+        UPDATE group_invites
+           SET use_count = use_count + 1
+         WHERE token_hash = %(h)s
+           AND revoked_at IS NULL
+           AND (expires_at IS NULL OR expires_at > NOW())
+           AND (max_uses IS NULL OR use_count < max_uses)
+        RETURNING id, group_id, target_poll_id
+        """,
+        {"h": hash_token(token)},
+    ).fetchone()
+    if invite is None:
+        return None
+
+    group_id = str(invite["group_id"])
+    target_poll_id = (
+        str(invite["target_poll_id"]) if invite.get("target_poll_id") else None
+    )
+
+    # Check existing membership across every browser linked to the
+    # requesting user_id. Same logic as
+    # `services/join_requests.is_member_or_creator` minus the creator
+    # leg — creators can redeem their own invite too (it's a no-op
+    # increment-then-skip-write path).
+    already_member_row = conn.execute(
+        """
+        SELECT 1 FROM group_members
+         WHERE group_id = %(g)s::uuid
+           AND browser_id IN (
+               SELECT browser_id FROM user_browsers WHERE user_id = %(u)s::uuid
+           )
+         LIMIT 1
+        """,
+        {"g": group_id, "u": user_id},
+    ).fetchone()
+    already_member = already_member_row is not None
+
+    if already_member:
+        # Roll back the use_count bump so a re-clicking member doesn't
+        # consume a use. A separate UPDATE keeps the redemption
+        # transaction concise; the race here is benign (a concurrent
+        # non-member redeem would have written its own row by now).
+        conn.execute(
+            """
+            UPDATE group_invites
+               SET use_count = use_count - 1
+             WHERE id = %(i)s::uuid
+            """,
+            {"i": str(invite["id"])},
+        )
+    else:
+        # Write membership keyed on the requester's earliest-linked
+        # browser_id — same pattern as Phase F's approve. ONE row is
+        # enough; load_user_visibility expands across user_browsers.
+        bid_row = conn.execute(
+            """
+            SELECT browser_id FROM user_browsers
+             WHERE user_id = %(u)s::uuid
+             ORDER BY linked_at ASC
+             LIMIT 1
+            """,
+            {"u": user_id},
+        ).fetchone()
+        if bid_row:
+            conn.execute(
+                """
+                INSERT INTO group_members (group_id, browser_id)
+                VALUES (%(g)s::uuid, %(b)s::uuid)
+                ON CONFLICT (group_id, browser_id) DO NOTHING
+                """,
+                {"g": group_id, "b": str(bid_row["browser_id"])},
+            )
+
+    # Resolve short_ids in one round-trip so the FE can build the
+    # redirect URL without a follow-up call.
+    group_short_id_row = conn.execute(
+        "SELECT short_id FROM groups WHERE id = %(g)s::uuid",
+        {"g": group_id},
+    ).fetchone()
+    target_poll_short_id: str | None = None
+    if target_poll_id:
+        poll_row = conn.execute(
+            "SELECT short_id FROM polls WHERE id = %(p)s::uuid",
+            {"p": target_poll_id},
+        ).fetchone()
+        if poll_row:
+            target_poll_short_id = poll_row.get("short_id")
+
+    return RedeemResult(
+        group_id=group_id,
+        group_short_id=(
+            group_short_id_row.get("short_id") if group_short_id_row else None
+        ),
+        target_poll_id=target_poll_id,
+        target_poll_short_id=target_poll_short_id,
+        already_member=already_member,
+    )

--- a/server/services/join_requests.py
+++ b/server/services/join_requests.py
@@ -1,0 +1,259 @@
+"""Phase F (group join requests) — server-side helpers.
+
+Three operations:
+  * `create_join_request(conn, group_id, requester_user_id, message)`
+    inserts a `pending` row. Idempotent via the partial unique index on
+    (group_id, requester_user_id) WHERE status='pending' — second call
+    while pending returns the existing row instead of failing.
+  * `list_pending_requests(conn, group_id)` reads pending rows with the
+    requester's email joined in (the only durable identifier we have
+    today; users without an email — passkey-only — surface as null).
+  * `decide_request(conn, request_id, decision, deciding_user_id)`
+    walks 'pending' → 'approved' | 'denied' AND (on approve) writes a
+    `group_members` row keyed on one of the requester's `user_browsers`
+    rows. Same load-bearing pattern as the membership-write helpers in
+    `services/memberships.py`: ON CONFLICT DO NOTHING so an existing
+    membership row keeps its original joined_at watermark.
+
+The membership write picks the requester's earliest-linked browser_id
+deterministically. Per `services/groups.py: load_user_visibility`,
+`is_caller_member_of_group` expands membership across every browser
+linked to a user_id, so ONE row is enough — every device the user is
+signed in on will see the group immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class JoinRequestSummary:
+    """Creator-facing view of a pending request. `requester_email` is
+    null for passkey-only users — Phase D registration permits accounts
+    with no email at all. UI falls back to a "Passkey user" placeholder
+    in that case."""
+
+    id: str
+    group_id: str
+    requester_user_id: str
+    requester_email: str | None
+    message: str | None
+    requested_at: datetime
+
+
+def create_join_request(
+    conn,
+    group_id: str,
+    requester_user_id: str,
+    message: str | None,
+) -> JoinRequestSummary:
+    """Insert a pending join request OR return the existing pending row.
+
+    Idempotent: the partial unique index forbids two pending rows for
+    the same (group, requester), so a repeated request just resolves to
+    the original. The original's `message` is NOT overwritten on the
+    second call — the creator has already been notified once and we
+    don't want a re-fire on every "polite re-request" tap. Phase I can
+    add an explicit "edit my message" action if anyone asks.
+    """
+    msg = (message or "").strip() or None
+    # Attempt INSERT; on conflict, SELECT the existing row. Two-step is
+    # the cleanest way to express "first writer wins, everyone else
+    # reads" in postgres without a RAISE-and-recover dance.
+    row = conn.execute(
+        """
+        INSERT INTO group_join_requests (group_id, requester_user_id, message)
+        VALUES (%(gid)s::uuid, %(uid)s::uuid, %(msg)s)
+        ON CONFLICT (group_id, requester_user_id)
+            WHERE status = 'pending'
+            DO NOTHING
+        RETURNING id, group_id, requester_user_id, message, requested_at
+        """,
+        {"gid": group_id, "uid": requester_user_id, "msg": msg},
+    ).fetchone()
+    if row is None:
+        row = conn.execute(
+            """
+            SELECT id, group_id, requester_user_id, message, requested_at
+              FROM group_join_requests
+             WHERE group_id = %(gid)s::uuid
+               AND requester_user_id = %(uid)s::uuid
+               AND status = 'pending'
+             LIMIT 1
+            """,
+            {"gid": group_id, "uid": requester_user_id},
+        ).fetchone()
+    return JoinRequestSummary(
+        id=str(row["id"]),
+        group_id=str(row["group_id"]),
+        requester_user_id=str(row["requester_user_id"]),
+        requester_email=None,
+        message=row.get("message"),
+        requested_at=row["requested_at"],
+    )
+
+
+def is_member_or_creator(
+    conn,
+    group_id: str,
+    user_id: str,
+) -> bool:
+    """Short-circuit for the request endpoint: if the caller is already
+    visible into the group via membership OR they're the recorded
+    creator, skip the join-request insert (and let the route return 200
+    instead of 201). Matches `is_caller_member_of_group`'s user_id leg
+    plus a creator check — both are cheap one-shot lookups."""
+    row = conn.execute(
+        """
+        SELECT 1 FROM group_members
+         WHERE group_id = %(g)s::uuid
+           AND browser_id IN (
+               SELECT browser_id FROM user_browsers WHERE user_id = %(u)s::uuid
+           )
+         LIMIT 1
+        """,
+        {"g": group_id, "u": user_id},
+    ).fetchone()
+    if row:
+        return True
+    row = conn.execute(
+        """
+        SELECT 1 FROM groups
+         WHERE id = %(g)s::uuid AND creator_user_id = %(u)s::uuid
+         LIMIT 1
+        """,
+        {"g": group_id, "u": user_id},
+    ).fetchone()
+    return row is not None
+
+
+def list_pending_requests(conn, group_id: str) -> list[JoinRequestSummary]:
+    """Pending requests for a group, oldest first. The email column is
+    the requester's most-recently-verified email across their identity
+    rows (NULL for passkey-only)."""
+    rows = conn.execute(
+        """
+        SELECT r.id,
+               r.group_id,
+               r.requester_user_id,
+               r.message,
+               r.requested_at,
+               (
+                   SELECT ui.email
+                     FROM user_identities ui
+                    WHERE ui.user_id = r.requester_user_id
+                      AND ui.email IS NOT NULL
+                    ORDER BY ui.created_at DESC
+                    LIMIT 1
+               ) AS requester_email
+          FROM group_join_requests r
+         WHERE r.group_id = %(g)s::uuid
+           AND r.status = 'pending'
+         ORDER BY r.requested_at ASC
+        """,
+        {"g": group_id},
+    ).fetchall()
+    return [
+        JoinRequestSummary(
+            id=str(r["id"]),
+            group_id=str(r["group_id"]),
+            requester_user_id=str(r["requester_user_id"]),
+            requester_email=r.get("requester_email"),
+            message=r.get("message"),
+            requested_at=r["requested_at"],
+        )
+        for r in rows
+    ]
+
+
+@dataclass
+class DecidedRequest:
+    """Result of `decide_request`. Carries the new status + the
+    requester's user_id so the router can drive any follow-up
+    notification (Phase F doesn't fire one on deny — the requester
+    doesn't get told "why" — but the data is here for Phase I)."""
+
+    request_id: str
+    group_id: str
+    requester_user_id: str
+    status: str  # 'approved' | 'denied'
+
+
+def decide_request(
+    conn,
+    request_id: str,
+    decision: str,
+    deciding_user_id: str,
+) -> DecidedRequest | None:
+    """Walk a pending request to 'approved' or 'denied'. Returns None
+    when the request doesn't exist or isn't pending (idempotent: a
+    double-tap on Approve doesn't re-fire side effects).
+
+    On approve, writes a `group_members` row keyed on the requester's
+    earliest-linked browser_id. Picking one browser is sufficient —
+    `load_user_visibility` expands membership across every linked
+    browser via `user_browsers` — and picking the earliest gives the
+    most-permissive `joined_at` for the closed-before-join filter.
+
+    The decision row's `decided_at` is set to NOW(); `decided_by_user_id`
+    records who clicked the button so the audit history is intact even
+    after the creator's user row is deleted (FK is ON DELETE SET NULL).
+    """
+    if decision not in ("approved", "denied"):
+        raise ValueError(f"invalid decision: {decision!r}")
+
+    # Atomic transition: only flip if currently pending. RETURNING is
+    # what tells us whether the transition actually fired (vs the row
+    # being absent or already-decided).
+    row = conn.execute(
+        """
+        UPDATE group_join_requests
+           SET status = %(s)s,
+               decided_at = NOW(),
+               decided_by_user_id = %(d)s::uuid
+         WHERE id = %(r)s::uuid
+           AND status = 'pending'
+        RETURNING id, group_id, requester_user_id
+        """,
+        {"s": decision, "r": request_id, "d": deciding_user_id},
+    ).fetchone()
+    if row is None:
+        return None
+
+    if decision == "approved":
+        # Pick the requester's earliest-linked browser_id. They must
+        # have at least one (the request endpoint required user_id,
+        # which requires a session, which requires linked browser),
+        # but defensive: skip the membership write if none exist (the
+        # row stays approved; next browser link picks it up via the
+        # auto-claim path described in docs/auth-access-model.md).
+        bid_row = conn.execute(
+            """
+            SELECT browser_id FROM user_browsers
+             WHERE user_id = %(u)s::uuid
+             ORDER BY linked_at ASC
+             LIMIT 1
+            """,
+            {"u": str(row["requester_user_id"])},
+        ).fetchone()
+        if bid_row:
+            conn.execute(
+                """
+                INSERT INTO group_members (group_id, browser_id)
+                VALUES (%(g)s::uuid, %(b)s::uuid)
+                ON CONFLICT (group_id, browser_id) DO NOTHING
+                """,
+                {"g": str(row["group_id"]), "b": str(bid_row["browser_id"])},
+            )
+
+    return DecidedRequest(
+        request_id=str(row["id"]),
+        group_id=str(row["group_id"]),
+        requester_user_id=str(row["requester_user_id"]),
+        status=decision,
+    )

--- a/server/services/push.py
+++ b/server/services/push.py
@@ -260,6 +260,57 @@ def _fetch_subscriptions(conn, browser_ids: Iterable[str]) -> list[dict]:
     return [dict(r) for r in rows]
 
 
+def _dispatch_pushes(
+    subscriptions: list[dict],
+    payload: dict,
+    vapid: VapidKeys | None,
+) -> None:
+    """Run the actual web-push / APNS sends + record per-subscription
+    outcomes (success → reset failure_count; 410/BadDeviceToken → delete
+    the dead row; other failures → mark + log). Called from both
+    fan-out helpers below — extracted so adding a third event type
+    (e.g. Phase F's join-request notifications) doesn't fork the dispatch
+    logic.
+
+    The actual sends run OUTSIDE any `get_db()` block — holding a DB
+    connection while waiting on the push services would block other
+    inbound API requests. We only re-open a connection at the end to
+    persist per-subscription outcomes.
+    """
+    web_results: list[tuple[str, bool, str | None, bool]] = []
+    apns_results: list[tuple[str, bool, str | None, bool]] = []
+
+    web_subs = [s for s in subscriptions if s["kind"] == "web_push"]
+    apns_subs = [s for s in subscriptions if s["kind"] == "apns"]
+
+    if web_subs and vapid is not None:
+        for sub in web_subs:
+            ok, err, should_delete = _send_web_push(sub, payload, vapid)
+            web_results.append((sub["id"], ok, err, should_delete))
+
+    if apns_subs and apns_configured():
+        jwt_token = _apns_jwt(int(time.time()))
+        with httpx.Client(http2=True) as client:
+            for sub in apns_subs:
+                ok, err, should_delete = _send_apns(sub, payload, client, jwt_token)
+                apns_results.append((sub["id"], ok, err, should_delete))
+
+    with get_db() as conn:
+        for sub_id, ok, err, should_delete in web_results + apns_results:
+            if ok:
+                conn.execute(
+                    "UPDATE push_subscriptions SET failure_count = 0, last_error = NULL, "
+                    "updated_at = NOW() WHERE id = %(id)s",
+                    {"id": sub_id},
+                )
+            elif should_delete:
+                _delete_subscription(conn, sub_id)
+                log.info("Deleted dead push subscription %s: %s", sub_id, err)
+            else:
+                _mark_failure(conn, sub_id, err or "unknown")
+                log.warning("Push send failed for subscription %s: %s", sub_id, err)
+
+
 def fan_out_new_poll(group_id: str, creator_browser_id: str | None, payload: dict) -> None:
     """Send a 'new poll' push to every group member (except the creator)
     whose notification preference is on. Safe to call inline OR from a
@@ -291,41 +342,52 @@ def fan_out_new_poll(group_id: str, creator_browser_id: str | None, payload: dic
                 return
             vapid = _load_vapid_from_db(conn)
 
-        # The actual send happens outside the get_db() block so we don't
-        # hold a DB connection while waiting on the push services. We
-        # only re-open a connection to record success/failure outcomes.
-        web_results: list[tuple[str, bool, str | None, bool]] = []
-        apns_results: list[tuple[str, bool, str | None, bool]] = []
-
-        web_subs = [s for s in subscriptions if s["kind"] == "web_push"]
-        apns_subs = [s for s in subscriptions if s["kind"] == "apns"]
-
-        if web_subs and vapid is not None:
-            for sub in web_subs:
-                ok, err, should_delete = _send_web_push(sub, payload, vapid)
-                web_results.append((sub["id"], ok, err, should_delete))
-
-        if apns_subs and apns_configured():
-            jwt_token = _apns_jwt(int(time.time()))
-            with httpx.Client(http2=True) as client:
-                for sub in apns_subs:
-                    ok, err, should_delete = _send_apns(sub, payload, client, jwt_token)
-                    apns_results.append((sub["id"], ok, err, should_delete))
-
-        # Record outcomes
-        with get_db() as conn:
-            for sub_id, ok, err, should_delete in web_results + apns_results:
-                if ok:
-                    conn.execute(
-                        "UPDATE push_subscriptions SET failure_count = 0, last_error = NULL, "
-                        "updated_at = NOW() WHERE id = %(id)s",
-                        {"id": sub_id},
-                    )
-                elif should_delete:
-                    _delete_subscription(conn, sub_id)
-                    log.info("Deleted dead push subscription %s: %s", sub_id, err)
-                else:
-                    _mark_failure(conn, sub_id, err or "unknown")
-                    log.warning("Push send failed for subscription %s: %s", sub_id, err)
+        _dispatch_pushes(subscriptions, payload, vapid)
     except Exception as exc:  # noqa: BLE001
         log.exception("fan_out_new_poll failed: %s", exc)
+
+
+def fan_out_join_request(
+    group_id: str,
+    creator_user_id: str,
+    payload: dict,
+) -> None:
+    """Phase F: send a 'someone wants to join your group' push to every
+    browser the creator is signed in on, subject to the per-group
+    notification preference. Same safety contract as `fan_out_new_poll`:
+    every error caught, logged, and swallowed so a failing push service
+    can't block the request response.
+
+    Recipients are derived from `user_browsers WHERE user_id = creator`
+    (one per linked browser), filtered down to those with active push
+    subscriptions, and gated on the same `notify_new_poll` pref the
+    new-poll path uses — for v1 the per-group pref is the single signal
+    that the creator wants to hear about anything happening on the
+    group. Phase I can add a dedicated `notify_join_request` column if
+    we want to surface join requests separately from new-poll noise.
+    """
+    try:
+        with get_db() as conn:
+            recipients = conn.execute(
+                """
+                SELECT DISTINCT ub.browser_id::text AS browser_id
+                  FROM user_browsers ub
+                  LEFT JOIN group_notification_preferences pref
+                    ON pref.browser_id = ub.browser_id
+                   AND pref.group_id = %(gid)s::uuid
+                 WHERE ub.user_id = %(uid)s::uuid
+                   AND COALESCE(pref.notify_new_poll, TRUE) = TRUE
+                """,
+                {"gid": group_id, "uid": creator_user_id},
+            ).fetchall()
+            browser_ids = [r["browser_id"] for r in recipients]
+            if not browser_ids:
+                return
+            subscriptions = _fetch_subscriptions(conn, browser_ids)
+            if not subscriptions:
+                return
+            vapid = _load_vapid_from_db(conn)
+
+        _dispatch_pushes(subscriptions, payload, vapid)
+    except Exception as exc:  # noqa: BLE001
+        log.exception("fan_out_join_request failed: %s", exc)

--- a/server/tests/test_invites.py
+++ b/server/tests/test_invites.py
@@ -1,0 +1,550 @@
+"""Phase G (group invite links) end-to-end coverage.
+
+Exercises every documented behavior in `services/invites.py` +
+`routers/groups.py: create/list/revoke` + `routers/auth.py: redeem`:
+
+  * POST /api/groups/{id}/invites
+    - anonymous → 401
+    - non-creator → 403
+    - groups with no recorded creator → 403
+    - mode='single' enforces max_uses=1 regardless of body
+    - mode='multi' accepts max_uses or NULL
+    - cross-group target_poll_id silently downgraded to NULL
+    - response surfaces the raw token + URL exactly once
+  * GET /api/groups/{id}/invites
+    - creator sees active invites; revoked/expired filtered out
+    - non-creator → 403
+  * DELETE /api/groups/{id}/invites/{invite_id}
+    - creator revokes → 204
+    - non-owner → 404 (no info leak)
+    - already-revoked → 404
+  * POST /api/auth/invites/{token}/redeem
+    - anonymous → 401
+    - invalid token → 404
+    - revoked → 404
+    - fully-used (single) → 404
+    - expired → 404
+    - fresh redeem → 200, writes membership, increments use_count
+    - already-member → 200, already_member=true, use_count NOT bumped
+    - target_poll_id surfaces target_poll_short_id
+
+Tests follow the same magic-link sign-in pattern as
+`test_group_privacy.py` + `test_join_requests.py`.
+"""
+
+import time
+import uuid
+
+import psycopg
+import pytest
+
+from services.auth import (
+    generate_token,
+    hash_token,
+    normalize_email,
+)
+from tests.conftest import TEST_DB_URL
+
+
+@pytest.fixture
+def creator_browser():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def joiner_browser():
+    return str(uuid.uuid4())
+
+
+def _bid_headers(bid):
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+def _bearer_headers(bid, token):
+    h = _bid_headers(bid)
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _issue_known_magic_link(email, browser_id):
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO magic_link_tokens
+                  (token_hash, email, browser_id, expires_at)
+                VALUES
+                  (%s, %s, %s, NOW() + INTERVAL '15 minutes')
+                """,
+                (hash_token(token), normalize_email(email), browser_id),
+            )
+        conn.commit()
+    return token
+
+
+def _sign_in(client, browser_id, email=None):
+    raw_email = email or f"phaseg-{uuid.uuid4().hex[:8]}@example.com"
+    token = _issue_known_magic_link(raw_email, browser_id)
+    resp = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": token},
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    return body["session_token"], body["user"]["user_id"]
+
+
+def _create_private_group(client, browser_id, token):
+    resp = client.post(
+        "/api/groups",
+        headers=_bearer_headers(browser_id, token),
+    )
+    assert resp.status_code == 201, resp.text
+    group = resp.json()
+    assert group["privacy"] == "private"
+    return group
+
+
+# ----------------------------------------------------------------- create
+
+
+def test_create_invite_anonymous_returns_401(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    resp = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bid_headers(creator_browser),  # no bearer
+    )
+    assert resp.status_code == 401
+
+
+def test_create_invite_non_creator_returns_403(
+    client, creator_browser, joiner_browser
+):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    jtoken, _ = _sign_in(client, joiner_browser)
+
+    resp = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert resp.status_code == 403
+
+
+def test_create_invite_creator_returns_token_and_url(
+    client, creator_browser
+):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    resp = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["mode"] == "multi"
+    assert body["use_count"] == 0
+    assert body["token"], "raw token must be returned on create"
+    assert body["url"].endswith(f"/invite/{body['token']}")
+
+
+def test_create_invite_single_forces_max_uses_1(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    # Even if the caller passes max_uses=99, single mode normalizes to 1.
+    resp = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "single", "max_uses": 99},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["mode"] == "single"
+    assert body["max_uses"] == 1
+
+
+def test_create_invite_invalid_mode_returns_400(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    resp = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "weird"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 400
+
+
+def test_create_invite_cross_group_target_poll_silently_dropped(
+    client, creator_browser
+):
+    ctoken, cuser = _sign_in(client, creator_browser)
+    group_a = _create_private_group(client, creator_browser, ctoken)
+
+    # Create a poll in a DIFFERENT group (group B).
+    second_browser = str(uuid.uuid4())
+    btoken, _ = _sign_in(client, second_browser)
+    group_b = _create_private_group(client, second_browser, btoken)
+    poll_resp = client.post(
+        "/api/polls",
+        json={
+            "creator_secret": f"x-{uuid.uuid4().hex[:6]}",
+            "creator_name": "Other",
+            "group_id": group_b["id"],
+            "questions": [{"question_type": "yes_no", "category": "yes_no"}],
+        },
+        headers=_bearer_headers(second_browser, btoken),
+    )
+    assert poll_resp.status_code == 201, poll_resp.text
+    other_poll_id = poll_resp.json()["id"]
+
+    # Creator of group A tries to set group B's poll as target.
+    resp = client.post(
+        f"/api/groups/{group_a['id']}/invites",
+        json={"mode": "multi", "target_poll_id": other_poll_id},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 201, resp.text
+    # Silently dropped — target_poll_id is NULL in the response.
+    assert resp.json()["target_poll_id"] is None
+
+
+# ----------------------------------------------------------------- list
+
+
+def test_list_invites_non_creator_returns_403(
+    client, creator_browser, joiner_browser
+):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    jtoken, _ = _sign_in(client, joiner_browser)
+
+    resp = client.get(
+        f"/api/groups/{group['id']}/invites",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert resp.status_code == 403
+
+
+def test_list_invites_creator_sees_active(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "single"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+
+    resp = client.get(
+        f"/api/groups/{group['id']}/invites",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 200, resp.text
+    items = resp.json()
+    assert len(items) == 2
+    # List omits token + url (one-shot at create).
+    for item in items:
+        assert item.get("token") is None
+        assert item.get("url") is None
+
+
+def test_list_invites_excludes_revoked(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    invite_id = create.json()["id"]
+
+    revoke = client.delete(
+        f"/api/groups/{group['id']}/invites/{invite_id}",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert revoke.status_code == 204
+
+    listed = client.get(
+        f"/api/groups/{group['id']}/invites",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert listed.json() == []
+
+
+# --------------------------------------------------------------- revoke
+
+
+def test_revoke_non_creator_returns_403_at_group_level(
+    client, creator_browser, joiner_browser
+):
+    """Trying to revoke a creator-owned invite from a different user
+    fails the group-level creator gate (_require_creator) → 403,
+    before the per-invite ownership check fires."""
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    invite_id = create.json()["id"]
+
+    jtoken, _ = _sign_in(client, joiner_browser)
+    resp = client.delete(
+        f"/api/groups/{group['id']}/invites/{invite_id}",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert resp.status_code == 403
+
+
+def test_revoke_unknown_invite_returns_404(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    resp = client.delete(
+        f"/api/groups/{group['id']}/invites/{uuid.uuid4()}",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 404
+
+
+def test_revoke_already_revoked_returns_404(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    invite_id = create.json()["id"]
+
+    first = client.delete(
+        f"/api/groups/{group['id']}/invites/{invite_id}",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert first.status_code == 204
+    second = client.delete(
+        f"/api/groups/{group['id']}/invites/{invite_id}",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert second.status_code == 404
+
+
+# --------------------------------------------------------------- redeem
+
+
+def test_redeem_anonymous_returns_401(client, creator_browser):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    raw_token = create.json()["token"]
+
+    resp = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bid_headers(str(uuid.uuid4())),  # no bearer
+    )
+    assert resp.status_code == 401
+
+
+def test_redeem_invalid_token_returns_404(client, joiner_browser):
+    jtoken, _ = _sign_in(client, joiner_browser)
+    resp = client.post(
+        f"/api/auth/invites/{generate_token()}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert resp.status_code == 404
+
+
+def test_redeem_revoked_returns_404(
+    client, creator_browser, joiner_browser
+):
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    invite_id = create.json()["id"]
+    raw_token = create.json()["token"]
+
+    client.delete(
+        f"/api/groups/{group['id']}/invites/{invite_id}",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+
+    jtoken, _ = _sign_in(client, joiner_browser)
+    resp = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert resp.status_code == 404
+
+
+def test_redeem_grants_membership_and_visibility(
+    client, creator_browser, joiner_browser
+):
+    """Happy path: joiner can't see the private group; redeem; can see
+    it. Same shape as the Phase F approve happy-path test."""
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    raw_token = create.json()["token"]
+
+    jtoken, _ = _sign_in(client, joiner_browser)
+    pre = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert pre.status_code == 404
+
+    redeem = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert redeem.status_code == 200, redeem.text
+    body = redeem.json()
+    assert body["group_id"] == group["id"]
+    assert body["already_member"] is False
+
+    post = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert post.status_code == 200
+
+
+def test_redeem_single_use_consumed_after_first(
+    client, creator_browser, joiner_browser
+):
+    """single-mode invite is fully-used after one redeem; a second
+    joiner gets 404."""
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "single"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    raw_token = create.json()["token"]
+
+    # First joiner consumes it.
+    jtoken1, _ = _sign_in(client, joiner_browser)
+    first = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken1),
+    )
+    assert first.status_code == 200
+
+    # Second joiner hits 404.
+    second_browser = str(uuid.uuid4())
+    jtoken2, _ = _sign_in(client, second_browser)
+    second = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(second_browser, jtoken2),
+    )
+    assert second.status_code == 404
+
+
+def test_redeem_already_member_is_noop_no_use_count_bump(
+    client, creator_browser, joiner_browser
+):
+    """A member re-clicking the URL shouldn't consume an invite use."""
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi", "max_uses": 5},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    raw_token = create.json()["token"]
+
+    jtoken, _ = _sign_in(client, joiner_browser)
+    first = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert first.status_code == 200
+    assert first.json()["already_member"] is False
+
+    # Same user re-clicks.
+    second = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert second.status_code == 200
+    assert second.json()["already_member"] is True
+
+    # use_count should still be 1 (not 2).
+    listed = client.get(
+        f"/api/groups/{group['id']}/invites",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    items = listed.json()
+    assert len(items) == 1
+    assert items[0]["use_count"] == 1
+
+
+def test_redeem_returns_target_poll_short_id(
+    client, creator_browser, joiner_browser
+):
+    """target_poll_id at invite-create surfaces target_poll_short_id
+    in the redeem response so the FE can build the deep-link redirect."""
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    # Create a poll in the group.
+    poll_resp = client.post(
+        "/api/polls",
+        json={
+            "creator_secret": f"x-{uuid.uuid4().hex[:6]}",
+            "creator_name": "Creator",
+            "group_id": group["id"],
+            "questions": [{"question_type": "yes_no", "category": "yes_no"}],
+        },
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert poll_resp.status_code == 201
+    poll = poll_resp.json()
+
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi", "target_poll_id": poll["id"]},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    raw_token = create.json()["token"]
+
+    jtoken, _ = _sign_in(client, joiner_browser)
+    redeem = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert redeem.status_code == 200
+    body = redeem.json()
+    assert body["target_poll_id"] == poll["id"]
+    assert body["target_poll_short_id"] == poll["short_id"]

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -1,0 +1,525 @@
+"""Phase F (group join requests) end-to-end coverage.
+
+Exercises every state machine transition documented in
+`docs/auth-access-model.md` + `services/join_requests.py`:
+
+  * POST /join-requests
+    - anonymous → 401
+    - signed-in non-member → 201 + status='pending'
+    - signed-in non-member, repeat → 200 + status='already_pending'
+    - signed-in member → 200 + status='already_member'
+    - signed-in creator → 200 + status='already_member'
+    - 404 on unresolvable route
+  * GET /join-requests
+    - anonymous → 401
+    - non-creator → 403
+    - creator → list, oldest first
+    - 404 on unresolvable route
+    - groups without a recorded creator → 403
+  * POST /join-requests/<id>/decide
+    - anonymous → 401
+    - non-creator → 403
+    - cross-group request_id (creator of A tries to decide a request
+      on group B) → 404
+    - already-decided → 404
+    - approve → status='approved', requester gets membership +
+      visibility on next read
+    - deny → status='denied', no membership
+
+Tests use the shared `client` fixture and mirror
+`test_group_privacy.py`'s magic-link sign-in helper so the session
+token is real.
+"""
+
+import uuid
+
+import psycopg
+import pytest
+
+from services.auth import (
+    generate_token,
+    hash_token,
+    normalize_email,
+)
+from tests.conftest import TEST_DB_URL
+
+
+@pytest.fixture
+def creator_browser():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def requester_browser():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def stranger_browser():
+    return str(uuid.uuid4())
+
+
+def _bid_headers(bid):
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+def _bearer_headers(bid, token):
+    h = _bid_headers(bid)
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _issue_known_magic_link(email, browser_id):
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO magic_link_tokens
+                  (token_hash, email, browser_id, expires_at)
+                VALUES
+                  (%s, %s, %s, NOW() + INTERVAL '15 minutes')
+                """,
+                (hash_token(token), normalize_email(email), browser_id),
+            )
+        conn.commit()
+    return token
+
+
+def _sign_in(client, browser_id, email=None):
+    """Run a full magic-link verify and return (session_token, user_id,
+    email). The email is the server-normalized (lowercase, trimmed)
+    form so tests can compare against `requester_email` from list /
+    create endpoint responses without surface mismatches."""
+    raw_email = email or f"phasef-{uuid.uuid4().hex[:8]}@example.com"
+    token = _issue_known_magic_link(raw_email, browser_id)
+    resp = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": token},
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    return body["session_token"], body["user"]["user_id"], normalize_email(raw_email)
+
+
+def _create_private_group(client, browser_id, token):
+    """Signed-in create → privacy='private', creator_user_id recorded."""
+    resp = client.post(
+        "/api/groups",
+        headers=_bearer_headers(browser_id, token),
+    )
+    assert resp.status_code == 201, resp.text
+    group = resp.json()
+    assert group["privacy"] == "private"
+    return group
+
+
+def _create_public_anon_group(client, browser_id):
+    """Anonymous create → privacy='public', creator_user_id NULL.
+    Used for the "no recorded creator" 403 cases."""
+    resp = client.post("/api/groups", headers=_bid_headers(browser_id))
+    assert resp.status_code == 201, resp.text
+    group = resp.json()
+    assert group["privacy"] == "public"
+    assert group["creator_user_id"] is None
+    return group
+
+
+# --------------------------------------------------------------------- create
+
+
+def test_create_join_request_anonymous_returns_401(
+    client, creator_browser, stranger_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "Hi"},
+        headers=_bid_headers(stranger_browser),
+    )
+    assert resp.status_code == 401
+
+
+def test_create_join_request_unknown_group_returns_404(
+    client, requester_browser
+):
+    rtoken, _, _ = _sign_in(client, requester_browser)
+    bogus = str(uuid.uuid4())
+    resp = client.post(
+        f"/api/groups/{bogus}/join-requests",
+        json={"message": "Hi"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 404
+
+
+def test_create_join_request_new_returns_pending(
+    client, creator_browser, requester_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    rtoken, _, remail = _sign_in(client, requester_browser)
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "Hi, it's Alice"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["request"]["message"] == "Hi, it's Alice"
+    assert body["request"]["requester_email"] == remail
+
+
+def test_create_join_request_repeat_returns_already_pending(
+    client, creator_browser, requester_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    rtoken, _, _ = _sign_in(client, requester_browser)
+    first = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "first"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert first.json()["status"] == "pending"
+
+    # Second call with DIFFERENT message — the existing pending row
+    # wins (no overwrite), status reports 'already_pending'.
+    second = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "second"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["status"] == "already_pending"
+    assert second.json()["request"]["message"] == "first"
+
+
+def test_create_join_request_creator_short_circuits(
+    client, creator_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "I am the creator"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "already_member"
+    assert resp.json()["request"] is None
+
+
+def test_create_join_request_existing_member_short_circuits(
+    client, creator_browser, requester_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    # Approve the requester so they have a membership row.
+    rtoken, _, _ = _sign_in(client, requester_browser)
+    create = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "let me in"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = create.json()["request"]["id"]
+    decide = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert decide.status_code == 200, decide.text
+
+    # Now they're a member — re-request should short-circuit.
+    repeat = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "again"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert repeat.status_code == 200
+    assert repeat.json()["status"] == "already_member"
+
+
+# ----------------------------------------------------------------------- list
+
+
+def test_list_join_requests_anonymous_returns_401(client, creator_browser):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    resp = client.get(
+        f"/api/groups/{group['id']}/join-requests",
+        headers=_bid_headers(creator_browser),  # no token
+    )
+    assert resp.status_code == 401
+
+
+def test_list_join_requests_non_creator_returns_403(
+    client, creator_browser, requester_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    rtoken, _, _ = _sign_in(client, requester_browser)
+
+    resp = client.get(
+        f"/api/groups/{group['id']}/join-requests",
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 403
+
+
+def test_list_join_requests_creator_sees_pending_in_order(
+    client, creator_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    # Two requesters with different emails so we can spot ordering.
+    rb1 = str(uuid.uuid4())
+    rb2 = str(uuid.uuid4())
+    rt1, _, e1 = _sign_in(client, rb1)
+    rt2, _, e2 = _sign_in(client, rb2)
+    client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "first"},
+        headers=_bearer_headers(rb1, rt1),
+    )
+    client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "second"},
+        headers=_bearer_headers(rb2, rt2),
+    )
+
+    resp = client.get(
+        f"/api/groups/{group['id']}/join-requests",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 2
+    assert body[0]["message"] == "first"
+    assert body[0]["requester_email"] == e1
+    assert body[1]["message"] == "second"
+    assert body[1]["requester_email"] == e2
+
+
+def test_list_join_requests_anon_created_group_returns_403(
+    client, creator_browser
+):
+    """Anonymous-created groups have no recorded creator — no one can
+    list them. Phase I will add a 'claim' upgrade path."""
+    group = _create_public_anon_group(client, creator_browser)
+    ctoken, _, _ = _sign_in(client, creator_browser)
+
+    resp = client.get(
+        f"/api/groups/{group['id']}/join-requests",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 403
+
+
+# --------------------------------------------------------------------- decide
+
+
+def test_decide_anonymous_returns_401(client, creator_browser):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    bogus_request = str(uuid.uuid4())
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests/{bogus_request}/decide",
+        json={"action": "approve"},
+        headers=_bid_headers(creator_browser),
+    )
+    assert resp.status_code == 401
+
+
+def test_decide_non_creator_returns_403(
+    client, creator_browser, requester_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    rtoken, _, _ = _sign_in(client, requester_browser)
+
+    create = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "let me in"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = create.json()["request"]["id"]
+
+    # Requester tries to approve their own request.
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 403
+
+
+def test_decide_cross_group_request_returns_404(
+    client, creator_browser, requester_browser
+):
+    """Creator of group A can't decide on a request belonging to
+    group B — even if they correctly guess the request_id. The
+    route_id + request_id pairing is enforced server-side."""
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group_a = _create_private_group(client, creator_browser, ctoken)
+    # Different creator browser → different user → different group.
+    second_creator_browser = str(uuid.uuid4())
+    btoken, _, _ = _sign_in(client, second_creator_browser)
+    group_b = _create_private_group(client, second_creator_browser, btoken)
+
+    rtoken, _, _ = _sign_in(client, requester_browser)
+    create = client.post(
+        f"/api/groups/{group_b['id']}/join-requests",
+        json={"message": "for B"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = create.json()["request"]["id"]
+
+    # Creator of A tries to decide on a request that belongs to B.
+    resp = client.post(
+        f"/api/groups/{group_a['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 404
+
+
+def test_decide_already_decided_returns_404(
+    client, creator_browser, requester_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    rtoken, _, _ = _sign_in(client, requester_browser)
+
+    create = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "let me in"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = create.json()["request"]["id"]
+    first = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert first.status_code == 200
+    second = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert second.status_code == 404
+
+
+def test_decide_invalid_action_returns_400(
+    client, creator_browser, requester_browser
+):
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    rtoken, _, _ = _sign_in(client, requester_browser)
+    create = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "x"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = create.json()["request"]["id"]
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "maybe"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 400
+
+
+def test_approve_writes_membership_and_grants_visibility(
+    client, creator_browser, requester_browser
+):
+    """End-to-end: requester can't see the private group; after
+    approve, they CAN see it via /by-route-id. This is the load-bearing
+    happy path."""
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    rtoken, _, _ = _sign_in(client, requester_browser)
+
+    # Pre-approval: requester can't see the private group.
+    pre = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert pre.status_code == 404
+
+    create = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "let me in"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = create.json()["request"]["id"]
+    decide = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert decide.status_code == 200
+    assert decide.json()["status"] == "approved"
+
+    # Post-approval: requester sees the group (no longer 404).
+    post = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert post.status_code == 200, post.text
+
+
+def test_deny_does_not_grant_membership_and_allows_re_request(
+    client, creator_browser, requester_browser
+):
+    """Deny walks the row to 'denied' (partial unique frees up the
+    slot), so the requester can re-request after a denial."""
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+    rtoken, _, _ = _sign_in(client, requester_browser)
+
+    first = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "first"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = first.json()["request"]["id"]
+    deny = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "deny"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert deny.status_code == 200
+    assert deny.json()["status"] == "denied"
+
+    # Requester still can't see the group.
+    blocked = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert blocked.status_code == 404
+
+    # Re-request should succeed (partial-unique constraint frees the
+    # slot when the prior row is no longer 'pending').
+    again = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "second"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert again.status_code == 200
+    assert again.json()["status"] == "pending"
+    assert again.json()["request"]["id"] != request_id


### PR DESCRIPTION
## Summary

Two phases of the auth & access model in one branch (independent migrations + features, but they pair naturally on /info as the "how do strangers get into my private group" pair).

### Phase F — join requests (migration 115)

- `group_join_requests` table with partial unique index on `(group_id, requester_user_id) WHERE status='pending'` so users can re-request after a denial without clobbering an open request.
- Three endpoints on `routers/groups.py`: create / list (creator-only) / decide (creator-only). Idempotent — repeat-request returns the existing pending row + `status='already_pending'`; member/creator short-circuits return `status='already_member'` and skip the insert + push fire.
- Push fan-out on a new pending request via `services/push.py: fan_out_join_request` — walks `user_browsers WHERE user_id = creator` so the creator gets notified on every device they're signed in on, not just the one that received the request. Gated on the existing per-group `notify_new_poll` pref. Refactored the send + record-outcomes loop out of `fan_out_new_poll` so adding a third event type doesn't fork the loop.
- FE: `<JoinRequestsSection>` on /info (creator-only) with approve/deny per row; "Request to join" CTA on the signed-in `GroupNotFound` page. The 404 page now accepts a `routeId` prop so it can POST against the resolved group even when the route is otherwise unreachable.

### Phase G — invite links (migration 116)

- `group_invites` table with sha256-only token storage (same model as sessions + magic-link tokens). Raw token + host-derived URL returned exactly ONCE at create time.
- Four endpoints: create/list/revoke on `routers/groups.py` (all creator-only), redeem on `routers/auth.py` (signed-in only, anonymous returns 401). Redeem does an atomic conditional UPDATE on `use_count < max_uses` to serialize concurrent clicks at row-lock granularity; already-member redemptions roll back the bump so re-clicking doesn't consume a use.
- `services/fe_origin.py: resolve_fe_origin` lifts the FE-origin allowlist out of `routers/auth.py` so magic-link and invite URL minting share one allowlist.
- FE: `<InviteLinksSection>` on /info (creator-only) with Create + Copy + Revoke; `/invite/[token]/page.tsx` redemption landing page that auto-redeems for signed-in viewers and surfaces a sign-in CTA for anonymous viewers.

## Test plan

- [x] 36 new server tests (`test_join_requests.py` + `test_invites.py`); pre-existing 451-test suite stays green (full suite 487 passing).
- [x] Migration 115 + 116 apply cleanly from scratch on a local Postgres.
- [ ] Manual: sign in on a fresh browser, create a private group, mint an invite, redeem in a second browser → joiner sees group on home.
- [ ] Manual: revoke a pending request from /info → push notification not re-fired on duplicate "polite re-request" taps.
- [ ] Manual: anonymous viewer at `/invite/<token>` → sign-in modal → SESSION_CHANGED_EVENT fires → auto-redeem → router.replace to `/g/<group>`.

Docs updated in `docs/auth-access-model.md` + `CLAUDE.md` (Phase F + G sections, pitfalls, design notes).


---
_Generated by [Claude Code](https://claude.ai/code/session_012LmCEedL9iBL6gLZLiTdbQ)_