### PR TITLE
Redesign settings: read-only profile + dedicated /settings/edit editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2644,6 +2644,16 @@ The MIME-type / 5 MiB constants are intentionally duplicated from `routers/group
 
 ---
 
+## Settings Page Layout (read-only + dedicated editor)
+
+The settings page (`app/settings/page.tsx`) is a read-only profile + account surface; editing the photo / name / reference location happens on a dedicated `/settings/edit` route (`app/settings/edit/page.tsx`), mirroring the `/info → /edit-title` pattern.
+
+- **Header chrome lives in the page, not the template.** `app/settings/page.tsx` renders its own floating back (→ `/`) + **Edit** (→ `/settings/edit`) buttons via `<HeaderPortal>` using the same `fixed left-3/right-3 z-30 ... rounded-full bg-white ... border` bubble class stack as `/info`. The old template-level settings back button was removed. `app/template.tsx` still renders the centered settings *title*, and `isSettingsEditPage` (`/settings/edit[/]`) is added to the fallback-header exclusions so the editor renders only its own back + Save buttons.
+- **The settings header title is the saved account/display name, falling back to "Settings".** `template.tsx` holds a `settingsName` state (init null for SSR parity → "Settings" on first paint), reads `getUserName()` on mount + on `SESSION_CHANGED_EVENT`, keyed on `[pathname]` (name edits happen on `/settings/edit`, which navigates back and remounts the template, so the on-mount read catches them). Don't lazy-init from `getUserName()` in `useState` — that produces a hydration mismatch on the `<h1>` text.
+- **Read-only vs editable split.** Settings shows: read-only avatar (the name is the title now, so there's no Name row), a card with Reference Location + Theme rows, the Unread-polls toggles, and the account/sign-in cluster. The editor owns the staging logic (image crop/upload/remove + account gate, `CompactNameField`, typed-location geocode-on-Save, detect/clear) with a header Save + "Discard your changes?" confirmation; there is NO bottom Save button on the settings page anymore.
+- **The account / sign-in cluster sits directly below the avatar** (Account row, Add-a-sign-in-method, Passkeys, the shared status `message`, Sign out) — account identity reads as a unit under the account image. **Sign out is a separate full-width button behind a `ConfirmationModal`**, not an inline link. The Delete-account and Clear-Settings buttons were removed (and with them `apiDeleteAccount` + the `clearUser*` / `apiDeleteMyUserImage` / `clearCachedMyUserProfile` usage on this page).
+- **`/settings/edit` navigation uses `navigateWithTransition` (view transitions), not the group slide-overlay** — settings isn't a group-family route. Back from the editor is `navigateWithTransition(router, '/settings', 'back')` (a push to a fixed destination, matching `/edit-title`'s "back = go to the parent page" convention, not `history.back`).
+
 ## Theme Switcher (Light / Dark / System)
 
 The settings page (`app/settings/page.tsx`) exposes a 3-option sliding segmented control for color theme. The preference lives in `localStorage[whoeverwants_theme]` (`THEME_KEY` exported from `lib/theme.ts`); selecting "System" REMOVES the key so the page falls through to `prefers-color-scheme`.

--- a/app/settings/edit/page.tsx
+++ b/app/settings/edit/page.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import {
+  getUserName,
+  saveUserName,
+  getUserLocation,
+  saveUserLocation,
+  clearUserLocation,
+  type UserLocation,
+} from "@/lib/userProfile";
+import { isValidUserName } from "@/lib/nameValidation";
+import {
+  apiGeocode,
+  apiUploadMyUserImage,
+  apiDeleteMyUserImage,
+} from "@/lib/api";
+import { usePageReady } from "@/lib/usePageReady";
+import { navigateWithTransition } from "@/lib/viewTransitions";
+import { detectAndSaveUserLocation, GeolocationDeniedError } from "@/lib/geolocation";
+import CompactNameField from "@/components/CompactNameField";
+import InitialBubble from "@/components/InitialBubble";
+import ImageCropModal from "@/components/ImageCropModal";
+import AccountGateModal from "@/components/AccountGateModal";
+import ConfirmationModal from "@/components/ConfirmationModal";
+import HeaderPortal from "@/components/HeaderPortal";
+import { useMyUserImageUrl } from "@/lib/useMyUserImageUrl";
+import { haptic } from "@/lib/haptics";
+
+/**
+ * Profile editor — mirrors the /info → /edit-title pattern. Image, name, and
+ * reference location are edited here; the main settings page displays them
+ * read-only. Changes commit on the header Save button (image upload/remove,
+ * name, typed location are deferred); the location "Detect"/"Clear" controls
+ * commit immediately. Back triggers a "Discard changes?" confirmation when
+ * anything is staged.
+ */
+export default function SettingsEditPage() {
+  const router = useRouter();
+  usePageReady(true);
+
+  const [name, setName] = useState("");
+  const [initialName, setInitialName] = useState("");
+  const [locationInput, setLocationInput] = useState("");
+  const [savedLocation, setSavedLocation] = useState<UserLocation | null>(null);
+  const [isGeolocating, setIsGeolocating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  // Image staging mirrors /edit-title: pendingCroppedBlob (new upload) vs
+  // pendingImageRemoval (clear). The current account image comes from the
+  // shared useMyUserImageUrl() hook.
+  const [pickedFile, setPickedFile] = useState<File | null>(null);
+  const [pendingCroppedBlob, setPendingCroppedBlob] = useState<Blob | null>(null);
+  const [pendingImageRemoval, setPendingImageRemoval] = useState(false);
+  const [localImagePreviewUrl, setLocalImagePreviewUrl] = useState<string | null>(null);
+  const [photoGateOpen, setPhotoGateOpen] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const serverImageUrl = useMyUserImageUrl();
+
+  useEffect(() => {
+    const savedName = getUserName() ?? "";
+    setName(savedName);
+    setInitialName(savedName);
+    setSavedLocation(getUserLocation());
+  }, []);
+
+  // Object-URL lifecycle for the cropped preview blob.
+  useEffect(() => {
+    if (!pendingCroppedBlob) {
+      setLocalImagePreviewUrl(null);
+      return;
+    }
+    const u = URL.createObjectURL(pendingCroppedBlob);
+    setLocalImagePreviewUrl(u);
+    return () => {
+      URL.revokeObjectURL(u);
+    };
+  }, [pendingCroppedBlob]);
+
+  const effectiveImageUrl = pendingCroppedBlob
+    ? localImagePreviewUrl
+    : pendingImageRemoval
+      ? null
+      : serverImageUrl;
+
+  const hasPendingImageChange = pendingCroppedBlob !== null || pendingImageRemoval;
+  const nameChanged = name.trim() !== initialName.trim();
+  const hasUnsavedChanges = nameChanged || locationInput.trim() !== "" || hasPendingImageChange;
+
+  const openFilePicker = () => {
+    if (saving) return;
+    // The photo is account data — gate behind the same account-setup modal as
+    // creating a group / voting when the user has no name/account yet.
+    if (!isValidUserName(getUserName())) {
+      setPhotoGateOpen(true);
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const onFileChosen = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setPickedFile(file);
+  };
+
+  const onCropConfirm = (croppedBlob: Blob) => {
+    setPendingCroppedBlob(croppedBlob);
+    setPendingImageRemoval(false);
+    setPickedFile(null);
+  };
+
+  const onRemoveImage = () => {
+    if (saving) return;
+    if (pendingCroppedBlob) {
+      setPendingCroppedBlob(null);
+      return;
+    }
+    if (serverImageUrl) {
+      setPendingImageRemoval(true);
+    }
+  };
+
+  const navigateAway = () => {
+    navigateWithTransition(router, "/settings", "back");
+  };
+
+  const handleBack = () => {
+    if (hasUnsavedChanges) {
+      setShowDiscardConfirm(true);
+      return;
+    }
+    navigateAway();
+  };
+
+  const discardAndLeave = () => {
+    setShowDiscardConfirm(false);
+    navigateAway();
+  };
+
+  const handleSave = async () => {
+    if (saving) return;
+    haptic.success();
+    setSaving(true);
+    setMessage(null);
+
+    try {
+      saveUserName(name);
+      setInitialName(name.trim());
+
+      // Geocode a typed location if provided.
+      if (locationInput.trim()) {
+        const result = await apiGeocode(locationInput.trim());
+        if (result && result.lat && result.lon) {
+          const loc: UserLocation = {
+            latitude: parseFloat(result.lat),
+            longitude: parseFloat(result.lon),
+            label: result.label,
+          };
+          saveUserLocation(loc);
+          setSavedLocation(loc);
+          setLocationInput("");
+        } else {
+          setMessage({ type: "error", text: "Could not find that location. Try a zip code or city name." });
+          setSaving(false);
+          return;
+        }
+      }
+
+      if (pendingCroppedBlob) {
+        // Pass the current name so the server can mint an account to own the
+        // photo when the caller has none yet (the openFilePicker gate ensures
+        // a name exists). Ignored when an account already resolves.
+        await apiUploadMyUserImage(pendingCroppedBlob, name);
+        setPendingCroppedBlob(null);
+      } else if (pendingImageRemoval) {
+        await apiDeleteMyUserImage();
+        setPendingImageRemoval(false);
+      }
+
+      navigateAway();
+    } catch {
+      setMessage({ type: "error", text: "Failed to save settings" });
+      setSaving(false);
+    }
+  };
+
+  const handleDetectLocation = async () => {
+    setIsGeolocating(true);
+    setMessage(null);
+    try {
+      const loc = await detectAndSaveUserLocation();
+      setSavedLocation(loc);
+      setLocationInput("");
+      setMessage({ type: "success", text: `Location set to ${loc.label}` });
+    } catch (err) {
+      if (err instanceof GeolocationDeniedError) {
+        setMessage({ type: "error", text: "Location access denied" });
+      } else {
+        setMessage({ type: "error", text: "Failed to determine your location" });
+      }
+    } finally {
+      setIsGeolocating(false);
+    }
+  };
+
+  return (
+    <>
+      {/* Floating opaque-bubble buttons portaled outside .responsive-scaling-container
+       *  so position:fixed is viewport-relative on desktop. Mirrors the /info +
+       *  /edit-title back + action buttons. */}
+      <HeaderPortal>
+        <button
+          onClick={handleBack}
+          className="fixed left-3 z-30 w-10 h-10 flex items-center justify-center rounded-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 active:opacity-70"
+          style={{ top: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+          aria-label="Go back"
+        >
+          <svg className="w-6 h-6 text-gray-700 dark:text-gray-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="fixed right-3 z-30 h-10 px-4 flex items-center justify-center rounded-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 active:opacity-70 disabled:opacity-50 text-blue-600 dark:text-blue-400 text-sm font-medium"
+          style={{ top: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+          aria-label="Save profile"
+        >
+          {saving ? "..." : "Save"}
+        </button>
+      </HeaderPortal>
+
+      <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 1.05rem)" }}>
+        {/* Avatar + badges — camera badge opens the file picker; X badge stages
+            an image removal (only shown when an image is displayed). Both badges
+            are siblings of the avatar button so their handlers stay independent. */}
+        <div className="flex flex-col items-center mb-6">
+          <div className="relative">
+            <button
+              type="button"
+              onClick={openFilePicker}
+              disabled={saving}
+              aria-label="Change profile photo"
+              className="block outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full disabled:opacity-60"
+            >
+              <InitialBubble
+                imageUrl={effectiveImageUrl}
+                name={name}
+                sizeClassName="w-28 h-28"
+                textSizeClassName="text-2xl"
+              />
+              <span
+                className="absolute bottom-0 right-0 w-9 h-9 rounded-full bg-blue-600 dark:bg-blue-500 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900"
+                aria-hidden
+              >
+                <CameraPencilIcon />
+              </span>
+            </button>
+            {effectiveImageUrl && !saving && (
+              <button
+                type="button"
+                onClick={onRemoveImage}
+                aria-label="Remove profile photo"
+                className="absolute top-0 right-0 w-7 h-7 rounded-full bg-gray-500 dark:bg-gray-600 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900 hover:bg-gray-600 dark:hover:bg-gray-500 active:scale-95 transition-transform"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            )}
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={onFileChosen}
+            className="hidden"
+          />
+        </div>
+
+        {/* Name */}
+        <div className="mb-6">
+          <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
+            <CompactNameField name={name} setName={setName} disabled={saving} />
+          </section>
+        </div>
+
+        {/* Reference Location */}
+        <div className="mb-6">
+          <label htmlFor="location" className="block text-sm font-medium mb-1">
+            Reference Location
+          </label>
+          {savedLocation && (
+            <div className="mb-2 flex items-center gap-2">
+              <span className="text-sm text-gray-600 dark:text-gray-400">Current:</span>
+              <span className="text-sm font-medium">{savedLocation.label}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  clearUserLocation();
+                  setSavedLocation(null);
+                }}
+                className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+              >
+                Clear
+              </button>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              id="location"
+              value={locationInput}
+              onChange={(e) => setLocationInput(e.target.value)}
+              onBlur={(e) => setLocationInput(e.target.value.trim())}
+              placeholder={savedLocation ? "Update location..." : "Zip code or city name..."}
+              maxLength={200}
+              className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
+              disabled={saving || isGeolocating}
+            />
+            <button
+              type="button"
+              onClick={handleDetectLocation}
+              disabled={saving || isGeolocating}
+              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Detect my location"
+            >
+              {isGeolocating ? (
+                <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+              ) : (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              )}
+            </button>
+          </div>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            Used as the reference point for calculating distance in location-based questions
+          </p>
+        </div>
+
+        {message && (
+          <div
+            className={`mb-4 p-3 rounded-md text-sm ${
+              message.type === "success"
+                ? "bg-green-100 dark:bg-green-900/20 text-green-700 dark:text-green-300 border border-green-400 dark:border-green-600"
+                : "bg-red-100 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-400 dark:border-red-600"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+      </div>
+
+      {pickedFile && (
+        <ImageCropModal
+          file={pickedFile}
+          onCancel={() => setPickedFile(null)}
+          onConfirm={onCropConfirm}
+        />
+      )}
+
+      <AccountGateModal
+        isOpen={photoGateOpen}
+        message="to add a profile photo"
+        onSubmit={() => {
+          setPhotoGateOpen(false);
+          fileInputRef.current?.click();
+        }}
+        onCancel={() => setPhotoGateOpen(false)}
+      />
+
+      <ConfirmationModal
+        isOpen={showDiscardConfirm}
+        message="Discard your changes?"
+        confirmText="Discard"
+        confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
+        onConfirm={discardAndLeave}
+        onCancel={() => setShowDiscardConfirm(false)}
+      />
+    </>
+  );
+}
+
+function CameraPencilIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 7h3l2-3h6l2 3h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" />
+      <circle cx="12" cy="13" r="3.5" />
+    </svg>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -361,8 +361,9 @@ export default function SettingsPage() {
         </button>
       </HeaderPortal>
 
-      {/* Profile — read-only display of avatar + name + reference location.
-          Editing lives on /settings/edit (via the header Edit button). */}
+      {/* Profile — read-only avatar (the name is the header title). The card
+          below holds reference location + theme. Editing the photo / name /
+          location lives on /settings/edit (via the header Edit button). */}
       <div className="mb-6 flex flex-col items-center">
         <InitialBubble
           imageUrl={serverImageUrl}
@@ -374,12 +375,6 @@ export default function SettingsPage() {
 
       <div className="mb-6">
         <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4 divide-y divide-gray-200 dark:divide-gray-700">
-          <div className="flex items-center justify-between gap-3 h-12">
-            <span className="text-base font-normal shrink-0">Name</span>
-            <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
-              {name.trim() || "Not set"}
-            </span>
-          </div>
           <div className="flex items-center justify-between gap-3 h-12">
             <span className="text-base font-normal shrink-0">Reference Location</span>
             <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -13,7 +13,6 @@ import {
   apiSignOut,
   apiListPasskeys,
   apiDeletePasskey,
-  apiDeleteAccount,
   getCurrentUser,
   type PasskeySummary,
 } from "@/lib/api";
@@ -106,8 +105,6 @@ export default function SettingsPage() {
   // signed in AND the account has no 'email' provider (passkey-only /
   // OAuth-only / name-only).
   const [addSignInOpen, setAddSignInOpen] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [deleteInFlight, setDeleteInFlight] = useState(false);
 
   const hasEmailIdentity = !!currentUser?.providers?.includes("email");
 
@@ -178,28 +175,6 @@ export default function SettingsPage() {
       await apiSignOut();
     } finally {
       setSignOutInFlight(false);
-    }
-  };
-
-  const handleDeleteAccount = async () => {
-    if (deleteInFlight) return;
-    setDeleteInFlight(true);
-    try {
-      await apiDeleteAccount();
-      setShowDeleteConfirm(false);
-      // clearSession (inside apiDeleteAccount) fires SESSION_CHANGED_EVENT,
-      // so the subscribed effect flips currentUser → null and the UI
-      // reverts to the anonymous state without a navigation.
-      setMessage({ type: "success", text: "Your account was deleted." });
-    } catch (err) {
-      setShowDeleteConfirm(false);
-      setMessage({
-        type: "error",
-        text:
-          err instanceof Error ? err.message : "Couldn't delete your account.",
-      });
-    } finally {
-      setDeleteInFlight(false);
     }
   };
 
@@ -655,25 +630,6 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      {/* Delete account — Phase I. Only when signed in. Cascades through
-          every users(id) FK server-side; this browser reverts to
-          anonymous (groups + created polls stay reachable). */}
-      {currentUser && (
-        <div className="mb-6">
-          <button
-            type="button"
-            onClick={() => setShowDeleteConfirm(true)}
-            className="w-full rounded-full border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors flex items-center justify-center font-medium text-base h-12"
-          >
-            Delete account
-          </button>
-          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
-            Permanently removes your account and sign-in methods. Polls and
-            groups you created stay on this device.
-          </p>
-        </div>
-      )}
-
       {/* About Section */}
       <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
         <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 text-center">
@@ -715,16 +671,6 @@ export default function SettingsPage() {
           await handleSignOut();
         }}
         onCancel={() => setShowSignOutConfirm(false)}
-      />
-
-      <ConfirmationModal
-        isOpen={showDeleteConfirm}
-        title="Delete account?"
-        message="This permanently deletes your account and all sign-in methods (email, passkeys, connected accounts). This can't be undone. Polls and groups you created stay on this device."
-        confirmText={deleteInFlight ? "Deleting…" : "Delete account"}
-        confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
-        onConfirm={handleDeleteAccount}
-        onCancel={() => setShowDeleteConfirm(false)}
       />
 
       <SignInModal

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -598,7 +598,7 @@ export default function SettingsPage() {
           About
         </h3>
         <p className="text-sm text-gray-600 dark:text-gray-400 text-center mb-4">
-          WhoeverWants is an open-source questioning application
+          WhoeverWants is free and open-source
         </p>
         <a
           href="https://github.com/samcarey/whoeverwants"

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -373,124 +373,9 @@ export default function SettingsPage() {
         />
       </div>
 
-      <div className="mb-6">
-        <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4 divide-y divide-gray-200 dark:divide-gray-700">
-          <div className="flex items-center justify-between gap-3 h-12">
-            <span className="text-base font-normal shrink-0">Reference Location</span>
-            <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
-              {savedLocation ? savedLocation.label : "Not set"}
-            </span>
-          </div>
-          <label className="flex items-center justify-between gap-3 h-12 cursor-pointer">
-            <span className="text-base font-normal shrink-0">Theme</span>
-            <span className="relative inline-flex items-center gap-1.5 text-base font-normal text-gray-500 dark:text-gray-500">
-              {selectedTheme?.icon}
-              {selectedTheme?.label}
-              <svg
-                aria-hidden="true"
-                className="w-4 h-4 shrink-0"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04L10 15.148l2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              <select
-                value={theme}
-                onChange={(e) => handleThemeChange(e.target.value as ThemePreference)}
-                className="absolute inset-0 opacity-0 cursor-pointer"
-                aria-label="Theme"
-              >
-                {THEME_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </span>
-          </label>
-        </section>
-      </div>
-
-      {/* Unread polls: the app-icon badge counts unread polls, and the gold
-          bar on group cards marks them. Three account-synced switches.
-          "Stay unread until I respond" gates the two re-light toggles (inert
-          in that mode, where unread = open + un-responded). */}
-      <div className="mb-6">
-        <h2 className="block text-[17.5px] font-medium text-gray-500 dark:text-gray-400 mb-1 px-1">
-          Unread polls
-        </h2>
-        <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4 divide-y divide-gray-200 dark:divide-gray-700">
-          <div
-            className="flex items-center justify-between gap-3 h-12 cursor-pointer"
-            onClick={() => updateBadge({ ...badge, todoMode: !badge.todoMode })}
-          >
-            <span className="text-base font-normal shrink-0">Stay unread until I respond</span>
-            <SliderSwitch
-              checked={badge.todoMode}
-              onChange={(v) => updateBadge({ ...badge, todoMode: v })}
-              aria-label="Stay unread until I respond"
-            />
-          </div>
-          <div
-            className={`flex items-center justify-between gap-3 h-12 ${
-              badge.todoMode ? "cursor-not-allowed" : "cursor-pointer"
-            }`}
-            onClick={() => {
-              if (!badge.todoMode) updateBadge({ ...badge, onVotingOpen: !badge.onVotingOpen });
-            }}
-          >
-            <span
-              className={`text-base font-normal shrink-0 ${
-                badge.todoMode ? "text-gray-400 dark:text-gray-500" : ""
-              }`}
-            >
-              Mark unread when voting opens
-            </span>
-            <SliderSwitch
-              checked={badge.onVotingOpen}
-              onChange={(v) => updateBadge({ ...badge, onVotingOpen: v })}
-              disabled={badge.todoMode}
-              aria-label="Mark unread when voting opens"
-            />
-          </div>
-          <div
-            className={`flex items-center justify-between gap-3 h-12 ${
-              badge.todoMode ? "cursor-not-allowed" : "cursor-pointer"
-            }`}
-            onClick={() => {
-              if (!badge.todoMode) updateBadge({ ...badge, onResults: !badge.onResults });
-            }}
-          >
-            <span
-              className={`text-base font-normal shrink-0 ${
-                badge.todoMode ? "text-gray-400 dark:text-gray-500" : ""
-              }`}
-            >
-              Mark unread when results arrive
-            </span>
-            <SliderSwitch
-              checked={badge.onResults}
-              onChange={(v) => updateBadge({ ...badge, onResults: v })}
-              disabled={badge.todoMode}
-              aria-label="Mark unread when results arrive"
-            />
-          </div>
-        </section>
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          {badge.todoMode
-            ? "An open poll stays unread until you vote or abstain — opening it isn't enough. The app-icon badge counts these."
-            : "Opening a poll marks it read. It becomes unread again when voting opens or results arrive (toggles above)."}
-        </p>
-      </div>
-
-      {/* Account section — Phase A + B (sign in/out) + Phase I (linked
-          identities, recovery email, delete). Single-row "Account" +
-          Sign out / Sign in header; when signed in, a second row lists
-          the linked sign-in methods. */}
+      {/* Account / sign-in cluster — sits directly below the account image:
+          sign in (or signed-in email + linked methods), add a sign-in method,
+          passkeys, the shared status message, and sign out. */}
       <div className="mb-6">
         <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
           <div className="flex items-center justify-between gap-3 h-12">
@@ -646,6 +531,120 @@ export default function SettingsPage() {
           {signOutInFlight ? "Signing out…" : "Sign out"}
         </button>
       )}
+
+      <div className="mb-6">
+        <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4 divide-y divide-gray-200 dark:divide-gray-700">
+          <div className="flex items-center justify-between gap-3 h-12">
+            <span className="text-base font-normal shrink-0">Reference Location</span>
+            <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
+              {savedLocation ? savedLocation.label : "Not set"}
+            </span>
+          </div>
+          <label className="flex items-center justify-between gap-3 h-12 cursor-pointer">
+            <span className="text-base font-normal shrink-0">Theme</span>
+            <span className="relative inline-flex items-center gap-1.5 text-base font-normal text-gray-500 dark:text-gray-500">
+              {selectedTheme?.icon}
+              {selectedTheme?.label}
+              <svg
+                aria-hidden="true"
+                className="w-4 h-4 shrink-0"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04L10 15.148l2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <select
+                value={theme}
+                onChange={(e) => handleThemeChange(e.target.value as ThemePreference)}
+                className="absolute inset-0 opacity-0 cursor-pointer"
+                aria-label="Theme"
+              >
+                {THEME_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+        </section>
+      </div>
+
+      {/* Unread polls: the app-icon badge counts unread polls, and the gold
+          bar on group cards marks them. Three account-synced switches.
+          "Stay unread until I respond" gates the two re-light toggles (inert
+          in that mode, where unread = open + un-responded). */}
+      <div className="mb-6">
+        <h2 className="block text-[17.5px] font-medium text-gray-500 dark:text-gray-400 mb-1 px-1">
+          Unread polls
+        </h2>
+        <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4 divide-y divide-gray-200 dark:divide-gray-700">
+          <div
+            className="flex items-center justify-between gap-3 h-12 cursor-pointer"
+            onClick={() => updateBadge({ ...badge, todoMode: !badge.todoMode })}
+          >
+            <span className="text-base font-normal shrink-0">Stay unread until I respond</span>
+            <SliderSwitch
+              checked={badge.todoMode}
+              onChange={(v) => updateBadge({ ...badge, todoMode: v })}
+              aria-label="Stay unread until I respond"
+            />
+          </div>
+          <div
+            className={`flex items-center justify-between gap-3 h-12 ${
+              badge.todoMode ? "cursor-not-allowed" : "cursor-pointer"
+            }`}
+            onClick={() => {
+              if (!badge.todoMode) updateBadge({ ...badge, onVotingOpen: !badge.onVotingOpen });
+            }}
+          >
+            <span
+              className={`text-base font-normal shrink-0 ${
+                badge.todoMode ? "text-gray-400 dark:text-gray-500" : ""
+              }`}
+            >
+              Mark unread when voting opens
+            </span>
+            <SliderSwitch
+              checked={badge.onVotingOpen}
+              onChange={(v) => updateBadge({ ...badge, onVotingOpen: v })}
+              disabled={badge.todoMode}
+              aria-label="Mark unread when voting opens"
+            />
+          </div>
+          <div
+            className={`flex items-center justify-between gap-3 h-12 ${
+              badge.todoMode ? "cursor-not-allowed" : "cursor-pointer"
+            }`}
+            onClick={() => {
+              if (!badge.todoMode) updateBadge({ ...badge, onResults: !badge.onResults });
+            }}
+          >
+            <span
+              className={`text-base font-normal shrink-0 ${
+                badge.todoMode ? "text-gray-400 dark:text-gray-500" : ""
+              }`}
+            >
+              Mark unread when results arrive
+            </span>
+            <SliderSwitch
+              checked={badge.onResults}
+              onChange={(v) => updateBadge({ ...badge, onResults: v })}
+              disabled={badge.todoMode}
+              aria-label="Mark unread when results arrive"
+            />
+          </div>
+        </section>
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          {badge.todoMode
+            ? "An open poll stays unread until you vote or abstain — opening it isn't enough. The app-icon badge counts these."
+            : "Opening a poll marks it read. It becomes unread again when voting opens or results arrive (toggles above)."}
+        </p>
+      </div>
 
       {/* Divider */}
       <div className="border-t border-gray-200 dark:border-gray-700 pt-6 mb-6">

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getUserName, saveUserName, clearUserName, getUserLocation, saveUserLocation, clearUserLocation, type UserLocation } from "@/lib/userProfile";
-import { isValidUserName } from "@/lib/nameValidation";
+import { getUserName, clearUserName, getUserLocation, clearUserLocation, type UserLocation } from "@/lib/userProfile";
 import {
-  apiGeocode,
   apiGetMyUserProfile,
-  apiUploadMyUserImage,
   apiDeleteMyUserImage,
   cacheMyUserProfile,
   clearCachedMyUserProfile,
@@ -30,11 +27,9 @@ import { SESSION_CHANGED_EVENT, type SessionUser } from "@/lib/session";
 import SignInModal from "@/components/SignInModal";
 import AddSignInOptionsModal from "@/components/AddSignInOptionsModal";
 import { usePageReady } from "@/lib/usePageReady";
-import { detectAndSaveUserLocation, GeolocationDeniedError } from "@/lib/geolocation";
-import CompactNameField from "@/components/CompactNameField";
+import { navigateWithTransition } from "@/lib/viewTransitions";
+import HeaderPortal from "@/components/HeaderPortal";
 import InitialBubble from "@/components/InitialBubble";
-import ImageCropModal from "@/components/ImageCropModal";
-import AccountGateModal from "@/components/AccountGateModal";
 import { useMyUserImageUrl } from "@/lib/useMyUserImageUrl";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import { getStoredTheme, saveTheme, type ThemePreference } from "@/lib/theme";
@@ -45,7 +40,6 @@ import {
   type BadgeSettings,
 } from "@/lib/badgeSettings";
 import SliderSwitch from "@/components/SliderSwitch";
-import { haptic } from "@/lib/haptics";
 
 const THEME_OPTIONS: ReadonlyArray<{ value: ThemePreference; label: string; icon: React.ReactNode }> = [
   {
@@ -83,38 +77,19 @@ export default function SettingsPage() {
   const router = useRouter();
   usePageReady(true);
   const [name, setName] = useState("");
-  // Snapshot of the saved name at mount, so the Save button can detect
-  // "user cleared their saved name" (name="" but savedName was non-empty)
-  // as a real change to commit — without this, clearing the name leaves
-  // Save disabled with nothing else dirty.
-  const [initialName, setInitialName] = useState("");
-  const [locationInput, setLocationInput] = useState("");
   const [savedLocation, setSavedLocation] = useState<UserLocation | null>(null);
   const [theme, setTheme] = useState<ThemePreference>("system");
   // App-icon badge model. Init to defaults (SSR-safe); pulled from the
   // effective settings (account when signed in, else localStorage) on mount
   // and whenever the signed-in identity changes.
   const [badge, setBadge] = useState<BadgeSettings>(DEFAULT_BADGE_SETTINGS);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isGeolocating, setIsGeolocating] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null);
 
-  // Profile-image state mirrors the staging pattern from /edit-title:
-  // pendingCroppedBlob (new upload pending Save) vs pendingImageRemoval
-  // (clear pending Save). The current account image comes from the shared
-  // `useMyUserImageUrl()` hook, which reads the cache synchronously and
-  // refreshes on USER_PROFILE_CHANGED_EVENT — so it clears on sign-out and
-  // updates on sign-in (account photo) without bespoke state to keep in sync.
-  const [pickedFile, setPickedFile] = useState<File | null>(null);
-  const [pendingCroppedBlob, setPendingCroppedBlob] = useState<Blob | null>(null);
-  const [pendingImageRemoval, setPendingImageRemoval] = useState(false);
-  const [localImagePreviewUrl, setLocalImagePreviewUrl] = useState<string | null>(null);
+  // Read-only display of the current profile image. Editing (upload /
+  // remove) lives on /settings/edit; this just reflects the cached value
+  // and refreshes on USER_PROFILE_CHANGED_EVENT (clears on sign-out,
+  // updates on sign-in).
   const serverImageUrl = useMyUserImageUrl();
-  const [imageSaving, setImageSaving] = useState(false);
-  const [showDiscardImageConfirm, setShowDiscardImageConfirm] = useState(false);
-  // Account-setup gate shown when an account-less user tries to add a photo.
-  const [photoGateOpen, setPhotoGateOpen] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // Initialize null for SSR parity (no localStorage on the server); the
   // mount effect below seeds from the cached profile, then apiGetMe()
@@ -123,6 +98,7 @@ export default function SettingsPage() {
   const [currentUser, setCurrentUser] = useState<SessionUser | null>(null);
   const [signInModalOpen, setSignInModalOpen] = useState(false);
   const [signOutInFlight, setSignOutInFlight] = useState(false);
+  const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
 
   // "Add a sign-in method" — opens the shared AddSignInOptionsModal (the
   // same surface the home-page recovery banner opens), which links
@@ -149,67 +125,16 @@ export default function SettingsPage() {
   const [passkeyDeletePending, setPasskeyDeletePending] = useState<string | null>(null);
   const [passkeyError, setPasskeyError] = useState<string | null>(null);
 
-  // Refs mirror the latest field state so the SESSION_CHANGED handler can
-  // read them without re-subscribing (and re-running) on every keystroke.
-  const nameRef = useRef(name);
-  const initialNameRef = useRef(initialName);
-  useEffect(() => { nameRef.current = name; }, [name]);
-  useEffect(() => { initialNameRef.current = initialName; }, [initialName]);
-  // Tracks the last-seen signed-in user so we can detect an actual sign-in
-  // (or account switch) vs. an incidental session event for the same user.
-  const prevUserIdRef = useRef<string | null>(null);
-
-  // Subscribe to session changes so sign-in (from the modal) and
-  // sign-out (from this page or anywhere else) flip the displayed state
-  // without a route navigation. Also runs once on mount to seed from
-  // the localStorage-cached profile (the useState init above is null
-  // for SSR parity).
-  //
-  // On an actual sign-in (the user_id changed to a new account):
-  //   - account HAS a name → it's authoritative: overwrite the field with it
-  //     (even over an unsaved edit — that edit belonged to the prior context).
-  //   - account has NO name but a name is entered here → tie it to the account
-  //     (covers "enter a name, then create a passkey account", where the typed
-  //     value may never have hit localStorage, so the sign-in seed read null).
-  // Otherwise (same user / sign-out) just reflect localStorage, without
-  // clobbering an in-progress unsaved edit.
+  // Name + reference location are read-only here (edited on /settings/edit).
+  // Reflect localStorage on mount and on every session change: sign-in
+  // mirrors the account name to local (via persistSignIn) before
+  // SESSION_CHANGED fires, and sign-out clears it — so reading
+  // getUserName() / getUserLocation() here is always current.
   useEffect(() => {
     const sync = () => {
-      const user = getCurrentUser();
-      setCurrentUser(user);
-      // Reflect localStorage location (cleared on sign-out by clearSession,
-      // which runs before SESSION_CHANGED fires) so the displayed location
-      // clears instantly without a remount. Location isn't account-synced,
-      // so mirroring localStorage is always correct.
+      setCurrentUser(getCurrentUser());
+      setName(getUserName() ?? "");
       setSavedLocation(getUserLocation());
-      const userId = user?.user_id ?? null;
-      const justSignedIn = userId !== null && userId !== prevUserIdRef.current;
-      prevUserIdRef.current = userId;
-
-      const localName = getUserName() ?? "";
-      const fieldName = nameRef.current.trim();
-      const accountName = user?.name?.trim() || "";
-
-      if (justSignedIn && accountName) {
-        // saveUserName mirrors it to localStorage too (no-op if already there).
-        saveUserName(accountName);
-        setName(accountName);
-        setInitialName(accountName);
-        return;
-      }
-      if (justSignedIn && fieldName && isValidUserName(fieldName)) {
-        // saveUserName persists locally AND (signed in) pushes to the account.
-        saveUserName(fieldName);
-        setName(fieldName);
-        setInitialName(fieldName);
-        return;
-      }
-
-      const dirty = nameRef.current !== initialNameRef.current;
-      if (!dirty && nameRef.current !== localName) {
-        setName(localName);
-        setInitialName(localName);
-      }
     };
     sync();
     window.addEventListener(SESSION_CHANGED_EVENT, sync);
@@ -368,15 +293,6 @@ export default function SettingsPage() {
   };
 
   useEffect(() => {
-    const savedName = getUserName();
-    if (savedName) {
-      setName(savedName);
-      setInitialName(savedName);
-    }
-    const loc = getUserLocation();
-    if (loc) {
-      setSavedLocation(loc);
-    }
     setTheme(getStoredTheme());
 
     // Sync the cached profile with the server. cacheMyUserProfile fires
@@ -389,27 +305,6 @@ export default function SettingsPage() {
       });
   }, []);
 
-  // Object-URL lifecycle for the cropped preview blob.
-  useEffect(() => {
-    if (!pendingCroppedBlob) {
-      setLocalImagePreviewUrl(null);
-      return;
-    }
-    const u = URL.createObjectURL(pendingCroppedBlob);
-    setLocalImagePreviewUrl(u);
-    return () => {
-      URL.revokeObjectURL(u);
-    };
-  }, [pendingCroppedBlob]);
-
-  const effectiveImageUrl = pendingCroppedBlob
-    ? localImagePreviewUrl
-    : pendingImageRemoval
-      ? null
-      : serverImageUrl;
-
-  const hasPendingImageChange = pendingCroppedBlob !== null || pendingImageRemoval;
-
   const selectedTheme = THEME_OPTIONS.find((o) => o.value === theme);
 
   const handleThemeChange = (next: ThemePreference) => {
@@ -417,153 +312,12 @@ export default function SettingsPage() {
     saveTheme(next);
   };
 
-  const openFilePicker = () => {
-    if (imageSaving) return;
-    // The photo is account data — gate behind the same account-setup modal
-    // as creating a group / voting when the user has no name/account yet.
-    // After the modal mints + signs in, proceed to the picker.
-    if (!isValidUserName(getUserName())) {
-      setPhotoGateOpen(true);
-      return;
-    }
-    fileInputRef.current?.click();
-  };
-
-  const onFileChosen = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    e.target.value = '';
-    if (!file) return;
-    setPickedFile(file);
-  };
-
-  const onCropConfirm = (croppedBlob: Blob) => {
-    setPendingCroppedBlob(croppedBlob);
-    setPendingImageRemoval(false);
-    setPickedFile(null);
-  };
-
-  const onRemoveImage = () => {
-    if (imageSaving) return;
-    // If a new crop is staged but not saved, just drop it. Otherwise
-    // stage a removal of the existing server image.
-    if (pendingCroppedBlob) {
-      setPendingCroppedBlob(null);
-      return;
-    }
-    if (serverImageUrl) {
-      setPendingImageRemoval(true);
-    }
-  };
-
-  // Apply whichever image change is pending. Caller owns the loading
-  // flag + user-visible status message; this just runs the network
-  // calls + state writes. Returns when there's nothing to do.
-  const commitPendingImageChange = async (): Promise<void> => {
-    if (pendingCroppedBlob) {
-      // Pass the current name so the server can mint an account to own the
-      // photo when the caller has none yet (the openFilePicker gate ensures
-      // a name exists). Ignored when an account already resolves. The upload
-      // helper caches the new profile + fires USER_PROFILE_CHANGED_EVENT, so
-      // the avatar (via useMyUserImageUrl) updates without setting state here.
-      await apiUploadMyUserImage(pendingCroppedBlob, name);
-      setPendingCroppedBlob(null);
-    } else if (pendingImageRemoval) {
-      await apiDeleteMyUserImage();
-      setPendingImageRemoval(false);
-    }
-  };
-
-  const saveImageChange = async () => {
-    if (imageSaving || !hasPendingImageChange) return;
-    haptic.success();
-    setImageSaving(true);
-    setMessage(null);
-    try {
-      await commitPendingImageChange();
-      setMessage({ type: 'success', text: 'Photo updated!' });
-    } catch {
-      setMessage({ type: 'error', text: 'Failed to update photo' });
-    } finally {
-      setImageSaving(false);
-    }
-  };
-
-  const discardImageChange = () => {
-    setShowDiscardImageConfirm(false);
-    setPendingCroppedBlob(null);
-    setPendingImageRemoval(false);
-  };
-
-  const handleSave = async () => {
-    haptic.success();
-    setIsLoading(true);
-    setMessage(null);
-
-    try {
-      saveUserName(name);
-      setInitialName(name.trim());
-
-      // Geocode location input if provided and different from saved
-      if (locationInput.trim()) {
-        const result = await apiGeocode(locationInput.trim());
-        if (result && result.lat && result.lon) {
-          const loc: UserLocation = {
-            latitude: parseFloat(result.lat),
-            longitude: parseFloat(result.lon),
-            label: result.label,
-          };
-          saveUserLocation(loc);
-          setSavedLocation(loc);
-          setLocationInput("");
-        } else {
-          setMessage({ type: 'error', text: 'Could not find that location. Try a zip code or city name.' });
-          setIsLoading(false);
-          return;
-        }
-      }
-
-      if (hasPendingImageChange) {
-        await commitPendingImageChange();
-      }
-
-      setMessage({ type: 'success', text: 'Settings saved!' });
-      setTimeout(() => {
-        router.back();
-      }, 1000);
-    } catch {
-      setMessage({ type: 'error', text: 'Failed to save settings' });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleDetectLocation = async () => {
-    setIsGeolocating(true);
-    setMessage(null);
-    try {
-      const loc = await detectAndSaveUserLocation();
-      setSavedLocation(loc);
-      setLocationInput("");
-      setMessage({ type: 'success', text: `Location set to ${loc.label}` });
-    } catch (err) {
-      if (err instanceof GeolocationDeniedError) {
-        setMessage({ type: 'error', text: 'Location access denied' });
-      } else {
-        setMessage({ type: 'error', text: 'Failed to determine your location' });
-      }
-    } finally {
-      setIsGeolocating(false);
-    }
-  };
-
   const handleClearAll = async () => {
     if (!confirm('Are you sure you want to clear your settings?')) return;
     clearUserName();
     clearUserLocation();
     setName("");
-    setInitialName("");
     setSavedLocation(null);
-    setLocationInput("");
     // Also clear any uploaded profile image — "clear my settings" is
     // an everything-on-this-browser wipe, so the image goes too. Server
     // delete is fire-and-forget; the local cache is cleared either way
@@ -575,8 +329,6 @@ export default function SettingsPage() {
       // owns the FE state
     }
     clearCachedMyUserProfile();
-    setPendingCroppedBlob(null);
-    setPendingImageRemoval(false);
     setMessage({ type: 'success', text: 'Settings cleared!' });
     setTimeout(() => {
       router.push('/');
@@ -585,140 +337,56 @@ export default function SettingsPage() {
 
   return (
     <div className="question-content">
-      {/* Profile photo section — sits at the top of the page since the
-          avatar reads as the "you" identity for everything else below.
-          Tap the avatar (or the camera badge) to open the file picker;
-          the X badge stages a removal of an existing image. */}
+      {/* Floating opaque-bubble buttons portaled outside .responsive-scaling-container
+       *  so position:fixed is viewport-relative on desktop. Back navigates home;
+       *  Edit opens /settings/edit (image / name / location). Mirrors the /info page. */}
+      <HeaderPortal>
+        <button
+          onClick={() => navigateWithTransition(router, '/', 'back')}
+          className="fixed left-3 z-30 w-10 h-10 flex items-center justify-center rounded-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 active:opacity-70"
+          style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}
+          aria-label="Go back"
+        >
+          <svg className="w-6 h-6 text-gray-700 dark:text-gray-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <button
+          onClick={() => navigateWithTransition(router, '/settings/edit', 'forward')}
+          className="fixed right-3 z-30 h-10 px-4 flex items-center justify-center rounded-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 active:opacity-70 text-blue-600 dark:text-blue-400 text-sm font-medium"
+          style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}
+          aria-label="Edit profile"
+        >
+          Edit
+        </button>
+      </HeaderPortal>
+
+      {/* Profile — read-only display of avatar + name + reference location.
+          Editing lives on /settings/edit (via the header Edit button). */}
       <div className="mb-6 flex flex-col items-center">
-        <div className="relative">
-          <button
-            type="button"
-            onClick={openFilePicker}
-            disabled={imageSaving}
-            aria-label="Change profile photo"
-            className="block outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full disabled:opacity-60"
-          >
-            <InitialBubble
-              imageUrl={effectiveImageUrl}
-              name={name}
-              sizeClassName="w-28 h-28"
-              textSizeClassName="text-2xl"
-            />
-            <span
-              className="absolute bottom-0 right-0 w-9 h-9 rounded-full bg-blue-600 dark:bg-blue-500 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900"
-              aria-hidden
-            >
-              <CameraPencilIcon />
-            </span>
-          </button>
-          {effectiveImageUrl && !imageSaving && (
-            <button
-              type="button"
-              onClick={onRemoveImage}
-              aria-label="Remove profile photo"
-              className="absolute top-0 right-0 w-7 h-7 rounded-full bg-gray-500 dark:bg-gray-600 text-white flex items-center justify-center shadow-md ring-2 ring-white dark:ring-gray-900 hover:bg-gray-600 dark:hover:bg-gray-500 active:scale-95 transition-transform"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          )}
-        </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          onChange={onFileChosen}
-          className="hidden"
+        <InitialBubble
+          imageUrl={serverImageUrl}
+          name={name}
+          sizeClassName="w-28 h-28"
+          textSizeClassName="text-2xl"
         />
-        {hasPendingImageChange && (
-          <div className="mt-3 flex items-center gap-2">
-            <button
-              type="button"
-              onClick={saveImageChange}
-              disabled={imageSaving}
-              className="px-3 py-1.5 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium disabled:opacity-50"
-            >
-              {imageSaving ? 'Saving…' : pendingImageRemoval ? 'Save (remove photo)' : 'Save photo'}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDiscardImageConfirm(true)}
-              disabled={imageSaving}
-              className="px-3 py-1.5 rounded-full border border-gray-300 dark:border-gray-600 text-sm font-medium disabled:opacity-50"
-            >
-              Cancel
-            </button>
-          </div>
-        )}
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
-          Shown wherever your name appears
-        </p>
       </div>
 
-      {/* Name Input Section */}
       <div className="mb-6">
-        <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
-          <CompactNameField name={name} setName={setName} disabled={isLoading} />
+        <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4 divide-y divide-gray-200 dark:divide-gray-700">
+          <div className="flex items-center justify-between gap-3 h-12">
+            <span className="text-base font-normal shrink-0">Name</span>
+            <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
+              {name.trim() || "Not set"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-3 h-12">
+            <span className="text-base font-normal shrink-0">Reference Location</span>
+            <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
+              {savedLocation ? savedLocation.label : "Not set"}
+            </span>
+          </div>
         </section>
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          This name will be automatically filled in voting forms
-        </p>
-      </div>
-
-      {/* Location Section */}
-      <div className="mb-6">
-        <label htmlFor="location" className="block text-sm font-medium mb-1">
-          Reference Location
-        </label>
-        {savedLocation && (
-          <div className="mb-2 flex items-center gap-2">
-            <span className="text-sm text-gray-600 dark:text-gray-400">Current:</span>
-            <span className="text-sm font-medium">{savedLocation.label}</span>
-            <button
-              type="button"
-              onClick={() => { clearUserLocation(); setSavedLocation(null); }}
-              className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-            >
-              Clear
-            </button>
-          </div>
-        )}
-        <div className="flex gap-2">
-          <input
-            type="text"
-            id="location"
-            value={locationInput}
-            onChange={(e) => setLocationInput(e.target.value)}
-            onBlur={(e) => setLocationInput(e.target.value.trim())}
-            placeholder={savedLocation ? "Update location..." : "Zip code or city name..."}
-            maxLength={200}
-            className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
-            disabled={isLoading || isGeolocating}
-          />
-          <button
-            type="button"
-            onClick={handleDetectLocation}
-            disabled={isLoading || isGeolocating}
-            className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            title="Detect my location"
-          >
-            {isGeolocating ? (
-              <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-            ) : (
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-            )}
-          </button>
-        </div>
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          Used as the reference point for calculating distance in location-based questions
-        </p>
       </div>
 
       <div className="mb-6">
@@ -755,9 +423,6 @@ export default function SettingsPage() {
             </span>
           </label>
         </section>
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          System follows your device&apos;s appearance setting
-        </p>
       </div>
 
       {/* Unread polls: the app-icon badge counts unread polls, and the gold
@@ -841,19 +506,9 @@ export default function SettingsPage() {
           <div className="flex items-center justify-between gap-3 h-12">
             <span className="text-base font-normal shrink-0">Account</span>
             {currentUser ? (
-              <div className="flex items-center gap-3 min-w-0">
-                <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
-                  {currentUser.email || "Signed in"}
-                </span>
-                <button
-                  type="button"
-                  onClick={handleSignOut}
-                  disabled={signOutInFlight}
-                  className="text-sm text-red-600 dark:text-red-400 hover:underline disabled:opacity-50 shrink-0"
-                >
-                  {signOutInFlight ? "Signing out…" : "Sign out"}
-                </button>
-              </div>
+              <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
+                {currentUser.email || "Signed in"}
+              </span>
             ) : (
               <button
                 type="button"
@@ -875,11 +530,11 @@ export default function SettingsPage() {
             </div>
           )}
         </section>
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          {currentUser
-            ? "Your polls and groups are tied to your account."
-            : "Sign in to keep your polls and groups across devices."}
-        </p>
+        {!currentUser && (
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            Sign in to keep your polls and groups across devices.
+          </p>
+        )}
       </div>
 
       {/* Add a sign-in method — for signed-in accounts that lack an email
@@ -994,13 +649,18 @@ export default function SettingsPage() {
         </div>
       )}
 
-      <button
-        onClick={handleSave}
-        disabled={isLoading || (name.trim() === initialName.trim() && !locationInput.trim() && !hasPendingImageChange)}
-        className="w-full rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-base h-12 disabled:opacity-50 disabled:cursor-not-allowed mb-6"
-      >
-        {isLoading ? 'Saving...' : 'Save'}
-      </button>
+      {/* Sign out — separate full-width button, confirmed via modal. Only
+          shown when signed in. */}
+      {currentUser && (
+        <button
+          type="button"
+          onClick={() => setShowSignOutConfirm(true)}
+          disabled={signOutInFlight}
+          className="w-full rounded-full border border-gray-300 dark:border-gray-600 text-red-600 dark:text-red-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors flex items-center justify-center font-medium text-base h-12 disabled:opacity-50 mb-6"
+        >
+          {signOutInFlight ? "Signing out…" : "Sign out"}
+        </button>
+      )}
 
       {/* Divider */}
       <div className="border-t border-gray-200 dark:border-gray-700 pt-6 mb-6">
@@ -1064,31 +724,17 @@ export default function SettingsPage() {
         </a>
       </div>
 
-      {pickedFile && (
-        <ImageCropModal
-          file={pickedFile}
-          onCancel={() => setPickedFile(null)}
-          onConfirm={onCropConfirm}
-        />
-      )}
-
-      <AccountGateModal
-        isOpen={photoGateOpen}
-        message="to add a profile photo"
-        onSubmit={() => {
-          setPhotoGateOpen(false);
-          fileInputRef.current?.click();
-        }}
-        onCancel={() => setPhotoGateOpen(false)}
-      />
-
       <ConfirmationModal
-        isOpen={showDiscardImageConfirm}
-        message="Discard photo changes?"
-        confirmText="Discard"
+        isOpen={showSignOutConfirm}
+        title="Sign out?"
+        message="Sign out of your account on this device?"
+        confirmText={signOutInFlight ? "Signing out…" : "Sign out"}
         confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
-        onConfirm={discardImageChange}
-        onCancel={() => setShowDiscardImageConfirm(false)}
+        onConfirm={async () => {
+          setShowSignOutConfirm(false);
+          await handleSignOut();
+        }}
+        onCancel={() => setShowSignOutConfirm(false)}
       />
 
       <ConfirmationModal
@@ -1129,13 +775,4 @@ function formatProviders(providers: string[]): string {
   return providers
     .map((p) => PROVIDER_LABELS[p] || p.charAt(0).toUpperCase() + p.slice(1))
     .join(", ");
-}
-
-function CameraPencilIcon() {
-  return (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M3 7h3l2-3h6l2 3h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" />
-      <circle cx="12" cy="13" r="3.5" />
-    </svg>
-  );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -502,10 +502,6 @@ export default function SettingsPage() {
               </p>
             )}
           </section>
-          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-            Passkeys let you sign in with Touch ID, Face ID, or a hardware
-            key — no email link needed.
-          </p>
         </div>
       )}
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -493,7 +493,7 @@ export default function SettingsPage() {
         <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
           {badge.todoMode
             ? "An open poll stays unread until you vote or abstain — opening it isn't enough. The app-icon badge counts these."
-            : "Opening a poll marks it read. It becomes unread again when voting opens or results arrive (toggles above). The app-icon badge counts unread polls."}
+            : "Opening a poll marks it read. It becomes unread again when voting opens or results arrive (toggles above)."}
         </p>
       </div>
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,12 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getUserName, clearUserName, getUserLocation, clearUserLocation, type UserLocation } from "@/lib/userProfile";
+import { getUserName, getUserLocation, type UserLocation } from "@/lib/userProfile";
 import {
   apiGetMyUserProfile,
-  apiDeleteMyUserImage,
   cacheMyUserProfile,
-  clearCachedMyUserProfile,
   apiGetMe,
   apiGetAuthProviders,
   apiSignOut,
@@ -285,29 +283,6 @@ export default function SettingsPage() {
   const handleThemeChange = (next: ThemePreference) => {
     setTheme(next);
     saveTheme(next);
-  };
-
-  const handleClearAll = async () => {
-    if (!confirm('Are you sure you want to clear your settings?')) return;
-    clearUserName();
-    clearUserLocation();
-    setName("");
-    setSavedLocation(null);
-    // Also clear any uploaded profile image — "clear my settings" is
-    // an everything-on-this-browser wipe, so the image goes too. Server
-    // delete is fire-and-forget; the local cache is cleared either way
-    // so the FE state is consistent immediately.
-    try {
-      await apiDeleteMyUserImage();
-    } catch {
-      // ignore — server may be unreachable, the cache clear below still
-      // owns the FE state
-    }
-    clearCachedMyUserProfile();
-    setMessage({ type: 'success', text: 'Settings cleared!' });
-    setTimeout(() => {
-      router.push('/');
-    }, 1000);
   };
 
   return (
@@ -614,19 +589,6 @@ export default function SettingsPage() {
           {badge.todoMode
             ? "An open poll stays unread until you vote or abstain — opening it isn't enough. The app-icon badge counts these."
             : "Opening a poll marks it read. It becomes unread again when voting opens or results arrive (toggles above)."}
-        </p>
-      </div>
-
-      {/* Divider */}
-      <div className="border-t border-gray-200 dark:border-gray-700 pt-6 mb-6">
-        <button
-          onClick={handleClearAll}
-          className="w-full rounded-full border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors flex items-center justify-center font-medium text-base h-12"
-        >
-          Clear Settings
-        </button>
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
-          Remove your saved name, location, and profile photo from this browser
         </p>
       </div>
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -530,11 +530,6 @@ export default function SettingsPage() {
             </div>
           )}
         </section>
-        {!currentUser && (
-          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-            Sign in to keep your polls and groups across devices.
-          </p>
-        )}
       </div>
 
       {/* Add a sign-in method — for signed-in accounts that lack an email

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -386,11 +386,6 @@ export default function SettingsPage() {
               {savedLocation ? savedLocation.label : "Not set"}
             </span>
           </div>
-        </section>
-      </div>
-
-      <div className="mb-6">
-        <section className="rounded-3xl bg-gray-50 dark:bg-gray-800 px-4">
           <label className="flex items-center justify-between gap-3 h-12 cursor-pointer">
             <span className="text-base font-normal shrink-0">Theme</span>
             <span className="relative inline-flex items-center gap-1.5 text-base font-normal text-gray-500 dark:text-gray-500">

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState, Suspense } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import HeaderPortal from '@/components/HeaderPortal';
 import { useLongPress } from '@/lib/useLongPress';
 import { installClientLogForwarder } from '@/lib/clientLogForwarder';
 import { usePrefetch } from '@/lib/prefetch';
@@ -133,6 +132,9 @@ function TemplateInner({ children }: AppTemplateProps) {
   // of the new group button + padding treatment via isGroupRootView.
   const isGroupLikePage = isGroupRootView(pathname);
   const isSettingsPage = pathname === '/settings' || pathname === '/settings/';
+  // The profile editor (/settings/edit) renders its own fixed back + Save
+  // buttons via HeaderPortal, so it must opt out of the fallback header.
+  const isSettingsEditPage = pathname === '/settings/edit' || pathname === '/settings/edit/';
   // Phase G: /invite/<token> is a redemption landing page that renders
   // its own full-screen redirect-or-sign-in UI. The template's
   // fallback header would just sit above it as empty chrome.
@@ -148,7 +150,7 @@ function TemplateInner({ children }: AppTemplateProps) {
   return (
     <>
       {/* Fallback header for pages without a page-specific header (not group, settings, home, invite redemption, or create-modal). */}
-      {!isGroupFamilyPage && !isSettingsPage && !isInvitePage && pathname !== '/' && (
+      {!isGroupFamilyPage && !isSettingsPage && !isSettingsEditPage && !isInvitePage && pathname !== '/' && (
         <div className="sticky top-0 z-30 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700"
              style={{ paddingTop: 'env(safe-area-inset-top)' }}>
           <div className="relative flex items-start justify-between pt-2 pb-2 pl-2 pr-2.5">
@@ -241,24 +243,6 @@ function TemplateInner({ children }: AppTemplateProps) {
         </div>
       </div>
 
-      {/* Header elements rendered outside scaling container */}
-      <HeaderPortal>
-        {/* Back arrow in upper left — settings page always navigates to home. */}
-        {isSettingsPage && (
-          <div className="fixed left-0 z-50" style={{ top: 'calc(env(safe-area-inset-top, 0px) + 10px)' }}>
-            <button
-              onClick={() => navigateWithTransition(router, '/', 'back')}
-              className="w-12 h-16 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
-              aria-label="Go back"
-            >
-              <svg className="w-7 h-7 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
-            </button>
-          </div>
-        )}
-
-      </HeaderPortal>
     </>
   );
 }

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -9,6 +9,8 @@ import { navigateWithTransition, NAV_COUNT_KEY } from '@/lib/viewTransitions';
 import { getCachedQuestionById, getCachedQuestionByShortId } from '@/lib/questionCache';
 import { isUuidLike, isGroupRootView } from '@/lib/questionId';
 import { HOME_SELECTION_MODE_CHANGE_EVENT, type HomeSelectionModeChangeDetail } from '@/lib/eventChannels';
+import { getUserName } from '@/lib/userProfile';
+import { SESSION_CHANGED_EVENT } from '@/lib/session';
 
 // `CreateQuestionContent` (the bubble-bar + create-poll-modal owner) is
 // mounted in `app/layout.tsx` via `<PersistentCreatePollHost />` so it
@@ -104,6 +106,19 @@ function TemplateInner({ children }: AppTemplateProps) {
     };
   }, []);
 
+  // Settings header title: the saved account/display name when set, else
+  // "Settings". Init null (SSR parity → "Settings" on the first paint), then
+  // read getUserName() on mount + on every session change (sign-in/out). Name
+  // edits happen on /settings/edit, which navigates back here and remounts the
+  // template, so the on-mount read picks those up too.
+  const [settingsName, setSettingsName] = useState<string | null>(null);
+  useEffect(() => {
+    const update = () => setSettingsName(getUserName()?.trim() || null);
+    update();
+    window.addEventListener(SESSION_CHANGED_EVENT, update);
+    return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
+  }, [pathname]);
+
   // Hide the settings gear on the home page when GroupList enters
   // bulk-forget selection mode — the cancel (X) button portals into the
   // same upper-left slot and the gear's tap target would compete with it.
@@ -187,7 +202,7 @@ function TemplateInner({ children }: AppTemplateProps) {
             className="max-w-4xl mx-auto px-16 pb-1 page-title-safe-top"
           >
             <h1 className="text-2xl font-bold text-center break-words select-none" {...longPressProps}>
-              Settings
+              {settingsName || 'Settings'}
             </h1>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Restyles the settings back button to the floating-bubble look of the group info page and adds an **Edit** button that opens a new `/settings/edit` route (image / name / reference location), mirroring the `/info → /edit-title` pattern. The main settings page now shows these read-only, with no bottom Save button.
- The settings header title shows the saved account/display name when set (falls back to "Settings").
- Reference Location + Theme are read-only rows in one card (Name moved to the header title).
- Moves the account / sign-in cluster (Account, Add sign-in method, Passkeys, status message, Sign out) directly below the avatar. **Sign out** is now a separate full-width button behind a confirmation modal.
- Removes the Delete account and Clear Settings buttons, and several redundant helper captions.
- Reword the About blurb to "WhoeverWants is free and open-source".

## Test plan
- [ ] `/settings` renders read-only (avatar, Account/sign-in cluster, Reference Location + Theme, Unread polls, About); no Save/Clear/Delete buttons.
- [ ] Tapping **Edit** opens `/settings/edit`; editing name + Save returns to `/settings` with the name as the header title and initials in the avatar.
- [ ] Back from the editor with unsaved changes prompts "Discard your changes?".
- [ ] Signed-in: Add-sign-in / Passkeys / Sign out appear in the cluster below the avatar; Sign out confirms via modal.

https://claude.ai/code/session_01RMWBEeYVBhej4fxmepJRLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMWBEeYVBhej4fxmepJRLG)_