### PR TITLE
New-options banner: informational, above the card, simpler label

### DIFF
--- a/components/NewOptionsBanner.tsx
+++ b/components/NewOptionsBanner.tsx
@@ -1,11 +1,12 @@
-// Amber "new options available since you last ranked" alert. Shared by the
-// poll detail page's steady-state ("Your Ballot") view (QuestionBallot) and the
-// in-edit ranking ballot (RankingSection) so both surfaces stay in lockstep.
+// Amber "new options since you last ranked" note. Shared by the poll detail
+// page's steady-state ("Your Ballot") view (QuestionBallot) and the in-edit
+// ranking ballot (RankingSection) so both surfaces stay in lockstep.
 // New-options detection lives in QuestionBallot's `newOptions` memo
 // (seen-options snapshot from lib/browserQuestionAccess.ts).
 //
-// When `onClick` is provided the banner is a button ("— tap to rank" + chevron)
-// that enters ranking-edit mode; without it the banner is informational.
+// Informational only — entering edit mode is reached via the edit affordance
+// right next to it (the "Edit" button in RankingSection's summary, the
+// "Your Ballot" link in QuestionBallot's steady-state view).
 
 const WARNING_ICON = (
   <svg className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -16,30 +17,11 @@ const WARNING_ICON = (
 interface NewOptionsBannerProps {
   count: number;
   className?: string;
-  onClick?: () => void;
 }
 
-export default function NewOptionsBanner({ count, className = "mb-2", onClick }: NewOptionsBannerProps) {
+export default function NewOptionsBanner({ count, className = "mb-2" }: NewOptionsBannerProps) {
   if (count <= 0) return null;
-  const label = `New option${count > 1 ? "s" : ""} available since you last ranked`;
-
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={`${className} w-full px-3 py-2 bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded-lg flex items-center gap-2 text-left hover:bg-amber-100 dark:hover:bg-amber-900/50 active:opacity-80 transition-colors`}
-      >
-        {WARNING_ICON}
-        <span className="flex-1 text-sm text-amber-800 dark:text-amber-200 font-medium">
-          {label} — tap to rank
-        </span>
-        <svg className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
-      </button>
-    );
-  }
+  const label = `New option${count > 1 ? "s" : ""} since you last ranked`;
 
   return (
     <div className={`${className} px-3 py-2 bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded-lg flex items-center gap-2`}>

--- a/components/QuestionBallot.tsx
+++ b/components/QuestionBallot.tsx
@@ -1445,15 +1445,13 @@ const QuestionBallot = forwardRef<QuestionBallotHandle, QuestionBallotProps>(fun
                 </div>
               ) : hasVoted && !isEditingVote && !canSubmitSuggestions && hasCompletedRanking && questionOptions.length !== 2 ? (
                 <>
-                  {/* Surface the "new options added" banner up-front on poll
-                      open, so the user sees it without first tapping into the
-                      ballot. Tapping it enters edit mode (same as "Your Ballot"),
-                      where RankingSection drops the new options into the unranked
-                      pool. RankingSection shows the same banner once editing. */}
-                  <NewOptionsBanner
-                    count={newOptions.length}
-                    onClick={isLoadingVoteData ? undefined : () => setIsEditingVote(true)}
-                  />
+                  {/* Surface the "new options added" note up-front on poll open,
+                      so the user sees it without first tapping into the ballot.
+                      Informational only — the "Your Ballot" link right below is
+                      the edit affordance. RankingSection shows the same note
+                      once editing, where the new options land in the unranked
+                      pool. */}
+                  <NewOptionsBanner count={newOptions.length} />
                   <div className="text-center">
                     <button
                       type="button"

--- a/components/RankingSection.tsx
+++ b/components/RankingSection.tsx
@@ -162,13 +162,6 @@ export default function RankingSection({
   // During suggestion phase, only show after user has submitted suggestions
   if (canSubmitSuggestions && !hasVoted) return null;
 
-  // When the user has voted but isn't yet editing, the banner is a button:
-  // tapping it enters ranking-edit mode. RankableOptions then restores the prior
-  // rankings (initialRanking/initialTiers) and drops the new options into the
-  // unranked "no preference" pool. While already editing, the banner is just an
-  // informational note (no action left to take).
-  const newOptionsBannerClickable = !isEditingRanking && !isQuestionClosed && !isLoadingVoteData;
-
   return (
     <>
       {/* "Early Voting" header/countdown/warning stays OUTSIDE the ballot
@@ -183,12 +176,14 @@ export default function RankingSection({
         </>
       )}
 
+      {/* Informational note ABOVE the ranking card (not inside it). Editing is
+          reached via the "Edit" button in the card's summary. mt-3 gives space
+          above it in edit mode (where the Early Voting header is hidden) and
+          collapses with the warning's mb-3 in the summary view. */}
+      <NewOptionsBanner count={newOptions?.length ?? 0} className="mt-3 mb-2" />
+
       {card(
       <>
-      <NewOptionsBanner
-        count={newOptions?.length ?? 0}
-        onClick={newOptionsBannerClickable ? enterRankingEdit : undefined}
-      />
 
       <div className="mb-2">
         {showSummary && hasSubmittedRankings && (


### PR DESCRIPTION
## Summary
Refines the shared `components/NewOptionsBanner.tsx` (added in #481) per design feedback:
- **Drops the word "available"** from the label → "New option(s) since you last ranked".
- **Drops the clickable "— tap to rank" button variant** — the banner is now informational only. Entering edit mode is via the affordance right next to it (the "Edit" button in RankingSection's summary, the "Your Ballot" link in QuestionBallot's steady-state view).
- **In RankingSection the note now renders above the ranking card** (not inside it), with `mt-3` top spacing so it has breathing room in edit mode (where the Early Voting header is hidden) and collapses with the warning's `mb-3` in the summary view.
- QuestionBallot's "Your Ballot" view shows the same informational note above the Your Ballot link.

Builds on #478 (banner→edit) and #481 (banner on poll-detail open); supersedes the clickable styling those introduced.

## Test plan
- [x] Verified live on a dev server (early-voting ranked-choice suggestion poll): banner renders above the card as "New option since you last ranked" with space above it; tapping the Edit button enters edit mode with the prior ranking preserved and the new option in the unranked pool.

https://claude.ai/code/session_01N1tPdMUSuDHaMcFC99yCu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1tPdMUSuDHaMcFC99yCu5)_