### PR TITLE
Document recurring-vote fairness exploration (clear-all banked IRV)

### DIFF
--- a/docs/recurring-vote-fairness/README.md
+++ b/docs/recurring-vote-fairness/README.md
@@ -1,0 +1,217 @@
+# Recurring-Vote Fairness — Design Exploration
+
+**Status:** exploration / research log. Nothing here is implemented in the app yet.
+This documents a scheme (and the variants considered, with simulation evidence) for
+letting chronically-outvoted minorities occasionally get their way in *recurring*
+group decisions. A future session can develop or critique this.
+
+**Reproduce the numbers:** `python3 sim_scenarios.py` and `python3 sim_robustness.py`
+(plain Python 3, no deps). Both scripts live in this directory and are the source of
+every table below.
+
+---
+
+## 1. The problem
+
+Recurring low-stakes group picks — the canonical case is *"4 friends vote on a lunch
+or movie every week."* Three friends keep voting the same way; the fourth is
+perpetually outvoted and never gets their pick. We want the minority to win
+**occasionally and deterministically** (not by coin flip), with a roughly
+proportional cadence (majority wins a few times, then the minority once, repeat).
+
+**Scope / values (decided during the exploration):**
+- This is for **low-stakes, variety-desirable decisions** (entertainment, food),
+  **not** important decisions that should be optimized for the best outcome. For
+  important decisions you *want* the majority/compromise to win; here variety is a
+  feature.
+- **Goals:** (1) don't waste votes, (2) proportional / varied influence over time,
+  (3) **no strategic burden** — honest ranking should be the only input, low
+  cognitive load, (4) decent overall satisfaction subject to variety.
+- **Non-goal:** maximizing single-round utility.
+
+**Prior art** this resembles (for a future session to mine): *perpetual voting*
+(Lackner 2020), *storable votes*, and proportional-representation-over-time. We
+arrived at the scheme below from first principles but it sits in that family.
+
+---
+
+## 2. Recommended scheme — "clear-all banked IRV"
+
+A normal ranked-choice (IRV) vote each round, with a per-voter, per-option **bank**
+of points that carries across rounds and gives perennial losers growing weight.
+
+**Mechanism:**
+- **Bank:** `bank[(voter, option)]`, integer, starts at 0.
+- **Ballot weight:** a ballot resting on option `o` counts as `w·bank[(v,o)] + 1`
+  (the `+1` is this round's live vote). On an IRV transfer, the weight is
+  **recomputed from the new option's bank**, *not* carried from the eliminated
+  candidate. Use `w = 1`.
+- **Accrual (flat):** at the end of each round, every option a voter ranked that
+  did **not** win gains `+1` in that voter's bank.
+- **Consumption (clear-all):** when an option wins, every voter in the winning
+  **coalition** (ballots resting on the winner at the end) loses **all** their
+  banked points for that winning option (reset to 0). Losers keep their banks.
+- **Saving points** for a future round = simply *don't rank* the option (an unranked
+  option can't draw your points) or abstain (risks none). No separate "spend / hold"
+  decision — the system applies banks automatically, so there is **nothing to
+  strategize**.
+- **Memory bound (optional, hygiene only):** banks may be capped or decayed so they
+  don't grow unbounded, but the cap must be **generous** (see §4) or it
+  re-introduces starvation.
+
+**Why this shape:**
+- **No manufactured support.** Banks only amplify an option a voter *ranks this
+  round*; an option nobody currently ranks scores 0 regardless of history. History
+  can boost real current support, never invent it.
+- **Eventual-win guarantee.** A perennial loser's bank grows every round until it
+  overcomes the majority; clearing it on the win resets the cycle. This yields a
+  stable, ~proportional cadence (see Scenario A: `AAAC AAAC …`).
+- **Automatic ⇒ no strategy.** The voter never decides when to "cash in"; the system
+  spends optimally for them. This was the decisive reason we abandoned the
+  manual-boost / storable-votes direction (see §3).
+- **Variety auto-scales to genuine disagreement** (see §4, EXP4): when people mostly
+  agree it forces little variety; when tastes truly differ it spreads wins widely.
+  It surfaces the diversity that majoritarian IRV suppresses rather than randomizing.
+
+---
+
+## 3. Variants considered (and why rejected / kept)
+
+| Idea | Verdict | Reason |
+|---|---|---|
+| **clear-minimal** consumption (spend only the *pivotal* points to win, refund the rest) | **Rejected** | Unstable. Lets winners keep a reserve, so popular options trade cheaply and **starve a lone minority** (Scenario B: C wins **0%**), or a primed minority **over-wins** (Scenario A: 50%). |
+| **clear-all** consumption | **Kept (recommended)** | Forces every winner back to zero, so slow accumulators reliably break through → proportional, stable, no starvation. |
+| Clear the **resting coalition** vs **everyone who ranked** the winner | Keep coalition | ~Identical in sim (within noise); coalition is simpler. |
+| **Bank weight `w`** as a variety dial | Keep `w=1`, don't expose | It's a **switch, not a dial**: any `w>0` flips to high-variety/no-starvation, then saturates (EXP2). |
+| **Cap / decay** on banks | Optional, hygiene only | Bounds memory without changing behavior *if generous*; **the cap is the real variety dial** but it's coupled to starvation (§4, EXP5). |
+| **Accrual rule** (flat vs regret-/rank-weighted) | **Kept flat** (deliberately not changed) | Flat = no incentive to misrank. Position-based accrual (e.g. "bank options ranked above the winner") sharpens fairness but **re-introduces a bury-your-favorite incentive**. Left as an open question; not simulated in depth. |
+| **Manual boosting / storable votes** (voter chooses when to spend banked points) | **Rejected** | Makes spending a human decision → strategic timing, a free-rider / volunteer's-dilemma among co-supporters, and cognitive load. Violates goal (3). Automating the spend dissolves all of it. |
+| **Original idea: accumulate ranked ballots across cycles, cross off the winner** | **Rejected** | Cadence uncontrollable; crossing-off destroys information (old ballots exhaust); majority's transferred lower-prefs distort outcomes; rewards strategic burying; opaque. |
+
+---
+
+## 4. Key findings (simulation evidence)
+
+Metrics: **variety** = normalized entropy of the win distribution (0 = one option
+always wins, 1 = uniform); **shut-out** = fraction of voters whose top choice
+*never* wins (starvation); **worst-drought** = longest run of rounds the
+most-neglected voter waits for a #1 win; **tot_sat** = total Borda satisfaction;
+**gini** = inequality of per-voter satisfaction.
+
+### 4.1 Three hand-built scenarios (`sim_scenarios.py`)
+
+**Scenario A — 3 love A, 1 loves C (shared 2nd choice B):**
+
+| variant | win shares | total sat | worst-off voter | cadence |
+|---|---|---|---|---|
+| plain IRV | A 100% | 3.00 | 0.00 | `AAAA…` |
+| **clear-all** | **A 75% / C 25%** | 2.50 | 0.25 | `AAAC` (clean, proportional) |
+| clear-minimal | A 50% / C 50% | 2.01 | 0.50 | `→ ACAC` (over-shoots) |
+
+**Scenario B — two blocs (2×A, 2×B) + lone C:**
+
+| variant | win shares | total sat | worst-off |
+|---|---|---|---|
+| plain IRV | A 100% | 3.50 | 0.50 |
+| **clear-all** | A 43% / B 43% / **C 14%** | 2.94 | 0.35 |
+| clear-minimal | A 50% / B 50% / **C 0%** | 3.25 | 0.25 |
+
+**Scenario C — dominant 3×P bloc + lonely Q, R, S:**
+
+| variant | win shares | total sat | worst-off |
+|---|---|---|---|
+| plain IRV | P 100% | 3.67 | 0.00 |
+| **clear-all** | P 40 / Q 20 / R 20 / S 20 | 3.13 | 0.40 |
+| clear-minimal | P 50 / Q 10 / R 20 / S 20 | 3.14 | 0.36 |
+
+Takeaways: clear-all un-starves the minority everywhere; clear-minimal is erratic
+(B starves the lone C entirely). Both initial worries ("clear-all over-equalizes" /
+"clear-minimal starves") turned out to attach to the *opposite* variant from
+intuition — clear-minimal is the dangerous one.
+
+### 4.2 Robustness battery (`sim_robustness.py`, ensembles of random profiles)
+
+- **EXP1 — variant comparison (8 voters, 5 options, random ballots):** baseline
+  starves **44%** of voters; all clear-all variants → **0%** shut-out, variety
+  0.25 → ~0.85, gini 0.22 → 0.07, at a ~12% total-satisfaction cost. coalition /
+  rankers / +cap=8 / +decay=0.9 are all within noise.
+- **EXP2 — `w` saturates:** w=0.5 already gives variety 0.83 & 0% shut-out; w=1/2/4
+  are indistinguishable. `w` is a switch, not a dial.
+- **EXP3 — scale (4→50 voters × 3→8 options):** **shut-out = 0% in every cell.**
+  Variety rises with more voters (0.56 → 0.99). Worst-drought stays bounded
+  (3–16 rounds) even at N=20, M=8.
+- **EXP4 — ballot styles (N=10, M=6):** clear-all drives shut-out 30–53% → **0%**
+  across random, Mallows (popular-favorite), high-noise, and partial top-3 ballots.
+  **Variety auto-scales to real disagreement:** Mallows low-noise (everyone mostly
+  agrees) → clear-all adds only 0.38 variety and largely respects the consensus;
+  random tastes → 0.86.
+- **EXP5 — cap sweep = the actual variety dial, but coupled to starvation:**
+
+  | cap | variety | shut-out | worst drought |
+  |---|---|---|---|
+  | 1 | 0.59 | 17% | 319 |
+  | 3 | 0.76 | 7% | 175 |
+  | 5 | 0.83 | 1% | 48 |
+  | 10 | 0.85 | 0% | 8 |
+  | none | 0.86 | 0% | 8 |
+
+  **Structural fact:** guaranteeing everyone *eventually* wins requires banks that
+  can grow large enough to overcome any majority. Cap the memory too tightly and a
+  lopsided minority is permanently locked out again. If you cap, set it generously
+  (≈ several × group size).
+
+---
+
+## 5. Recommended configuration
+
+> **clear-all + coalition-clear + `w = 1` + uncapped** (or a generous cap ≈ 5–10× the
+> typical group size, purely so banks don't grow without bound — it won't change
+> behavior). One mechanism, essentially zero tunable parameters, no starvation, and
+> variety that tracks genuine disagreement.
+
+If a particular group/decision-type wants *less* variety (more majoritarian), the
+**cap** is the single dial — but keep it ≥ ~group size or lopsided minorities start
+getting starved again.
+
+---
+
+## 6. Important cautions
+
+- **"How often someone gets their #1" ≠ satisfaction.** In Scenario B the lone
+  minority's top-choice rate rose (0% → 14%) while their *actual* satisfaction
+  **fell** (0.50 → 0.35), because rotation also inflicts their *worst* option (B,
+  popular with others) on them, where plain IRV had given everyone a quiet
+  compromise (A). This is acceptable — even desirable — for low-stakes, variety-first
+  decisions, but it is exactly why this scheme should **not** be used for important
+  decisions.
+- **No-starvation requires large banks** (see EXP5). Bounded memory ⇒ possible
+  permanent starvation for sufficiently lopsided splits.
+- **Flat accrual is slightly odd but harmless:** you accrue "want" even for options
+  you ranked *last*, and 46–88% of accrued points are never spent. It works and is
+  gaming-safe; sharpening it is an open question (§7).
+
+---
+
+## 7. Open questions / next steps
+
+For a future session to develop or critique:
+
+1. **Preference drift.** Every simulation here used **fixed** preferences for the
+   whole run. Real entertainment tastes drift. Add a drift model and re-check that
+   droughts stay bounded (drift could help — a neglected option becomes popular — or
+   hurt — a moving favorite never lets a bank mature).
+2. **Strategic robustness.** We argued flat accrual + automatic spend leaves nothing
+   to game, but never simulated an adversarial voter. Confirm no profitable
+   misranking exists.
+3. **Accrual rule.** Does regret-based accrual (only bank options ranked above the
+   winner) meaningfully sharpen fairness, and is its re-introduced bury-your-favorite
+   incentive actually exploitable in practice? (Kept flat for now by request.)
+4. **Satisfaction-aware objective.** For *semi*-important decisions, should the rule
+   avoid overriding a compromise that's already serving the minority well
+   (the Scenario-B backfire)?
+5. **Product integration.** This maps naturally onto the existing poll/group model
+   as a *recurring poll* that carries per-voter/per-option banks across cycles. The
+   app already has ranked-choice IRV; the additions are the bank store, the
+   `w·bank+1` weighting, flat accrual, and clear-all on win. Note the IRV base makes
+   a clean "pivotal amount" hard to define — another reason clear-all (which needs no
+   pivotal computation) beats clear-minimal.

--- a/docs/recurring-vote-fairness/sim_robustness.py
+++ b/docs/recurring-vote-fairness/sim_robustness.py
@@ -1,0 +1,212 @@
+"""
+Recurring-vote fairness — robustness battery for the clear-all scheme.
+
+Flat accrual is FIXED (+1 to every ranked non-winner each round). We vary:
+  - bank weight w           (how much stored grievance amplifies a live vote)
+  - who gets cleared on win  (resting coalition vs everyone who ranked the winner)
+  - cap / decay              (bound the memory)
+  - scale                    (4..50 voters, 3..8 options)
+  - ballot model             (random, Mallows popular-favorite, partial top-k)
+
+Metrics:
+  variety        normalized entropy of the win distribution (0=one winner, 1=uniform)
+  opts_won       fraction of options that win at least once
+  shut-out       fraction of voters whose TOP choice never wins  (starvation)
+  worst_drought  longest run of rounds the most-neglected voter waits for a #1 win
+  tot_sat        total Borda satisfaction across voters
+  gini           inequality of per-voter satisfaction (0=equal)
+
+Headline findings (see README.md): clear-all drives shut-out to 0% across every
+scale and ballot style tested, roughly triples variety, costs ~5-12% total
+satisfaction. w is a near-switch (any w>0 flips it on, then saturates). The cap
+is the real variety dial, but it is COUPLED to the no-starvation guarantee:
+caps below ~5 re-introduce starvation. Variety auto-scales to genuine preference
+diversity (Mallows low-noise -> little forced variety; random -> lots).
+
+Run:  python3 sim_robustness.py
+"""
+import math
+import random
+from statistics import mean
+
+
+def weighted_irv(rankings, banks, options, w, rng):
+    eliminated = set()
+    voters = list(rankings.keys())
+    while True:
+        active = [o for o in options if o not in eliminated]
+        tally = {o: 0.0 for o in active}
+        assign = {}
+        for v in voters:
+            choice = None
+            for o in rankings[v]:
+                if o not in eliminated:
+                    choice = o
+                    break
+            assign[v] = choice
+            if choice is not None:
+                tally[choice] += w * banks.get((v, choice), 0.0) + 1
+        total = sum(tally.values())
+        if total == 0:
+            return None, set()
+        best = max(active, key=lambda o: (tally[o], rng.random()))
+        if tally[best] * 2 > total or len(active) == 1:
+            return best, {v for v in voters if assign[v] == best}
+        worst = min(active, key=lambda o: (tally[o], rng.random()))
+        eliminated.add(worst)
+
+
+def simulate(rankings, options, cfg, rounds, rng):
+    """cfg: dict(w, clear in {'none','coalition','rankers'}, cap=None, decay=1.0)"""
+    banks = {}
+    voters = list(rankings.keys())
+    winners = []
+    w, clear = cfg["w"], cfg["clear"]
+    cap, decay = cfg.get("cap"), cfg.get("decay", 1.0)
+    for _ in range(rounds):
+        win, coal = weighted_irv(rankings, banks, options, w, rng)
+        winners.append(win)
+        if clear == "none" or win is None:
+            continue
+        if clear == "coalition":
+            for v in coal:
+                banks[(v, win)] = 0.0
+        elif clear == "rankers":
+            for v in voters:
+                if win in rankings[v]:
+                    banks[(v, win)] = 0.0
+        if decay != 1.0:
+            for k in list(banks):
+                banks[k] *= decay
+        for v in voters:
+            for o in rankings[v]:
+                if o != win:
+                    banks[(v, o)] = banks.get((v, o), 0.0) + 1
+                    if cap is not None and banks[(v, o)] > cap:
+                        banks[(v, o)] = cap
+    return winners
+
+
+def borda(ranking, w, M):
+    return (M - 1 - ranking.index(w)) / (M - 1) if w in ranking else 0.0
+
+
+def gini(xs):
+    xs = sorted(xs)
+    n, s = len(xs), sum(xs)
+    if s == 0:
+        return 0.0
+    return (2 * sum((i + 1) * x for i, x in enumerate(xs)) / (n * s)) - (n + 1) / n
+
+
+def metrics(rankings, options, winners, M):
+    R = len(winners)
+    voters = list(rankings.keys())
+    counts = {o: winners.count(o) for o in options}
+    ps = [c / R for c in counts.values() if c > 0]
+    variety = (-sum(p * math.log(p) for p in ps)) / math.log(M) if M > 1 else 0.0
+    toprate, sat, droughts = {}, {}, []
+    for v in voters:
+        wins = [i for i, w in enumerate(winners) if w == rankings[v][0]]
+        toprate[v] = len(wins) / R
+        sat[v] = mean(borda(rankings[v], w, M) for w in winners)
+        idx = [-1] + wins + [R]
+        droughts.append(max(idx[i + 1] - idx[i] - 1 for i in range(len(idx) - 1)))
+    return dict(
+        variety=variety,
+        opts_won=sum(1 for o in options if counts[o] > 0) / M,
+        shut=sum(1 for v in voters if toprate[v] == 0) / len(voters),
+        min_top=min(toprate.values()),
+        tot_sat=sum(sat.values()),
+        gini=gini(list(sat.values())),
+        worst_drought=max(droughts),
+    )
+
+
+def gen_random(N, M, rng, top_k=None):
+    r = {}
+    for i in range(N):
+        perm = list(range(M))
+        rng.shuffle(perm)
+        r[i] = perm[:top_k] if top_k else perm
+    return r
+
+
+def gen_mallows(N, M, rng, swaps, top_k=None):
+    central, r = list(range(M)), {}
+    for i in range(N):
+        p = central[:]
+        for _ in range(swaps):
+            j = rng.randrange(M - 1)
+            p[j], p[j + 1] = p[j + 1], p[j]
+        r[i] = p[:top_k] if top_k else p
+    return r
+
+
+def ensemble(profile_fn, M, cfg, rounds=400, trials=40, base_seed=0):
+    acc = {}
+    for t in range(trials):
+        rng = random.Random(base_seed * 1000 + t)
+        rankings = profile_fn(rng)
+        winners = simulate(rankings, list(range(M)), cfg, rounds, rng)
+        for k, v in metrics(rankings, list(range(M)), winners, M).items():
+            acc.setdefault(k, []).append(v)
+    return {k: mean(v) for k, v in acc.items()}
+
+
+def row(label, m):
+    print(f"  {label:<22} variety={m['variety']:.2f}  opts_won={m['opts_won']:.0%}  "
+          f"shut-out={m['shut']:.0%}  worst-drought={m['worst_drought']:.0f}  "
+          f"tot_sat={m['tot_sat']:.2f}  gini={m['gini']:.2f}")
+
+
+if __name__ == "__main__":
+    pf = lambda rng: gen_random(8, 5, rng)
+
+    print("=" * 96)
+    print("EXP1 — variant comparison  (8 voters, 5 options, full random ballots)")
+    row("baseline (w=0)",       ensemble(pf, 5, dict(w=0, clear="none")))
+    row("clear-all coalition",  ensemble(pf, 5, dict(w=1, clear="coalition")))
+    row("clear-all rankers",    ensemble(pf, 5, dict(w=1, clear="rankers")))
+    row("clear-all + cap=8",    ensemble(pf, 5, dict(w=1, clear="coalition", cap=8)))
+    row("clear-all + decay=.9", ensemble(pf, 5, dict(w=1, clear="coalition", decay=0.9)))
+
+    print("=" * 96)
+    print("EXP2 — bank-weight dial  (clear-all coalition) — note it SATURATES, not a smooth dial")
+    for w in [0, 0.5, 1, 2, 4]:
+        row(f"w={w}", ensemble(pf, 5, dict(w=w, clear="coalition")))
+
+    print("=" * 96)
+    print("EXP3 — scale robustness  (clear-all coalition, w=1, full random ballots)")
+    for N in [4, 8, 20, 50]:
+        for M in [3, 5, 8]:
+            m = ensemble(lambda rng, N=N, M=M: gen_random(N, M, rng), M,
+                         dict(w=1, clear="coalition"), rounds=400, trials=25)
+            print(f"  N={N:<3} M={M}:  variety={m['variety']:.2f}  opts_won={m['opts_won']:.0%}  "
+                  f"shut-out={m['shut']:.0%}  worst-drought={m['worst_drought']:.0f}  "
+                  f"tot_sat={m['tot_sat']:.2f}")
+
+    print("=" * 96)
+    print("EXP4 — ballot-style robustness  (clear-all coalition, w=1; N=10, M=6)")
+    M = 6
+    models = {
+        "random full":        lambda rng: gen_random(10, 6, rng),
+        "mallows low-noise":  lambda rng: gen_mallows(10, 6, rng, swaps=2),
+        "mallows high-noise": lambda rng: gen_mallows(10, 6, rng, swaps=8),
+        "partial top-3":      lambda rng: gen_random(10, 6, rng, top_k=3),
+        "mallows+partial":    lambda rng: gen_mallows(10, 6, rng, swaps=4, top_k=3),
+    }
+    for name, fn in models.items():
+        base = ensemble(fn, M, dict(w=0, clear="none"))
+        ca = ensemble(fn, M, dict(w=1, clear="coalition"))
+        print(f"  {name:<20} baseline: variety={base['variety']:.2f} shut={base['shut']:.0%} "
+              f"sat={base['tot_sat']:.2f}   |  clear-all: variety={ca['variety']:.2f} "
+              f"shut={ca['shut']:.0%} worst-drought={ca['worst_drought']:.0f} sat={ca['tot_sat']:.2f}")
+
+    print("=" * 96)
+    print("EXP5 — cap sweep  (8 voters, 5 options, clear-all coalition, w=1) — cap is the variety dial")
+    print("       but low caps RE-INTRODUCE starvation: the no-starvation guarantee needs big banks")
+    for cap in [1, 2, 3, 5, 10, None]:
+        m = ensemble(pf, 5, dict(w=1, clear="coalition", cap=cap))
+        print(f"  cap={str(cap):<5} variety={m['variety']:.2f}  shut-out={m['shut']:.0%}  "
+              f"worst-drought={m['worst_drought']:.0f}  tot_sat={m['tot_sat']:.2f}  gini={m['gini']:.2f}")

--- a/docs/recurring-vote-fairness/sim_scenarios.py
+++ b/docs/recurring-vote-fairness/sim_scenarios.py
@@ -1,0 +1,155 @@
+"""
+Recurring-vote fairness — single-scenario simulation.
+
+Explores a "banked-points modified IRV" for recurring low-stakes group decisions
+(e.g. a weekly lunch/entertainment pick) where we want chronically-outvoted
+minorities to occasionally get their way, deterministically (not by luck).
+
+Mechanism under test:
+  - Each voter has a per-option bank of points: bank[(voter, option)].
+  - A ballot resting on option o counts as  w*bank[(v,o)] + 1  (the +1 is this
+    round's live vote). On IRV transfer the weight is recomputed from the NEW
+    option's bank, NOT carried from the previous candidate.
+  - Accrual (FIXED, "flat"): at the end of each round every option a voter ranked
+    that did NOT win gains +1 in that voter's bank.
+  - Consumption variants compared here:
+      baseline      : no banks at all (plain IRV every round)
+      clear_all     : the winning coalition loses ALL their bank for the winner
+      clear_minimal : the winning coalition loses only the minimal pivotal amount,
+                      found by refunding points until the winner would flip
+
+Conclusion from this file (see ../recurring-vote-fairness/README.md):
+  clear_all is stable and ~proportional; clear_minimal is unstable — it either
+  starves a lone minority (Scenario B: C wins 0%) or over-serves one (Scenario A:
+  50%). We proceed with clear_all.
+
+Run:  python3 sim_scenarios.py
+"""
+
+
+def weighted_irv(rankings, banks, options, w=1):
+    eliminated = set()
+    voters = list(rankings.keys())
+    order = list(options)
+    while True:
+        active = [o for o in options if o not in eliminated]
+        tally = {o: 0 for o in active}
+        assignment = {}
+        for v in voters:
+            choice = None
+            for o in rankings[v]:
+                if o not in eliminated:
+                    choice = o
+                    break
+            assignment[v] = choice
+            if choice is not None:
+                tally[choice] += w * banks.get((v, choice), 0) + 1
+        total = sum(tally.values())
+        if total == 0:
+            return None, set(), assignment
+        best = max(active, key=lambda o: (tally[o], -order.index(o)))
+        if tally[best] * 2 > total or len(active) == 1:
+            coalition = {v for v in voters if assignment[v] == best}
+            return best, coalition, assignment
+        worst = min(active, key=lambda o: (tally[o], -order.index(o)))
+        eliminated.add(worst)
+
+
+def minimal_spend(rankings, banks, options, winner, coalition):
+    """Greedily refund the winner's coalition's bank one point at a time (in a
+    fixed cycling order) while the winner still wins. What can't be refunded is
+    the minimal pivotal spend."""
+    work = dict(banks)
+    members = sorted(coalition)
+    while True:
+        progress = False
+        for v in members:
+            if work.get((v, winner), 0) <= 0:
+                continue
+            work[(v, winner)] -= 1
+            w2, _, _ = weighted_irv(rankings, work, options)
+            if w2 == winner:
+                progress = True
+            else:
+                work[(v, winner)] += 1
+        if not progress:
+            break
+    return {v: banks.get((v, winner), 0) - work.get((v, winner), 0) for v in coalition}
+
+
+def simulate(rankings, options, variant, rounds):
+    banks = {}
+    winners = []
+    voters = list(rankings.keys())
+    accrued = consumed = 0
+    for _ in range(rounds):
+        w, coal, _ = weighted_irv(rankings, banks, options)
+        winners.append(w)
+        if w is None or variant == "baseline":
+            continue
+        if variant == "clear_all":
+            for v in coal:
+                consumed += banks.get((v, w), 0)
+                banks[(v, w)] = 0
+        elif variant == "clear_minimal":
+            for v, c in minimal_spend(rankings, banks, options, w, coal).items():
+                if c:
+                    banks[(v, w)] = banks.get((v, w), 0) - c
+                    consumed += c
+        for v in voters:                       # flat accrual
+            for o in rankings[v]:
+                if o != w:
+                    banks[(v, o)] = banks.get((v, o), 0) + 1
+                    accrued += 1
+    return winners, accrued, consumed
+
+
+def borda(ranking, w, M):
+    return (M - 1 - ranking.index(w)) / (M - 1) if w in ranking else 0.0
+
+
+def report(name, rankings, options, rounds=300):
+    M = len(options)
+    voters = list(rankings.keys())
+    print("=" * 72)
+    print(name)
+    for v in voters:
+        print(f"    {v}: {rankings[v]}")
+    print()
+    for variant in ["baseline", "clear_all", "clear_minimal"]:
+        winners, accrued, consumed = simulate(rankings, options, variant, rounds)
+        shares = {o: winners.count(o) / rounds for o in options}
+        toprate = {v: sum(1 for w in winners if w == rankings[v][0]) / rounds for v in voters}
+        avgsat = {v: sum(borda(rankings[v], w, M) for w in winners) / rounds for v in voters}
+        print(f"  --- {variant} ---")
+        print("    win shares : " + "  ".join(f"{o}:{shares[o]:.0%}" for o in options))
+        print("    top-choice win rate: " + "  ".join(f"{v}:{toprate[v]:.0%}" for v in voters))
+        print(f"    satisfaction total={sum(avgsat.values()):.2f}  "
+              f"min-voter={min(avgsat.values()):.2f}  "
+              f"(per-voter " + " ".join(f"{avgsat[v]:.2f}" for v in voters) + ")")
+        if variant != "baseline":
+            print(f"    points accrued={accrued} consumed={consumed} "
+                  f"unspent={1 - consumed/accrued:.0%}")
+        print("    first 32 winners: " + "".join(str(w) for w in winners[:32]))
+        print()
+
+
+if __name__ == "__main__":
+    # Scenario A: 3 love A, 1 loves C, everyone's 2nd choice is B
+    report("SCENARIO A  (3 vs 1, shared 2nd choice B)", {
+        "v1": ["A", "B", "C"], "v2": ["A", "B", "C"],
+        "v3": ["A", "B", "C"], "v4": ["C", "B", "A"],
+    }, ["A", "B", "C"])
+
+    # Scenario B: two blocs (A,B) + lone minority C
+    report("SCENARIO B  (two blocs A & B, lone minority C)", {
+        "v1": ["A", "B", "C"], "v2": ["A", "B", "C"],
+        "v3": ["B", "A", "C"], "v4": ["B", "A", "C"],
+        "v5": ["C", "A", "B"],
+    }, ["A", "B", "C"])
+
+    # Scenario C: dominant 3-voter P bloc + lonely R & S
+    report("SCENARIO C  (dominant P bloc, lonely R & S)", {
+        "v1": ["P", "Q", "R", "S"], "v2": ["P", "Q", "R", "S"], "v3": ["P", "Q", "R", "S"],
+        "v4": ["Q", "P", "R", "S"], "v5": ["R", "S", "Q", "P"], "v6": ["S", "R", "Q", "P"],
+    }, ["P", "Q", "R", "S"])


### PR DESCRIPTION
## Summary

Adds a research log + reproducible simulations under `docs/recurring-vote-fairness/`
for a scheme that lets chronically-outvoted minorities occasionally get their way in
**recurring low-stakes** group decisions (e.g. the weekly lunch/movie pick), where
variety is desirable over single-round optimality.

Nothing here is wired into the app — it's a design exploration so a future session can
develop or critique the idea.

- `README.md` — the findings: the recommended scheme (**clear-all banked IRV**), every
  variant considered and why it was rejected/kept, simulation evidence, cautions, and
  open questions.
- `sim_scenarios.py` — three hand-built scenarios (baseline IRV vs clear-all vs clear-minimal).
- `sim_robustness.py` — robustness battery across scale (4→50 voters, 3→8 options) and
  ballot styles (random, Mallows popular-favorite, partial ballots), plus the cap sweep.

### Headline conclusions
- **clear-all banked IRV** (per-voter/per-option banks, ballot weight `bank+1`, flat
  accrual, winner's coalition cleared on win) drives voter starvation from 30–53% to
  **0%** across every scale and ballot style tested, at a ~5–12% total-satisfaction cost.
- **clear-minimal** (consume only pivotal points) is unstable — it starves lone
  minorities or over-serves them — and is rejected.
- Variety **auto-scales to genuine disagreement**; the bank weight is a switch (not a
  dial); the cap is the real variety dial but is coupled to the no-starvation guarantee.

## Test plan
- [x] `python3 docs/recurring-vote-fairness/sim_scenarios.py` reproduces the documented tables
- [x] `python3 docs/recurring-vote-fairness/sim_robustness.py` reproduces the documented tables
- [x] Docs-only change — no app code, build, or runtime surface touched

https://claude.ai/code/session_011PFReDWc9LnTdwxJQERjwR

---
_Generated by [Claude Code](https://claude.ai/code/session_011PFReDWc9LnTdwxJQERjwR)_