### PR TITLE
fix(ios): pin CODE_SIGN_IDENTITY to "Apple Distribution"

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -385,6 +385,24 @@ jobs:
           # from the patched pbxproj. Trade-off: slower archive (~30s →
           # ~2min), acceptable because iOS builds only run on native-file
           # changes / release publishes / push-to-main.
+          #
+          # `CODE_SIGN_IDENTITY="Apple Distribution"` is also load-bearing.
+          # Without it, xcodebuild's automatic signing can pick a
+          # "Team Provisioning Profile" (Development type) even for Release
+          # archives, especially after the profile cache was cleared and
+          # `-allowProvisioningUpdates` re-fetches. The dev-signed IPA then
+          # uploads to App Store Connect and gets rejected with the
+          # cryptic `bundle identifier cannot be changed from the current
+          # value` error — Apple's poorly-worded way of saying "this
+          # binary's signing context doesn't match an App Store record."
+          # Pinning the cert identity to Distribution forces selection of
+          # a Store provisioning profile (dev certs can't sign with Store
+          # profiles), restoring the correct distribution-signing chain.
+          # This appears to be the canary-vs-prod difference: ASC accepted
+          # dev-signed IPAs for `.latest` (perhaps because it was first
+          # uploaded that way and inherited that signing state) but rejects
+          # them for `.app`, hence prod builds were failing while canary
+          # builds succeeded with the same workflow.
           xcodebuild \
             -project "$PROJECT" \
             -scheme "$SCHEME" \
@@ -398,6 +416,7 @@ jobs:
             DEVELOPMENT_TEAM="$TEAM_ID" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             clean archive > build/xcodebuild-archive.log 2>&1 || {
               echo "::error::Archive failed — tail of log:"
               tail -100 build/xcodebuild-archive.log


### PR DESCRIPTION
## Summary

Fourth and (hopefully) final piece of the prod-iOS-build puzzle. Diagnostic via on-disk profile inspection on the Mac runner showed Xcode embedded `iOS Team Provisioning Profile: com.whoeverwants.app` (a **Development** type profile) in the prod archive, not the Distribution-type `iOS Team Store Provisioning Profile: com.whoeverwants.app` that also exists on disk. With `-allowProvisioningUpdates` + automatic signing, xcodebuild can prefer dev profiles for Release archives if a dev profile got fetched first.

App Store Connect rejects dev-signed IPAs with the misleadingly-worded `Validation failed (409) ... bundle identifier cannot be changed from the current value, '<sibling-bundle>'` error — Apple's poorly-phrased way of saying "this binary's signing context doesn't match an App Store record." The error surfaces for `.app` but not `.latest`, likely because `.latest`'s ASC record was originally established with dev-signed builds and tolerates them.

## Fix

Add `CODE_SIGN_IDENTITY="Apple Distribution"` to the xcodebuild archive flags. Forces selection of a Distribution certificate, which in turn forces selection of a Store provisioning profile (dev certs can't sign with Store profiles). Works symmetrically for canary and prod.

## Test plan

- [ ] PR checks green.
- [ ] After merge: push-to-main fires iOS prod build → embeds a Store profile (UUID likely `1b46cf1f-...` based on what's on disk) → IPA uploads successfully to TestFlight under `WhoeverWants` (Apple ID `6762459339`).
- [ ] Next canary build also picks Store profile for `.latest` — no regression.

If THIS one also fails, the next move is manual signing with explicit profile UUIDs, but that's brittle so let's try this first.

https://claude.ai/code/session_01FWtVGNKz3wt7xwSMHsuyu6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWtVGNKz3wt7xwSMHsuyu6)_