### PR TITLE
Phase I auth: account management (recovery email + delete account)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -946,7 +946,7 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 
 ## Auth & Access Model
 
-> **Phases A + B + C + D + E + F + G shipped.** A+B = identity
+> **Phases A + B + C + D + E + F + G + I shipped.** A+B = identity
 > foundation + magic-link email sign-in (migration 112). C = "Sign in
 > with Apple" + "Sign in with Google" on web, plus native Apple AND
 > native Google Sign In on Capacitor iOS via
@@ -965,7 +965,10 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 > signed-in viewers auto-redeem on landing, anonymous viewers get a
 > sign-in CTA. Phase H (per-vote anonymity) is **retired** — anonymous
 > voting is "leave the voter name blank"; no per-vote on/off toggle is
-> planned. Full plan + rationale in `docs/auth-access-model.md`.
+> planned. I = account management (migration 118) — Settings shows
+> linked sign-in methods, passkey-only / OAuth-only accounts can attach
+> a recovery email, and any account can be deleted. Full plan +
+> rationale in `docs/auth-access-model.md`.
 
 **Cross-browser visibility for signed-in users.** Every read that
 asks "is the caller a member of this group?" must walk
@@ -1315,10 +1318,63 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
 - H: ~~per-vote anonymity~~ **NOT PLANNED.** Voters can already submit
   without a name (existing `voter_name` nullability); no per-vote on/off
   toggle is on the roadmap.
-- I (partial): "claim an anonymous-created group" so legacy
-  creator_user_id can be set after-the-fact, enabling
-  privacy-flip on grandfathered groups.
+- I (account settings — **shipped**): linked-identities display +
+  add-recovery-email + delete-account (migration 118). See "Phase I"
+  below. Still deferred within I: retire `creator_secret`; "claim an
+  anonymous-created group" so legacy creator_user_id can be set
+  after-the-fact, enabling privacy-flip on grandfathered groups.
 - C-follow-up: ~~native Google Sign In on iOS~~ **shipped** (per-bundle iOS client IDs hardcoded in `lib/oauth.ts: GOOGLE_IOS_CLIENT_IDS`; reversed URL scheme stamped into `Info.plist: CFBundleURLTypes` by `ios-build.yml`; uses the same `@capgo/capacitor-social-login` plugin as Apple native).
+
+**Phase I (account management) shipped in migration 118.** Adds a
+nullable `magic_link_tokens.user_id` (ON DELETE CASCADE) that tags a
+magic-link token as a recovery-email-ATTACH token rather than a
+SIGN-IN token. The two flows are kept uncrossed by predicate:
+`consume_magic_link` (sign-in) adds `AND user_id IS NULL`;
+`peek_recovery_email_token` / `consume_recovery_email_token` (attach)
+add `AND user_id IS NOT NULL`. Three new auth endpoints + a delete:
+  * `POST /api/auth/recovery-email/request {email}` — signed-in only
+    (401 anon). Rejects (400) accounts that ALREADY have an 'email'
+    identity (adding a 2nd email is out of scope — recovery email is for
+    passkey-only / OAuth-only accounts that lack one). Mints a
+    user_id-tagged token + sends "confirm recovery email" via
+    `send_recovery_email`. Throttled (reuses `email_throttled`) — a
+    throttled request still returns 202 accepted (no leak).
+  * `POST /api/auth/recovery-email/verify {token}` — requires BOTH
+    proofs: the token (email control) AND a signed-in session whose
+    user_id matches the token's user_id (account control, else 403).
+    The token is PEEKED, not consumed, until both checks pass — a
+    wrong-device click (403) or already-taken email (409) leaves it
+    usable for a correct retry within its TTL. Returns the refreshed
+    `UserSummary` (no new session issued). FE landing page:
+    `app/auth/recovery-email/page.tsx` (distinct from `/auth/verify`).
+  * `DELETE /api/auth/me` — signed-in only. Single
+    `DELETE FROM users WHERE id=...`; every users(id) FK declared in
+    migrations 112–117 CASCADEs (sessions, identities, browser links,
+    passkeys, this user's join requests + invites, recovery tokens) or
+    SET NULLs (`groups.creator_user_id`,
+    `group_join_requests.decided_by_user_id`). `group_members` is
+    browser-keyed (no user_id col) so the browser keeps its memberships
+    + poll creator_secrets and reverts to anonymous. 204.
+  * `attach_email_identity(conn, user_id, email)` returns
+    `'attached' | 'already_linked' | 'conflict'`. Conflict spans ALL
+    providers: an email another user proved via Google can't be claimed
+    here as a sign-in email. Idempotent on re-attach (already_linked).
+
+  **`fetchWithBase` now returns `undefined` on HTTP 204** (was an
+  unconditional `res.json()`, which throws "Unexpected end of JSON
+  input" on an empty body). Fixes a latent issue for every `<void>`
+  DELETE/POST endpoint (sign-out, delete-passkey, delete-account).
+
+  FE: `apiRequestRecoveryEmail` / `apiVerifyRecoveryEmail` /
+  `apiDeleteAccount` in `lib/api/auth.ts`. Settings page (`app/settings/page.tsx`)
+  gains: a "Sign-in methods" row listing linked providers
+  (`formatProviders`), an "Add a recovery email" affordance (gated on
+  `currentUser && !providers.includes('email')`), and a red "Delete
+  account" button → `ConfirmationModal`. `apiVerifyRecoveryEmail`
+  updates the cached session user so the new 'email' provider surfaces
+  everywhere; `apiDeleteAccount` clears local session (fires
+  `SESSION_CHANGED_EVENT` → settings reverts to anonymous without a nav).
+  Tests: `server/tests/test_account_management.py` (15 tests).
 
 **Phase F (group join requests) shipped in migration 115.** Adds
 `group_join_requests(id, group_id, requester_user_id, message,

--- a/app/auth/recovery-email/page.tsx
+++ b/app/auth/recovery-email/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { apiVerifyRecoveryEmail, ApiError } from "@/lib/api";
+import { usePageReady } from "@/lib/usePageReady";
+
+/**
+ * Phase I: recovery-email confirmation landing page. The email's link
+ * points here with `?token=...`; we POST it to the recovery-email verify
+ * endpoint, which binds the email to the CURRENTLY SIGNED-IN account
+ * (the server requires the session's user_id to match the token's).
+ *
+ * Distinct from `/auth/verify` (sign-in): this confirms an email being
+ * ADDED to an existing account, so it requires the user to already be
+ * signed in on this device — hence the 403 → "open on the right device"
+ * copy below.
+ */
+
+type Status = "verifying" | "success" | "error";
+
+function RecoveryEmailContent() {
+  const router = useRouter();
+  usePageReady(true);
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<Status>("verifying");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [email, setEmail] = useState<string | null>(null);
+  const attemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (attemptedRef.current) return;
+    attemptedRef.current = true;
+
+    const token = searchParams.get("token");
+    if (!token) {
+      setStatus("error");
+      setErrorMessage("This confirmation link is missing its token.");
+      return;
+    }
+
+    (async () => {
+      try {
+        const user = await apiVerifyRecoveryEmail(token);
+        setEmail(user.email);
+        setStatus("success");
+        setTimeout(() => router.replace("/settings"), 1500);
+      } catch (err) {
+        setStatus("error");
+        if (err instanceof ApiError) {
+          if (err.status === 401) {
+            setErrorMessage(
+              "You need to be signed in on this device to confirm a recovery email.",
+            );
+          } else if (err.status === 403) {
+            setErrorMessage(
+              "This link belongs to a different account. Open it on the device where you're signed in to that account.",
+            );
+          } else if (err.status === 409) {
+            setErrorMessage(
+              "That email is already used by another account.",
+            );
+          } else {
+            setErrorMessage(err.message || "Couldn't confirm this link.");
+          }
+        } else {
+          setErrorMessage("Couldn't reach the server. Try again in a moment.");
+        }
+      }
+    })();
+  }, [router, searchParams]);
+
+  return (
+    <div className="question-content text-center pt-16">
+      {status === "verifying" && (
+        <div className="flex flex-col items-center gap-4">
+          <svg
+            className="w-8 h-8 animate-spin text-blue-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+          <p className="text-gray-700 dark:text-gray-300">
+            Confirming your recovery email…
+          </p>
+        </div>
+      )}
+      {status === "success" && (
+        <div>
+          <h1 className="text-xl font-semibold mb-2">Recovery email added</h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            {email ? `You can now sign in with ${email}` : null}
+          </p>
+        </div>
+      )}
+      {status === "error" && (
+        <div>
+          <h1 className="text-xl font-semibold mb-2">
+            Couldn&apos;t add this email
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            {errorMessage}
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500 mb-4">
+            Confirmation links expire after 15 minutes and can only be used
+            once.
+          </p>
+          <button
+            type="button"
+            onClick={() => router.replace("/settings")}
+            className="rounded-full bg-blue-600 hover:bg-blue-700 text-white px-6 h-11 font-medium"
+          >
+            Back to settings
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function RecoveryEmailPage() {
+  return (
+    <Suspense fallback={null}>
+      <RecoveryEmailContent />
+    </Suspense>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,7 +17,10 @@ import {
   apiSignOut,
   apiListPasskeys,
   apiDeletePasskey,
+  apiRequestRecoveryEmail,
+  apiDeleteAccount,
   getCurrentUser,
+  ApiError,
   type PasskeySummary,
 } from "@/lib/api";
 import {
@@ -112,6 +115,21 @@ export default function SettingsPage() {
   const [signInModalOpen, setSignInModalOpen] = useState(false);
   const [signOutInFlight, setSignOutInFlight] = useState(false);
 
+  // Phase I — recovery email + delete account. The recovery affordance
+  // is shown only when signed in AND the account has no 'email' provider
+  // (passkey-only / OAuth-only). `recoveryOpen` reveals the inline input;
+  // `recoverySent` swaps it for a "check your inbox" acknowledgement.
+  const [recoveryOpen, setRecoveryOpen] = useState(false);
+  const [recoveryEmail, setRecoveryEmail] = useState("");
+  const [recoveryInFlight, setRecoveryInFlight] = useState(false);
+  const [recoverySent, setRecoverySent] = useState(false);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
+  const [recoveryEmailConfigured, setRecoveryEmailConfigured] = useState(true);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleteInFlight, setDeleteInFlight] = useState(false);
+
+  const hasEmailIdentity = !!currentUser?.providers?.includes("email");
+
   // Phase D — passkeys. Only fetched + shown when signed in. The server
   // tier capability + browser capability are both gates: the server
   // tier check comes from /api/auth/providers (memoized in
@@ -149,6 +167,16 @@ export default function SettingsPage() {
       });
   }, []);
 
+  // Reset the recovery-email form whenever the signed-in identity
+  // changes (sign-out, or sign-in as a different user) so a previous
+  // session's "check your inbox" state doesn't leak into the next.
+  useEffect(() => {
+    setRecoveryOpen(false);
+    setRecoverySent(false);
+    setRecoveryEmail("");
+    setRecoveryError(null);
+  }, [currentUser?.user_id]);
+
   const handleSignOut = async () => {
     if (signOutInFlight) return;
     setSignOutInFlight(true);
@@ -156,6 +184,49 @@ export default function SettingsPage() {
       await apiSignOut();
     } finally {
       setSignOutInFlight(false);
+    }
+  };
+
+  const handleSendRecoveryEmail = async () => {
+    if (recoveryInFlight) return;
+    const email = recoveryEmail.trim();
+    if (!email) return;
+    setRecoveryError(null);
+    setRecoveryInFlight(true);
+    try {
+      const res = await apiRequestRecoveryEmail(email);
+      setRecoveryEmailConfigured(res.email_configured);
+      setRecoverySent(true);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setRecoveryError(err.message || "Couldn't send the confirmation email.");
+      } else {
+        setRecoveryError("Couldn't reach the server. Try again in a moment.");
+      }
+    } finally {
+      setRecoveryInFlight(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    if (deleteInFlight) return;
+    setDeleteInFlight(true);
+    try {
+      await apiDeleteAccount();
+      setShowDeleteConfirm(false);
+      // clearSession (inside apiDeleteAccount) fires SESSION_CHANGED_EVENT,
+      // so the subscribed effect flips currentUser → null and the UI
+      // reverts to the anonymous state without a navigation.
+      setMessage({ type: "success", text: "Your account was deleted." });
+    } catch (err) {
+      setShowDeleteConfirm(false);
+      setMessage({
+        type: "error",
+        text:
+          err instanceof Error ? err.message : "Couldn't delete your account.",
+      });
+    } finally {
+      setDeleteInFlight(false);
     }
   };
 
@@ -637,10 +708,10 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      {/* Account section — Phase A + B. Single-line row with the
-          signed-in email + Sign Out, or a Sign In CTA when anonymous.
-          Sits below Theme so it groups visually with the other
-          single-row settings. */}
+      {/* Account section — Phase A + B (sign in/out) + Phase I (linked
+          identities, recovery email, delete). Single-row "Account" +
+          Sign out / Sign in header; when signed in, a second row lists
+          the linked sign-in methods. */}
       <div className="mb-6">
         <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
           <div className="flex items-center justify-between gap-3 h-12">
@@ -669,6 +740,16 @@ export default function SettingsPage() {
               </button>
             )}
           </div>
+          {currentUser && (
+            <div className="flex items-center justify-between gap-3 h-12 border-t border-gray-200 dark:border-gray-700">
+              <span className="text-base font-normal shrink-0">
+                Sign-in methods
+              </span>
+              <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
+                {formatProviders(currentUser.providers)}
+              </span>
+            </div>
+          )}
         </section>
         <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
           {currentUser
@@ -676,6 +757,82 @@ export default function SettingsPage() {
             : "Sign in to keep your polls and groups across devices."}
         </p>
       </div>
+
+      {/* Recovery email — Phase I. Only for signed-in accounts that lack
+          an email identity (passkey-only / OAuth-only). Adds an email
+          they can sign in with if they lose their device. */}
+      {currentUser && !hasEmailIdentity && (
+        <div className="mb-6">
+          <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-base font-normal">Recovery email</span>
+              {!recoveryOpen && !recoverySent && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRecoveryOpen(true);
+                    setRecoveryError(null);
+                  }}
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Add a recovery email
+                </button>
+              )}
+            </div>
+            {recoverySent ? (
+              <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                {recoveryEmailConfigured
+                  ? "Check your inbox for a confirmation link. It expires in 15 minutes."
+                  : "Email isn't configured on this server — the confirmation link was written to the API logs."}
+              </p>
+            ) : recoveryOpen ? (
+              <div className="mt-3 flex flex-col gap-2">
+                <input
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  value={recoveryEmail}
+                  onChange={(e) => setRecoveryEmail(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSendRecoveryEmail();
+                  }}
+                  placeholder="you@example.com"
+                  className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 h-11 text-base"
+                />
+                <div className="flex items-center gap-3 justify-end">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRecoveryOpen(false);
+                      setRecoveryEmail("");
+                      setRecoveryError(null);
+                    }}
+                    className="text-sm text-gray-500 dark:text-gray-400 hover:underline"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSendRecoveryEmail}
+                    disabled={recoveryInFlight || !recoveryEmail.trim()}
+                    className="rounded-full bg-blue-600 hover:bg-blue-700 text-white px-5 h-9 text-sm font-medium disabled:opacity-50"
+                  >
+                    {recoveryInFlight ? "Sending…" : "Send link"}
+                  </button>
+                </div>
+                {recoveryError && (
+                  <p className="text-xs text-red-600 dark:text-red-400">
+                    {recoveryError}
+                  </p>
+                )}
+              </div>
+            ) : null}
+          </section>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            Add an email so you can still sign in if you lose this device.
+          </p>
+        </div>
+      )}
 
       {/* Passkeys section — Phase D. Visible only when signed in AND
           the server tier supports passkeys AND the browser exposes
@@ -784,6 +941,25 @@ export default function SettingsPage() {
         </p>
       </div>
 
+      {/* Delete account — Phase I. Only when signed in. Cascades through
+          every users(id) FK server-side; this browser reverts to
+          anonymous (groups + created polls stay reachable). */}
+      {currentUser && (
+        <div className="mb-6">
+          <button
+            type="button"
+            onClick={() => setShowDeleteConfirm(true)}
+            className="w-full rounded-full border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors flex items-center justify-center font-medium text-base h-12"
+          >
+            Delete account
+          </button>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
+            Permanently removes your account and sign-in methods. Polls and
+            groups you created stay on this device.
+          </p>
+        </div>
+      )}
+
       {/* About Section */}
       <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
         <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 text-center">
@@ -831,12 +1007,39 @@ export default function SettingsPage() {
         onCancel={() => setShowDiscardImageConfirm(false)}
       />
 
+      <ConfirmationModal
+        isOpen={showDeleteConfirm}
+        title="Delete account?"
+        message="This permanently deletes your account and all sign-in methods (email, passkeys, connected accounts). This can't be undone. Polls and groups you created stay on this device."
+        confirmText={deleteInFlight ? "Deleting…" : "Delete account"}
+        confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
+        onConfirm={handleDeleteAccount}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
+
       <SignInModal
         isOpen={signInModalOpen}
         onClose={() => setSignInModalOpen(false)}
       />
     </div>
   );
+}
+
+// Human-readable labels for the provider strings the server returns
+// (`user_identities.provider`). Anything unrecognized falls through to a
+// title-cased form so a future provider doesn't render as a raw token.
+const PROVIDER_LABELS: Record<string, string> = {
+  email: "Email",
+  google: "Google",
+  apple: "Apple",
+  passkey: "Passkey",
+};
+
+function formatProviders(providers: string[]): string {
+  if (!providers || providers.length === 0) return "—";
+  return providers
+    .map((p) => PROVIDER_LABELS[p] || p.charAt(0).toUpperCase() + p.slice(1))
+    .join(", ");
 }
 
 function CameraPencilIcon() {

--- a/database/migrations/118_recovery_email_tokens_down.sql
+++ b/database/migrations/118_recovery_email_tokens_down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE magic_link_tokens DROP COLUMN IF EXISTS user_id;
+
+COMMIT;

--- a/database/migrations/118_recovery_email_tokens_up.sql
+++ b/database/migrations/118_recovery_email_tokens_up.sql
@@ -1,0 +1,32 @@
+-- Phase I of the auth & access model (see docs/auth-access-model.md
+-- → "Adding a recovery email to a passkey-only account").
+--
+-- Phase D lets a user create an account with a passkey and no email at
+-- all (`user_identities` carries only a 'passkey' row). Losing the only
+-- device with that credential strands the account. Phase I lets such
+-- users attach an email after the fact as a recovery / alternate sign-in
+-- path, reusing the existing magic-link machinery.
+--
+-- The twist: the magic-link token must be tagged with the user_id that
+-- requested the attach, so the verify step knows which account to bind
+-- the email to. A nullable `user_id` column on `magic_link_tokens` is
+-- the lightest carrier:
+--
+--   * Sign-in tokens (Phase B) leave `user_id` NULL.
+--   * Recovery-email-attach tokens (Phase I) set `user_id`.
+--
+-- The two flows are kept uncrossed by predicate:
+--   * `consume_magic_link` (sign-in) adds `AND user_id IS NULL` so a
+--     recovery token can never be redeemed as a fresh sign-in.
+--   * `consume_recovery_email_token` (attach) adds `AND user_id IS NOT
+--     NULL` so a sign-in token can never be redeemed as an attach.
+--
+-- ON DELETE CASCADE so deleting a user (Phase I account deletion) also
+-- drops any in-flight recovery tokens they minted.
+
+BEGIN;
+
+ALTER TABLE magic_link_tokens
+  ADD COLUMN user_id UUID REFERENCES users(id) ON DELETE CASCADE;
+
+COMMIT;

--- a/docs/auth-access-model.md
+++ b/docs/auth-access-model.md
@@ -247,7 +247,7 @@ the original session for the rationale.
 | F | Join requests (shipped) | `group_join_requests` table (migration 115), request/approve/deny endpoints, push notification fan-out to creator's `user_browsers`, /info "Pending requests" creator section, "Request to join" CTA on signed-in 404 page | E |
 | G | Invite links (shipped) | `group_invites` table (migration 116), creator-side create/list/revoke endpoints, anonymous-allowed `/invite/<token>` landing page that auto-redeems for signed-in viewers, `InviteLinksSection` on /info | E |
 | H | ~~Per-vote anonymity~~ | **NOT PLANNED.** Anonymity flags on votes + read-time filter were originally designed but retired. Anonymous participation is "leave the voter name blank"; no per-vote on/off toggle. | — |
-| I | Polish | account settings (linked identities, **add recovery email to passkey-only account**, sign out, delete), retire `creator_secret` | A–G |
+| I | Polish (partial — **shipped**) | linked-identities display, **add recovery email** (migration 118: `magic_link_tokens.user_id`; `POST /api/auth/recovery-email/{request,verify}`), **delete account** (`DELETE /api/auth/me`), sign out (Phase A). Still deferred: retire `creator_secret`; "claim an anonymous-created group". | A–G |
 
 Phase A and B ship together as the first PR — A is invisible alone; B is
 the smallest end-to-end auth that proves the model.
@@ -341,12 +341,25 @@ the smallest end-to-end auth that proves the model.
   triggered FROM the create-poll modal when a user picks "private" and
   isn't signed in).
 
-## Adding a recovery email to a passkey-only account (Phase I)
+## Adding a recovery email to a passkey-only account (Phase I — SHIPPED)
+
+> **Shipped** (migration 118 + `POST /api/auth/recovery-email/{request,verify}`).
+> Went with option (a) for the merge conflict (refuse, don't merge).
+> One hardening beyond the original sketch: `verify` requires BOTH the
+> token (email control) AND a signed-in session whose `user_id` matches
+> the token's `user_id` (account control) — so a stranger who receives
+> a mistyped link can't bind it to the requester's account. The token is
+> PEEKED (not consumed) until both checks pass, so a wrong-device click
+> or an already-taken email leaves it usable for a correct retry within
+> its TTL. The gate also spans ALL providers: an email another user
+> proved via Google can't be claimed here as a sign-in email. The
+> request endpoint rejects accounts that already have an 'email'
+> identity (adding a SECOND email is out of scope).
 
 Phase D (anonymous passkey registration) lets users create an account
 with no email at all — `user_identities` carries only a `passkey` row,
 `email` is NULL. Recovery is the cost: lose the device with the only
-credential and the account is unreachable. Phase I will let those
+credential and the account is unreachable. Phase I lets those
 users attach an email after the fact as a recovery path.
 
 The mechanics reuse the existing magic-link flow with one twist:

--- a/lib/api/_internal.ts
+++ b/lib/api/_internal.ts
@@ -123,6 +123,13 @@ async function fetchWithBase<T>(base: string, path: string, options?: RequestIni
     throw new ApiError(res.status, detail);
   }
 
+  // 204 No Content (sign-out, delete-passkey, delete-account) has an
+  // empty body — calling res.json() on it throws "Unexpected end of JSON
+  // input". Return undefined for void callers instead.
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
   return res.json();
 }
 

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -115,6 +115,55 @@ export async function apiSignOut(): Promise<void> {
   clearSession();
 }
 
+// Phase I: account management — recovery email + delete account.
+
+export interface RecoveryEmailRequestResponse {
+  accepted: boolean;
+  email_configured: boolean;
+}
+
+/** Phase I: send a "confirm your recovery email" link to `email`,
+ *  tagged with the current (signed-in) user. The server gates on the
+ *  account not already having an email identity. Throws `ApiError` on
+ *  401 (not signed in) / 400 (invalid email OR account already has an
+ *  email). */
+export async function apiRequestRecoveryEmail(
+  email: string,
+): Promise<RecoveryEmailRequestResponse> {
+  return authFetch<RecoveryEmailRequestResponse>("/recovery-email/request", {
+    method: "POST",
+    body: JSON.stringify({ email }),
+  });
+}
+
+/** Phase I: confirm a recovery-email link, binding the email to the
+ *  current account. Returns the refreshed profile (now including the
+ *  'email' provider) and updates the cached session user so every
+ *  surface reflects the new identity. No new session is issued.
+ *
+ *  Throws `ApiError`: 401 (not signed in), 403 (link belongs to a
+ *  different account), 409 (email already used by another account),
+ *  400 (invalid / expired link). The verify page maps these to copy. */
+export async function apiVerifyRecoveryEmail(
+  token: string,
+): Promise<SessionUser> {
+  const user = await authFetch<SessionUser>("/recovery-email/verify", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  });
+  updateCachedSessionUser(user);
+  return user;
+}
+
+/** Phase I: permanently delete the signed-in account. The server
+ *  cascades through every users(id) FK; this browser reverts to
+ *  anonymous (keeping its group memberships + poll creator secrets).
+ *  Clears local session state on success. */
+export async function apiDeleteAccount(): Promise<void> {
+  await authFetch<void>("/me", { method: "DELETE" });
+  clearSession();
+}
+
 /** Synchronous read of the currently-cached signed-in user. Use
  *  `apiGetMe()` to refresh from the server. */
 export function getCurrentUser(): SessionUser | null {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -99,6 +99,9 @@ export {
   apiDeletePasskey,
   apiRenamePasskey,
   apiRedeemInvite,
+  apiRequestRecoveryEmail,
+  apiVerifyRecoveryEmail,
+  apiDeleteAccount,
   getCurrentUser,
 } from "./auth";
 export type {
@@ -110,4 +113,5 @@ export type {
   PasskeyListResponse,
   PasskeyRegistrationResult,
   InviteRedeemResult,
+  RecoveryEmailRequestResponse,
 } from "./auth";

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -15,6 +15,9 @@
 `GET  /api/auth/providers`                      list which sign-in methods are wired up
 `GET  /api/auth/me`                              resolve current session → user profile
 `POST /api/auth/sign-out`                        revoke current session, unlink browser
+`POST /api/auth/recovery-email/request`         Phase I: send "confirm recovery email" link
+`POST /api/auth/recovery-email/verify`          Phase I: attach the confirmed email identity
+`DELETE /api/auth/me`                            Phase I: delete the signed-in account
 
 Identity resolution for the current request is done by
 `IdentityMiddleware` in `server/middleware.py` (sets
@@ -40,17 +43,22 @@ from middleware import (
 )
 from services.auth import (
     CompletedSignIn,
+    attach_email_identity,
     complete_sign_in,
     consume_magic_link,
+    consume_recovery_email_token,
+    delete_user_account,
     email_throttled,
     is_valid_email,
     issue_magic_link,
     load_user_profile,
     normalize_email,
+    peek_recovery_email_token,
     revoke_session,
     unlink_browser,
+    user_has_email_identity,
 )
-from services.email import email_configured, send_magic_link
+from services.email import email_configured, send_magic_link, send_recovery_email
 from services.oauth import (
     OAuthVerificationError,
     apple_configured,
@@ -440,6 +448,153 @@ def sign_out(request: Request):
         if token:
             revoke_session(conn, token)
         unlink_browser(conn, browser_id=browser_id)
+
+
+# ---------------------------------------------------------------------------
+# Account management — Phase I
+# ---------------------------------------------------------------------------
+#
+# Recovery email: attach an email-provider identity to an account that
+# lacks one (passkey-only, or OAuth-only). Two steps mirroring magic-link
+# sign-in — request (mints a user_id-tagged token + sends the link) and
+# verify (binds the email after confirming BOTH email control via the
+# token AND account control via the session). See
+# docs/auth-access-model.md → "Adding a recovery email".
+#
+# Account deletion: a single DELETE that cascades through every
+# users(id) FK (declared with the right ON DELETE action in migrations
+# 112–117). The browser keeps its group memberships + poll creator
+# secrets and reverts to anonymous.
+
+
+class RecoveryEmailRequestBody(BaseModel):
+    email: str = Field(min_length=3, max_length=254)
+
+
+class RecoveryEmailRequestResponse(BaseModel):
+    """Same shape as the magic-link request response. `accepted` is
+    always True for valid input (no per-step leak about whether the
+    address is already taken — that's surfaced at verify). `email_configured`
+    lets the FE warn on dev tiers that the link only appears in API logs."""
+
+    accepted: bool
+    email_configured: bool
+
+
+class RecoveryEmailVerifyBody(BaseModel):
+    token: str = Field(min_length=8, max_length=128)
+
+
+@router.post(
+    "/recovery-email/request",
+    response_model=RecoveryEmailRequestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def request_recovery_email(req: RecoveryEmailRequestBody, request: Request):
+    """Send a "confirm your recovery email" link to `email`, tagged with
+    the current user_id. Signed-in only.
+
+    Rejects (400) when the account already has an email identity — this
+    feature ADDS an email to an account that lacks one; adding a second
+    email is out of scope (docs → "Out of scope for v1"). Throttling and
+    "email belongs to someone else" do NOT 4xx here — the former returns
+    a generic accepted, the latter is caught at verify so we don't leak
+    which addresses are registered."""
+    user_id = _require_signed_in(request)
+
+    if not is_valid_email(req.email):
+        raise HTTPException(status_code=400, detail="Invalid email address")
+
+    email = normalize_email(req.email)
+    browser_id = _browser_id(request)
+    fe_origin = _resolve_fe_origin(request)
+
+    with get_db() as conn:
+        if user_has_email_identity(conn, user_id):
+            raise HTTPException(
+                status_code=400,
+                detail="This account already has an email address.",
+            )
+        if email_throttled(conn, email):
+            log.info("Recovery-email request throttled for %s", email)
+            return RecoveryEmailRequestResponse(
+                accepted=True, email_configured=email_configured()
+            )
+        issued = issue_magic_link(
+            conn, email=email, browser_id=browser_id, user_id=user_id
+        )
+
+    verify_url = f"{fe_origin}/auth/recovery-email?token={issued.token}"
+    ok = send_recovery_email(to_email=email, verify_url=verify_url)
+    if not ok:
+        log.error("Recovery-email send failed for %s", email)
+
+    return RecoveryEmailRequestResponse(
+        accepted=True, email_configured=email_configured()
+    )
+
+
+@router.post("/recovery-email/verify", response_model=UserSummary)
+def verify_recovery_email(req: RecoveryEmailVerifyBody, request: Request):
+    """Confirm a recovery-email link and bind the email to the account.
+
+    Requires BOTH proofs at once (option (a) in the doc):
+      * email control — possession of the token sent to that address;
+      * account control — a signed-in session whose user_id matches the
+        token's user_id (403 otherwise, so a stranger who received a
+        mistyped link can't attach it to the requester's account).
+
+    The token is PEEKED (not consumed) until both checks pass, so a
+    wrong-device click or an already-taken email leaves it usable for a
+    correct retry within its 15-minute TTL. No new session is issued —
+    the user was already signed in to confirm.
+    """
+    user_id = _require_signed_in(request)
+    with get_db() as conn:
+        peeked = peek_recovery_email_token(conn, req.token)
+        if not peeked:
+            raise HTTPException(
+                status_code=400, detail="Invalid or expired link"
+            )
+        if peeked.user_id != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "This link belongs to a different account. Open it on "
+                    "the device where you're signed in to that account."
+                ),
+            )
+        result = attach_email_identity(conn, user_id=user_id, email=peeked.email)
+        if result == "conflict":
+            raise HTTPException(
+                status_code=409,
+                detail="That email is already used by another account.",
+            )
+        # Both checks passed (attached OR already_linked) → burn the token.
+        consume_recovery_email_token(conn, req.token)
+        profile = load_user_profile(conn, user_id)
+    if not profile:
+        raise HTTPException(status_code=401, detail="Account no longer exists")
+    return UserSummary(
+        user_id=profile.user_id,
+        email=profile.email,
+        providers=profile.providers,
+        created_at=profile.created_at,
+    )
+
+
+@router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
+def delete_account(request: Request):
+    """Delete the signed-in user's account. Cascades through every
+    users(id) FK (sessions, identities, browser links, passkeys, this
+    user's join requests + invites; groups they created keep working
+    with creator_user_id NULL). The caller's browser reverts to
+    anonymous — group memberships (browser-keyed) and poll creator
+    secrets survive, so previously-created polls remain manageable from
+    this browser."""
+    user_id = _require_signed_in(request)
+    with get_db() as conn:
+        delete_user_account(conn, user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -299,23 +299,30 @@ def issue_magic_link(
     *,
     email: str,
     browser_id: str | None,
+    user_id: str | None = None,
 ) -> IssuedMagicLink:
     """Mint a new magic-link token for `email`. Caller is responsible
     for sending the email containing the raw token. Throttling is
-    enforced via `email_throttled` BEFORE this is called."""
+    enforced via `email_throttled` BEFORE this is called.
+
+    `user_id` is NULL for sign-in tokens (Phase B) and set for
+    recovery-email-attach tokens (Phase I). The two flows are kept
+    uncrossed by the consume predicates — see `consume_magic_link`
+    (NULL only) and `consume_recovery_email_token` (NOT NULL only)."""
     token = generate_token()
     expires_at = datetime.now(timezone.utc) + timedelta(minutes=MAGIC_LINK_TTL_MINUTES)
     conn.execute(
         """
         INSERT INTO magic_link_tokens
-          (token_hash, email, browser_id, expires_at)
+          (token_hash, email, browser_id, user_id, expires_at)
         VALUES
-          (%(h)s, %(e)s, %(b)s, %(exp)s)
+          (%(h)s, %(e)s, %(b)s, %(u)s, %(exp)s)
         """,
         {
             "h": hash_token(token),
             "e": normalize_email(email),
             "b": browser_id,
+            "u": user_id,
             "exp": expires_at,
         },
     )
@@ -354,6 +361,10 @@ def consume_magic_link(conn, token: str) -> ConsumedMagicLink | None:
     """Atomically validate + mark-used. Returns the email if the token
     was valid and not yet used; None otherwise. Wrap the predicate + the
     UPDATE in one statement so two simultaneous clicks don't both pass.
+
+    `AND user_id IS NULL` scopes this to SIGN-IN tokens — a Phase I
+    recovery-email-attach token (which carries a user_id) can never be
+    redeemed here as a fresh sign-in.
     """
     if not token:
         return None
@@ -363,6 +374,7 @@ def consume_magic_link(conn, token: str) -> ConsumedMagicLink | None:
            SET used_at = NOW()
          WHERE token_hash = %(h)s
            AND used_at IS NULL
+           AND user_id IS NULL
            AND expires_at > NOW()
         RETURNING email, browser_id
         """,
@@ -374,6 +386,171 @@ def consume_magic_link(conn, token: str) -> ConsumedMagicLink | None:
         email=row["email"],
         requesting_browser_id=str(row["browser_id"]) if row.get("browser_id") else None,
     )
+
+
+# ---------------------------------------------------------------------------
+# Recovery email — Phase I
+# ---------------------------------------------------------------------------
+#
+# Attach an email identity to an account that doesn't have one yet
+# (passkey-only, or OAuth-only without an 'email' provider row). Reuses
+# the magic-link table (tokens tagged with user_id) for email-control
+# proof. The verify step additionally requires the caller's session to
+# match the token's user_id, so possessing the link alone can't bind an
+# email to someone else's account.
+
+
+@dataclass
+class RecoveryEmailToken:
+    email: str
+    user_id: str
+
+
+def peek_recovery_email_token(conn, token: str) -> RecoveryEmailToken | None:
+    """Read a recovery-email-attach token WITHOUT marking it used.
+
+    `AND user_id IS NOT NULL` scopes this to attach tokens (a sign-in
+    token can't be redeemed here). Peeking (rather than the atomic
+    consume) lets the verify endpoint validate session-ownership +
+    email-conflict BEFORE burning the token — so a wrong-device click or
+    an already-taken email leaves the token usable for a correct retry
+    within its TTL. `consume_recovery_email_token` is called only after
+    those checks pass.
+    """
+    if not token:
+        return None
+    row = conn.execute(
+        """
+        SELECT email, user_id FROM magic_link_tokens
+         WHERE token_hash = %(h)s
+           AND used_at IS NULL
+           AND user_id IS NOT NULL
+           AND expires_at > NOW()
+        """,
+        {"h": hash_token(token)},
+    ).fetchone()
+    if not row:
+        return None
+    return RecoveryEmailToken(email=row["email"], user_id=str(row["user_id"]))
+
+
+def consume_recovery_email_token(conn, token: str) -> RecoveryEmailToken | None:
+    """Mark a recovery-email token used and return its (email, user_id).
+
+    The `used_at IS NULL` predicate is the concurrency guard — two
+    simultaneous verifies both peek successfully but only one wins the
+    UPDATE. Returns None if the token was already consumed between peek
+    and consume (rare two-tab race)."""
+    if not token:
+        return None
+    row = conn.execute(
+        """
+        UPDATE magic_link_tokens
+           SET used_at = NOW()
+         WHERE token_hash = %(h)s
+           AND used_at IS NULL
+           AND user_id IS NOT NULL
+           AND expires_at > NOW()
+        RETURNING email, user_id
+        """,
+        {"h": hash_token(token)},
+    ).fetchone()
+    if not row:
+        return None
+    return RecoveryEmailToken(email=row["email"], user_id=str(row["user_id"]))
+
+
+def user_has_email_identity(conn, user_id: str) -> bool:
+    """True if this user already has an 'email'-provider identity. Gates
+    the recovery-email request endpoint: the feature only adds an email
+    to accounts that lack one (adding a SECOND email is out of scope —
+    see docs/auth-access-model.md → 'Out of scope for v1')."""
+    row = conn.execute(
+        """
+        SELECT 1 FROM user_identities
+         WHERE user_id = %(u)s::uuid AND provider = 'email'
+         LIMIT 1
+        """,
+        {"u": user_id},
+    ).fetchone()
+    return row is not None
+
+
+def attach_email_identity(conn, *, user_id: str, email: str) -> str:
+    """Bind an email-provider identity to `user_id`.
+
+    Returns a status discriminator:
+      * 'attached'       — new identity row inserted.
+      * 'already_linked' — this user already has this exact email
+                           identity (idempotent no-op).
+      * 'conflict'       — the email is already used by a DIFFERENT
+                           user (via any provider). Refused — binding it
+                           would let this user hijack magic-link sign-in
+                           for an address another account proved control
+                           of. (Option (a) in the doc: account merge
+                           requires proving control of both sides at the
+                           same time, which an attach can't.)
+
+    The conflict check spans ALL providers, not just 'email': if user B
+    signed in with Google using foo@x.com, that address is "theirs" and
+    user A can't claim it as a sign-in email.
+    """
+    normalized = normalize_email(email)
+    rows = conn.execute(
+        """
+        SELECT user_id, provider, provider_user_id FROM user_identities
+         WHERE email = %(e)s
+        """,
+        {"e": normalized},
+    ).fetchall()
+
+    for r in rows:
+        if r["provider"] == "email" and r["provider_user_id"] == normalized:
+            return "already_linked" if str(r["user_id"]) == user_id else "conflict"
+
+    if any(str(r["user_id"]) != user_id for r in rows):
+        return "conflict"
+
+    # Email is unused, or only carried by THIS user via a non-email
+    # provider (e.g. they signed in with Google using this address).
+    # Safe to add the email-provider identity so they gain magic-link
+    # sign-in / recovery too.
+    conn.execute(
+        """
+        INSERT INTO user_identities (provider, provider_user_id, user_id, email)
+        VALUES ('email', %(e)s, %(u)s::uuid, %(e)s)
+        ON CONFLICT (provider, provider_user_id) DO NOTHING
+        """,
+        {"e": normalized, "u": user_id},
+    )
+    return "attached"
+
+
+def delete_user_account(conn, user_id: str) -> bool:
+    """Delete a user and everything that cascades from it.
+
+    Every FK that references `users(id)` was declared in migrations
+    112–117 with the right ON DELETE action for this single statement to
+    be a clean teardown:
+      * user_identities, user_browsers, sessions, passkey_credentials,
+        passkey_challenges, group_join_requests.requester_user_id,
+        group_invites.created_by_user_id, magic_link_tokens.user_id
+        → CASCADE (rows deleted).
+      * groups.creator_user_id, group_join_requests.decided_by_user_id
+        → SET NULL (group / decision survives, ownership cleared).
+
+    `group_members` is keyed on browser_id (no user_id column), so the
+    browser keeps its memberships and works anonymously after deletion —
+    which is the intended "drop the user layer, keep the browser"
+    behavior. Polls / votes have no user FK either, so they survive
+    intact (creator_secret still authorizes the original creator's
+    browser). Returns True if a row was deleted, False if the user was
+    already gone (idempotent)."""
+    row = conn.execute(
+        "DELETE FROM users WHERE id = %(u)s::uuid RETURNING id",
+        {"u": user_id},
+    ).fetchone()
+    return row is not None
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/email.py
+++ b/server/services/email.py
@@ -124,3 +124,32 @@ def send_magic_link(*, to_email: str, magic_url: str) -> bool:
 </body></html>
 """
     return send_email(EmailMessage(to=to_email, subject=subject, html=html, text=text))
+
+
+def send_recovery_email(*, to_email: str, verify_url: str) -> bool:
+    """Send the Phase I "confirm this recovery email" link. `verify_url`
+    is the full FE URL (e.g.
+    `https://whoeverwants.com/auth/recovery-email?token=...`). Copy
+    differs from the sign-in link: this CONFIRMS an email the user is
+    adding to an existing account, so the "if you didn't request this"
+    line is reassuring rather than a security warning."""
+    subject = "Confirm your WhoeverWants recovery email"
+    text = (
+        "Tap the link below to confirm this email as a way to sign in to "
+        "your WhoeverWants account. It expires in 15 minutes and can only "
+        "be used once.\n\n"
+        f"{verify_url}\n\n"
+        "If you didn't request this, you can ignore this email — nothing "
+        "will be added to any account."
+    )
+    html = f"""<!doctype html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #111; line-height: 1.5;">
+  <p>Tap the link below to confirm this email as a way to sign in to your WhoeverWants account. It expires in 15 minutes and can only be used once.</p>
+  <p style="margin: 24px 0;">
+    <a href="{verify_url}" style="background: #2563eb; color: white; padding: 12px 20px; text-decoration: none; border-radius: 8px; display: inline-block; font-weight: 500;">Confirm recovery email</a>
+  </p>
+  <p style="font-size: 12px; color: #6b7280;">Or copy this URL: <br/><span style="word-break: break-all;">{verify_url}</span></p>
+  <p style="font-size: 12px; color: #6b7280; margin-top: 24px;">If you didn't request this, you can ignore this email — nothing will be added to any account.</p>
+</body></html>
+"""
+    return send_email(EmailMessage(to=to_email, subject=subject, html=html, text=text))

--- a/server/tests/test_account_management.py
+++ b/server/tests/test_account_management.py
@@ -1,0 +1,464 @@
+"""Phase I (account management) end-to-end coverage.
+
+Two features, both documented in docs/auth-access-model.md → Phase I:
+
+  * Recovery email — attach an email identity to an account that lacks
+    one (passkey-only / OAuth-only). Two steps:
+      - POST /api/auth/recovery-email/request {email}
+          anonymous → 401
+          signed-in passkey-only + valid email → 202 accepted
+          signed-in account that ALREADY has an email → 400
+          invalid email → 400
+      - POST /api/auth/recovery-email/verify {token}
+          anonymous → 401
+          invalid / expired token → 400
+          token's user_id != session user_id → 403 (token survives)
+          email already used by another account → 409 (token survives)
+          happy path → 200, 'email' now in providers, email surfaces
+          + the attached email can then SIGN IN to the same user
+  * Account deletion — DELETE /api/auth/me
+      anonymous → 401
+      signed-in → 204, session invalidated, user row gone
+      cascade: groups they created survive with creator_user_id NULL;
+               sessions / identities / browser links gone; browser
+               keeps its group_members row (reverts to anonymous)
+
+  * Flow isolation — a recovery token can't be redeemed as a sign-in and
+    vice versa (the two consume predicates are user_id NULL vs NOT NULL).
+
+Mirrors test_auth.py's helpers: tokens are minted directly into
+`magic_link_tokens` with a known raw value so verify can be driven
+without scraping the email log.
+"""
+
+import os
+import uuid
+
+import psycopg
+import pytest
+
+from services.auth import (
+    attach_email_identity,
+    generate_token,
+    hash_token,
+    normalize_email,
+)
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from main import app  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def browser_id():
+    return str(uuid.uuid4())
+
+
+def _bid_headers(bid):
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+def _bearer_headers(bid, token):
+    h = _bid_headers(bid)
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _unique_email() -> str:
+    return f"phasei-{uuid.uuid4().hex[:10]}@example.com"
+
+
+def _issue_signin_token(email, browser_id=None) -> str:
+    """A sign-in magic-link token (user_id NULL)."""
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO magic_link_tokens
+                  (token_hash, email, browser_id, expires_at)
+                VALUES (%s, %s, %s, NOW() + INTERVAL '15 minutes')
+                """,
+                (hash_token(token), normalize_email(email), browser_id),
+            )
+        conn.commit()
+    return token
+
+
+def _mint_recovery_token(email, user_id, browser_id=None) -> str:
+    """A recovery-email-attach token (user_id set)."""
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO magic_link_tokens
+                  (token_hash, email, browser_id, user_id, expires_at)
+                VALUES (%s, %s, %s, %s::uuid, NOW() + INTERVAL '15 minutes')
+                """,
+                (hash_token(token), normalize_email(email), browser_id, user_id),
+            )
+        conn.commit()
+    return token
+
+
+def _sign_in_email(client, browser_id, email=None):
+    """Full magic-link sign-in (creates an 'email' identity). Returns
+    (session_token, user_id, normalized_email)."""
+    raw = email or _unique_email()
+    token = _issue_signin_token(raw, browser_id)
+    resp = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": token},
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    return body["session_token"], body["user"]["user_id"], normalize_email(raw)
+
+
+def _create_passkey_only_user(browser_id):
+    """Insert a users row + a passkey-provider identity (no email) + a
+    session, returning (session_token, user_id). Mirrors the state Phase
+    D anonymous passkey registration leaves an account in."""
+    token = generate_token()
+    cred_id = f"cred-{uuid.uuid4().hex}"
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO users DEFAULT VALUES RETURNING id")
+            user_id = str(cur.fetchone()[0])
+            cur.execute(
+                """
+                INSERT INTO user_identities
+                  (provider, provider_user_id, user_id, email)
+                VALUES ('passkey', %s, %s::uuid, NULL)
+                """,
+                (cred_id, user_id),
+            )
+            cur.execute(
+                """
+                INSERT INTO user_browsers (browser_id, user_id)
+                VALUES (%s::uuid, %s::uuid)
+                ON CONFLICT (browser_id) DO NOTHING
+                """,
+                (browser_id, user_id),
+            )
+            cur.execute(
+                """
+                INSERT INTO sessions
+                  (token_hash, user_id, browser_id, expires_at, last_used_at)
+                VALUES (%s, %s::uuid, %s::uuid, NOW() + INTERVAL '30 days', NOW())
+                """,
+                (hash_token(token), user_id, browser_id),
+            )
+        conn.commit()
+    return token, user_id
+
+
+def _row_count(sql, params):
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchone()[0]
+
+
+# --------------------------------------------------------------------- request
+
+
+def test_recovery_request_anonymous_401(client, browser_id):
+    resp = client.post(
+        "/api/auth/recovery-email/request",
+        json={"email": _unique_email()},
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 401, resp.text
+
+
+def test_recovery_request_passkey_only_accepted(client, browser_id):
+    token, _ = _create_passkey_only_user(browser_id)
+    resp = client.post(
+        "/api/auth/recovery-email/request",
+        json={"email": _unique_email()},
+        headers=_bearer_headers(browser_id, token),
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["accepted"] is True
+
+
+def test_recovery_request_rejected_when_account_already_has_email(
+    client, browser_id
+):
+    token, _, _ = _sign_in_email(client, browser_id)
+    resp = client.post(
+        "/api/auth/recovery-email/request",
+        json={"email": _unique_email()},
+        headers=_bearer_headers(browser_id, token),
+    )
+    assert resp.status_code == 400, resp.text
+    assert "already has an email" in resp.json()["detail"].lower()
+
+
+def test_recovery_request_invalid_email_400(client, browser_id):
+    token, _ = _create_passkey_only_user(browser_id)
+    resp = client.post(
+        "/api/auth/recovery-email/request",
+        json={"email": "not-an-email"},
+        headers=_bearer_headers(browser_id, token),
+    )
+    assert resp.status_code == 400, resp.text
+
+
+# ---------------------------------------------------------------------- verify
+
+
+def test_recovery_verify_anonymous_401(client, browser_id):
+    token, user_id = _create_passkey_only_user(browser_id)
+    rtoken = _mint_recovery_token(_unique_email(), user_id)
+    # No Authorization header → not signed in.
+    resp = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": rtoken},
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 401, resp.text
+
+
+def test_recovery_verify_invalid_token_400(client, browser_id):
+    token, _ = _create_passkey_only_user(browser_id)
+    resp = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": generate_token()},
+        headers=_bearer_headers(browser_id, token),
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_recovery_verify_happy_path_attaches_and_can_sign_in(
+    client, browser_id
+):
+    session_token, user_id = _create_passkey_only_user(browser_id)
+    email = _unique_email()
+    rtoken = _mint_recovery_token(email, user_id, browser_id)
+
+    resp = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": rtoken},
+        headers=_bearer_headers(browser_id, session_token),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "email" in body["providers"]
+    assert "passkey" in body["providers"]
+    assert body["email"] == normalize_email(email)
+    assert body["user_id"] == user_id
+
+    # The token is now spent — a replay 400s.
+    replay = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": rtoken},
+        headers=_bearer_headers(browser_id, session_token),
+    )
+    assert replay.status_code == 400, replay.text
+
+    # The attached email can now SIGN IN, resolving to the SAME user.
+    signin_token = _issue_signin_token(email, str(uuid.uuid4()))
+    signin = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": signin_token},
+        headers=_bid_headers(str(uuid.uuid4())),
+    )
+    assert signin.status_code == 200, signin.text
+    assert signin.json()["user"]["user_id"] == user_id
+
+
+def test_recovery_verify_wrong_user_403_token_survives(client):
+    # User A requests recovery for an email; user B (signed in) clicks it.
+    bid_a = str(uuid.uuid4())
+    bid_b = str(uuid.uuid4())
+    _, user_a = _create_passkey_only_user(bid_a)
+    session_b, _ = _create_passkey_only_user(bid_b)
+    email = _unique_email()
+    rtoken = _mint_recovery_token(email, user_a, bid_a)
+
+    # B (a different account) clicks A's link → 403, no attach.
+    resp = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": rtoken},
+        headers=_bearer_headers(bid_b, session_b),
+    )
+    assert resp.status_code == 403, resp.text
+    assert _row_count(
+        "SELECT COUNT(*) FROM user_identities WHERE provider='email' AND provider_user_id=%s",
+        (normalize_email(email),),
+    ) == 0
+
+    # The token survived B's wrong-device click — A can still redeem it.
+    session_a, _ = _create_passkey_only_user(bid_a)  # fresh session for A's browser
+    # (re-link the original user to bid_a so the session matches user_a)
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE sessions SET user_id = %s::uuid WHERE token_hash = %s",
+                (user_a, hash_token(session_a)),
+            )
+        conn.commit()
+    ok = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": rtoken},
+        headers=_bearer_headers(bid_a, session_a),
+    )
+    assert ok.status_code == 200, ok.text
+    assert "email" in ok.json()["providers"]
+
+
+def test_recovery_verify_email_conflict_409_token_survives(client):
+    # User A owns email E (signed in via magic-link). User B (passkey-only)
+    # tries to attach E → 409, E stays bound to A only.
+    bid_a = str(uuid.uuid4())
+    bid_b = str(uuid.uuid4())
+    _, user_a, email = _sign_in_email(client, bid_a)
+    session_b, user_b = _create_passkey_only_user(bid_b)
+    rtoken = _mint_recovery_token(email, user_b, bid_b)
+
+    resp = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": rtoken},
+        headers=_bearer_headers(bid_b, session_b),
+    )
+    assert resp.status_code == 409, resp.text
+    # E still belongs only to A.
+    assert _row_count(
+        "SELECT COUNT(*) FROM user_identities WHERE provider='email' AND provider_user_id=%s",
+        (email,),
+    ) == 1
+    assert _row_count(
+        "SELECT COUNT(*) FROM user_identities WHERE provider='email' AND provider_user_id=%s AND user_id=%s::uuid",
+        (email, user_b),
+    ) == 0
+
+
+# ----------------------------------------------------- attach_email_identity()
+
+
+def test_attach_email_identity_branches():
+    """Unit-level coverage of the three return discriminators."""
+    email = _unique_email()
+    with psycopg.connect(TEST_DB_URL, row_factory=psycopg.rows.dict_row) as conn:
+        # Fresh passkey-only user.
+        user_id = str(
+            conn.execute("INSERT INTO users DEFAULT VALUES RETURNING id").fetchone()["id"]
+        )
+        conn.execute(
+            "INSERT INTO user_identities (provider, provider_user_id, user_id) VALUES ('passkey', %s, %s::uuid)",
+            (f"cred-{uuid.uuid4().hex}", user_id),
+        )
+
+        assert attach_email_identity(conn, user_id=user_id, email=email) == "attached"
+        assert attach_email_identity(conn, user_id=user_id, email=email) == "already_linked"
+
+        # A different user claiming the same email → conflict.
+        other = str(
+            conn.execute("INSERT INTO users DEFAULT VALUES RETURNING id").fetchone()["id"]
+        )
+        assert attach_email_identity(conn, user_id=other, email=email) == "conflict"
+        conn.rollback()
+
+
+# ---------------------------------------------------------------- flow isolation
+
+
+def test_signin_token_cannot_be_redeemed_as_recovery(client, browser_id):
+    session_token, _ = _create_passkey_only_user(browser_id)
+    signin_token = _issue_signin_token(_unique_email())  # user_id NULL
+    resp = client.post(
+        "/api/auth/recovery-email/verify",
+        json={"token": signin_token},
+        headers=_bearer_headers(browser_id, session_token),
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_recovery_token_cannot_be_redeemed_as_signin(client, browser_id):
+    _, user_id = _create_passkey_only_user(browser_id)
+    rtoken = _mint_recovery_token(_unique_email(), user_id)  # user_id set
+    resp = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": rtoken},
+        headers=_bid_headers(str(uuid.uuid4())),
+    )
+    assert resp.status_code == 400, resp.text
+
+
+# --------------------------------------------------------------- delete account
+
+
+def test_delete_account_anonymous_401(client, browser_id):
+    resp = client.delete("/api/auth/me", headers=_bid_headers(browser_id))
+    assert resp.status_code == 401, resp.text
+
+
+def test_delete_account_invalidates_session_and_removes_user(client, browser_id):
+    session_token, user_id = _create_passkey_only_user(browser_id)
+    # Sanity: /me works before deletion.
+    me = client.get("/api/auth/me", headers=_bearer_headers(browser_id, session_token))
+    assert me.status_code == 200, me.text
+
+    resp = client.delete(
+        "/api/auth/me", headers=_bearer_headers(browser_id, session_token)
+    )
+    assert resp.status_code == 204, resp.text
+
+    # Session is gone — the same token no longer resolves.
+    me2 = client.get(
+        "/api/auth/me", headers=_bearer_headers(browser_id, session_token)
+    )
+    assert me2.status_code == 401, me2.text
+
+    assert _row_count("SELECT COUNT(*) FROM users WHERE id=%s::uuid", (user_id,)) == 0
+    assert _row_count(
+        "SELECT COUNT(*) FROM user_identities WHERE user_id=%s::uuid", (user_id,)
+    ) == 0
+    assert _row_count(
+        "SELECT COUNT(*) FROM user_browsers WHERE user_id=%s::uuid", (user_id,)
+    ) == 0
+
+
+def test_delete_account_keeps_created_group_with_null_creator(client, browser_id):
+    session_token, user_id = _create_passkey_only_user(browser_id)
+    # Signed-in create → private group with creator_user_id = user_id.
+    grp = client.post(
+        "/api/groups", headers=_bearer_headers(browser_id, session_token)
+    )
+    assert grp.status_code == 201, grp.text
+    group = grp.json()
+    group_id = group["id"]
+    assert group["creator_user_id"] == user_id
+
+    resp = client.delete(
+        "/api/auth/me", headers=_bearer_headers(browser_id, session_token)
+    )
+    assert resp.status_code == 204, resp.text
+
+    # Group survives; creator_user_id is SET NULL.
+    assert _row_count("SELECT COUNT(*) FROM groups WHERE id=%s::uuid", (group_id,)) == 1
+    assert _row_count(
+        "SELECT COUNT(*) FROM groups WHERE id=%s::uuid AND creator_user_id IS NULL",
+        (group_id,),
+    ) == 1
+    # The browser keeps its membership (reverts to anonymous).
+    assert _row_count(
+        "SELECT COUNT(*) FROM group_members WHERE group_id=%s::uuid AND browser_id=%s::uuid",
+        (group_id, browser_id),
+    ) == 1


### PR DESCRIPTION
## Summary

Phase I (Polish) of the auth & access model — the account-settings surface. Builds on the shipped A–G phases.

- **Recovery email** — passkey-only / OAuth-only accounts can attach an email to sign in with if they lose their device. Migration 118 adds a nullable `magic_link_tokens.user_id` (ON DELETE CASCADE) that tags a token as an *attach* token vs a *sign-in* token; the two flows stay uncrossed by predicate (`consume_magic_link` requires `user_id IS NULL`, the recovery consume requires `IS NOT NULL`). `POST /api/auth/recovery-email/{request,verify}` reuse the magic-link machinery. **Verify requires both proofs at once**: the token (email control) *and* a signed-in session whose `user_id` matches the token's (account control, else 403). The token is *peeked* until both checks pass, so a wrong-device click (403) or an already-taken email (409) leaves it usable for a correct retry within its TTL. The conflict check spans all providers (an email another user proved via Google can't be claimed here).
- **Delete account** — `DELETE /api/auth/me` is a single `DELETE FROM users`; every `users(id)` FK declared in migrations 112–117 CASCADEs (sessions, identities, browser links, passkeys, join requests, invites, recovery tokens) or SET NULLs (`groups.creator_user_id`, `group_join_requests.decided_by_user_id`). `group_members` is browser-keyed, so the browser keeps its memberships + poll creator secrets and reverts to anonymous.
- **Settings UI** — a "Sign-in methods" row listing linked providers, an "Add a recovery email" affordance (only when the account has no email identity), and a red "Delete account" button + confirmation. New landing page `app/auth/recovery-email/page.tsx`.
- **Latent fix** — `fetchWithBase` now returns `undefined` on HTTP 204 instead of calling `res.json()` on an empty body (was a latent issue for every `<void>` DELETE/POST endpoint: sign-out, delete-passkey, delete-account).

Docs (`docs/auth-access-model.md`, `CLAUDE.md`) updated to mark Phase I shipped. Still deferred within Phase I: retire `creator_secret`; "claim an anonymous-created group".

## Test plan

- [x] 15 new server tests (`server/tests/test_account_management.py`): recovery request/verify gating + happy path + 403/409/replay, delete cascade, flow isolation
- [x] Full server suite green (509 passed)
- [x] Migration 118 applies on a dev DB
- [x] End-to-end on the dev tier: delete-account (204 → session 401), recovery attach (`[passkey]` → `[email, passkey]`) + the attached email signs in to the same user
- [x] Signed-in Settings UI verified via screenshot (recovery + delete sections render, gated correctly)
- [ ] CI (lint + Vercel build) green

https://claude.ai/code/session_01PLCZVwJrCR2nPwShwnDcVN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLCZVwJrCR2nPwShwnDcVN)_