### PR TITLE
Account-owned poll authorship (migration 122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1376,22 +1376,38 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
   toggle is on the roadmap.
 - I (account settings — **shipped**): linked-identities display +
   add-recovery-email + delete-account (migration 118). See "Phase I"
-  below. Still deferred within I: retire `creator_secret`; "claim an
-  anonymous-created group" so legacy creator_user_id can be set
-  after-the-fact, enabling privacy-flip on grandfathered groups.
-  - **TODO (retire `creator_secret`): now that the
-    `accessible_question_ids` / `forgotten_question_ids` localStorage
-    lists are gone (group visibility is server-side `group_members`),
-    the localStorage `creator_secret` (`lib/browserQuestionAccess.ts`,
-    key `question_creator_secrets`) is the LAST per-browser local
-    signal that gates a privileged action — it's the poll-ownership
-    authorization for close / reopen / cutoff / edit. It doesn't follow
-    the user across devices and is lost on a localStorage clear. The
-    eventual goal is account-owned poll authorship: record the signed-in
-    creator's `user_id` on the poll (mirroring `groups.creator_user_id`)
-    and authorize mutations against the session instead of a
-    per-browser secret. Until then, `creator_secret` stays as-is — it's
-    intentionally OUT OF SCOPE for the membership/visibility work.**
+  below. Still deferred within I: "claim an anonymous-created group" so
+  legacy `creator_user_id` can be set after-the-fact, enabling
+  privacy-flip on grandfathered groups.
+  - **Account-owned poll authorship — SHIPPED (migration 122).** Polls
+    now record `creator_user_id` (the signed-in creator's user_id; NULL
+    for anonymous-created polls), mirroring `groups.creator_user_id`.
+    The shared `_authorize_poll` chokepoint in `routers/polls.py`
+    (close / reopen / cutoff-suggestions / cutoff-availability) is
+    **additive**: a mutation is authorized if EITHER the session's
+    `user_id` matches the poll's `creator_user_id` (account path — works
+    on any device the creator is signed in on, no per-browser secret
+    needed) OR the request's `creator_secret` matches (the sole
+    authority for anonymous polls + a backwards-compatible fallback for
+    the signed-in creator's original browser). So `creator_secret` is
+    **NOT retired** — it still exists and is still written on every poll
+    — but it's no longer the ONLY authority, and the cross-device gap it
+    left is closed for signed-in creators. The four poll-mutation
+    request models' `creator_secret` became `str | None = None`; the FE
+    sends an empty secret from a device without one and the bearer token
+    authorizes. FE gating goes through `isPollCreatedByViewer(poll,
+    anchorQuestionId)` in `lib/browserQuestionAccess.ts` (secret-OR-
+    session, mirroring the server). The avatar "creatorIsMe" check
+    (`app/g/[groupShortId]/p/[pollShortId]/page.tsx`) and the create-poll
+    30s duplicate-redirect dedup (`getCreatorSecret(existing.id)`) are
+    display / double-submit concerns and intentionally still use the
+    per-browser secret — they're not authorization. **Still genuinely
+    deferred**: fully removing `creator_secret` (needs a "claim
+    anonymous poll" flow first, like the group equivalent), and "edit
+    poll/question" (title/options) — there is no poll-edit-mutation
+    endpoint today, so the TODO's "edit" reduces to the four
+    close/reopen/cutoff endpoints. Tests:
+    `server/tests/test_poll_authorship.py`.
 - C-follow-up: ~~native Google Sign In on iOS~~ **shipped** (per-bundle iOS client IDs hardcoded in `lib/oauth.ts: GOOGLE_IOS_CLIENT_IDS`; reversed URL scheme stamped into `Info.plist: CFBundleURLTypes` by `ios-build.yml`; uses the same `@capgo/capacitor-social-login` plugin as Apple native).
 
 **Phase I (account management) shipped in migration 118.** Adds a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1402,12 +1402,57 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
     30s duplicate-redirect dedup (`getCreatorSecret(existing.id)`) are
     display / double-submit concerns and intentionally still use the
     per-browser secret — they're not authorization. **Still genuinely
-    deferred**: fully removing `creator_secret` (needs a "claim
-    anonymous poll" flow first, like the group equivalent), and "edit
-    poll/question" (title/options) — there is no poll-edit-mutation
+    deferred**: fully removing `creator_secret` (see the TODO below), and
+    "edit poll/question" (title/options) — there is no poll-edit-mutation
     endpoint today, so the TODO's "edit" reduces to the four
     close/reopen/cutoff endpoints. Tests:
     `server/tests/test_poll_authorship.py`.
+  - **TODO — fully retire `creator_secret` (separate session/PR; needs
+    design first).** Migration 122 made auth additive (session OR
+    secret) but did NOT remove the secret, because it's still the *only*
+    authority in two cases:
+    1. **Anonymous polls** (`creator_user_id` NULL) — no account to
+       match against, so the secret is the sole way to authorize a
+       close/reopen/cutoff.
+    2. **A signed-in creator's original browser after sign-out** — the
+       session is gone so the account branch fails, but the secret in
+       that browser's localStorage still authorizes.
+    To delete the column + all FE secret plumbing
+    (`generateCreatorSecret` / `storeCreatorSecret` / `getCreatorSecret` /
+    `recordQuestionCreation`, the `question_creator_secrets` localStorage
+    key, the `creator_secret` request/response fields), both cases must
+    be re-homed onto the identity model that already governs group
+    membership: `browser_id` (+ `user_browsers` → `user_id`). Candidate
+    approach: record the creating `browser_id` on the poll (a
+    `creator_browser_id` column, mirroring `creator_user_id`) and
+    authorize a mutation when the request's `browser_id` equals
+    `creator_browser_id` OR is linked via `user_browsers` to the poll's
+    `creator_user_id` (same expansion `load_user_visibility` already
+    does). That unifies on one primitive and resolves BOTH cases at once
+    (anon → browser_id match; signed-out creating browser → still its own
+    browser_id). Open questions that need a human decision (hence a
+    separate PR):
+    - **Threat model.** `browser_id` is echoed in the `X-Browser-Id`
+      response header on EVERY request (intentional, for cross-tab
+      adoption), so it's more observable than the secret (localStorage-
+      only, sent only on mutations). Authorizing on `browser_id` means
+      anyone who learns a victim's `browser_id` could mutate their
+      anonymous polls. Decide if that's acceptable, or whether anonymous
+      poll mutation should instead require sign-in / a claim.
+    - **Legacy polls can't be backfilled.** Existing rows recorded only
+      the secret — the creating `browser_id` was never stored on the poll
+      (`group_members` is group-level, not poll-creator). So either keep
+      the column as a read-only fallback for pre-migration polls (a long
+      transition window) or accept that legacy anonymous polls become
+      immutable.
+    - **"Claim an anonymous poll" flow** (parallel to the already-
+      deferred "claim an anonymous-created group"): lets a signed-in user
+      adopt a poll they created while anonymous, setting `creator_user_id`
+      after the fact — needed for the anonymous-then-sign-in creator to
+      manage it cross-device without the secret.
+    - **Product call:** is account-gated poll creation on the table
+      (every poll always gets a `creator_user_id`)? That makes retirement
+      trivial but breaks the app's anonymous-first stance.
 - C-follow-up: ~~native Google Sign In on iOS~~ **shipped** (per-bundle iOS client IDs hardcoded in `lib/oauth.ts: GOOGLE_IOS_CLIENT_IDS`; reversed URL scheme stamped into `Info.plist: CFBundleURLTypes` by `ios-build.yml`; uses the same `@capgo/capacitor-social-login` plugin as Apple native).
 
 **Phase I (account management) shipped in migration 118.** Adds a

--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -13,7 +13,7 @@ import { apiGetQuestionResults, apiGetGroupByRouteId, apiGetGroupSummary, apiGet
 import type { Poll } from "@/lib/types";
 import { useGroupVoting } from "@/lib/useGroupVoting";
 import type { QuestionResults } from "@/lib/types";
-import { getCreatorSecret } from "@/lib/browserQuestionAccess";
+import { getCreatorSecret, isPollCreatedByViewer } from "@/lib/browserQuestionAccess";
 import { getCachedAccessiblePolls, getCachedGroupSummary, getCachedPollById, getCachedPollByShortId } from "@/lib/questionCache";
 import {
   POLL_PENDING_EVENT,
@@ -1885,6 +1885,10 @@ export function GroupContent({ groupId, overlayCardsOffset }: GroupContentProps)
         const modalWrapper = wrapperFor(modalQuestion);
         if (!modalWrapper) return null;
         const isModalClosed = !!modalWrapper.is_closed;
+        // Creator via per-browser secret OR signed-in account (migration 122).
+        const isCreatorOrDev =
+          isPollCreatedByViewer(modalWrapper, modalQuestion.id) ||
+          process.env.NODE_ENV === 'development';
         return (
           <FollowUpModal
             isOpen={showModal}
@@ -1894,28 +1898,26 @@ export function GroupContent({ groupId, overlayCardsOffset }: GroupContentProps)
             onClose={() => setShowModal(false)}
             onDelete={() => setPendingAction({ kind: 'forget', question: modalQuestion })}
             onReopen={
-              isModalClosed &&
-              (!!getCreatorSecret(modalQuestion.id) || process.env.NODE_ENV === 'development')
+              isModalClosed && isCreatorOrDev
                 ? () => setPendingAction({ kind: 'reopen', question: modalQuestion })
                 : undefined
             }
             onCloseQuestion={
-              !isModalClosed &&
-              (!!getCreatorSecret(modalQuestion.id) || process.env.NODE_ENV === 'development')
+              !isModalClosed && isCreatorOrDev
                 ? () => setPendingAction({ kind: 'close', question: modalQuestion })
                 : undefined
             }
             onCutoffAvailability={
               !isModalClosed &&
               isInTimeAvailabilityPhase(modalQuestion) &&
-              (!!getCreatorSecret(modalQuestion.id) || process.env.NODE_ENV === 'development')
+              isCreatorOrDev
                 ? () => setPendingAction({ kind: 'cutoff-availability', question: modalQuestion })
                 : undefined
             }
             onCutoffSuggestions={
               !isModalClosed &&
               isInSuggestionPhase(modalQuestion, modalWrapper.prephase_deadline ?? null) &&
-              (!!getCreatorSecret(modalQuestion.id) || process.env.NODE_ENV === 'development')
+              isCreatorOrDev
                 ? () => setPendingAction({ kind: 'cutoff-suggestions', question: modalQuestion })
                 : undefined
             }
@@ -1953,7 +1955,9 @@ export function GroupContent({ groupId, overlayCardsOffset }: GroupContentProps)
             }
           } else if (action.kind === 'reopen') {
             try {
-              const secret = getCreatorSecret(action.question.id) || 'dev-override';
+              // Empty when the viewer is the signed-in creator on another
+              // device — the bearer token authorizes via creator_user_id.
+              const secret = getCreatorSecret(action.question.id) ?? '';
               const pollId = action.question.poll_id;
               if (!pollId) {
                 console.error('Cannot reopen question without poll_id');
@@ -1992,11 +1996,9 @@ export function GroupContent({ groupId, overlayCardsOffset }: GroupContentProps)
               ? apiCutoffPollSuggestions
               : apiCutoffPollAvailability;
             try {
-              const secret = getCreatorSecret(action.question.id);
-              if (!secret) {
-                console.error(`Missing creator secret for ${action.kind}`);
-                return;
-              }
+              // Empty when the viewer is the signed-in creator on another
+              // device — the bearer token authorizes via creator_user_id.
+              const secret = getCreatorSecret(action.question.id) ?? '';
               const pollId = action.question.poll_id;
               if (!pollId) {
                 console.error(`Cannot ${action.kind} without poll_id`);

--- a/app/g/[groupShortId]/p/[pollShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/info/page.tsx
@@ -36,6 +36,11 @@ import InitialBubble from "@/components/InitialBubble";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import PollActionButton, { CutoffIcon } from "@/components/PollActionButton";
 import { getCreatorSecret } from "@/lib/browserQuestionAccess";
+import {
+  getCachedSessionUser,
+  SESSION_CHANGED_EVENT,
+  type SessionUser,
+} from "@/lib/session";
 import { getUserName, isCurrentUserName } from "@/lib/userProfile";
 import { useMyUserImageUrl } from "@/lib/useMyUserImageUrl";
 import {
@@ -185,8 +190,24 @@ function Info({ poll, setPoll, groupId, onBack }: InfoProps) {
     () => (anchor ? getCreatorSecret(anchor.id) : null),
     [anchor?.id],
   );
+  // Account-owned authorship (migration 122): the signed-in creator can
+  // manage their poll from any device — even one without the per-browser
+  // creator_secret. Subscribe to SESSION_CHANGED so the controls appear/
+  // disappear on sign-in/out without a remount.
+  const [sessionUser, setSessionUser] = useState<SessionUser | null>(null);
+  useEffect(() => {
+    setSessionUser(getCachedSessionUser());
+    const update = () => setSessionUser(getCachedSessionUser());
+    window.addEventListener(SESSION_CHANGED_EVENT, update);
+    return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
+  }, []);
+  const viewerIsCreator =
+    !!creatorSecret ||
+    (!!sessionUser &&
+      !!poll.creator_user_id &&
+      sessionUser.user_id === poll.creator_user_id);
   const isCreatorOrDev =
-    !!creatorSecret || process.env.NODE_ENV === "development";
+    viewerIsCreator || process.env.NODE_ENV === "development";
 
   const canReopen = isClosed && isCreatorOrDev;
   const canClose = !isClosed && isCreatorOrDev;
@@ -242,11 +263,11 @@ function Info({ poll, setPoll, groupId, onBack }: InfoProps) {
       return;
     }
 
-    const secret = creatorSecret || (process.env.NODE_ENV === "development" ? "dev-override" : "");
-    if (!secret) {
-      console.error(`Missing creator secret for ${kind}`);
-      return;
-    }
+    // The per-browser secret authorizes anonymous-created polls + the
+    // creating browser. A signed-in creator on another device has no secret
+    // here — they send an empty one and the server authorizes against their
+    // session (the poll's creator_user_id matches their user_id).
+    const secret = creatorSecret ?? "";
 
     try {
       setSubmitting(true);

--- a/components/QuestionBallot.tsx
+++ b/components/QuestionBallot.tsx
@@ -16,7 +16,7 @@ import { apiGetQuestionResults, apiGetVotes, apiSubmitPollVotes, apiCutoffPollSu
 import { invalidateQuestion, getCachedQuestionById, getCachedQuestionResults, getCachedVotes } from "@/lib/questionCache";
 import RankableOptions from "@/components/RankableOptions";
 
-import { isCreatedByThisBrowser, getCreatorSecret, recordQuestionCreation, storeSeenQuestionOptions, getSeenQuestionOptions } from "@/lib/browserQuestionAccess";
+import { isPollCreatedByViewer, getCreatorSecret, recordQuestionCreation, storeSeenQuestionOptions, getSeenQuestionOptions } from "@/lib/browserQuestionAccess";
 import { hasQuestionData } from "@/lib/forgetQuestion";
 import { getUserName, saveUserName } from "@/lib/userProfile";
 import { isValidUserName } from "@/lib/nameValidation";
@@ -497,7 +497,10 @@ const QuestionBallot = forwardRef<QuestionBallotHandle, QuestionBallotProps>(fun
     // of a poll all share the wrapper's creator_secret, which is
     // recorded per question id on the create-question page when the poll
     // is created. No fallback inheritance is needed.
-    setIsCreator(isCreatedByThisBrowser(question.id));
+    // Creator via per-browser secret OR signed-in account (migration 122):
+    // a signed-in creator on another device has no local secret but their
+    // session matches the poll's creator_user_id.
+    setIsCreator(isPollCreatedByViewer(poll, question.id));
 
     // Check if browser has any data for this question
     setHasQuestionDataState(hasQuestionData(question.id));
@@ -774,19 +777,15 @@ const QuestionBallot = forwardRef<QuestionBallotHandle, QuestionBallotProps>(fun
 
   const handleCutoffSuggestionsClick = () => {
     if (isCuttingOffSuggestions || !isCreator) return;
-    const creatorSecret = getCreatorSecret(question.id);
-    if (!creatorSecret) {
-      alert('You do not have permission to cutoff suggestions.');
-      return;
-    }
     setShowCutoffConfirmModal(true);
   };
 
   const handleCutoffSuggestions = async () => {
     setShowCutoffConfirmModal(false);
     if (isCuttingOffSuggestions || !isCreator) return;
-    const creatorSecret = getCreatorSecret(question.id);
-    if (!creatorSecret) return;
+    // Empty when the viewer is the signed-in creator on another device — the
+    // bearer token authorizes the cutoff against the poll's creator_user_id.
+    const creatorSecret = getCreatorSecret(question.id) ?? '';
     const pollId = question.poll_id;
     if (!pollId) {
       console.error('Cannot cutoff suggestions without poll_id');

--- a/database/migrations/122_poll_creator_user_id_down.sql
+++ b/database/migrations/122_poll_creator_user_id_down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE polls DROP COLUMN IF EXISTS creator_user_id;
+
+COMMIT;

--- a/database/migrations/122_poll_creator_user_id_up.sql
+++ b/database/migrations/122_poll_creator_user_id_up.sql
@@ -1,0 +1,24 @@
+-- Account-owned poll authorship.
+--
+-- Adds `polls.creator_user_id` — the user_id of the signed-in creator,
+-- mirroring `groups.creator_user_id` (migration 114). NULL for
+-- anonymous-created polls (those keep authorizing close/reopen/cutoff via
+-- the per-browser `creator_secret`). When set, poll mutations may be
+-- authorized against the session's user_id instead of the secret, so a
+-- signed-in creator can manage their poll from any device they're signed
+-- in on (the secret never followed them across browsers).
+--
+-- The signed-in / anonymous split lives in `_insert_poll`
+-- (`server/routers/polls.py`): signed-in → creator_user_id = session
+-- user_id, anonymous → NULL. `creator_secret` is still written on every
+-- poll regardless, so the secret path remains the fallback authority.
+--
+-- ON DELETE SET NULL so deleting a user (Phase I) reverts their polls to
+-- secret-only authorization rather than cascading the rows away.
+
+BEGIN;
+
+ALTER TABLE polls
+  ADD COLUMN creator_user_id UUID REFERENCES users(id) ON DELETE SET NULL;
+
+COMMIT;

--- a/lib/api/_internal.ts
+++ b/lib/api/_internal.ts
@@ -266,6 +266,7 @@ export function toPoll(data: any): Poll {
     group_short_id: data.group_short_id ?? null,
     creator_secret: data.creator_secret ?? null,
     creator_name: data.creator_name ?? null,
+    creator_user_id: data.creator_user_id ?? null,
     response_deadline: data.response_deadline ?? null,
     prephase_deadline: data.prephase_deadline ?? null,
     prephase_deadline_minutes: data.prephase_deadline_minutes ?? null,

--- a/lib/browserQuestionAccess.ts
+++ b/lib/browserQuestionAccess.ts
@@ -1,3 +1,5 @@
+import { getCachedSessionUser } from './session';
+
 // Browser storage for poll-ownership creator secrets + per-question
 // "seen options" snapshots.
 //
@@ -88,6 +90,25 @@ export function getCreatorSecret(questionId: string): string | null {
 // Check if this browser created a specific question
 export function isCreatedByThisBrowser(questionId: string): boolean {
   return getCreatorSecret(questionId) !== null;
+}
+
+// Is the current viewer the creator of this poll? Mirrors the server's
+// `_authorize_poll` (migration 122): authorized via EITHER the per-browser
+// creator_secret for `anchorQuestionId` (the browser that created it), OR a
+// signed-in session matching the poll's recorded `creator_user_id` (which
+// works on any device the creator is signed in on — the secret never followed
+// them across browsers). Callers that need to re-render on sign-in/out must
+// also subscribe to SESSION_CHANGED_EVENT; this reads the cached user
+// synchronously.
+export function isPollCreatedByViewer(
+  poll: { creator_user_id?: string | null } | null | undefined,
+  anchorQuestionId: string | null | undefined,
+): boolean {
+  if (anchorQuestionId && isCreatedByThisBrowser(anchorQuestionId)) return true;
+  const creatorUserId = poll?.creator_user_id;
+  if (!creatorUserId) return false;
+  const user = getCachedSessionUser();
+  return !!user && user.user_id === creatorUserId;
 }
 
 // Record question creation. Persists the creator secret (poll-ownership

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -164,6 +164,12 @@ export interface Poll {
   group_short_id?: string | null;
   creator_secret?: string | null;
   creator_name?: string | null;
+  // Migration 122: the signed-in creator's user_id (null for anonymous-created
+  // polls + pre-122 cached polls). When it matches the current session's
+  // user_id, the viewer is the poll's creator on ANY device — the
+  // close/reopen/cutoff controls show and the server authorizes those
+  // mutations against the session, not just the per-browser creator_secret.
+  creator_user_id?: string | null;
   response_deadline?: string | null;
   prephase_deadline?: string | null;
   prephase_deadline_minutes?: number | null;

--- a/server/models.py
+++ b/server/models.py
@@ -102,13 +102,18 @@ class SubmitPollVotesRequest(BaseModel):
     items: list[PollVoteItem] = Field(..., min_length=1)
 
 
+# `creator_secret` is optional on the poll-mutation requests: a signed-in
+# creator managing their poll from another device has no per-browser secret,
+# so they authorize via their session bearer token instead (the poll's
+# `creator_user_id` matches their user_id). Anonymous-created polls still
+# require the matching secret — see `_authorize_poll` in routers/polls.py.
 class CloseQuestionRequest(BaseModel):
-    creator_secret: str
+    creator_secret: str | None = None
     close_reason: CloseReason = CloseReason.manual
 
 
 class ReopenQuestionRequest(BaseModel):
-    creator_secret: str
+    creator_secret: str | None = None
 
 
 class UpdateGroupTitleRequest(BaseModel):
@@ -117,7 +122,7 @@ class UpdateGroupTitleRequest(BaseModel):
 
 
 class CutoffSuggestionsRequest(BaseModel):
-    creator_secret: str
+    creator_secret: str | None = None
 
 
 class AccessibleQuestionsRequest(BaseModel):
@@ -304,6 +309,12 @@ class PollResponse(BaseModel):
     short_id: str | None = None
     creator_secret: str | None = None
     creator_name: str | None = None
+    # Migration 122: the signed-in creator's user_id, recorded at create
+    # time (NULL for anonymous-created polls). When set, the FE shows the
+    # creator's close/reopen/cutoff controls to that account on any device,
+    # and the server authorizes those mutations against the session — not
+    # just the per-browser `creator_secret`.
+    creator_user_id: str | None = None
     response_deadline: str | None = None
     prephase_deadline: str | None = None
     prephase_deadline_minutes: int | None = None

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -263,7 +263,7 @@ def _insert_poll(
     row = conn.execute(
         """
         INSERT INTO polls (
-            creator_secret, creator_name, response_deadline,
+            creator_secret, creator_name, creator_user_id, response_deadline,
             prephase_deadline, prephase_deadline_minutes,
             context, details,
             min_responses, show_preliminary_results, allow_pre_ranking,
@@ -271,7 +271,7 @@ def _insert_poll(
             created_at, updated_at
         )
         VALUES (
-            %(creator_secret)s, %(creator_name)s, %(response_deadline)s,
+            %(creator_secret)s, %(creator_name)s, %(creator_user_id)s, %(response_deadline)s,
             %(prephase_deadline)s, %(prephase_deadline_minutes)s,
             %(context)s, %(details)s,
             %(min_responses)s, %(show_preliminary_results)s, %(allow_pre_ranking)s,
@@ -283,6 +283,7 @@ def _insert_poll(
         {
             "creator_secret": req.creator_secret,
             "creator_name": req.creator_name,
+            "creator_user_id": creator_user_id,
             "response_deadline": req.response_deadline,
             "prephase_deadline": prephase_deadline,
             "prephase_deadline_minutes": req.prephase_deadline_minutes,
@@ -461,6 +462,9 @@ def _row_to_poll(
         group_short_id=row.get("group_short_id"),
         creator_secret=row.get("creator_secret"),
         creator_name=row.get("creator_name"),
+        creator_user_id=(
+            str(row["creator_user_id"]) if row.get("creator_user_id") else None
+        ),
         response_deadline=_iso_or_none(row.get("response_deadline")),
         prephase_deadline=_iso_or_none(row.get("prephase_deadline")),
         prephase_deadline_minutes=row.get("prephase_deadline_minutes"),
@@ -832,15 +836,21 @@ def get_poll(short_id: str):
 # Poll-level operations (Phase 3)
 #
 # These mirror the per-question close/reopen/cutoff endpoints but operate on the
-# poll wrapper + every question atomically. Authorization is gated on
-# polls.creator_secret; question secrets match because they were copied at
-# creation time. After Phase 5 the wrapper-level fields will be the sole source
-# of truth, but until then we maintain both copies so legacy per-question readers
-# (results, votes) keep working unchanged.
+# poll wrapper + every question atomically.
+#
+# Authorization is account-aware (migration 122). A poll created by a signed-in
+# user records `creator_user_id`; that account may mutate the poll from any
+# device it's signed in on, authorized by the session bearer token alone. The
+# per-browser `creator_secret` remains valid too — it's the ONLY authority for
+# anonymous-created polls (creator_user_id NULL), and a backwards-compatible
+# fallback for the signed-in creator's original browser. The check is additive:
+# session-match OR secret-match passes.
 # ---------------------------------------------------------------------------
 
 
-def _authorize_poll(conn, poll_id: str, creator_secret: str) -> dict:
+def _authorize_poll(
+    conn, poll_id: str, creator_secret: str | None, request: Request
+) -> dict:
     require_uuid(poll_id, "poll_id")
     row = conn.execute(
         "SELECT * FROM polls WHERE id = %(id)s",
@@ -848,13 +858,27 @@ def _authorize_poll(conn, poll_id: str, creator_secret: str) -> dict:
     ).fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="Poll not found")
-    if row.get("creator_secret") != creator_secret:
-        raise HTTPException(status_code=403, detail="Invalid creator secret")
-    return dict(row)
+    poll = dict(row)
+    # Account-owned poll: a signed-in session matching the recorded creator
+    # is sufficient — works cross-device, no per-browser secret needed.
+    creator_user_id = poll.get("creator_user_id")
+    user_id = _user_id(request)
+    if creator_user_id is not None and user_id is not None and str(creator_user_id) == str(user_id):
+        return poll
+    # Fall back to the per-browser secret (sole authority for anonymous polls;
+    # backwards-compat for the signed-in creator's original browser).
+    if creator_secret and poll.get("creator_secret") == creator_secret:
+        return poll
+    raise HTTPException(status_code=403, detail="Invalid creator secret")
 
 
 @router.post("/{poll_id}/close", response_model=PollResponse)
-def close_poll(poll_id: str, req: CloseQuestionRequest, background_tasks: BackgroundTasks):
+def close_poll(
+    poll_id: str,
+    req: CloseQuestionRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
     """Close a poll. Phase 5: only the wrapper carries is_closed/close_reason —
     closing the wrapper closes every question automatically.
 
@@ -869,7 +893,7 @@ def close_poll(poll_id: str, req: CloseQuestionRequest, background_tasks: Backgr
     """
     now = datetime.now(timezone.utc)
     with get_db() as conn:
-        wrapper = _authorize_poll(conn, poll_id, req.creator_secret)
+        wrapper = _authorize_poll(conn, poll_id, req.creator_secret, request)
         conn.execute(
             """
             UPDATE polls
@@ -917,12 +941,12 @@ def close_poll(poll_id: str, req: CloseQuestionRequest, background_tasks: Backgr
 
 
 @router.post("/{poll_id}/reopen", response_model=PollResponse)
-def reopen_poll(poll_id: str, req: ReopenQuestionRequest):
+def reopen_poll(poll_id: str, req: ReopenQuestionRequest, request: Request):
     """Reopen a closed poll. Phase 5: only the wrapper's is_closed
     matters; questions inherit it via JOIN."""
     now = datetime.now(timezone.utc)
     with get_db() as conn:
-        _authorize_poll(conn, poll_id, req.creator_secret)
+        _authorize_poll(conn, poll_id, req.creator_secret, request)
         conn.execute(
             """
             UPDATE polls
@@ -946,7 +970,10 @@ def reopen_poll(poll_id: str, req: ReopenQuestionRequest):
 
 @router.post("/{poll_id}/cutoff-suggestions", response_model=PollResponse)
 def cutoff_poll_suggestions(
-    poll_id: str, req: CutoffSuggestionsRequest, background_tasks: BackgroundTasks
+    poll_id: str,
+    req: CutoffSuggestionsRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
 ):
     """End the suggestion phase across every question that's still in it.
 
@@ -962,7 +989,7 @@ def cutoff_poll_suggestions(
     """
     now = datetime.now(timezone.utc)
     with get_db() as conn:
-        wrapper = _authorize_poll(conn, poll_id, req.creator_secret)
+        wrapper = _authorize_poll(conn, poll_id, req.creator_secret, request)
 
         # Phase 5: prephase_deadline is wrapper-level. Validate that there's an
         # open suggestion phase (deadline in the future), and that at least one
@@ -1139,7 +1166,10 @@ def submit_poll_votes(poll_id: str, req: SubmitPollVotesRequest, request: Reques
 
 @router.post("/{poll_id}/cutoff-availability", response_model=PollResponse)
 def cutoff_poll_availability(
-    poll_id: str, req: CutoffSuggestionsRequest, background_tasks: BackgroundTasks
+    poll_id: str,
+    req: CutoffSuggestionsRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
 ):
     """End the availability phase of the poll's time question (≤1 enforced
     on create). Phase 5: prephase_deadline is wrapper-level.
@@ -1148,7 +1178,7 @@ def cutoff_poll_availability(
     contract as cutoff-suggestions)."""
     now = datetime.now(timezone.utc)
     with get_db() as conn:
-        wrapper = _authorize_poll(conn, poll_id, req.creator_secret)
+        wrapper = _authorize_poll(conn, poll_id, req.creator_secret, request)
         deadline = wrapper.get("prephase_deadline")
         in_phase = deadline is not None and deadline > now
         time_questions = conn.execute(

--- a/server/tests/test_poll_authorship.py
+++ b/server/tests/test_poll_authorship.py
@@ -1,0 +1,251 @@
+"""Account-owned poll authorship (migration 122).
+
+A poll created by a signed-in user records `creator_user_id`. That account
+may close / reopen / cutoff the poll from ANY device it's signed in on,
+authorized by its session bearer token alone — the per-browser
+`creator_secret` never followed the user across browsers. The secret remains:
+  * the SOLE authority for anonymous-created polls (creator_user_id NULL), and
+  * a backwards-compatible fallback for the signed-in creator's own browser.
+
+Authorization is the shared `_authorize_poll` helper, so close + reopen
+exercise the same gate every poll mutation uses (cutoff endpoints included).
+
+Mirrors test_group_privacy.py's signed-in helpers (real magic-link verify).
+"""
+
+import uuid
+
+import psycopg
+
+from services.auth import generate_token, hash_token, normalize_email
+from tests.conftest import TEST_DB_URL
+
+
+def _bid_headers(bid):
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+def _bearer_headers(bid, token):
+    h = _bid_headers(bid)
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _issue_known_magic_link(email, browser_id):
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO magic_link_tokens
+                  (token_hash, email, browser_id, expires_at)
+                VALUES (%s, %s, %s, NOW() + INTERVAL '15 minutes')
+                """,
+                (hash_token(token), normalize_email(email), browser_id),
+            )
+        conn.commit()
+    return token
+
+
+def _sign_in(client, browser_id, email=None):
+    """Full magic-link verify → (session_token, user_id)."""
+    email = email or f"authorship-{uuid.uuid4().hex[:8]}@example.com"
+    token = _issue_known_magic_link(email, browser_id)
+    resp = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": token},
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    return body["session_token"], body["user"]["user_id"]
+
+
+def _create_poll(client, browser_id, token=None, *, secret=None, **kwargs):
+    secret = secret or f"secret-{uuid.uuid4().hex[:8]}"
+    payload = {
+        "creator_secret": secret,
+        "creator_name": "Authorship Tester",
+        "questions": [{"question_type": "yes_no", "category": "yes_no"}],
+    }
+    payload.update(kwargs)
+    resp = client.post(
+        "/api/polls", json=payload, headers=_bearer_headers(browser_id, token)
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# creator_user_id is recorded at create time + surfaced on the response
+# ---------------------------------------------------------------------------
+
+
+class TestCreatorUserIdRecording:
+    def test_signed_in_create_records_creator_user_id(self, client):
+        bid = str(uuid.uuid4())
+        token, user_id = _sign_in(client, bid)
+        poll = _create_poll(client, bid, token)
+        assert poll["creator_user_id"] == user_id
+
+    def test_anonymous_create_has_null_creator_user_id(self, client):
+        bid = str(uuid.uuid4())
+        poll = _create_poll(client, bid)
+        assert poll["creator_user_id"] is None
+
+    def test_creator_user_id_survives_readback(self, client):
+        bid = str(uuid.uuid4())
+        token, user_id = _sign_in(client, bid)
+        poll = _create_poll(client, bid, token)
+        resp = client.get(
+            f"/api/polls/by-id/{poll['id']}",
+            headers=_bearer_headers(bid, token),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["creator_user_id"] == user_id
+
+
+# ---------------------------------------------------------------------------
+# Account creator authorizes mutations cross-device (no per-browser secret)
+# ---------------------------------------------------------------------------
+
+
+class TestAccountCreatorCrossDevice:
+    def test_close_from_other_device_no_secret(self, client):
+        """Creator signs in on browser A, creates the poll. On browser B
+        (different browser_id, same account token, NO stored secret) the
+        session authorizes the close."""
+        bid_a = str(uuid.uuid4())
+        token, _ = _sign_in(client, bid_a)
+        poll = _create_poll(client, bid_a, token)
+
+        bid_b = str(uuid.uuid4())  # a device that never saw the secret
+        resp = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={},  # creator_secret omitted entirely
+            headers=_bearer_headers(bid_b, token),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["is_closed"] is True
+
+    def test_reopen_from_other_device_empty_secret(self, client):
+        bid_a = str(uuid.uuid4())
+        token, _ = _sign_in(client, bid_a)
+        poll = _create_poll(client, bid_a, token)
+        # Close it (via secret on the creating browser).
+        client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={"creator_secret": poll["creator_secret"]},
+            headers=_bearer_headers(bid_a, token),
+        )
+        # Reopen from another browser using only the session.
+        bid_b = str(uuid.uuid4())
+        resp = client.post(
+            f"/api/polls/{poll['id']}/reopen",
+            json={"creator_secret": ""},
+            headers=_bearer_headers(bid_b, token),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["is_closed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Non-creators are rejected
+# ---------------------------------------------------------------------------
+
+
+class TestNonCreatorRejected:
+    def test_other_signed_in_user_cannot_close(self, client):
+        creator_bid = str(uuid.uuid4())
+        creator_token, _ = _sign_in(client, creator_bid)
+        poll = _create_poll(client, creator_bid, creator_token)
+
+        stranger_bid = str(uuid.uuid4())
+        stranger_token, _ = _sign_in(client, stranger_bid)
+        resp = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={},
+            headers=_bearer_headers(stranger_bid, stranger_token),
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_anonymous_cannot_close_account_poll_without_secret(self, client):
+        creator_bid = str(uuid.uuid4())
+        token, _ = _sign_in(client, creator_bid)
+        poll = _create_poll(client, creator_bid, token)
+        # No token, no secret.
+        resp = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={},
+            headers=_bid_headers(str(uuid.uuid4())),
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_wrong_secret_no_session_rejected(self, client):
+        creator_bid = str(uuid.uuid4())
+        token, _ = _sign_in(client, creator_bid)
+        poll = _create_poll(client, creator_bid, token)
+        resp = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={"creator_secret": "not-the-secret"},
+            headers=_bid_headers(str(uuid.uuid4())),
+        )
+        assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# creator_secret remains valid (backwards-compat + anonymous polls)
+# ---------------------------------------------------------------------------
+
+
+class TestSecretStillWorks:
+    def test_creating_browser_secret_still_closes(self, client):
+        """The signed-in creator's original browser keeps working via the
+        secret even with no session attached (e.g. signed out)."""
+        bid = str(uuid.uuid4())
+        token, _ = _sign_in(client, bid)
+        poll = _create_poll(client, bid, token)
+        resp = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={"creator_secret": poll["creator_secret"]},
+            headers=_bid_headers(bid),  # no Authorization header
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["is_closed"] is True
+
+    def test_anonymous_poll_requires_matching_secret(self, client):
+        bid = str(uuid.uuid4())
+        poll = _create_poll(client, bid)  # anonymous → creator_user_id NULL
+        # Wrong secret → 403.
+        bad = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={"creator_secret": "wrong"},
+            headers=_bid_headers(bid),
+        )
+        assert bad.status_code == 403, bad.text
+        # Correct secret → 200.
+        good = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={"creator_secret": poll["creator_secret"]},
+            headers=_bid_headers(bid),
+        )
+        assert good.status_code == 200, good.text
+        assert good.json()["is_closed"] is True
+
+    def test_signed_in_non_creator_with_correct_secret_still_closes(self, client):
+        """The secret is authority regardless of session: someone who
+        somehow has the secret (e.g. shared) can close even when their
+        session doesn't match the creator. Documents the additive OR."""
+        creator_bid = str(uuid.uuid4())
+        creator_token, _ = _sign_in(client, creator_bid)
+        poll = _create_poll(client, creator_bid, creator_token)
+
+        other_bid = str(uuid.uuid4())
+        other_token, _ = _sign_in(client, other_bid)
+        resp = client.post(
+            f"/api/polls/{poll['id']}/close",
+            json={"creator_secret": poll["creator_secret"]},
+            headers=_bearer_headers(other_bid, other_token),
+        )
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary
- Record the signed-in creator's `user_id` on each poll (migration 122 adds `polls.creator_user_id`, nullable FK → `users(id)`, `ON DELETE SET NULL`), mirroring `groups.creator_user_id`.
- Make the shared `_authorize_poll` chokepoint (close / reopen / cutoff-suggestions / cutoff-availability) **additive**: a mutation is authorized if the session's `user_id` matches the poll's `creator_user_id` **OR** the request's `creator_secret` matches. So a signed-in creator can now manage their poll from any device they're signed in on — the per-browser secret no longer had to follow them.
- `creator_secret` is **not** retired: it stays the sole authority for anonymous-created polls and a same-browser fallback after sign-out. The three poll-mutation request models made `creator_secret` optional; the FE sends an empty secret from a device without one and the bearer token authorizes.
- FE: `Poll.creator_user_id` + `toPoll`; new `isPollCreatedByViewer(poll, anchorId)` (secret OR session) drives creator-gating on the poll info page (session-reactive), the group long-press modal, and `QuestionBallot`.
- Documented a follow-up TODO in CLAUDE.md for fully retiring `creator_secret` (the two remaining cases + a candidate `browser_id`-based design + open threat-model / legacy-poll / claim-flow questions) — intentionally deferred to a separate session.

## Test plan
- [x] New `server/tests/test_poll_authorship.py` (11 tests): records `creator_user_id`; cross-device close/reopen with no secret; non-creator 403; anonymous poll still requires the secret; secret remains valid backwards-compatibly.
- [x] Full server suite green (550 passed) after rebase on main.
- [x] Live demo on the branch dev server: signed-in creator's poll closed from a second browser using only the account session (200), a different signed-in user rejected (403).

https://claude.ai/code/session_01ByiRHFWNtKvjDG3YihSaXE

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByiRHFWNtKvjDG3YihSaXE)_