### PR TITLE
Fix accidental multi-accounts: sign-in absorb, browser identity, name-required, explicit merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -691,7 +691,8 @@ The user's saved display name (`lib/userProfile.ts: getUserName/saveUserName`, l
 - **`<AccountGateModal>` (`components/AccountGateModal.tsx`) is the canonical "we need an account" surface** (it replaced the old name-only `NameRequiredModal`, now deleted). Layout per the owner's spec: **sign-in methods FIRST** (`<SignInOptions mode="signin">` — a returning user's account name auto-fills + the gate auto-proceeds), THEN a "name or alias" field + Continue that mints a recovery-less account via `apiCreateNameAccount`. Three callsites, unchanged in shape (`onSubmit`/`onCancel`, `message` is a contextual phrase folded into the title — "Sign in to vote"): `CreateGroupButtonHost`, `CreateQuestionContent` (category bubble tap), `PollDetail` (every vote Submit path). z-`[75]`.
   - **Sign-in that yields no name keeps the modal open.** `handleSignInComplete` reads `getCurrentUser()?.name`; if the (now-signed-in) account is nameless it clears + focuses the name field, and `apiCreateNameAccount`'s signed-in branch then SETS the name on the existing account rather than minting a second one. So the name field is the universal finisher regardless of which path the user took.
 - **`<SignInOptions mode="signin"|"link">` (`components/SignInOptions.tsx`) is the single shared provider-button block** (Google / Apple / passkey / email) behind `SignInModal`, `AccountGateModal`, `AddSignInOptionsModal`, and (via SignInModal) Settings — so every "auth surface" looks identical. `mode` only changes labels, the passkey button set, and the email endpoint; the OAuth handlers are byte-identical because the SERVER decides link-vs-switch from the bearer token (signed-in `/oauth/{provider}` ATTACHES the identity to the current account via `attach_oauth_identity`; anonymous creates/switches via `complete_sign_in`). `onComplete` fires only on SYNCHRONOUS success (OAuth/passkey) — email is async ("check your inbox" is its terminal inline state). Don't re-inline the buttons anywhere; extend this component.
-- **Providing a name creates a recovery-less account (migration 123).** `POST /api/auth/account/name` mints a `users` row (`display_name` set, no `user_identities` → `providers: []`), links the browser, issues a session — OR, when already signed in, just sets the name on the existing account. Existing `group_members` rows (browser-keyed) carry over for free. Because such an account can't be recovered if the device is lost, `users.recovery_reminder_dismissed` + the home-page banner nudge the user to add a sign-in method.
+- **Providing a name creates a browser-tied account (migration 123 + 128).** `POST /api/auth/account/name` mints a `users` row (`display_name` set) + a device-bound `browser` identity (migration 128 — so `providers: ['browser']`, NOT empty; the invariant is "every account has ≥1 identity, no session without one"), links the browser, issues a session — OR, when already signed in, just sets the name on the existing account. The `browser` identity is a first-class-but-weak sign-in method (shows as "This browser" in Settings, `provider_user_id` is a random marker NOT the browser_id, resolution stays via `user_browsers`); `account_has_durable_identity` (`provider <> 'browser'`) is the "real account?" predicate. Existing `group_members` rows (browser-keyed) carry over for free. Because such an account can't be recovered if the device is lost, `users.recovery_reminder_dismissed` + the home-page banner nudge the user to add a DURABLE method (`hasRecoveryMethod` in `RecoveryReminderHost` counts only email/google/apple, never `browser`/passkey).
+- **A name is required for every account; sign-in completion enforces it (no nameless accounts).** A name is needed for any action beyond viewing public groups / generating link previews. A durable sign-in (OAuth / passkey / magic link) can land on a brand-new nameless account, so every interactive sign-in completion collects one: the shared `<NamePromptPanel>` (`components/NamePromptPanel.tsx`, name input + `apiCreateNameAccount`) is shown by `SignInModal` + `/auth/verify` when the resulting account is nameless, and is `AccountGateModal`'s always-visible "or just provide a name" path. `NamePromptPanel` focuses on mount only when passed `autoFocus` (SignInModal / verify, where it mounts only-when-needed); `AccountGateModal` passes `focusNonce` (bumped after a nameless sign-in) so the name field does NOT steal focus / pop the mobile keyboard when the gate first opens as a passive alternative to signing in.
 - **`<RecoveryReminderHost>` (`components/RecoveryReminderHost.tsx`, mounted in `app/layout.tsx` outside ResponsiveScaling like CreateGroupButtonHost)** shows a bottom-left "Secure your account" banner on `/` when signed in AND the account has no email/Google/Apple identity (`hasRecoveryMethod`) AND `!recovery_reminder_dismissed`. Tapping opens `<AddSignInOptionsModal>` = `<SignInOptions mode="link">` (links a method to the current account; OAuth/passkey appear only when the tier+device support them — on dev with no OAuth config + no platform authenticator, only the email path shows) + a "Don't remind me again" toggle (`apiSetRecoveryReminderDismissed`). Adding a recovery identity hides the banner automatically (providers change); the toggle hides it without one. Settings opens the SAME `AddSignInOptionsModal` via the "Add a sign-in method" row (shown when signed in + no email identity) — it replaced the old bespoke inline recovery-email section.
   - **Pitfall: `addInitScript(() => localStorage.clear())` in a Playwright demo re-runs on EVERY navigation**, so it wipes a session created mid-flow on the next `goto`. A fresh `browser.newContext()` already starts anonymous — don't clear at all.
 - **No inline `<CompactNameField>` in ballots or the create-poll form.** Earlier iterations rendered "Your Name" inputs in the wrapper Submit sections of `app/g/[groupShortId]/p/[pollShortId]/page.tsx`, the create-poll modal bottom card, and each ballot's internal Submit (`QuestionBallot.tsx`, `RankingSection.tsx`, `QuestionBallot/TimeBallotSection.tsx`, `SuggestionVotingInterface.tsx`). They're all gone. Per-poll name overrides are not supported — your name is your name.
@@ -996,8 +997,8 @@ state can be shared as one click. Lives in `server/routers/auth.py`
 ("Dev-only instant sign-in links" section) + `app/auth/instant/page.tsx`.
 
 - **`POST /api/auth/dev/instant-link`** (caller: developer, via curl). Body
-  `{name?="Demo User", next?}`. Mints a recovery-less account
-  (`create_name_only_account` → `providers: []`), returns
+  `{name?="Demo User", next?}`. Mints a browser-tied account
+  (`create_name_only_account` → `providers: ['browser']`, migration 128), returns
   `{url, session_token, expires_at, user_id, name, browser_id}`. `url` =
   `<fe_origin>/auth/instant?token=<sessionToken>[&next=<urlencoded path>]`.
   The `session_token` is a **real 90-day bearer** — keep using it (with the
@@ -1498,22 +1499,50 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
       `create_poll` pins a creating browser_id and `creator_headers(poll)` /
       `close_poll` / `reopen_poll` / `cutoff_poll` replay it so mutations
       authorize.
-  - **TODO — merge an auto-created anonymous account into a real one on
-    sign-in.** When an anonymous-account browser later signs in with a
-    real identity (email / OAuth / passkey), `link_browser_to_user`
-    repoints the browser to the real user_id — orphaning the anonymous
-    account AND its polls/groups (whose `creator_user_id` still points at
-    the orphan). Effect: the just-signed-in user loses creator authority
-    over polls they made while anonymous (until they're back on... nothing
-    — the browser is repointed). A future PR should, at sign-in, move the
-    anonymous account's `creator_user_id` rows (polls + groups), its
-    `group_members`/poll authorship, etc. onto the signed-in account, then
-    delete the orphan. Parallel to the already-deferred "claim an
-    anonymous-created group". The anonymous group stays PUBLIC so
-    URL-sharing keeps working regardless; this is purely about restoring
-    the creator's management controls cross-identity. **Still no
-    poll-edit-mutation endpoint** (title/options), so "edit" remains the
-    four close/reopen/cutoff endpoints.
+  - **Account merge on sign-in — SHIPPED.** A browser-tied / name-only /
+    auto-created account has no DURABLE identity (only a `browser`
+    provider row, or none — `account_has_durable_identity` in
+    `services/auth.py` is the `provider <> 'browser'` predicate). When
+    that browser later signs in with a real identity, `complete_sign_in`
+    ABSORBS the weak account instead of orphaning it (no more stranded
+    `creator_user_id`): if the incoming identity is BRAND NEW it folds
+    the freshly-minted account INTO the prior weak account (keeper =
+    prior, which gains the durable identity — upgrade in place); if the
+    incoming identity already belongs to a real account it folds the weak
+    account's data INTO that account (keeper = the real one). A browser
+    already on a durable account is left alone (real account switch). The
+    reusable primitive is `merge_accounts(conn, *, source_user_id,
+    dest_user_id)` — it repoints every `users(id)`-referencing column
+    (identities except the source's redundant `browser` marker, browsers,
+    sessions, passkeys, polls/groups `creator_user_id`, invites, join
+    requests with partial-unique-pending dedup, magic-link tokens,
+    user_profiles keeping dest's photo on PK collision,
+    group_notification_preferences with dedup, user_contacts both
+    directions avoiding self-contacts) then deletes the source user, and
+    copies the source's `display_name` onto the dest only when the dest
+    has none. Tests: `server/tests/test_account_merge.py`. **Caveat
+    (shared device):** a browser-only account IS "whoever is on this
+    browser," so absorbing it moves polls made on this browser into the
+    signed-in account — accepted as the lesser evil vs. orphaning them.
+    **Still no poll-edit-mutation endpoint** (title/options), so "edit"
+    remains the four close/reopen/cutoff endpoints.
+  - **Explicit two-account merge — SHIPPED.** For users who ended up with
+    TWO real accounts that never auto-merge (passkey-only + email,
+    Apple-relay + Google — no shared verified-email signal). Settings →
+    "Combine another account" (`components/MergeAccountModal.tsx` →
+    `<SignInOptions mode="merge">`) lets a signed-in user (A) authenticate
+    the OTHER account (B); the server folds B into A via `merge_accounts`.
+    Dual proof authorizes it: A's bearer + B's just-verified ceremony. The
+    `merge` flag on `POST /api/auth/oauth/{google,apple}` +
+    `/passkey/authentication/verify` triggers `merge_in_other_account`
+    (which resolves B via the read-only `resolve_existing_user_for_identity`
+    and folds it in) when a signed-in caller verifies an identity owned by
+    a different account — otherwise the existing `409 conflict` stands.
+    Only the SYNCHRONOUS ceremonies (OAuth / passkey) support merge — email
+    is async (the link lands on `/auth/verify` with no merge context) and
+    passkey-registration would mint a new credential, so both are hidden in
+    `mode="merge"`. The keeper is always A (the bearer's account), so the
+    FE stays signed in as A throughout.
 - C-follow-up: ~~native Google Sign In on iOS~~ **shipped** (per-bundle iOS client IDs hardcoded in `lib/oauth.ts: GOOGLE_IOS_CLIENT_IDS`; reversed URL scheme stamped into `Info.plist: CFBundleURLTypes` by `ios-build.yml`; uses the same `@capgo/capacitor-social-login` plugin as Apple native).
 
 **Phase I (account management) shipped in migration 118.** Adds a

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -3,6 +3,8 @@
 import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { apiVerifyMagicLink, ApiError } from "@/lib/api";
+import { isValidUserName } from "@/lib/nameValidation";
+import NamePromptPanel from "@/components/NamePromptPanel";
 import { usePageReady } from "@/lib/usePageReady";
 
 /**
@@ -16,7 +18,7 @@ import { usePageReady } from "@/lib/usePageReady";
  * eat the token before the user actually taps it.
  */
 
-type Status = "verifying" | "success" | "error";
+type Status = "verifying" | "success" | "needName" | "error";
 
 function VerifyPageContent() {
   const router = useRouter();
@@ -42,6 +44,13 @@ function VerifyPageContent() {
       try {
         const res = await apiVerifyMagicLink(token);
         setEmail(res.user.email);
+        // The app requires a name for every account. A first-time email
+        // sign-in lands on a nameless account — collect a name before
+        // redirecting instead of leaving the account nameless.
+        if (!isValidUserName(res.user.name?.trim() ?? "")) {
+          setStatus("needName");
+          return;
+        }
         setStatus("success");
         // Brief pause so the user reads the confirmation, then settings.
         setTimeout(() => router.replace("/settings"), 1500);
@@ -89,6 +98,20 @@ function VerifyPageContent() {
           <p className="text-gray-600 dark:text-gray-400">
             {email ? `as ${email}` : null}
           </p>
+        </div>
+      )}
+      {status === "needName" && (
+        <div className="max-w-sm mx-auto text-left">
+          <h1 className="text-xl font-semibold mb-2 text-center">
+            You&apos;re signed in
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 text-center">
+            Add a name or alias so others can see who you are.
+          </p>
+          <NamePromptPanel
+            onComplete={() => router.replace("/settings")}
+            focusNonce={1}
+          />
         </div>
       )}
       {status === "error" && (

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -110,7 +110,7 @@ function VerifyPageContent() {
           </p>
           <NamePromptPanel
             onComplete={() => router.replace("/settings")}
-            focusNonce={1}
+            autoFocus
           />
         </div>
       )}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -656,6 +656,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   google: "Google",
   apple: "Apple",
   passkey: "Passkey",
+  browser: "This browser",
 };
 
 function formatProviders(providers: string[]): string {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -23,6 +23,7 @@ import {
 import { SESSION_CHANGED_EVENT, type SessionUser } from "@/lib/session";
 import SignInModal from "@/components/SignInModal";
 import AddSignInOptionsModal from "@/components/AddSignInOptionsModal";
+import MergeAccountModal from "@/components/MergeAccountModal";
 import { usePageReady } from "@/lib/usePageReady";
 import { navigateWithTransition } from "@/lib/viewTransitions";
 import HeaderPortal from "@/components/HeaderPortal";
@@ -103,6 +104,9 @@ export default function SettingsPage() {
   // signed in AND the account has no 'email' provider (passkey-only /
   // OAuth-only / name-only).
   const [addSignInOpen, setAddSignInOpen] = useState(false);
+  // "Combine another account" — folds a second real account into this one
+  // (for users who accidentally created two). Opens MergeAccountModal.
+  const [mergeOpen, setMergeOpen] = useState(false);
 
   const hasEmailIdentity = !!currentUser?.providers?.includes("email");
 
@@ -352,6 +356,20 @@ export default function SettingsPage() {
               <span className="text-base font-normal text-gray-500 dark:text-gray-500 truncate">
                 {formatProviders(currentUser.providers)}
               </span>
+            </div>
+          )}
+          {currentUser && (
+            <div className="flex items-center justify-between gap-3 h-12 border-t border-gray-200 dark:border-gray-700">
+              <span className="text-base font-normal shrink-0">
+                Have two accounts?
+              </span>
+              <button
+                type="button"
+                onClick={() => setMergeOpen(true)}
+                className="text-base font-normal text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Combine another account
+              </button>
             </div>
           )}
         </section>
@@ -640,6 +658,10 @@ export default function SettingsPage() {
         onClose={() => setSignInModalOpen(false)}
       />
 
+      <MergeAccountModal
+        isOpen={mergeOpen}
+        onClose={() => setMergeOpen(false)}
+      />
       <AddSignInOptionsModal
         isOpen={addSignInOpen}
         onClose={() => setAddSignInOpen(false)}

--- a/components/AccountGateModal.tsx
+++ b/components/AccountGateModal.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useRef, useState } from "react";
 import ModalPortal from "./ModalPortal";
 import SignInOptions from "./SignInOptions";
-import { MAX_NAME_LENGTH, validateUserName, isValidUserName } from "@/lib/nameValidation";
+import NamePromptPanel from "./NamePromptPanel";
+import { isValidUserName } from "@/lib/nameValidation";
 import { getUserName } from "@/lib/userProfile";
-import { apiCreateNameAccount, getCurrentUser } from "@/lib/api";
+import { getCurrentUser } from "@/lib/api";
 
 interface AccountGateModalProps {
   isOpen: boolean;
@@ -35,10 +36,7 @@ export default function AccountGateModal({
   onCancel,
   message,
 }: AccountGateModalProps) {
-  const [name, setName] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [nameFocusNonce, setNameFocusNonce] = useState(0);
   const openedAtRef = useRef(0);
 
   const onCancelRef = useRef(onCancel);
@@ -49,9 +47,6 @@ export default function AccountGateModal({
   useEffect(() => {
     if (!isOpen) return;
     openedAtRef.current = Date.now();
-    setName(getUserName() ?? "");
-    setError(null);
-    setSubmitting(false);
   }, [isOpen]);
 
   useEffect(() => {
@@ -69,41 +64,18 @@ export default function AccountGateModal({
 
   if (!isOpen) return null;
 
-  const validation = validateUserName(name);
-  const errorText =
-    error ?? (name.length > 0 && !validation.ok ? validation.error : null);
-
   // A sign-in (OAuth / passkey) completed inside SignInOptions. If the
   // resulting account already carries a name (returning user), we're done —
   // proceed. Otherwise the user is now signed in but nameless: keep the modal
-  // open so they fill in the "name or alias" field, which `apiCreateNameAccount`
-  // then writes to the existing account.
+  // open and focus the "name or alias" field, which `NamePromptPanel` writes
+  // to the existing account.
   const handleSignInComplete = () => {
     const accountName = getCurrentUser()?.name?.trim() || getUserName()?.trim() || "";
     if (isValidUserName(accountName)) {
       onSubmit();
       return;
     }
-    setName("");
-    setError(null);
-    // Nudge focus toward the name field now that sign-in alone didn't finish.
-    setTimeout(() => inputRef.current?.focus(), 50);
-  };
-
-  const handleContinue = async () => {
-    const trimmed = name.trim();
-    if (!validateUserName(trimmed).ok) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      // Creates a recovery-less account (anonymous) OR sets the name on the
-      // already-signed-in account; persists the session either way.
-      await apiCreateNameAccount(trimmed);
-      onSubmit();
-    } catch {
-      setError("Couldn't save your name. Try again in a moment.");
-      setSubmitting(false);
-    }
+    setNameFocusNonce((n) => n + 1);
   };
 
   const handleBackdropClick = () => {
@@ -144,36 +116,7 @@ export default function AccountGateModal({
             <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
           </div>
 
-          <input
-            id="account-gate-name"
-            ref={inputRef}
-            type="text"
-            value={name}
-            onChange={(e) => {
-              setName(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && validation.ok && !submitting) {
-                e.preventDefault();
-                void handleContinue();
-              }
-            }}
-            maxLength={MAX_NAME_LENGTH}
-            placeholder="e.g. Alex"
-            className="w-full mb-3 px-3 py-2 text-base bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          {errorText && (
-            <p className="mb-3 text-sm text-red-600 dark:text-red-400">{errorText}</p>
-          )}
-          <button
-            type="button"
-            onClick={handleContinue}
-            disabled={!validation.ok || submitting}
-            className="w-full rounded-full bg-foreground text-background h-11 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {submitting ? "Setting up…" : "Continue"}
-          </button>
+          <NamePromptPanel onComplete={onSubmit} focusNonce={nameFocusNonce} />
         </div>
       </div>
     </ModalPortal>

--- a/components/MergeAccountModal.tsx
+++ b/components/MergeAccountModal.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import ModalPortal from "./ModalPortal";
+import SignInOptions from "./SignInOptions";
+
+interface MergeAccountModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Settings → "Combine another account". For when a user accidentally ended up
+ * with two real accounts (e.g. a passkey account and a Google account, or
+ * Apple "Hide My Email" + Google). The user is signed into account A; each
+ * button here AUTHENTICATES the OTHER account (B) and the server folds B into
+ * A — B's polls, groups, and sign-in methods move onto A, and B is deleted.
+ *
+ * The dual proof authorizes it: A's bearer (already signed in) + B's
+ * just-completed sign-in ceremony. `<SignInOptions mode="merge">` passes the
+ * `merge` flag to the OAuth / passkey verify endpoints; the caller stays
+ * signed in as A throughout. Only the synchronous ceremonies are offered
+ * (email is async and doesn't fit an in-modal merge).
+ */
+export default function MergeAccountModal({
+  isOpen,
+  onClose,
+}: MergeAccountModalProps) {
+  const openedAtRef = useRef(0);
+
+  useEffect(() => {
+    if (isOpen) openedAtRef.current = Date.now();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handle);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handle);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleBackdropClick = () => {
+    if (Date.now() - openedAtRef.current < 400) return;
+    onClose();
+  };
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-[80] flex items-center justify-center p-4 overflow-y-auto">
+        <div
+          className="absolute inset-0 bg-black/50 dark:bg-black/70"
+          onClick={handleBackdropClick}
+        />
+        <div className="relative w-full max-w-sm rounded-2xl bg-white dark:bg-gray-900 p-6 shadow-xl my-auto">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="absolute top-3 right-3 w-8 h-8 rounded-full flex items-center justify-center text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <h2 className="text-lg font-semibold mb-2 pr-6">Combine another account</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            Sign in to your <strong>other</strong> account below. Its polls,
+            groups, and sign-in methods move into this one, and the other
+            account is permanently removed. This can&apos;t be undone.
+          </p>
+
+          <SignInOptions mode="merge" onComplete={onClose} />
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/NamePromptPanel.tsx
+++ b/components/NamePromptPanel.tsx
@@ -36,9 +36,17 @@ export default function NamePromptPanel({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  // Skip the focus effect's initial mount run — callers that want focus on
+  // mount pass `autoFocus` (native). `focusNonce` is for focusing LATER (e.g.
+  // AccountGateModal bumps it after a nameless sign-in) without stealing focus
+  // when the panel first renders as a passive alternative to signing in.
+  const focusMountRef = useRef(true);
 
   useEffect(() => {
-    if (focusNonce === undefined) return;
+    if (focusMountRef.current) {
+      focusMountRef.current = false;
+      return;
+    }
     inputRef.current?.focus();
   }, [focusNonce]);
 

--- a/components/NamePromptPanel.tsx
+++ b/components/NamePromptPanel.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { MAX_NAME_LENGTH, validateUserName } from "@/lib/nameValidation";
+import { getUserName } from "@/lib/userProfile";
+import { apiCreateNameAccount } from "@/lib/api";
+
+interface NamePromptPanelProps {
+  /** Fired after the name is saved to the account (POST /api/auth/account/name,
+   *  which sets the name on the already-signed-in account, or mints a
+   *  browser-tied account when signed out). */
+  onComplete: () => void;
+  /** Bump to programmatically focus the field — e.g. after a sign-in that
+   *  landed on a nameless account, to draw the eye to the name step. */
+  focusNonce?: number;
+  autoFocus?: boolean;
+  ctaLabel?: string;
+}
+
+/**
+ * The "name or alias" entry step shared by every surface that must guarantee
+ * an account ends up with a name (the app requires one for any action beyond
+ * viewing public polls / link previews): `AccountGateModal` (always-shown
+ * alternative to signing in), `SignInModal` + `/auth/verify` (shown only when
+ * a durable sign-in landed on a still-nameless account). Owns the input,
+ * validation, and the `apiCreateNameAccount` call so the three callsites can't
+ * drift on the name rules.
+ */
+export default function NamePromptPanel({
+  onComplete,
+  focusNonce,
+  autoFocus,
+  ctaLabel = "Continue",
+}: NamePromptPanelProps) {
+  const [name, setName] = useState(() => getUserName() ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (focusNonce === undefined) return;
+    inputRef.current?.focus();
+  }, [focusNonce]);
+
+  const validation = validateUserName(name);
+  const errorText =
+    error ?? (name.length > 0 && !validation.ok ? validation.error : null);
+
+  const handleContinue = async () => {
+    const trimmed = name.trim();
+    if (!validateUserName(trimmed).ok) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiCreateNameAccount(trimmed);
+      onComplete();
+    } catch {
+      setError("Couldn't save your name. Try again in a moment.");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type="text"
+        value={name}
+        autoFocus={autoFocus}
+        onChange={(e) => {
+          setName(e.target.value);
+          setError(null);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && validation.ok && !submitting) {
+            e.preventDefault();
+            void handleContinue();
+          }
+        }}
+        maxLength={MAX_NAME_LENGTH}
+        placeholder="e.g. Alex"
+        className="w-full mb-3 px-3 py-2 text-base bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+      {errorText && (
+        <p className="mb-3 text-sm text-red-600 dark:text-red-400">{errorText}</p>
+      )}
+      <button
+        type="button"
+        onClick={handleContinue}
+        disabled={!validation.ok || submitting}
+        className="w-full rounded-full bg-foreground text-background h-11 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {submitting ? "Setting up…" : ctaLabel}
+      </button>
+    </div>
+  );
+}

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import ModalPortal from "./ModalPortal";
 import SignInOptions from "./SignInOptions";
+import NamePromptPanel from "./NamePromptPanel";
+import { isValidUserName } from "@/lib/nameValidation";
+import { getUserName } from "@/lib/userProfile";
+import { getCurrentUser } from "@/lib/api";
 
 interface SignInModalProps {
   isOpen: boolean;
@@ -21,13 +25,30 @@ interface SignInModalProps {
  */
 export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
   const openedAtRef = useRef<number>(0);
+  // The app requires a name for any account. A durable sign-in (OAuth /
+  // passkey) can land on a brand-new nameless account, so switch to the
+  // name step instead of closing until a name is set.
+  const [needName, setNeedName] = useState(false);
 
   // Suppress backdrop dismissal in the first 400ms after open so the
   // synthesized click after a long-press / tap that opened the modal doesn't
   // immediately close it. Mirrors FollowUpModal's pattern.
   useEffect(() => {
-    if (isOpen) openedAtRef.current = Date.now();
+    if (isOpen) {
+      openedAtRef.current = Date.now();
+      setNeedName(false);
+    }
   }, [isOpen]);
+
+  const handleSignInComplete = () => {
+    const accountName =
+      getCurrentUser()?.name?.trim() || getUserName()?.trim() || "";
+    if (isValidUserName(accountName)) {
+      onClose();
+      return;
+    }
+    setNeedName(true);
+  };
 
   useEffect(() => {
     if (!isOpen) return;
@@ -75,9 +96,20 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
             </svg>
           </button>
 
-          <h2 className="text-lg font-semibold mb-4 pr-6">Sign in</h2>
+          <h2 className="text-lg font-semibold mb-4 pr-6">
+            {needName ? "Choose a name" : "Sign in"}
+          </h2>
 
-          <SignInOptions mode="signin" onComplete={onClose} />
+          {needName ? (
+            <>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                Add a name or alias so others can see who you are.
+              </p>
+              <NamePromptPanel onComplete={onClose} focusNonce={1} />
+            </>
+          ) : (
+            <SignInOptions mode="signin" onComplete={handleSignInComplete} />
+          )}
         </div>
       </div>
     </ModalPortal>

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -105,7 +105,7 @@ export default function SignInModal({ isOpen, onClose }: SignInModalProps) {
               <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
                 Add a name or alias so others can see who you are.
               </p>
-              <NamePromptPanel onComplete={onClose} focusNonce={1} />
+              <NamePromptPanel onComplete={onClose} autoFocus />
             </>
           ) : (
             <SignInOptions mode="signin" onComplete={handleSignInComplete} />

--- a/components/SignInOptions.tsx
+++ b/components/SignInOptions.tsx
@@ -42,7 +42,7 @@ import { resolveActiveTheme } from "@/lib/theme";
  * behave consistently.
  */
 
-export type SignInOptionsMode = "signin" | "link";
+export type SignInOptionsMode = "signin" | "link" | "merge";
 
 interface SignInOptionsProps {
   mode: SignInOptionsMode;
@@ -57,6 +57,12 @@ interface SignInOptionsProps {
 
 export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) {
   const isLink = mode === "link";
+  // Explicit two-account merge: each provider button AUTHENTICATES the OTHER
+  // account and folds it into the current one (server `merge` flag). Only the
+  // synchronous ceremonies fit (OAuth / passkey sign-in) — email is async and
+  // passkey-registration would mint a new credential, not prove another
+  // account, so both are hidden in merge mode.
+  const isMerge = mode === "merge";
 
   const [serverProviders, setServerProviders] =
     useState<AuthProvidersResponse | null>(null);
@@ -121,7 +127,7 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
         setOAuthSubmitting("google");
         setError(null);
         try {
-          await apiSignInWithOAuth("google", idToken);
+          await apiSignInWithOAuth("google", idToken, { merge: isMerge });
           onCompleteRef.current?.();
         } catch (err) {
           setError(oauthErrorMessage(err, "Google", isLink));
@@ -139,14 +145,14 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
     return () => {
       cancelled = true;
     };
-  }, [emailSent, serverProviders?.google, isLink]);
+  }, [emailSent, serverProviders?.google, isLink, isMerge]);
 
   const handleGoogleSignIn = async () => {
     setError(null);
     setOAuthSubmitting("google");
     try {
       const idToken = await googleSignIn();
-      await apiSignInWithOAuth("google", idToken);
+      await apiSignInWithOAuth("google", idToken, { merge: isMerge });
       onComplete?.();
     } catch (err) {
       if (isOAuthCancel(err)) {
@@ -164,7 +170,7 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
     setOAuthSubmitting("apple");
     try {
       const idToken = await appleSignIn();
-      await apiSignInWithOAuth("apple", idToken);
+      await apiSignInWithOAuth("apple", idToken, { merge: isMerge });
       onComplete?.();
     } catch (err) {
       if (isOAuthCancel(err)) {
@@ -181,7 +187,7 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
     setError(null);
     setOAuthSubmitting("passkey");
     try {
-      await signInWithPasskey();
+      await signInWithPasskey({ merge: isMerge });
       onComplete?.();
     } catch (err) {
       if (err instanceof PasskeyCancelledError) {
@@ -256,12 +262,12 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
   // (Touch ID / Face ID / Windows Hello). In link mode it's the ONLY
   // passkey button (you're already signed in, so there's nothing to sign
   // into); in signin mode it accompanies the "sign in with a passkey" one.
-  const showPasskeyRegister = showPasskey && platformPasskey === true;
+  const showPasskeyRegister = showPasskey && platformPasskey === true && !isMerge;
   const busy = oauthSubmitting !== null;
 
   return (
     <div>
-      {emailSent ? (
+      {!isMerge && (emailSent ? (
         <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-3 py-3">
           <p className="text-sm text-gray-700 dark:text-gray-300">
             {isLink
@@ -307,13 +313,15 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
                 : "Send sign-in link"}
           </button>
         </form>
-      )}
+      ))}
 
-      <div className="flex items-center gap-3 my-4">
-        <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
-        <span className="text-xs text-gray-500 dark:text-gray-400">or</span>
-        <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
-      </div>
+      {!isMerge && (
+        <div className="flex items-center gap-3 my-4">
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+          <span className="text-xs text-gray-500 dark:text-gray-400">or</span>
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+        </div>
+      )}
 
       {showGoogle &&
         (isNativeIOS() ? (
@@ -326,9 +334,11 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
             <GoogleGlyph />
             {oauthSubmitting === "google"
               ? "Connecting…"
-              : isLink
-                ? "Connect Google"
-                : "Sign in with Google"}
+              : isMerge
+                ? "Combine via Google"
+                : isLink
+                  ? "Connect Google"
+                  : "Sign in with Google"}
           </button>
         ) : (
           <div className="mb-3">
@@ -349,9 +359,11 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
           <AppleGlyph />
           {oauthSubmitting === "apple"
             ? "Connecting…"
-            : isLink
-              ? "Connect Apple"
-              : "Sign in with Apple"}
+            : isMerge
+              ? "Combine via Apple"
+              : isLink
+                ? "Connect Apple"
+                : "Sign in with Apple"}
         </button>
       )}
       {/* Passkey: link mode → "Add a passkey" only; signin mode → sign in +
@@ -366,7 +378,9 @@ export default function SignInOptions({ mode, onComplete }: SignInOptionsProps) 
           <PasskeyGlyph />
           {oauthSubmitting === "passkey"
             ? "Signing in…"
-            : "Sign in with a passkey"}
+            : isMerge
+              ? "Combine via passkey"
+              : "Sign in with a passkey"}
         </button>
       )}
       {showPasskeyRegister && (

--- a/database/migrations/128_browser_identity_down.sql
+++ b/database/migrations/128_browser_identity_down.sql
@@ -1,0 +1,14 @@
+-- Reverse migration 128: drop the 'browser' identity rows and restore the
+-- original provider CHECK. Accounts whose ONLY identity was the browser
+-- marker revert to identity-less (the pre-128 state). Durable identities
+-- attached after 128 are untouched.
+
+BEGIN;
+
+DELETE FROM user_identities WHERE provider = 'browser';
+
+ALTER TABLE user_identities DROP CONSTRAINT IF EXISTS user_identities_provider_check;
+ALTER TABLE user_identities ADD CONSTRAINT user_identities_provider_check
+  CHECK (provider IN ('email', 'apple', 'google', 'passkey'));
+
+COMMIT;

--- a/database/migrations/128_browser_identity_up.sql
+++ b/database/migrations/128_browser_identity_up.sql
@@ -1,0 +1,37 @@
+-- Make the browser tie a first-class (device-bound) identity so the
+-- invariant "no session / account without an identity" holds literally.
+--
+-- The lightweight account created by the vote-first / "just provide a name"
+-- path used to have ZERO user_identities rows — an identity-less account.
+-- This migration models the browser tie as a real (but weak) identity
+-- provider, alongside email / apple / google / passkey, so it shows up as
+-- "This browser" in the account's sign-in methods and durable methods attach
+-- on top of it later (upgrade in place).
+--
+-- provider_user_id is a fresh random marker, NOT the browser_id: the browser
+-- identity is a LABEL ("this account is anchored to a browser"), never a
+-- re-resolvable credential. Browser → account resolution stays via
+-- `user_browsers` (unchanged). Using a random marker keeps the
+-- (provider, provider_user_id) PK collision-free across sign-out/recreate and
+-- merge_accounts moves, and avoids the "resurrect a deleted account by its
+-- browser_id" edge cases entirely.
+
+BEGIN;
+
+ALTER TABLE user_identities DROP CONSTRAINT IF EXISTS user_identities_provider_check;
+ALTER TABLE user_identities ADD CONSTRAINT user_identities_provider_check
+  CHECK (provider IN ('email', 'apple', 'google', 'passkey', 'browser'));
+
+-- Backfill: every existing identity-less account gets a 'browser' marker so
+-- the invariant holds retroactively. Covers vote-first auto-accounts,
+-- name-only accounts, and abandoned passkey-registration-options orphans.
+-- The marker is harmless for the orphans (they remain unreachable — no session,
+-- no browser link) and correct for the real browser accounts.
+INSERT INTO user_identities (provider, provider_user_id, user_id, email)
+SELECT 'browser', 'backfill-' || gen_random_uuid()::text, u.id, NULL
+  FROM users u
+ WHERE NOT EXISTS (
+   SELECT 1 FROM user_identities i WHERE i.user_id = u.id
+ );
+
+COMMIT;

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -346,10 +346,11 @@ export type OAuthProvider = "google" | "apple";
 export async function apiSignInWithOAuth(
   provider: OAuthProvider,
   idToken: string,
+  opts?: { merge?: boolean },
 ): Promise<SessionResponse> {
   const res = await authFetch<SessionResponse>(`/oauth/${provider}`, {
     method: "POST",
-    body: JSON.stringify({ id_token: idToken }),
+    body: JSON.stringify({ id_token: idToken, merge: opts?.merge ?? false }),
   });
   persistSignIn(res.session_token, res.user);
   return res;
@@ -430,10 +431,11 @@ export async function apiPasskeyAuthenticationOptions(): Promise<unknown> {
  *  fetches attach the bearer token. */
 export async function apiPasskeyAuthenticationVerify(
   credential: unknown,
+  opts?: { merge?: boolean },
 ): Promise<SessionResponse> {
   const res = await authFetch<SessionResponse>("/passkey/authentication/verify", {
     method: "POST",
-    body: JSON.stringify({ credential }),
+    body: JSON.stringify({ credential, merge: opts?.merge ?? false }),
   });
   persistSignIn(res.session_token, res.user);
   return res;

--- a/lib/passkeys.ts
+++ b/lib/passkeys.ts
@@ -317,7 +317,9 @@ export async function registerPasskey(
  *  passkey from their OS prompt; the server resolves the user_id from
  *  the credential. On success the SessionResponse is persisted into
  *  lib/session so subsequent fetches attach the bearer token. */
-export async function signInWithPasskey(): Promise<SessionResponse> {
+export async function signInWithPasskey(
+  opts?: { merge?: boolean },
+): Promise<SessionResponse> {
   if (!passkeySupported()) throw new PasskeyUnsupportedError();
   const options = (await apiPasskeyAuthenticationOptions()) as ServerAuthenticationOptions;
   const decoded = decodeAuthenticationOptions(options);
@@ -337,5 +339,5 @@ export async function signInWithPasskey(): Promise<SessionResponse> {
   }
   if (!credential) throw new PasskeyCancelledError();
   const serialized = serializeAuthenticationCredential(credential);
-  return apiPasskeyAuthenticationVerify(serialized);
+  return apiPasskeyAuthenticationVerify(serialized, opts);
 }

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -57,6 +57,7 @@ from services.auth import (
     link_browser_to_user,
     load_user_profile,
     lookup_session_user_id,
+    merge_in_other_account,
     normalize_email,
     peek_recovery_email_token,
     revoke_session,
@@ -170,6 +171,12 @@ class OAuthSignInBody(BaseModel):
     """
 
     id_token: str = Field(min_length=32, max_length=4096)
+    # Explicit two-account merge intent (set by Settings → "Combine another
+    # account"). When the signed-in caller verifies an identity owned by a
+    # DIFFERENT account, fold that account into the current one instead of
+    # 409-ing. Ignored when not signed in. Default false so ordinary sign-in /
+    # link behavior is unchanged.
+    merge: bool = False
 
 
 class ProvidersResponse(BaseModel):
@@ -544,6 +551,7 @@ def _handle_oauth_signin(
     provider_label: str,
     configured: bool,
     verify: callable,
+    merge: bool = False,
 ) -> SessionResponse:
     """Provider-agnostic OAuth handler. The verify endpoint passes its
     provider-specific `configured()` flag + `verify(id_token)` function;
@@ -568,7 +576,18 @@ def _handle_oauth_signin(
             # current account (e.g. a recovery-less name-only account
             # adding Google/Apple for recovery) rather than switching to
             # a separate account. Conflict when the identity (or its
-            # verified email) already belongs to a different user.
+            # verified email) already belongs to a different user — UNLESS
+            # the caller asked to merge, in which case fold that other
+            # account into the current one first (the bearer proves the
+            # current account; this just-verified identity proves the other).
+            if merge:
+                merge_in_other_account(
+                    conn,
+                    current_user_id=current_user_id,
+                    provider=identity.provider,
+                    provider_user_id=identity.provider_user_id,
+                    email=identity.email,
+                )
             result = attach_oauth_identity(
                 conn,
                 user_id=current_user_id,
@@ -622,6 +641,7 @@ def sign_in_with_google(req: OAuthSignInBody, request: Request):
         provider_label="Google",
         configured=google_configured(),
         verify=verify_google_id_token,
+        merge=req.merge,
     )
 
 
@@ -645,6 +665,7 @@ def sign_in_with_apple(req: OAuthSignInBody, request: Request):
         provider_label="Apple",
         configured=apple_configured(),
         verify=verify_apple_id_token,
+        merge=req.merge,
     )
 
 
@@ -976,6 +997,11 @@ class PasskeyAuthenticationVerifyBody(BaseModel):
     `navigator.credentials.get()`."""
 
     credential: dict
+    # Explicit two-account merge intent — same semantics as the OAuth body.
+    # When the signed-in caller authenticates a passkey owned by a DIFFERENT
+    # account, fold that account into the current one. Ignored when not
+    # signed in.
+    merge: bool = False
 
 
 class PasskeySummary(BaseModel):
@@ -1188,6 +1214,7 @@ def passkey_authentication_verify(
     browser_id = _require_browser_id(request)
     rp_id = _resolve_rp_id(request)
     origin = _resolve_fe_origin(request)
+    current_user_id = _user_id(request)
     try:
         with get_db() as conn:
             authed = complete_authentication(
@@ -1197,14 +1224,36 @@ def passkey_authentication_verify(
                 origin=origin,
                 credential_json=req.credential,
             )
-            completed = complete_sign_in(
-                conn,
-                provider="passkey",
-                provider_user_id=authed.credential_id,
-                email=None,
-                browser_id=browser_id,
-                user_agent=request.headers.get("user-agent"),
-            )
+            if current_user_id and req.merge:
+                # Explicit merge: the just-verified passkey proves the OTHER
+                # account; the bearer proves the current one. Fold the other
+                # into the current (the merge moves the credential onto it),
+                # then keep the caller on their current account.
+                merge_in_other_account(
+                    conn,
+                    current_user_id=current_user_id,
+                    provider="passkey",
+                    provider_user_id=authed.credential_id,
+                    email=None,
+                )
+                session = issue_session(
+                    conn,
+                    user_id=current_user_id,
+                    browser_id=browser_id,
+                    user_agent=request.headers.get("user-agent"),
+                )
+                profile = load_user_profile(conn, current_user_id)
+                assert profile is not None
+                completed = CompletedSignIn(session=session, profile=profile)
+            else:
+                completed = complete_sign_in(
+                    conn,
+                    provider="passkey",
+                    provider_user_id=authed.credential_id,
+                    email=None,
+                    browser_id=browser_id,
+                    user_agent=request.headers.get("user-agent"),
+                )
     except PasskeyError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return _signin_response(completed)

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -191,6 +191,66 @@ def resolve_or_merge_user(
     return ResolvedUser(user_id=user_id, is_new_user=True)
 
 
+def resolve_existing_user_for_identity(
+    conn,
+    *,
+    provider: str,
+    provider_user_id: str,
+    email: str | None,
+) -> str | None:
+    """Read-only sibling of `resolve_or_merge_user`: which EXISTING user does
+    this identity resolve to, WITHOUT inserting anything? Returns the user_id
+    via the (provider, provider_user_id) match, else the verified-email match,
+    else None. Used by the explicit-merge flow to find the "other account" to
+    fold into the signed-in one."""
+    existing = conn.execute(
+        """
+        SELECT user_id FROM user_identities
+        WHERE provider = %(p)s AND provider_user_id = %(pid)s
+        """,
+        {"p": provider, "pid": provider_user_id},
+    ).fetchone()
+    if existing:
+        return str(existing["user_id"])
+    if email:
+        merged = conn.execute(
+            """
+            SELECT user_id FROM user_identities
+            WHERE email = %(e)s
+            ORDER BY created_at ASC
+            LIMIT 1
+            """,
+            {"e": normalize_email(email)},
+        ).fetchone()
+        if merged:
+            return str(merged["user_id"])
+    return None
+
+
+def merge_in_other_account(
+    conn,
+    *,
+    current_user_id: str,
+    provider: str,
+    provider_user_id: str,
+    email: str | None,
+) -> bool:
+    """Explicit two-account merge: when a signed-in user (A) proves control of
+    an identity owned by a DIFFERENT existing account (B) — by completing B's
+    sign-in ceremony with merge intent — fold B into A. Returns True if a merge
+    happened (B existed and != A), False otherwise (identity unowned or already
+    A's). After this, A owns everything B had; the caller attaches the identity
+    to A (a no-op for credentials the merge already moved). The dual proof
+    (A's bearer + B's just-verified ceremony) is what authorizes the merge."""
+    other = resolve_existing_user_for_identity(
+        conn, provider=provider, provider_user_id=provider_user_id, email=email
+    )
+    if other and other != current_user_id:
+        merge_accounts(conn, source_user_id=other, dest_user_id=current_user_id)
+        return True
+    return False
+
+
 def link_browser_to_user(conn, *, user_id: str, browser_id: str | None) -> None:
     """Establish or update the browser → user link. ON CONFLICT
     (browser_id) DO UPDATE: a browser can only be linked to one user at

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -251,12 +251,10 @@ def create_anonymous_user(
     happen with BrowserIdMiddleware), the account is created unlinked and
     is effectively unmanageable — a defensive edge, not a real path.
 
-    TODO (account merge): if this browser later signs in with a real
-    identity (email / OAuth / passkey), `link_browser_to_user` repoints
-    the browser to the real user_id, orphaning this anonymous account and
-    its polls/groups. A future PR should merge the anonymous account into
-    the signed-in one (move creator_user_id on polls + groups, memberships,
-    etc., then delete the orphan). See docs/auth-access-model.md."""
+    Such an account has no durable identity, so when this browser later
+    signs in with a real identity (email / OAuth / passkey),
+    `complete_sign_in` ABSORBS it into the signed-in account rather than
+    orphaning its polls/groups — see `complete_sign_in` + `merge_accounts`."""
     row = conn.execute(
         "INSERT INTO users (display_name) VALUES (%(n)s) RETURNING id",
         {"n": display_name},
@@ -264,6 +262,203 @@ def create_anonymous_user(
     user_id = str(row["id"])
     link_browser_to_user(conn, user_id=user_id, browser_id=browser_id)
     return user_id
+
+
+def account_has_durable_identity(conn, user_id: str) -> bool:
+    """True if the account has at least one identity that isn't bound to a
+    single device — i.e. a way to sign back in from anywhere (email / apple
+    / google / passkey). The `provider <> 'browser'` filter is the
+    canonical "is this a real account vs. a throwaway?" predicate.
+
+    A browser-only (or, today, identity-less) account is the weak,
+    upgradeable kind created by the vote-first / name-only flow; signing in
+    with a durable identity absorbs it (see `complete_sign_in`). The
+    `'browser'` provider doesn't exist yet — it's introduced as a
+    first-class identity in a later migration — but excluding it here now
+    keeps this predicate correct across that change (today every existing
+    identity is durable, so an account with ANY identity row reads as
+    durable, which matches the current behavior)."""
+    row = conn.execute(
+        """
+        SELECT 1 FROM user_identities
+         WHERE user_id = %(u)s::uuid AND provider <> 'browser'
+         LIMIT 1
+        """,
+        {"u": user_id},
+    ).fetchone()
+    return row is not None
+
+
+def merge_accounts(conn, *, source_user_id: str, dest_user_id: str) -> None:
+    """Move everything owned by `source_user_id` onto `dest_user_id`, then
+    delete the source `users` row. Used by (a) sign-in absorb — folding a
+    weak browser-only account into the account the user signed into — and
+    (b) the explicit "combine my two accounts" flow.
+
+    Every column that references `users(id)` (enumerated from the
+    migrations) is repointed here; a missed table would either strand data
+    or fail the final source-user DELETE on a FK that's CASCADE/SET NULL.
+    Constrained tables (unique / partial-unique / composite PK) keep the
+    DEST row on collision and drop the source's, so the keeper's state
+    wins. Caller controls the transaction; this opens no connection.
+
+    Caveat (shared device): because a browser-only account IS effectively
+    "whoever is on this browser", absorbing it into the signed-in account
+    moves polls created on this browser into that account. On a shared
+    device that can mis-attribute the previous occupant's polls — accepted
+    as the lesser evil vs. orphaning them, and the only realistic source of
+    a browser-only account is the device owner's own vote-first flow."""
+    if source_user_id == dest_user_id:
+        return
+    p = {"src": source_user_id, "dst": dest_user_id}
+
+    # --- Identities + auth artifacts (no app-visible conflicts) ---
+    # PKs are (provider, provider_user_id) / browser_id / token_hash /
+    # credential_id — all globally unique, so a plain repoint can't collide.
+    conn.execute(
+        "UPDATE user_identities SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        "UPDATE user_browsers SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        "UPDATE sessions SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        "UPDATE passkey_credentials SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        "UPDATE passkey_challenges SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        "UPDATE magic_link_tokens SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
+        p,
+    )
+
+    # --- Authorship: the whole point of the merge ---
+    conn.execute(
+        "UPDATE polls SET creator_user_id = %(dst)s::uuid WHERE creator_user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        "UPDATE groups SET creator_user_id = %(dst)s::uuid WHERE creator_user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        "UPDATE group_invites SET created_by_user_id = %(dst)s::uuid WHERE created_by_user_id = %(src)s::uuid",
+        p,
+    )
+
+    # --- group_join_requests: decided_by is unconstrained; requester has a
+    # partial-unique (group_id, requester_user_id) WHERE status='pending'.
+    # Drop source pending rows that would collide with a dest pending row in
+    # the same group, then repoint the rest.
+    conn.execute(
+        "UPDATE group_join_requests SET decided_by_user_id = %(dst)s::uuid "
+        "WHERE decided_by_user_id = %(src)s::uuid",
+        p,
+    )
+    conn.execute(
+        """
+        DELETE FROM group_join_requests s
+         WHERE s.requester_user_id = %(src)s::uuid
+           AND s.status = 'pending'
+           AND EXISTS (
+             SELECT 1 FROM group_join_requests d
+              WHERE d.requester_user_id = %(dst)s::uuid
+                AND d.group_id = s.group_id
+                AND d.status = 'pending'
+           )
+        """,
+        p,
+    )
+    conn.execute(
+        "UPDATE group_join_requests SET requester_user_id = %(dst)s::uuid "
+        "WHERE requester_user_id = %(src)s::uuid",
+        p,
+    )
+
+    # --- user_profiles (PK user_id): keep dest's photo if it has one. ---
+    conn.execute(
+        """
+        UPDATE user_profiles SET user_id = %(dst)s::uuid
+         WHERE user_id = %(src)s::uuid
+           AND NOT EXISTS (SELECT 1 FROM user_profiles WHERE user_id = %(dst)s::uuid)
+        """,
+        p,
+    )
+    conn.execute("DELETE FROM user_profiles WHERE user_id = %(src)s::uuid", p)
+
+    # --- group_notification_preferences (partial-unique (user_id, group_id)):
+    # dest's pref wins per group.
+    conn.execute(
+        """
+        DELETE FROM group_notification_preferences s
+         WHERE s.user_id = %(src)s::uuid
+           AND EXISTS (
+             SELECT 1 FROM group_notification_preferences d
+              WHERE d.user_id = %(dst)s::uuid AND d.group_id = s.group_id
+           )
+        """,
+        p,
+    )
+    conn.execute(
+        "UPDATE group_notification_preferences SET user_id = %(dst)s::uuid "
+        "WHERE user_id = %(src)s::uuid",
+        p,
+    )
+
+    # --- user_contacts (PK (owner_user_id, contact_user_id)): move both
+    # directions, dedupe via ON CONFLICT (newest watermark wins), and never
+    # create a self-contact (owner == contact).
+    conn.execute(
+        """
+        INSERT INTO user_contacts (owner_user_id, contact_user_id, first_seen_at, last_seen_at)
+        SELECT %(dst)s::uuid, contact_user_id, first_seen_at, last_seen_at
+          FROM user_contacts
+         WHERE owner_user_id = %(src)s::uuid AND contact_user_id <> %(dst)s::uuid
+        ON CONFLICT (owner_user_id, contact_user_id) DO UPDATE
+          SET last_seen_at = GREATEST(user_contacts.last_seen_at, EXCLUDED.last_seen_at),
+              first_seen_at = LEAST(user_contacts.first_seen_at, EXCLUDED.first_seen_at)
+        """,
+        p,
+    )
+    conn.execute(
+        """
+        INSERT INTO user_contacts (owner_user_id, contact_user_id, first_seen_at, last_seen_at)
+        SELECT owner_user_id, %(dst)s::uuid, first_seen_at, last_seen_at
+          FROM user_contacts
+         WHERE contact_user_id = %(src)s::uuid AND owner_user_id <> %(dst)s::uuid
+        ON CONFLICT (owner_user_id, contact_user_id) DO UPDATE
+          SET last_seen_at = GREATEST(user_contacts.last_seen_at, EXCLUDED.last_seen_at),
+              first_seen_at = LEAST(user_contacts.first_seen_at, EXCLUDED.first_seen_at)
+        """,
+        p,
+    )
+    conn.execute(
+        "DELETE FROM user_contacts WHERE owner_user_id = %(src)s::uuid OR contact_user_id = %(src)s::uuid",
+        p,
+    )
+
+    # --- users: give the keeper the source's display name only if it has
+    # none (don't clobber the keeper's own name). Badge / recovery prefs stay
+    # the keeper's. Then drop the now-empty source user.
+    conn.execute(
+        """
+        UPDATE users SET display_name = src.display_name, updated_at = NOW()
+          FROM (SELECT display_name FROM users WHERE id = %(src)s::uuid) src
+         WHERE users.id = %(dst)s::uuid
+           AND users.display_name IS NULL
+           AND src.display_name IS NOT NULL
+        """,
+        p,
+    )
+    conn.execute("DELETE FROM users WHERE id = %(src)s::uuid", p)
 
 
 # ---------------------------------------------------------------------------
@@ -806,21 +1001,54 @@ def complete_sign_in(
     `profile` is guaranteed non-None by construction — `resolve_or_merge_user`
     inserted/found a row whose id we then pass to `load_user_profile` in
     the same transaction.
+
+    Absorb rule: if this browser is currently on a weak account (no durable
+    identity — the vote-first / name-only / auto-created throwaway) and the
+    incoming identity resolves elsewhere, fold the two together instead of
+    repointing the browser and orphaning the weak account's polls/groups:
+      * incoming identity is BRAND NEW  → it minted an empty account; fold
+        that into the existing weak account so the weak account keeps its
+        polls + name and merely GAINS the durable identity (upgrade in
+        place — the keeper stays the account the user already had).
+      * incoming identity already EXISTS → fold the weak account's data into
+        that pre-existing real account (the keeper).
+    A browser already on a durable account is NOT absorbed — that's a real
+    account switch, and the prior account stays recoverable.
     """
+    # Captured BEFORE link_browser_to_user repoints the browser below.
+    prior_user_id = get_user_id_for_browser(conn, browser_id)
+
     resolved = resolve_or_merge_user(
         conn,
         provider=provider,
         provider_user_id=provider_user_id,
         email=email,
     )
-    link_browser_to_user(conn, user_id=resolved.user_id, browser_id=browser_id)
+    keeper_user_id = resolved.user_id
+
+    if (
+        prior_user_id
+        and prior_user_id != keeper_user_id
+        and not account_has_durable_identity(conn, prior_user_id)
+    ):
+        if resolved.is_new_user:
+            merge_accounts(
+                conn, source_user_id=keeper_user_id, dest_user_id=prior_user_id
+            )
+            keeper_user_id = prior_user_id
+        else:
+            merge_accounts(
+                conn, source_user_id=prior_user_id, dest_user_id=keeper_user_id
+            )
+
+    link_browser_to_user(conn, user_id=keeper_user_id, browser_id=browser_id)
     session = issue_session(
         conn,
-        user_id=resolved.user_id,
+        user_id=keeper_user_id,
         browser_id=browser_id,
         user_agent=user_agent,
     )
-    profile = load_user_profile(conn, resolved.user_id)
+    profile = load_user_profile(conn, keeper_user_id)
     assert profile is not None, "profile must exist immediately after issue"
     return CompletedSignIn(session=session, profile=profile)
 

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -88,6 +88,33 @@ def hash_token(token: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# The device-bound "this browser" identity (migration 128). A first-class
+# but weak sign-in method: it makes a vote-first / name-only account satisfy
+# the "every account has an identity" invariant and surfaces as "This browser"
+# in the account's sign-in methods. It is NOT a re-resolvable credential —
+# `provider_user_id` is a random marker, and browser → account resolution
+# stays via `user_browsers`. `account_has_durable_identity` excludes it.
+BROWSER_PROVIDER = "browser"
+
+
+def _insert_browser_identity(conn, *, user_id: str) -> None:
+    """Attach a 'browser' identity marker to `user_id`. Idempotent-ish: a
+    random `provider_user_id` means re-calling adds a second harmless marker
+    rather than colliding, but callers only invoke this once at account
+    mint time."""
+    conn.execute(
+        """
+        INSERT INTO user_identities (provider, provider_user_id, user_id, email)
+        VALUES (%(p)s, %(pid)s, %(u)s::uuid, NULL)
+        """,
+        {
+            "p": BROWSER_PROVIDER,
+            "pid": f"browser-{secrets.token_urlsafe(16)}",
+            "u": user_id,
+        },
+    )
+
+
 @dataclass
 class ResolvedUser:
     user_id: str
@@ -260,6 +287,7 @@ def create_anonymous_user(
         {"n": display_name},
     ).fetchone()
     user_id = str(row["id"])
+    _insert_browser_identity(conn, user_id=user_id)
     link_browser_to_user(conn, user_id=user_id, browser_id=browser_id)
     return user_id
 
@@ -313,8 +341,16 @@ def merge_accounts(conn, *, source_user_id: str, dest_user_id: str) -> None:
     p = {"src": source_user_id, "dst": dest_user_id}
 
     # --- Identities + auth artifacts (no app-visible conflicts) ---
-    # PKs are (provider, provider_user_id) / browser_id / token_hash /
-    # credential_id — all globally unique, so a plain repoint can't collide.
+    # The source's device-bound 'browser' marker is meaningless once folded
+    # into another account (which keeps its own identities), so drop it rather
+    # than moving it — otherwise the dest accumulates redundant browser markers
+    # across repeated merges. Durable identities (email/apple/google/passkey)
+    # DO move. PKs are (provider, provider_user_id) / browser_id / token_hash /
+    # credential_id — all globally unique, so the repoint can't collide.
+    conn.execute(
+        "DELETE FROM user_identities WHERE user_id = %(src)s::uuid AND provider = 'browser'",
+        p,
+    )
     conn.execute(
         "UPDATE user_identities SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
         p,
@@ -1062,11 +1098,13 @@ def create_name_only_account(
 ) -> CompletedSignIn:
     """Create a recovery-less account from just a display name.
 
-    Mints a `users` row with the given name but NO `user_identities` row
-    (so `providers` is empty — there's no way to sign back in if the
-    device is lost), links the browser, and issues a session. The FE
-    nudges the user to add a recovery method afterwards via the
-    home-page banner (gated on `recovery_reminder_dismissed`).
+    Mints a `users` row with the given name + a device-bound `browser`
+    identity (so `providers` is `['browser']` — it satisfies the
+    "every account has an identity" invariant and shows as "This browser",
+    but there's no DURABLE way to sign back in if the device is lost),
+    links the browser, and issues a session. The FE nudges the user to
+    add a recovery method afterwards via the home-page banner (gated on
+    `recovery_reminder_dismissed`; `hasRecoveryMethod` ignores `browser`).
 
     Existing group memberships (keyed on browser_id) carry over for free:
     `load_user_visibility` unions the browser's own `group_members` rows
@@ -1078,6 +1116,7 @@ def create_name_only_account(
         {"n": display_name},
     ).fetchone()
     user_id = str(new_row["id"])
+    _insert_browser_identity(conn, user_id=user_id)
     link_browser_to_user(conn, user_id=user_id, browser_id=browser_id)
     session = issue_session(
         conn, user_id=user_id, browser_id=browser_id, user_agent=user_agent

--- a/server/tests/test_account_merge.py
+++ b/server/tests/test_account_merge.py
@@ -1,0 +1,222 @@
+"""Sign-in absorb + `merge_accounts` (the accidental-multi-account fix).
+
+A browser-only / identity-less account (the vote-first / name-only / auto-
+created throwaway) used to be ORPHANED when its browser later signed in with
+a real identity: `link_browser_to_user` repointed the browser, but the
+account's polls/groups kept `creator_user_id` pointing at the now-unreachable
+account, so the signed-in user lost authority over everything they'd made
+before signing in.
+
+`complete_sign_in` now absorbs that weak account instead:
+  * incoming identity BRAND NEW   → upgrade the weak account in place (it
+    gains the identity, keeps its polls; keeper = the weak account);
+  * incoming identity PRE-EXISTING → fold the weak account's data into the
+    real account (keeper = the real account).
+A browser already on a DURABLE account is left alone (real account switch).
+
+These tests drive the real magic-link verify path end-to-end and assert
+against the DB that authorship moved and the source user was deleted.
+"""
+
+import uuid
+
+import psycopg
+
+from services.auth import (
+    generate_token,
+    hash_token,
+    merge_accounts,
+    normalize_email,
+)
+from tests.conftest import TEST_DB_URL
+
+
+def _bid(bid):
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+def _bearer(bid, token):
+    h = _bid(bid)
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _issue_magic_link(email, browser_id):
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO magic_link_tokens (token_hash, email, browser_id, expires_at)
+                VALUES (%s, %s, %s, NOW() + INTERVAL '15 minutes')
+                """,
+                (hash_token(token), normalize_email(email), browser_id),
+            )
+        conn.commit()
+    return token
+
+
+def _sign_in(client, browser_id, email=None):
+    email = email or f"merge-{uuid.uuid4().hex[:8]}@example.com"
+    token = _issue_magic_link(email, browser_id)
+    resp = client.post(
+        "/api/auth/magic-link/verify", json={"token": token}, headers=_bid(browser_id)
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    return body["session_token"], body["user"]["user_id"], email
+
+
+def _poll_creator(poll_id):
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT creator_user_id FROM polls WHERE id = %s", (poll_id,))
+            row = cur.fetchone()
+    return str(row[0]) if row and row[0] else None
+
+
+def _user_exists(user_id):
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM users WHERE id = %s", (user_id,))
+            return cur.fetchone() is not None
+
+
+def _create_anon_poll(client, browser_id):
+    """Anonymous poll create → mints an auto-account bound to the browser
+    (no session). Returns (poll_id, auto_account_user_id)."""
+    resp = client.post(
+        "/api/polls",
+        json={"creator_name": "Anon Maker", "questions": [{"question_type": "yes_no", "category": "yes_no"}]},
+        headers=_bid(browser_id),
+    )
+    assert resp.status_code == 201, resp.text
+    poll_id = resp.json()["id"]
+    return poll_id, _poll_creator(poll_id)
+
+
+# --------------------------------------------------------------------------
+# Headline: anonymous auto-account is absorbed (upgraded in place) on sign-in
+# --------------------------------------------------------------------------
+
+
+def test_anon_autoaccount_upgraded_in_place_by_new_email(client):
+    """Create a poll anonymously, then magic-link a BRAND-NEW email on the
+    same browser. The auto-account stays the keeper, gains the email
+    identity, and keeps its poll — no orphan, no new account."""
+    bid = str(uuid.uuid4())
+    poll_id, auto_uid = _create_anon_poll(client, bid)
+    assert auto_uid is not None
+
+    token, signed_in_uid, _ = _sign_in(client, bid)
+
+    # Keeper IS the original auto-account (upgraded in place).
+    assert signed_in_uid == auto_uid
+    # Poll authorship unchanged → the signed-in user still owns it.
+    assert _poll_creator(poll_id) == auto_uid
+    # /me reports the email identity now lives on that account.
+    me = client.get("/api/auth/me", headers=_bearer(bid, token))
+    assert me.status_code == 200
+    assert "email" in me.json()["providers"]
+    # The signed-in user can mutate the poll (authority retained).
+    closed = client.post(f"/api/polls/{poll_id}/close", json={}, headers=_bearer(bid, token))
+    assert closed.status_code == 200, closed.text
+
+
+def test_anon_autoaccount_merged_into_existing_account(client):
+    """Account E exists (signed in on another browser). On a fresh browser,
+    create a poll anonymously, then magic-link E. The auto-account folds
+    INTO E: the poll moves to E and the auto-account is deleted."""
+    # Device 2 establishes account E.
+    other_bid = str(uuid.uuid4())
+    email = f"shared-{uuid.uuid4().hex[:8]}@example.com"
+    _, e_uid, _ = _sign_in(client, other_bid, email=email)
+
+    # Device 1: anonymous poll, then sign in as the SAME email.
+    bid = str(uuid.uuid4())
+    poll_id, auto_uid = _create_anon_poll(client, bid)
+    assert auto_uid != e_uid
+
+    token, keeper_uid, _ = _sign_in(client, bid, email=email)
+
+    assert keeper_uid == e_uid  # folded into the pre-existing real account
+    assert _poll_creator(poll_id) == e_uid  # poll moved
+    assert not _user_exists(auto_uid)  # throwaway deleted
+    closed = client.post(f"/api/polls/{poll_id}/close", json={}, headers=_bearer(bid, token))
+    assert closed.status_code == 200, closed.text
+
+
+def test_name_only_account_upgraded_by_email(client):
+    """A name-only account (session, no identity) that magic-links a new
+    email keeps its identity-less account as keeper and gains email."""
+    bid = str(uuid.uuid4())
+    created = client.post("/api/auth/account/name", json={"name": "Nameless"}, headers=_bid(bid))
+    assert created.status_code == 200, created.text
+    name_uid = created.json()["user"]["user_id"]
+
+    # Poll created while on the name-only account.
+    resp = client.post(
+        "/api/polls",
+        json={"creator_name": "Nameless", "questions": [{"question_type": "yes_no", "category": "yes_no"}]},
+        headers=_bearer(bid, created.json()["session_token"]),
+    )
+    assert resp.status_code == 201, resp.text
+    poll_id = resp.json()["id"]
+    assert _poll_creator(poll_id) == name_uid
+
+    token, keeper_uid, _ = _sign_in(client, bid)
+    assert keeper_uid == name_uid  # upgraded in place
+    assert _poll_creator(poll_id) == name_uid
+    me = client.get("/api/auth/me", headers=_bearer(bid, token))
+    assert "email" in me.json()["providers"]
+
+
+def test_durable_account_not_absorbed_on_switch(client):
+    """Already on a real (email) account, magic-linking a DIFFERENT email is
+    a switch, not a merge — the first account survives."""
+    bid = str(uuid.uuid4())
+    _, first_uid, _ = _sign_in(client, bid, email=f"first-{uuid.uuid4().hex[:8]}@example.com")
+    _, second_uid, _ = _sign_in(client, bid, email=f"second-{uuid.uuid4().hex[:8]}@example.com")
+
+    assert first_uid != second_uid
+    assert _user_exists(first_uid)  # not deleted — durable accounts aren't absorbed
+    assert _user_exists(second_uid)
+
+
+# --------------------------------------------------------------------------
+# merge_accounts primitive — constrained-table conflict handling
+# --------------------------------------------------------------------------
+
+
+def test_merge_accounts_keeps_dest_profile_and_moves_polls(client):
+    """Direct merge_accounts: poll authorship moves; on a user_profiles PK
+    collision the dest's photo is kept and the source's dropped; source
+    user is deleted."""
+    bid_src = str(uuid.uuid4())
+    poll_id, src_uid = _create_anon_poll(client, bid_src)
+    # A second auto-account to be the dest.
+    poll_id2, dst_uid = _create_anon_poll(client, str(uuid.uuid4()))
+
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            # Both accounts have a profile row → dest's must win.
+            for uid, mime in ((src_uid, "image/png"), (dst_uid, "image/jpeg")):
+                cur.execute(
+                    "INSERT INTO user_profiles (user_id, image_data, image_mime_type, image_updated_at) "
+                    "VALUES (%s::uuid, %s, %s, NOW())",
+                    (uid, b"\x89PNG", mime),
+                )
+        conn.commit()
+        with conn.cursor() as cur:
+            merge_accounts(conn, source_user_id=src_uid, dest_user_id=dst_uid)
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute("SELECT creator_user_id FROM polls WHERE id = %s", (poll_id,))
+            assert str(cur.fetchone()[0]) == dst_uid  # src poll moved to dest
+            cur.execute("SELECT image_mime_type FROM user_profiles WHERE user_id = %s::uuid", (dst_uid,))
+            assert cur.fetchone()[0] == "image/jpeg"  # dest's photo kept
+            cur.execute("SELECT 1 FROM user_profiles WHERE user_id = %s::uuid", (src_uid,))
+            assert cur.fetchone() is None  # src profile dropped
+            cur.execute("SELECT 1 FROM users WHERE id = %s::uuid", (src_uid,))
+            assert cur.fetchone() is None  # src user deleted

--- a/server/tests/test_account_merge.py
+++ b/server/tests/test_account_merge.py
@@ -18,17 +18,28 @@ These tests drive the real magic-link verify path end-to-end and assert
 against the DB that authorship moved and the source user was deleted.
 """
 
+import os
+import time
 import uuid
 
+import jwt
 import psycopg
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
 
-from services.auth import (
+os.environ.setdefault(
+    "GOOGLE_OAUTH_CLIENT_IDS", "test-google-client-id.apps.googleusercontent.com"
+)
+
+import services.oauth as oauth_module  # noqa: E402
+
+from services.auth import (  # noqa: E402
     generate_token,
     hash_token,
     merge_accounts,
     normalize_email,
 )
-from tests.conftest import TEST_DB_URL
+from tests.conftest import TEST_DB_URL  # noqa: E402
 
 
 def _bid(bid):
@@ -220,3 +231,127 @@ def test_merge_accounts_keeps_dest_profile_and_moves_polls(client):
             assert cur.fetchone() is None  # src profile dropped
             cur.execute("SELECT 1 FROM users WHERE id = %s::uuid", (src_uid,))
             assert cur.fetchone() is None  # src user deleted
+
+
+# --------------------------------------------------------------------------
+# Explicit two-account merge — OAuth (Settings "Combine another account")
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def google_keypair():
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+@pytest.fixture(autouse=True)
+def patch_google_jwks(monkeypatch, google_keypair):
+    _, pub = google_keypair
+
+    class _FakeKey:
+        def __init__(self, k):
+            self.key = k
+
+    class _FakeClient:
+        def get_signing_key_from_jwt(self, _t):
+            return _FakeKey(pub)
+
+    monkeypatch.setattr(oauth_module, "_google_jwks_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        oauth_module,
+        "_GOOGLE_AUDIENCES",
+        ("test-google-client-id.apps.googleusercontent.com",),
+    )
+
+
+def _sign_google(private_key, *, sub, email=None):
+    if email is None:
+        email = f"g-{uuid.uuid4().hex[:10]}@example.com"
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "https://accounts.google.com",
+            "aud": "test-google-client-id.apps.googleusercontent.com",
+            "sub": sub,
+            "email": email,
+            "email_verified": True,
+            "iat": now,
+            "exp": now + 600,
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+
+def test_oauth_merge_folds_other_account_in(client, google_keypair):
+    """A is signed in (email). B is a separate Google account that owns a
+    poll. A signs in with B's Google identity + merge=true → B folds into A:
+    A's id is unchanged, B's poll + identity move to A, B is deleted."""
+    private, _ = google_keypair
+    sub = f"sub-{uuid.uuid4().hex}"
+    g_email = f"merge-g-{uuid.uuid4().hex[:8]}@example.com"
+
+    # Account B: sign in with Google on its own browser, then create a poll
+    # (so the poll's creator_user_id is B).
+    bid_b = str(uuid.uuid4())
+    b_resp = client.post(
+        "/api/auth/oauth/google",
+        json={"id_token": _sign_google(private, sub=sub, email=g_email)},
+        headers=_bid(bid_b),
+    )
+    assert b_resp.status_code == 200, b_resp.text
+    b_uid = b_resp.json()["user"]["user_id"]
+    b_token = b_resp.json()["session_token"]
+    poll = client.post(
+        "/api/polls",
+        json={"creator_name": "B Maker", "questions": [{"question_type": "yes_no", "category": "yes_no"}]},
+        headers=_bearer(bid_b, b_token),
+    )
+    assert poll.status_code == 201, poll.text
+    poll_id = poll.json()["id"]
+    assert _poll_creator(poll_id) == b_uid
+
+    # Account A: a separate signed-in (email) account on its own browser.
+    bid_a = str(uuid.uuid4())
+    a_token, a_uid, _ = _sign_in(client, bid_a)
+    assert a_uid != b_uid
+
+    # A explicitly merges B in by verifying B's Google identity with merge=true.
+    merged = client.post(
+        "/api/auth/oauth/google",
+        json={"id_token": _sign_google(private, sub=sub, email=g_email), "merge": True},
+        headers=_bearer(bid_a, a_token),
+    )
+    assert merged.status_code == 200, merged.text
+    body = merged.json()
+    assert body["user"]["user_id"] == a_uid  # A stays the keeper
+    assert "google" in body["user"]["providers"]  # gained B's identity
+    assert "email" in body["user"]["providers"]  # kept its own
+    assert _poll_creator(poll_id) == a_uid  # B's poll moved to A
+    assert not _user_exists(b_uid)  # B deleted
+
+
+def test_oauth_link_conflict_without_merge_flag(client, google_keypair):
+    """Same setup, but WITHOUT merge=true → the link is refused with 409 and
+    nothing is merged (the safety default)."""
+    private, _ = google_keypair
+    sub = f"sub-{uuid.uuid4().hex}"
+
+    bid_b = str(uuid.uuid4())
+    b_resp = client.post(
+        "/api/auth/oauth/google",
+        json={"id_token": _sign_google(private, sub=sub, email="owner@example.com")},
+        headers=_bid(bid_b),
+    )
+    assert b_resp.status_code == 200, b_resp.text
+    b_uid = b_resp.json()["user"]["user_id"]
+
+    bid_a = str(uuid.uuid4())
+    a_token, a_uid, _ = _sign_in(client, bid_a)
+    conflict = client.post(
+        "/api/auth/oauth/google",
+        json={"id_token": _sign_google(private, sub=sub, email="owner@example.com")},
+        headers=_bearer(bid_a, a_token),
+    )
+    assert conflict.status_code == 409, conflict.text
+    assert _user_exists(a_uid) and _user_exists(b_uid)  # neither merged

--- a/server/tests/test_instant_link.py
+++ b/server/tests/test_instant_link.py
@@ -89,8 +89,9 @@ def test_mint_returns_link_and_resolvable_token(client, browser_id):
     )
     assert me.status_code == 200, me.text
     assert me.json()["user_id"] == body["user_id"]
-    # Recovery-less: no identities.
-    assert me.json()["providers"] == []
+    # Recovery-less: only the device-bound 'browser' identity (migration 128),
+    # no durable sign-in method.
+    assert me.json()["providers"] == ["browser"]
 
 
 def test_mint_default_name(client, browser_id):

--- a/server/tests/test_name_account.py
+++ b/server/tests/test_name_account.py
@@ -107,16 +107,19 @@ def test_create_name_account_anonymous(client, browser_id):
     assert len(body["session_token"]) >= 16
     user = body["user"]
     assert user["name"] == "Alice Tester"
-    assert user["providers"] == []
+    # Migration 128: the account carries a device-bound 'browser' identity
+    # (satisfies the "every account has an identity" invariant), but no
+    # DURABLE method — recovery_reminder still nudges them to add one.
+    assert user["providers"] == ["browser"]
     assert user["recovery_reminder_dismissed"] is False
 
-    # The issued token resolves via /me to the same recovery-less account.
+    # The issued token resolves via /me to the same browser-tied account.
     me = client.get(
         "/api/auth/me", headers=_bearer(browser_id, body["session_token"])
     )
     assert me.status_code == 200, me.text
     assert me.json()["user_id"] == user["user_id"]
-    assert me.json()["providers"] == []
+    assert me.json()["providers"] == ["browser"]
 
 
 def test_create_name_account_trims_and_validates(client, browser_id):


### PR DESCRIPTION
## Summary

Eliminates accidental account fragmentation and moves toward one user type (a name + ≥1 optional auth method), per the discussion. Four coherent increments:

1. **Absorb weak accounts on sign-in** (`fc2b235`) — a vote-first / name-only / auto-created account used to be *orphaned* when its browser later signed in with a real identity (its polls/groups kept `creator_user_id` pointing at the now-unreachable account). `complete_sign_in` now folds that weak account into the resolved account — **upgrade in place** when the incoming identity is new, **merge** into the pre-existing real account otherwise. A browser already on a durable account is left alone. New reusable `merge_accounts(source, dest)` primitive moves every `users(id)`-referencing column. No schema change.

2. **Browser-identity model** (migration 128, `e01c822`) — makes "no account/session without an identity" literally true: the browser tie is now a first-class (device-bound, weak) `browser` identity instead of an identity-less account. Surfaces as **"This browser"** in Settings; durable methods attach on top. 199 existing identity-less accounts backfilled. `hasRecoveryMethod` still ignores `browser`, so the recovery nudge keeps firing.

3. **Name required at every sign-in** (`8a42451`, `b2e9670`) — a name is required for any action beyond viewing public groups / link previews. Durable sign-ins (OAuth / passkey / magic link) that land nameless now collect a name via the shared `<NamePromptPanel>` (in `SignInModal` + `/auth/verify`); `AccountGateModal` refactored onto it. Viewing + previews stay account/name-free.

4. **Explicit two-account merge** (`69b10ad`) — Settings → **"Combine another account"** for users who already have two real accounts (passkey + Google, Apple-relay + Google). Signed in as A, authenticate the other account B; the server folds B into A (`merge` flag on OAuth + passkey verify → `merge_in_other_account`). Dual proof: A's bearer + B's just-verified ceremony.

## Test plan

- [x] Server: 617 pytest tests pass, incl. new `test_account_merge.py` (absorb each orphan path, `merge_accounts` constrained-table conflicts, OAuth merge folds-in + deletes-other, conflict-without-flag still 409s)
- [x] FE: `tsc --noEmit` clean, `eslint` 0 errors, vitest 192 passed
- [x] Live on dev: anonymous "vote-first" poll stays owned + closable after magic-link sign-in (`providers` → `['browser','email']`, name preserved); fresh magic-link account is nameless → providing a name fills it on the same account
- [ ] Needs a real browser/device (not coverable on the dev tier): OAuth/passkey *merge ceremonies* (OAuth unconfigured on dev — covered by server tests) and the visual rendering of the name-prompt + merge modals

https://claude.ai/code/session_014ucfSG3iBL6C62CcK6nfpV

---
_Generated by [Claude Code](https://claude.ai/code/session_014ucfSG3iBL6C62CcK6nfpV)_