### PR TITLE
Add dev-only instant sign-in links for sharing demos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -982,6 +982,58 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 > a recovery email, and any account can be deleted. Full plan +
 > rationale in `docs/auth-access-model.md`.
 
+### Dev Instant Sign-In Links (demo helper)
+
+Two **dev-tier-only** endpoints let a developer (or Claude assembling a
+demo) mint a throwaway account and hand back a single URL that signs the
+recipient straight into it with no prompts — so a specific pre-seeded app
+state can be shared as one click. Lives in `server/routers/auth.py`
+("Dev-only instant sign-in links" section) + `app/auth/instant/page.tsx`.
+
+- **`POST /api/auth/dev/instant-link`** (caller: developer, via curl). Body
+  `{name?="Demo User", next?}`. Mints a recovery-less account
+  (`create_name_only_account` → `providers: []`), returns
+  `{url, session_token, expires_at, user_id, name, browser_id}`. `url` =
+  `<fe_origin>/auth/instant?token=<sessionToken>[&next=<urlencoded path>]`.
+  The `session_token` is a **real 90-day bearer** — keep using it (with the
+  returned `browser_id` as `X-Browser-Id`) to seed the account's polls/votes
+  BEFORE sending the link. `next` is validated to a same-origin relative path
+  (`_safe_relative_next`); open-redirect targets (`//host`, `https://…`,
+  backslashes) are dropped to `/`.
+- **`POST /api/auth/instant/adopt`** (caller: recipient's browser, via
+  `apiAdoptInstantSession` on the `/auth/instant` page). Body `{token}`.
+  Validates the session token, **links the requesting browser to the
+  account**, returns the `UserSummary`; the FE then `persistSignIn`s. The
+  browser-link matches every other sign-in path (parity) — but note
+  visibility doesn't strictly depend on it: `load_user_visibility` already
+  unions across every browser linked to the account, and the recipient
+  carries the bearer, so the seeded data (membership keyed under the mint
+  browser, which `create_name_only_account` linked) is visible via the
+  account union regardless.
+- **Gating: non-prod only, via the request `Origin`.** Both endpoints
+  `503` when `services.fe_origin.is_prod_origin(request)` — i.e. a real prod
+  request (`Origin: https://whoeverwants.com`) OR **no/forged Origin** (which
+  `resolve_fe_origin` falls back to prod → gated off, the safe default). The
+  `/auth/instant` page additionally refuses on `hostname === 'whoeverwants.com'`.
+  This keeps the "sign a browser in from a URL token" capability (a
+  login-CSRF vector) off production entirely; on dev/canary the threat model
+  is throwaway demo data. The token is **reusable** (reload/re-click work);
+  no migration, no token table — the URL just carries the session token.
+- **Curl recipe** (always pass `Origin` — without it you get 503):
+  ```bash
+  ORIGIN=https://<slug>.dev.whoeverwants.com
+  BID=$(python3 -c 'import uuid;print(uuid.uuid4())')
+  # 1. mint
+  curl -s -X POST "$ORIGIN/api/auth/dev/instant-link" \
+    -H "Content-Type: application/json" -H "Origin: $ORIGIN" -H "X-Browser-Id: $BID" \
+    -d '{"name":"Sam"}'          # → session_token, user_id, group via later seeding
+  # 2. seed as the account (bearer + SAME X-Browser-Id) — POST /api/polls, votes, …
+  # 3. send: $ORIGIN/auth/instant?token=<session_token>&next=/g/<groupShortId>
+  ```
+  Build the final `&next=…` URL by hand after seeding (you know the group
+  short_id only post-seed); the mint's returned `url` has no `next` unless
+  you passed one up front. Tests: `server/tests/test_instant_link.py`.
+
 **Cross-browser visibility for signed-in users.** Every read that
 asks "is the caller a member of this group?" must walk
 `user_browsers` to expand membership across every browser the user

--- a/app/auth/instant/page.tsx
+++ b/app/auth/instant/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { apiAdoptInstantSession, ApiError } from "@/lib/api";
+import { usePageReady } from "@/lib/usePageReady";
+
+/**
+ * Dev-only instant sign-in landing page (demo helper). The link minted by
+ * `POST /api/auth/dev/instant-link` points here with `?token=<sessionToken>`
+ * (+ optional `&next=<relative path>`). We POST the token to `/instant/adopt`,
+ * which links this browser to the throwaway demo account and signs in, then
+ * redirect to `next` (default home).
+ *
+ * Gated to non-production hosts: the adopt endpoint already 503s on prod, but
+ * the page also short-circuits with a clear message so a stray prod link
+ * doesn't show a confusing error. See server/routers/auth.py for the threat
+ * model (this "sign a browser in from a URL token" capability is a login-CSRF
+ * vector kept off production entirely).
+ */
+
+type Status = "verifying" | "success" | "error" | "disabled";
+
+function sanitizeNext(value: string | null): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return "/";
+  if (value.includes("\\")) return "/";
+  return value;
+}
+
+function InstantPageContent() {
+  const router = useRouter();
+  usePageReady(true);
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<Status>("verifying");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [name, setName] = useState<string | null>(null);
+  const attemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (attemptedRef.current) return;
+    attemptedRef.current = true;
+
+    if (window.location.hostname === "whoeverwants.com") {
+      setStatus("disabled");
+      return;
+    }
+
+    const token = searchParams.get("token");
+    const next = sanitizeNext(searchParams.get("next"));
+    if (!token) {
+      setStatus("error");
+      setErrorMessage("This sign-in link is missing its token.");
+      return;
+    }
+
+    (async () => {
+      try {
+        const user = await apiAdoptInstantSession(token);
+        setName(user.name ?? null);
+        setStatus("success");
+        setTimeout(() => router.replace(next), 800);
+      } catch (err) {
+        setStatus("error");
+        if (err instanceof ApiError) {
+          setErrorMessage(err.message || "Couldn't sign you in with this link.");
+        } else {
+          setErrorMessage("Couldn't reach the server. Try again in a moment.");
+        }
+      }
+    })();
+  }, [router, searchParams]);
+
+  return (
+    <div className="question-content text-center pt-16">
+      {status === "verifying" && (
+        <div className="flex flex-col items-center gap-4">
+          <svg
+            className="w-8 h-8 animate-spin text-blue-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+          <p className="text-gray-700 dark:text-gray-300">Signing you in…</p>
+        </div>
+      )}
+      {status === "success" && (
+        <div>
+          <h1 className="text-xl font-semibold mb-2">You&apos;re signed in</h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            {name ? `as ${name}` : null}
+          </p>
+        </div>
+      )}
+      {status === "disabled" && (
+        <div>
+          <h1 className="text-xl font-semibold mb-2">Dev links only</h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            Instant sign-in links work only on preview / dev environments.
+          </p>
+        </div>
+      )}
+      {status === "error" && (
+        <div>
+          <h1 className="text-xl font-semibold mb-2">
+            Couldn&apos;t sign you in
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-4">
+            {errorMessage}
+          </p>
+          <button
+            type="button"
+            onClick={() => router.replace("/")}
+            className="rounded-full bg-blue-600 hover:bg-blue-700 text-white px-6 h-11 font-medium"
+          >
+            Go home
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function InstantPage() {
+  return (
+    <Suspense fallback={null}>
+      <InstantPageContent />
+    </Suspense>
+  );
+}

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -208,6 +208,48 @@ export async function apiSetRecoveryReminderDismissed(
   return user;
 }
 
+// Dev-only instant sign-in links (demo helper). See the matching section
+// in server/routers/auth.py. The mint endpoint is normally called via curl
+// when assembling a demo, not from the app — the helper is exported for
+// completeness / discoverability. The adopt helper IS used by the
+// `/auth/instant` landing page.
+
+export interface DevInstantLinkResult {
+  url: string;
+  session_token: string;
+  expires_at: string;
+  user_id: string;
+  name: string | null;
+  browser_id: string | null;
+}
+
+/** DEV-ONLY: mint a fresh throwaway account + a URL that instantly signs
+ *  the recipient into it. 503 on production. */
+export async function apiCreateDevInstantLink(
+  name?: string,
+  next?: string,
+): Promise<DevInstantLinkResult> {
+  return authFetch<DevInstantLinkResult>("/dev/instant-link", {
+    method: "POST",
+    body: JSON.stringify({ name, next }),
+  });
+}
+
+/** DEV-ONLY: adopt the session token carried in an instant-sign-in URL.
+ *  Links THIS browser to the account server-side (so its pre-seeded
+ *  groups become visible) and persists the session locally. 503 / 400 on
+ *  prod / invalid token. */
+export async function apiAdoptInstantSession(
+  token: string,
+): Promise<SessionUser> {
+  const user = await authFetch<SessionUser>("/instant/adopt", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  });
+  persistSignIn(token, user);
+  return user;
+}
+
 export async function apiRequestMagicLink(
   email: string,
 ): Promise<MagicLinkRequestResponse> {

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -209,31 +209,10 @@ export async function apiSetRecoveryReminderDismissed(
 }
 
 // Dev-only instant sign-in links (demo helper). See the matching section
-// in server/routers/auth.py. The mint endpoint is normally called via curl
-// when assembling a demo, not from the app — the helper is exported for
-// completeness / discoverability. The adopt helper IS used by the
-// `/auth/instant` landing page.
-
-export interface DevInstantLinkResult {
-  url: string;
-  session_token: string;
-  expires_at: string;
-  user_id: string;
-  name: string | null;
-  browser_id: string | null;
-}
-
-/** DEV-ONLY: mint a fresh throwaway account + a URL that instantly signs
- *  the recipient into it. 503 on production. */
-export async function apiCreateDevInstantLink(
-  name?: string,
-  next?: string,
-): Promise<DevInstantLinkResult> {
-  return authFetch<DevInstantLinkResult>("/dev/instant-link", {
-    method: "POST",
-    body: JSON.stringify({ name, next }),
-  });
-}
+// in server/routers/auth.py. The mint endpoint (POST /api/auth/dev/instant-link)
+// is called via curl when assembling a demo — there's no in-app caller, so no
+// FE client for it. The adopt helper below IS used by the `/auth/instant`
+// landing page.
 
 /** DEV-ONLY: adopt the session token carried in an instant-sign-in URL.
  *  Links THIS browser to the account server-side (so its pre-seeded

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -108,6 +108,8 @@ export {
   apiDeleteAccount,
   apiCreateNameAccount,
   apiSetRecoveryReminderDismissed,
+  apiCreateDevInstantLink,
+  apiAdoptInstantSession,
   getCurrentUser,
 } from "./auth";
 export type {
@@ -120,4 +122,5 @@ export type {
   PasskeyRegistrationResult,
   InviteRedeemResult,
   RecoveryEmailRequestResponse,
+  DevInstantLinkResult,
 } from "./auth";

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -108,7 +108,6 @@ export {
   apiDeleteAccount,
   apiCreateNameAccount,
   apiSetRecoveryReminderDismissed,
-  apiCreateDevInstantLink,
   apiAdoptInstantSession,
   getCurrentUser,
 } from "./auth";
@@ -122,5 +121,4 @@ export type {
   PasskeyRegistrationResult,
   InviteRedeemResult,
   RecoveryEmailRequestResponse,
-  DevInstantLinkResult,
 } from "./auth";

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -54,7 +54,9 @@ from services.auth import (
     is_valid_email,
     issue_magic_link,
     issue_session,
+    link_browser_to_user,
     load_user_profile,
+    lookup_session_user_id,
     normalize_email,
     peek_recovery_email_token,
     revoke_session,
@@ -208,6 +210,14 @@ class ProvidersResponse(BaseModel):
 def _resolve_fe_origin(request: Request) -> str:
     from services.fe_origin import resolve_fe_origin as _resolve
     return _resolve(request)
+
+
+def is_prod_origin(request: Request) -> bool:
+    """Thin alias so dev-only endpoints in this router can gate on the
+    shared `services.fe_origin.is_prod_origin` without re-importing it at
+    each call site."""
+    from services.fe_origin import is_prod_origin as _is_prod
+    return _is_prod(request)
 
 
 def _resolve_rp_id(request: Request) -> str:
@@ -371,6 +381,139 @@ def create_account_with_name(req: CreateNameAccountBody, request: Request):
                 user_agent=user_agent,
             )
     return _signin_response(completed)
+
+
+# ---------------------------------------------------------------------------
+# Dev-only instant sign-in links (demo helper)
+# ---------------------------------------------------------------------------
+#
+# Lets a developer (or Claude, when assembling a demo) mint a throwaway
+# account and hand back a URL that signs the recipient straight into it
+# with no prompts — so a specific app state / context can be shared as a
+# single click. Two endpoints:
+#
+#   POST /api/auth/dev/instant-link   (caller: the developer, via curl)
+#     mints a recovery-less account, returns a ready-to-send URL whose
+#     `?token` carries the account's session token + the live session
+#     token itself (so the caller can keep acting as the account to seed
+#     polls / votes before sending the link).
+#   POST /api/auth/instant/adopt      (caller: the recipient's browser)
+#     validates the session token from the URL, LINKS the recipient's
+#     browser to the account (so its browser-keyed group memberships +
+#     pre-seeded polls become visible — `load_user_visibility` unions
+#     across every browser linked to the user), and returns the profile.
+#
+# Both are gated to non-production tiers via `is_prod_origin`: a real
+# prod request (Origin https://whoeverwants.com, or no recognized
+# Origin) gets 503. This keeps the "sign a browser in from a URL token"
+# capability (a login-CSRF vector) off production entirely; on dev /
+# canary it's a convenience with a throwaway-data threat model.
+
+
+class DevInstantLinkBody(BaseModel):
+    # Defaults to a generic demo name so a bare call works; overridable so
+    # the demo account reads like a real participant.
+    name: str = Field(default="Demo User", min_length=1, max_length=50)
+    # Optional same-origin path to land on after sign-in (e.g. "/g/~abc").
+    # Validated server-side to a relative path; defaults to "/".
+    next: str | None = None
+
+
+class DevInstantLinkResponse(BaseModel):
+    url: str
+    session_token: str
+    expires_at: datetime
+    user_id: str
+    name: str | None
+    # Echoed so the caller knows which browser_id the account was linked
+    # to — seed the demo's polls/votes with this SAME X-Browser-Id so the
+    # membership rows land under a browser linked to the account.
+    browser_id: str | None
+
+
+class InstantAdoptBody(BaseModel):
+    token: str = Field(min_length=16, max_length=128)
+
+
+def _safe_relative_next(value: str | None) -> str:
+    """Coerce a caller-supplied `next` to a same-origin relative path, or
+    "/". Rejects absolute URLs, protocol-relative `//host` (open-redirect
+    vector), backslashes, and control chars. The FE page redirects to this
+    value, so it must never escape the app's own origin."""
+    if not value or not value.startswith("/") or value.startswith("//"):
+        return "/"
+    if "\\" in value or any(ord(c) < 0x20 for c in value):
+        return "/"
+    return value
+
+
+@router.post("/dev/instant-link", response_model=DevInstantLinkResponse)
+def create_dev_instant_link(req: DevInstantLinkBody, request: Request):
+    """DEV-ONLY: mint a fresh recovery-less account + return a URL that
+    instantly signs the recipient into it. 503 on production (see the
+    section comment above). The `session_token` is a real 90-day bearer —
+    keep using it (with the returned `browser_id` as X-Browser-Id) to seed
+    the account's polls/votes before sending `url`."""
+    if is_prod_origin(request):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Instant sign-in links aren't available on this tier",
+        )
+    display_name = validate_user_name(req.name, field="name")
+    next_path = _safe_relative_next(req.next)
+    browser_id = _browser_id(request)
+    fe_origin = _resolve_fe_origin(request)
+    with get_db() as conn:
+        completed = create_name_only_account(
+            conn,
+            display_name=display_name,
+            browser_id=browser_id,
+            user_agent=request.headers.get("user-agent"),
+        )
+    token = completed.session.token
+    url = f"{fe_origin}/auth/instant?token={token}"
+    if next_path != "/":
+        from urllib.parse import quote
+
+        url += f"&next={quote(next_path, safe='')}"
+    return DevInstantLinkResponse(
+        url=url,
+        session_token=token,
+        expires_at=completed.session.expires_at,
+        user_id=completed.profile.user_id,
+        name=completed.profile.display_name,
+        browser_id=browser_id,
+    )
+
+
+@router.post("/instant/adopt", response_model=UserSummary)
+def adopt_instant_session(req: InstantAdoptBody, request: Request):
+    """DEV-ONLY companion to /dev/instant-link. The recipient's browser
+    POSTs the session token carried in the instant-sign-in URL; we
+    validate it, link THIS browser to the account, and return the
+    profile. Linking is the load-bearing step — group memberships are
+    browser-keyed and visibility unions across every browser linked to
+    the user, so without it the recipient signs in but sees an empty
+    account. 503 on production."""
+    if is_prod_origin(request):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Instant sign-in links aren't available on this tier",
+        )
+    browser_id = _browser_id(request)
+    with get_db() as conn:
+        user_id = lookup_session_user_id(conn, req.token)
+        if not user_id:
+            raise HTTPException(
+                status_code=400, detail="Invalid or expired sign-in link"
+            )
+        link_browser_to_user(conn, user_id=user_id, browser_id=browser_id)
+        profile = load_user_profile(conn, user_id)
+    if not profile:
+        raise HTTPException(
+            status_code=400, detail="Invalid or expired sign-in link"
+        )
+    return _summary_from_profile(profile)
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/fe_origin.py
+++ b/server/services/fe_origin.py
@@ -37,6 +37,13 @@ _DEFAULT_FE_ORIGIN = os.environ.get(
     "FE_DEFAULT_ORIGIN", "https://whoeverwants.com"
 )
 
+# The one production FE origin. Used to gate dev-only features (the
+# instant-sign-in demo links) OFF on production while leaving them
+# available on canary / per-branch dev / localhost. Hardcoded (not the
+# env default) so a misconfigured `FE_DEFAULT_ORIGIN` can never flip a
+# real prod request into the "dev" bucket.
+PROD_FE_ORIGIN = "https://whoeverwants.com"
+
 
 def resolve_fe_origin(request: Request) -> str:
     """Pick the FE origin to embed in URLs for this request.
@@ -50,3 +57,15 @@ def resolve_fe_origin(request: Request) -> str:
     if origin and any(p.match(origin) for p in _ALLOWED_ORIGIN_PATTERNS):
         return origin
     return _DEFAULT_FE_ORIGIN
+
+
+def is_prod_origin(request: Request) -> bool:
+    """True when the request resolves to the production FE origin — OR to
+    no recognized origin (which falls back to prod). Dev-only endpoints
+    gate on `not is_prod_origin(request)` so they're automatically inert
+    on production (a real prod request carries `Origin:
+    https://whoeverwants.com`) while available on canary
+    (`latest.whoeverwants.com`), per-branch dev (`*.dev.whoeverwants.com`),
+    and localhost. A request with no/forged Origin defaults to prod →
+    gated off, so the safe default is "disabled"."""
+    return resolve_fe_origin(request) == PROD_FE_ORIGIN

--- a/server/tests/test_instant_link.py
+++ b/server/tests/test_instant_link.py
@@ -1,0 +1,241 @@
+"""Dev-only instant sign-in links (demo helper).
+
+Covers the two endpoints in server/routers/auth.py:
+
+  * POST /api/auth/dev/instant-link
+      dev origin + default body → 200; mints a recovery-less account
+        (providers == []), returns a /auth/instant?token=... URL whose
+        token resolves via /me to that account; echoes the linked
+        browser_id.
+      `next` is appended (url-encoded) when relative; an open-redirect
+        target ("//evil.com", "https://x") is dropped → no `next` param.
+      production origin (or no Origin) → 503 (feature is dev-only).
+
+  * POST /api/auth/instant/adopt
+      valid token on a DIFFERENT browser → 200 profile + links that
+        browser to the account (user_browsers row).
+      the link makes the account's browser-keyed memberships visible to
+        the recipient browser (end-to-end: seed a group under the mint
+        browser, see it via /groups/empty on the recipient browser).
+      invalid token → 400; production origin → 503.
+
+Gating is via the request Origin header (services/fe_origin.is_prod_origin):
+tests pass `Origin: http://localhost:3000` for the dev path and
+`https://whoeverwants.com` (or omit it) for the prod path.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import psycopg
+import pytest
+
+TEST_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://whoeverwants:whoeverwants@localhost:5432/whoeverwants",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from main import app  # noqa: E402
+
+DEV_ORIGIN = "http://localhost:3000"
+PROD_ORIGIN = "https://whoeverwants.com"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def browser_id():
+    return str(uuid.uuid4())
+
+
+def _headers(bid=None, token=None, origin=DEV_ORIGIN):
+    h = {}
+    if bid:
+        h["X-Browser-Id"] = bid
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    if origin:
+        h["Origin"] = origin
+    return h
+
+
+# ---------------------------------------------------------------- mint
+
+
+def test_mint_returns_link_and_resolvable_token(client, browser_id):
+    resp = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "Demo Sam"},
+        headers=_headers(bid=browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "/auth/instant?token=" in body["url"]
+    assert body["session_token"] in body["url"]
+    assert len(body["session_token"]) >= 16
+    assert body["name"] == "Demo Sam"
+    assert body["browser_id"] == browser_id
+
+    me = client.get(
+        "/api/auth/me", headers=_headers(bid=browser_id, token=body["session_token"])
+    )
+    assert me.status_code == 200, me.text
+    assert me.json()["user_id"] == body["user_id"]
+    # Recovery-less: no identities.
+    assert me.json()["providers"] == []
+
+
+def test_mint_default_name(client, browser_id):
+    resp = client.post(
+        "/api/auth/dev/instant-link", json={}, headers=_headers(bid=browser_id)
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "Demo User"
+
+
+def test_mint_appends_relative_next(client, browser_id):
+    resp = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "X", "next": "/g/~abc?p=~def"},
+        headers=_headers(bid=browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    url = resp.json()["url"]
+    assert "next=" in url
+    # url-encoded so the query separators in the path don't leak into the
+    # instant link's own query string.
+    assert "%2Fg%2F~abc" in url
+
+
+@pytest.mark.parametrize("bad_next", ["//evil.com", "https://evil.com", "evil", "\\x"])
+def test_mint_drops_open_redirect_next(client, browser_id, bad_next):
+    resp = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "X", "next": bad_next},
+        headers=_headers(bid=browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    assert "next=" not in resp.json()["url"]
+
+
+def test_mint_503_on_prod_origin(client, browser_id):
+    resp = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "X"},
+        headers=_headers(bid=browser_id, origin=PROD_ORIGIN),
+    )
+    assert resp.status_code == 503, resp.text
+
+
+def test_mint_503_when_no_origin(client, browser_id):
+    # No Origin header → resolve_fe_origin falls back to prod → gated off.
+    resp = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "X"},
+        headers=_headers(bid=browser_id, origin=None),
+    )
+    assert resp.status_code == 503, resp.text
+
+
+# ---------------------------------------------------------------- adopt
+
+
+def test_adopt_links_recipient_browser(client):
+    bid_a = str(uuid.uuid4())
+    bid_b = str(uuid.uuid4())
+    mint = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "Linker"},
+        headers=_headers(bid=bid_a),
+    )
+    token = mint.json()["session_token"]
+    user_id = mint.json()["user_id"]
+
+    adopt = client.post(
+        "/api/auth/instant/adopt",
+        json={"token": token},
+        headers=_headers(bid=bid_b),
+    )
+    assert adopt.status_code == 200, adopt.text
+    assert adopt.json()["user_id"] == user_id
+
+    with psycopg.connect(TEST_DB_URL) as conn:
+        row = conn.execute(
+            "SELECT user_id FROM user_browsers WHERE browser_id = %s::uuid",
+            (bid_b,),
+        ).fetchone()
+    assert row is not None and str(row[0]) == user_id
+
+
+def test_adopt_makes_seeded_group_visible(client):
+    """End-to-end: a group seeded under the mint browser is visible to the
+    recipient browser after adopt (membership union across browsers linked
+    to the same account)."""
+    bid_a = str(uuid.uuid4())
+    bid_b = str(uuid.uuid4())
+    mint = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "Seeder"},
+        headers=_headers(bid=bid_a),
+    )
+    token = mint.json()["session_token"]
+
+    # Seed an empty group whose membership is keyed on the MINT browser.
+    with psycopg.connect(TEST_DB_URL) as conn:
+        gid = conn.execute(
+            "INSERT INTO groups DEFAULT VALUES RETURNING id"
+        ).fetchone()[0]
+        conn.execute(
+            "INSERT INTO group_members (group_id, browser_id) "
+            "VALUES (%s::uuid, %s::uuid)",
+            (str(gid), bid_a),
+        )
+        conn.commit()
+
+    adopt = client.post(
+        "/api/auth/instant/adopt",
+        json={"token": token},
+        headers=_headers(bid=bid_b),
+    )
+    assert adopt.status_code == 200, adopt.text
+
+    # On the recipient browser, with the session bearer, the seeded group
+    # shows up via the account → linked-browsers union.
+    empty = client.post(
+        "/api/groups/empty", headers=_headers(bid=bid_b, token=token)
+    )
+    assert empty.status_code == 200, empty.text
+    assert str(gid) in {g["id"] for g in empty.json()}
+
+
+def test_adopt_400_on_bad_token(client, browser_id):
+    resp = client.post(
+        "/api/auth/instant/adopt",
+        json={"token": "not-a-real-token-aaaaaaaa"},
+        headers=_headers(bid=browser_id),
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_adopt_503_on_prod_origin(client, browser_id):
+    # Mint on a dev origin so the token is valid, then try to adopt on prod.
+    mint = client.post(
+        "/api/auth/dev/instant-link",
+        json={"name": "X"},
+        headers=_headers(bid=browser_id),
+    )
+    token = mint.json()["session_token"]
+    resp = client.post(
+        "/api/auth/instant/adopt",
+        json={"token": token},
+        headers=_headers(bid=str(uuid.uuid4()), origin=PROD_ORIGIN),
+    )
+    assert resp.status_code == 503, resp.text


### PR DESCRIPTION
## Summary
- Mint a throwaway account + a single-click URL that signs the recipient straight into it with no prompts, so a specific pre-seeded app state can be shared as one link (for sending demos on dev servers).
- `POST /api/auth/dev/instant-link` — mints a recovery-less account, returns a ready-to-send `…/auth/instant?token=…&next=…` URL plus the live session token (so the account can be seeded with polls/votes before the link is sent).
- `POST /api/auth/instant/adopt` + `app/auth/instant/page.tsx` — the recipient's browser exchanges the URL token, links the browser to the account, signs in, and redirects to a validated same-origin `?next=` path.
- **Both endpoints are gated to non-prod tiers** via the request `Origin` (`services.fe_origin.is_prod_origin`): a real prod request — or one with no/forged Origin — gets `503`. The landing page also refuses on `whoeverwants.com`. This keeps the "sign in from a URL token" (login-CSRF) capability off production entirely; on dev/canary the threat model is throwaway demo data.
- `next` is validated to a same-origin relative path server-side (open-redirect targets dropped) and again on the FE.
- Docs: new "Dev Instant Sign-In Links" subsection in CLAUDE.md (endpoints, gating, curl recipe, threat model).

No migration, no new token table — the URL carries the session token directly (reusable). Minting reuses `create_name_only_account`; adopt links the browser for parity with every other sign-in path.

## Test plan
- [x] `server/tests/test_instant_link.py` — 13 tests: mint shape + resolvable token, default name, relative-`next` appended, open-redirect `next` dropped, `503` on prod origin / no origin, adopt links recipient browser, end-to-end seeded-group visibility, `400` on bad token, `503` on prod adopt.
- [x] Existing auth suites still green (`test_auth`, `test_name_account`, `test_account_management` — 55 passed).
- [x] Verified live on the branch dev server: minted a "Sam" account, seeded a group with two polls + votes, clicked the link → instantly signed in and landed on the seeded group (screenshot).

https://claude.ai/code/session_01BiAofk9YDXoBasPpoPmhvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiAofk9YDXoBasPpoPmhvb)_