### PR TITLE
Soften time-poll preference card colors to faint theme-aware shades

### DIFF
--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -103,9 +103,9 @@ export default function TimeSlotBubbles({
           "border focus:outline-none focus:ring-2 focus:ring-offset-1",
           disabled ? "cursor-default opacity-60" : "cursor-pointer active:scale-95",
           state === "liked"
-            ? "bg-green-50 dark:bg-green-900/40 border-green-300 dark:border-green-700 text-green-800 dark:text-green-200 focus:ring-green-400"
+            ? "bg-green-100/70 dark:bg-green-900/70 border-green-300 dark:border-green-600 text-green-800 dark:text-green-100 focus:ring-green-400"
             : state === "disliked"
-            ? "bg-red-50 dark:bg-red-900/40 border-red-300 dark:border-red-700 text-red-800 dark:text-red-200 focus:ring-red-400"
+            ? "bg-red-100/70 dark:bg-red-900/70 border-red-300 dark:border-red-600 text-red-800 dark:text-red-100 focus:ring-red-400"
             : "bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 focus:ring-blue-400",
         ].join(" ")}
       >

--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -103,9 +103,9 @@ export default function TimeSlotBubbles({
           "border focus:outline-none focus:ring-2 focus:ring-offset-1",
           disabled ? "cursor-default opacity-60" : "cursor-pointer active:scale-95",
           state === "liked"
-            ? "bg-green-500 border-green-500 text-white focus:ring-green-400"
+            ? "bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 text-green-900 dark:text-green-100 focus:ring-green-400"
             : state === "disliked"
-            ? "bg-red-500 border-red-500 text-white focus:ring-red-400"
+            ? "bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 text-red-900 dark:text-red-100 focus:ring-red-400"
             : "bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 focus:ring-blue-400",
         ].join(" ")}
       >

--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -103,9 +103,9 @@ export default function TimeSlotBubbles({
           "border focus:outline-none focus:ring-2 focus:ring-offset-1",
           disabled ? "cursor-default opacity-60" : "cursor-pointer active:scale-95",
           state === "liked"
-            ? "bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 text-green-900 dark:text-green-100 focus:ring-green-400"
+            ? "bg-green-50 dark:bg-green-900/40 border-green-300 dark:border-green-700 text-green-800 dark:text-green-200 focus:ring-green-400"
             : state === "disliked"
-            ? "bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 text-red-900 dark:text-red-100 focus:ring-red-400"
+            ? "bg-red-50 dark:bg-red-900/40 border-red-300 dark:border-red-700 text-red-800 dark:text-red-200 focus:ring-red-400"
             : "bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 focus:ring-blue-400",
         ].join(" ")}
       >


### PR DESCRIPTION
## Summary
- In the time-poll preferences ballot (`components/TimeSlotBubbles.tsx`), tapping a slot bubble to like/dislike it now uses faint, theme-aware shades instead of the harsh fully-saturated `bg-green-500`/`bg-red-500` + white text.
- Liked/disliked fills are a 70% opacity wash on the base color — `bg-green-100/70 dark:bg-green-900/70` and `bg-red-100/70 dark:bg-red-900/70` — with softer borders (`*-300`/`dark:*-600`) and readable text (`*-800`/`dark:*-100`). The colored border carries the selection cue while the fill stays gentle.
- Light mode reads as a soft pastel tint; dark mode as a subtle translucent wash. Verified in both themes on a live time poll.

## Test plan
- [x] Time poll in the preferences phase: tap slot bubbles to cycle neutral → green (liked) → red (disliked); confirm the muted shades render correctly
- [x] Light theme — pastel green/red tint, readable text
- [x] Dark theme — translucent green/red wash, readable text
- [x] Neutral bubbles, period column, day labels, exclusion badge, and legend unaffected

https://claude.ai/code/session_012W4zkeBEndo8okkWosxRQ2

---
_Generated by [Claude Code](https://claude.ai/code/session_012W4zkeBEndo8okkWosxRQ2)_