### PR TITLE
Phase I: claim an anonymous-created group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1405,9 +1405,10 @@ in (`401`), `creator_user_id` must match the session's `user_id`
 or grandfathered) can't be flipped (`403`). The toggle is the
 escape hatch for signed-in users during the Phase F/G gap — a
 brand-new signed-in user creates a private group, realizes they
-can't share it yet, and flips public via /info. Phase I will add
-"claim an anonymous-created group" so legacy groups can also be
-flipped.
+can't share it yet, and flips public via /info. Grandfathered /
+anonymous-created groups can be UPGRADED via the Phase I claim
+endpoint (next section) — once claimed, the new creator can flip
+privacy normally.
 
 FE wiring:
 - `Group.privacy` + `Group.creatorUserId` on the canonical `Group`
@@ -1467,9 +1468,40 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
   toggle is on the roadmap.
 - I (account settings — **shipped**): linked-identities display +
   add-recovery-email + delete-account (migration 118). See "Phase I"
-  below. Still deferred within I: "claim an anonymous-created group" so
-  legacy `creator_user_id` can be set after-the-fact, enabling
-  privacy-flip on grandfathered groups.
+  below.
+  - **Claim an anonymous-created group — SHIPPED.** `POST /api/groups/{route_id}/claim`
+    lets any signed-in MEMBER of a group whose `creator_user_id IS NULL`
+    take over as the recorded creator. Atomic via
+    `UPDATE groups SET creator_user_id = %(uid)s WHERE id = %(gid)s AND creator_user_id IS NULL RETURNING id`
+    — first-mover wins; subsequent attempts (incl. from the same caller) 409.
+    Authorization: 401 anonymous, 403 non-member, 409 already-claimed.
+    There's no "proof of original creation" check — `creator_secret` was
+    retired in migration 123 and pre-Phase-E groups never had one;
+    membership is the only available signal, but it's load-bearing
+    (visitors of a private group can't reach this endpoint at all because
+    the by-route-id read 404s them; public-group visitors auto-join via
+    the by-route-id read before this is callable). Claim does NOT touch
+    privacy — the new creator can flip via the existing privacy endpoint
+    once claimed. `services/groups.py: claim_group(conn, group_id, user_id) → bool`
+    is the shared primitive; the router enforces the auth + does a
+    pre-check + handles the race-loss case. **FE wiring:** `apiClaimGroup(routeId)`
+    in `lib/api/groups.ts` (same `invalidateGroupPolls` pattern as
+    `apiUpdateGroupPrivacy`); `<GroupPrivacySection>` renders a "Claim
+    this group" button when `signedIn && !effectiveCreatorUserId`, and
+    on success fires `onCreatorClaimed(newUserId)` so the parent /info
+    page lifts the value into a `claimedCreatorOverride` state — every
+    downstream creator-only gate (JoinRequestsSection, InviteLinksSection)
+    flips on the same render via `effectiveCreatorUserId = override ?? group.creatorUserId`.
+    The cache-backed `group.creatorUserId` stays stale until the next
+    group fetch (bounded by questionCache TTL); the override is the
+    source of truth post-claim. **Pattern to reuse**: any future
+    "self-contained component mutation that affects parent-level gates"
+    should expose an `onChange`-style callback + an `effective*` prop
+    override so the parent can lift the optimistic state without an
+    event bus. Tests: `server/tests/test_claim_group.py` (7 tests:
+    401 anon, 404 unknown route, 403 non-member, 200 success, 409
+    re-claim same user, 409 second user, smoke that privacy-flip unlocks
+    post-claim).
   - **Account-owned poll authorship — SHIPPED (migrations 122 + 123).**
     `creator_secret` is **fully retired** (migration 123 dropped
     `polls.creator_secret` + all FE secret plumbing). Authorship is now

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -50,8 +50,19 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
     window.addEventListener(SESSION_CHANGED_EVENT, update);
     return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
   }, []);
+  // Phase I: when the viewer claims the group, GroupPrivacySection
+  // fires `onCreatorClaimed(newUserId)` and we lift the value here so
+  // every downstream creator-only gate (Join Requests, Invite Links)
+  // flips on the same render. The cache-backed `group.creatorUserId`
+  // remains stale until the next group fetch — bounded by the
+  // questionCache TTL — which is harmless since the override always
+  // wins.
+  const [claimedCreatorOverride, setClaimedCreatorOverride] = useState<
+    string | null
+  >(null);
+  const effectiveCreatorUserId = claimedCreatorOverride ?? group.creatorUserId;
   const viewerIsCreator =
-    !!session && !!group.creatorUserId && session.user_id === group.creatorUserId;
+    !!session && !!effectiveCreatorUserId && session.user_id === effectiveCreatorUserId;
 
   const goBack = () => {
     // Slide overlay: mount the group root above the current page and slide
@@ -131,7 +142,12 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
           </h1>
         </div>
 
-        <GroupPrivacySection group={group} groupId={groupId} />
+        <GroupPrivacySection
+          group={group}
+          groupId={groupId}
+          effectiveCreatorUserId={effectiveCreatorUserId}
+          onCreatorClaimed={setClaimedCreatorOverride}
+        />
 
         <JoinRequestsSection groupId={groupId} enabled={viewerIsCreator} />
 

--- a/components/GroupPrivacySection.tsx
+++ b/components/GroupPrivacySection.tsx
@@ -31,7 +31,7 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import SliderSwitch from "@/components/SliderSwitch";
 import SignInModal from "@/components/SignInModal";
@@ -55,7 +55,10 @@ interface Props {
   /** Optional override for the group's creator_user_id. When the parent
    *  has lifted an optimistic post-claim state, pass it here so the
    *  isCreator computation matches what the rest of /info sees (Join-
-   *  Requests / Invite-Links sections gate on the same value). */
+   *  Requests / Invite-Links sections gate on the same value). A null or
+   *  undefined value falls back to `group.creatorUserId` — there's no
+   *  way to "explicitly override to no-creator" because the cached value
+   *  already conveys that. */
   effectiveCreatorUserId?: string | null;
   /** Fires after a successful Phase I "claim" — the parent should
    *  store the new creator_user_id so its own `viewerIsCreator`
@@ -83,6 +86,17 @@ export default function GroupPrivacySection({
   const [error, setError] = useState<string | null>(null);
   const [signInOpen, setSignInOpen] = useState(false);
   const [claiming, setClaiming] = useState(false);
+  // 409-on-claim means a concurrent device beat us to it. Surface the
+  // error and hide the button — keeping it tappable just produces an
+  // infinite retry loop with stale local state until the user navigates
+  // away. The next group fetch (cache TTL bounded) will resync
+  // `group.creatorUserId` from the server.
+  const [claimRaced, setClaimRaced] = useState(false);
+  // In-flight guard for the claim POST: state-based `claiming` is read
+  // from the closure and a double-tap within the same render batch
+  // sees the old `false`. A ref flips synchronously, so the second tap
+  // bails before firing a second request that would 409.
+  const claimInFlightRef = useRef(false);
 
   // Mount + subscribe: seed `session` from the localStorage cache and
   // listen for live changes (sign-in via SignInModal, sign-out
@@ -104,21 +118,21 @@ export default function GroupPrivacySection({
 
   // Prefer the parent's lifted override (post-claim optimistic state)
   // over the stale `group.creatorUserId` from the cache — keeps every
-  // creator-only surface on /info in lockstep.
-  const creatorUserId =
-    effectiveCreatorUserId !== undefined
-      ? effectiveCreatorUserId
-      : group.creatorUserId;
+  // creator-only surface on /info in lockstep. `??` falls back on
+  // null/undefined identically; a string override always wins.
+  const creatorUserId = effectiveCreatorUserId ?? group.creatorUserId;
   const isCreator =
     !!session && !!creatorUserId && session.user_id === creatorUserId;
   const isPrivate = privacy === "private";
   // Phase I claim affordance: signed-in user, group has NO recorded
-  // creator. Anonymous viewers fall through to the existing sign-in
-  // nudge (different copy, same target action). The membership gate
-  // is enforced server-side — visiting /info implies membership for
-  // private groups already, and public-group visitors auto-join via
-  // the /by-route-id read endpoint before this section renders.
-  const canClaim = !!session && !creatorUserId;
+  // creator, AND we haven't already lost a claim race. Anonymous
+  // viewers fall through to the sign-in nudge (which surfaces a
+  // claim-specific message when the group is also claimable). The
+  // membership gate is enforced server-side — visiting /info implies
+  // membership for private groups already, and public-group visitors
+  // auto-join via the /by-route-id read endpoint before this section
+  // renders.
+  const canClaim = !!session && !creatorUserId && !claimRaced;
 
   const onToggle = (next: boolean) => {
     if (saving || !isCreator) return;
@@ -142,7 +156,8 @@ export default function GroupPrivacySection({
   };
 
   const onClaim = () => {
-    if (claiming || !canClaim) return;
+    if (claimInFlightRef.current || !canClaim) return;
+    claimInFlightRef.current = true;
     haptic.medium();
     setError(null);
     setClaiming(true);
@@ -151,11 +166,22 @@ export default function GroupPrivacySection({
         onCreatorClaimed?.(result.creator_user_id);
       })
       .catch((e) => {
-        const msg =
-          e instanceof ApiError ? e.message : "Failed to claim group";
-        setError(msg);
+        if (e instanceof ApiError && e.status === 409) {
+          // Someone else claimed first. Hide the button + show a clear
+          // explanation; the next group fetch will resync the creator
+          // server-side.
+          setClaimRaced(true);
+          setError("Another member just claimed this group.");
+        } else {
+          const msg =
+            e instanceof ApiError ? e.message : "Failed to claim group";
+          setError(msg);
+        }
       })
-      .finally(() => setClaiming(false));
+      .finally(() => {
+        claimInFlightRef.current = false;
+        setClaiming(false);
+      });
   };
 
   const stateLabel = isPrivate ? "Private" : "Public";
@@ -165,11 +191,16 @@ export default function GroupPrivacySection({
     (isPrivate ? "Only members can see this group." : "Anyone with the URL can see this group.")
     + (isCreator && isPrivate ? " Share an invite link to add others." : "");
 
-  // Sign-in nudge: anonymous viewer on a public group gets a quiet CTA
-  // explaining how to create private groups in the future. Doesn't fire
-  // for anonymous viewers on private groups (they wouldn't be here —
-  // the /info read 404s for non-members of private groups).
+  // Sign-in nudge: anonymous viewer on a public group gets a quiet CTA.
+  // Copy is context-aware — on a CLAIMABLE group (no recorded creator)
+  // the actionable hint is "Sign in to claim THIS group"; otherwise it's
+  // the general "Sign in to create private groups" pitch for future
+  // group creation. Doesn't fire for anonymous viewers on private groups
+  // (they wouldn't be here — the /info read 404s non-members).
   const showSignInNudge = !session && privacy !== "private";
+  const signInNudgeText = !creatorUserId
+    ? " to claim this group."
+    : " to create private groups.";
 
   return (
     <>
@@ -223,7 +254,7 @@ export default function GroupPrivacySection({
             >
               Sign in
             </button>
-            {" to create private groups."}
+            {signInNudgeText}
           </p>
         )}
         {canClaim && (

--- a/components/GroupPrivacySection.tsx
+++ b/components/GroupPrivacySection.tsx
@@ -37,6 +37,7 @@ import SliderSwitch from "@/components/SliderSwitch";
 import SignInModal from "@/components/SignInModal";
 import { haptic } from "@/lib/haptics";
 import {
+  apiClaimGroup,
   apiUpdateGroupPrivacy,
   ApiError,
 } from "@/lib/api";
@@ -51,12 +52,24 @@ interface Props {
   group: Group;
   groupId: string;
   className?: string;
+  /** Optional override for the group's creator_user_id. When the parent
+   *  has lifted an optimistic post-claim state, pass it here so the
+   *  isCreator computation matches what the rest of /info sees (Join-
+   *  Requests / Invite-Links sections gate on the same value). */
+  effectiveCreatorUserId?: string | null;
+  /** Fires after a successful Phase I "claim" — the parent should
+   *  store the new creator_user_id so its own `viewerIsCreator`
+   *  computation flips true on the next render and the other
+   *  creator-only sections appear without a page refresh. */
+  onCreatorClaimed?: (newCreatorUserId: string) => void;
 }
 
 export default function GroupPrivacySection({
   group,
   groupId,
   className = "mt-[0.96rem]",
+  effectiveCreatorUserId,
+  onCreatorClaimed,
 }: Props) {
   // Initialize as null to match SSR (no localStorage on the server);
   // the mount effect below seeds from the localStorage-cached profile
@@ -69,6 +82,7 @@ export default function GroupPrivacySection({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [signInOpen, setSignInOpen] = useState(false);
+  const [claiming, setClaiming] = useState(false);
 
   // Mount + subscribe: seed `session` from the localStorage cache and
   // listen for live changes (sign-in via SignInModal, sign-out
@@ -88,9 +102,23 @@ export default function GroupPrivacySection({
     setPrivacy(group.privacy);
   }, [group.privacy]);
 
+  // Prefer the parent's lifted override (post-claim optimistic state)
+  // over the stale `group.creatorUserId` from the cache — keeps every
+  // creator-only surface on /info in lockstep.
+  const creatorUserId =
+    effectiveCreatorUserId !== undefined
+      ? effectiveCreatorUserId
+      : group.creatorUserId;
   const isCreator =
-    !!session && !!group.creatorUserId && session.user_id === group.creatorUserId;
+    !!session && !!creatorUserId && session.user_id === creatorUserId;
   const isPrivate = privacy === "private";
+  // Phase I claim affordance: signed-in user, group has NO recorded
+  // creator. Anonymous viewers fall through to the existing sign-in
+  // nudge (different copy, same target action). The membership gate
+  // is enforced server-side — visiting /info implies membership for
+  // private groups already, and public-group visitors auto-join via
+  // the /by-route-id read endpoint before this section renders.
+  const canClaim = !!session && !creatorUserId;
 
   const onToggle = (next: boolean) => {
     if (saving || !isCreator) return;
@@ -111,6 +139,23 @@ export default function GroupPrivacySection({
         setError(msg);
       })
       .finally(() => setSaving(false));
+  };
+
+  const onClaim = () => {
+    if (claiming || !canClaim) return;
+    haptic.medium();
+    setError(null);
+    setClaiming(true);
+    apiClaimGroup(groupId)
+      .then((result) => {
+        onCreatorClaimed?.(result.creator_user_id);
+      })
+      .catch((e) => {
+        const msg =
+          e instanceof ApiError ? e.message : "Failed to claim group";
+        setError(msg);
+      })
+      .finally(() => setClaiming(false));
   };
 
   const stateLabel = isPrivate ? "Private" : "Public";
@@ -180,6 +225,23 @@ export default function GroupPrivacySection({
             </button>
             {" to create private groups."}
           </p>
+        )}
+        {canClaim && (
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={onClaim}
+              disabled={claiming}
+              className="w-full h-12 rounded-xl bg-blue-600 hover:bg-blue-700 active:scale-[0.99] disabled:opacity-60 text-white text-sm font-medium flex items-center justify-center transition-transform"
+              aria-label="Claim this group as creator"
+            >
+              {claiming ? "Claiming…" : "Claim this group"}
+            </button>
+            <p className="px-1 mt-2 text-xs text-gray-500 dark:text-gray-400">
+              This group has no recorded creator. Claim it to unlock
+              privacy, invite links, and join-request approvals.
+            </p>
+          </div>
         )}
       </section>
       <SignInModal isOpen={signInOpen} onClose={() => setSignInOpen(false)} />

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -329,6 +329,44 @@ export async function apiUpdateGroupPrivacy(
   return result;
 }
 
+/** Phase I: claim a group that has no recorded creator (grandfathered or
+ *  anonymous-created). Atomic server-side: first signed-in member to
+ *  claim wins via `UPDATE WHERE creator_user_id IS NULL`. After the
+ *  claim, the caller becomes the recorded creator and unlocks every
+ *  creator-only surface — privacy toggle, join-request approval,
+ *  invite-link minting.
+ *
+ *  Throws `ApiError` with status 401 (signed out), 403 (signed in but
+ *  not a member of the group), 404 (unknown group), or 409 (group
+ *  already has a creator — either claimed before or a concurrent claim
+ *  beat ours).
+ *
+ *  Invalidates every cached poll in the group (each carries
+ *  `group_creator_user_id`) plus the accessible-polls cache so
+ *  subsequent reads pick up the new creator id.
+ */
+export async function apiClaimGroup(
+  routeId: string,
+): Promise<{
+  group_id: string;
+  group_short_id: string | null;
+  privacy: string;
+  creator_user_id: string;
+}> {
+  const data = await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/claim`,
+    { method: 'POST' },
+  );
+  const result = {
+    group_id: data.group_id as string,
+    group_short_id: (data.group_short_id ?? null) as string | null,
+    privacy: data.privacy as string,
+    creator_user_id: data.creator_user_id as string,
+  };
+  invalidateGroupPolls(result.group_id);
+  return result;
+}
+
 /**
  * Phase F: join-request helpers.
  *

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -46,6 +46,7 @@ export {
   apiLeaveGroup,
   apiUpdateGroupTitle,
   apiUpdateGroupPrivacy,
+  apiClaimGroup,
   apiUploadGroupImage,
   apiDeleteGroupImage,
   apiCreateGroupJoinRequest,

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -67,6 +67,7 @@ from services.contacts import (
 from services.memberships import leave_group as _leave_group_row
 from services.groups import (
     _is_uuid_like,
+    claim_group as _claim_group_row,
     filter_visible_polls,
     get_group_metadata,
     grant_group_membership_inline,
@@ -125,6 +126,20 @@ class UpdateGroupPrivacyResponse(BaseModel):
     group_short_id: str | None = None
     privacy: str
     creator_user_id: str | None = None
+
+
+class ClaimGroupResponse(BaseModel):
+    """Returned by `POST /api/groups/{route_id}/claim`. Surfaces the new
+    `creator_user_id` (always the caller) so the FE can patch its
+    in-memory group state and immediately enable creator-only controls
+    (privacy toggle, join-request approval, invite-link minting)
+    without a refetch. `privacy` is included for parity with the
+    privacy endpoint's shape, even though claiming doesn't flip it."""
+
+    group_id: str
+    group_short_id: str | None = None
+    privacy: str
+    creator_user_id: str
 
 
 class GroupPreviewResponse(BaseModel):
@@ -771,6 +786,79 @@ def update_group_privacy(
         group_short_id=row.get("short_id"),
         privacy=row["privacy"],
         creator_user_id=str(creator_user_id) if creator_user_id else None,
+    )
+
+
+@router.post("/{route_id}/claim", response_model=ClaimGroupResponse)
+def claim_group_endpoint(route_id: str, request: Request):
+    """Phase I: signed-in member takes over as the recorded creator of a
+    group whose `creator_user_id` is NULL — i.e. anonymous-created or
+    grandfathered (pre-Phase-E) groups.
+
+    Why this exists: privacy / join-request / invite-link endpoints all
+    authorize against `groups.creator_user_id`. Groups without one are
+    stranded — no one can flip privacy or manage invites. Claiming
+    unlocks all of those for the new creator.
+
+    Authorization (defense in depth):
+      * 401 if not signed in (only accounts can be creators).
+      * 404 if the route doesn't resolve.
+      * 403 if the caller isn't a member of the group (any browser
+        linked to their user_id counts). Restricts claiming to people
+        with a demonstrated connection to the group — visiting the
+        URL once is enough to qualify (auto-join writes a member row
+        on public groups), so this is intentionally a low bar.
+      * 409 if the group already has a creator_user_id. First-mover
+        wins via the atomic UPDATE WHERE creator_user_id IS NULL in
+        `claim_group`. A creator can't re-claim (the row is no longer
+        NULL); transferring creator_user_id is out of scope.
+
+    There is no "proof of original creation" check — `creator_secret`
+    was retired in migration 123 and pre-Phase-E groups never carried
+    one anyway. Membership is the only available signal.
+    """
+    user_id = _user_id(request)
+    if not user_id:
+        raise HTTPException(
+            status_code=401, detail="Sign in to claim this group"
+        )
+    browser_id = _browser_id(request)
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        if not is_caller_member_of_group(
+            conn, group_id, browser_id=browser_id, user_id=user_id
+        ):
+            raise HTTPException(
+                status_code=403, detail="Join the group to claim it"
+            )
+        meta = get_group_metadata(conn, group_id)
+        if meta and meta["creator_user_id"]:
+            # Pre-claim check: distinguishes 'already claimed by
+            # someone else' (409) from 'race lost to a concurrent
+            # claim' (also 409 via the atomic UPDATE below). The
+            # caller sees one error code for both cases.
+            raise HTTPException(
+                status_code=409, detail="Group already has a creator"
+            )
+        if not _claim_group_row(conn, group_id, user_id):
+            # Lost the race — a concurrent claim landed between our
+            # metadata read and the UPDATE.
+            raise HTTPException(
+                status_code=409, detail="Group already has a creator"
+            )
+        row = conn.execute(
+            "SELECT id, short_id, privacy, creator_user_id FROM groups WHERE id = %(id)s",
+            {"id": group_id},
+        ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Group not found")
+    return ClaimGroupResponse(
+        group_id=str(row["id"]),
+        group_short_id=row.get("short_id"),
+        privacy=row["privacy"],
+        creator_user_id=str(row["creator_user_id"]),
     )
 
 

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -833,27 +833,16 @@ def claim_group_endpoint(route_id: str, request: Request):
             raise HTTPException(
                 status_code=403, detail="Join the group to claim it"
             )
-        meta = get_group_metadata(conn, group_id)
-        if meta and meta["creator_user_id"]:
-            # Pre-claim check: distinguishes 'already claimed by
-            # someone else' (409) from 'race lost to a concurrent
-            # claim' (also 409 via the atomic UPDATE below). The
-            # caller sees one error code for both cases.
+        # Single atomic UPDATE ... RETURNING — the WHERE creator_user_id IS NULL
+        # clause serializes concurrent claims at row-lock granularity. None on
+        # return means either (a) already claimed (the common case) or (b) the
+        # group was deleted mid-flight (no group-delete endpoint exists today,
+        # so this is essentially unreachable). Both surface as 409.
+        row = _claim_group_row(conn, group_id, user_id)
+        if row is None:
             raise HTTPException(
                 status_code=409, detail="Group already has a creator"
             )
-        if not _claim_group_row(conn, group_id, user_id):
-            # Lost the race — a concurrent claim landed between our
-            # metadata read and the UPDATE.
-            raise HTTPException(
-                status_code=409, detail="Group already has a creator"
-            )
-        row = conn.execute(
-            "SELECT id, short_id, privacy, creator_user_id FROM groups WHERE id = %(id)s",
-            {"id": group_id},
-        ).fetchone()
-    if not row:
-        raise HTTPException(status_code=404, detail="Group not found")
     return ClaimGroupResponse(
         group_id=str(row["id"]),
         group_short_id=row.get("short_id"),

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -276,6 +276,40 @@ def group_name_phrase(conn, group_id: str, *, override: str | None) -> str:
     return f'"{name}"' if name else "your group"
 
 
+def claim_group(conn, group_id: str, user_id: str) -> bool:
+    """Phase I: atomically claim a group that has no recorded creator.
+
+    Used to upgrade grandfathered (pre-Phase-E) groups and
+    anonymous-created groups so a signed-in user can take over as the
+    recorded creator — unlocking the privacy toggle, join-request
+    approval, and invite-link minting that would otherwise be stranded
+    on those groups forever.
+
+    Returns True iff the row was just claimed by this caller. False
+    when someone else already holds creator_user_id (race or
+    pre-claimed). The atomic `WHERE creator_user_id IS NULL` clause
+    serializes concurrent claims at row-lock granularity: whoever wins
+    the lock writes their user_id, the loser sees 0 rows updated.
+
+    There's no "proof of original creation" check — `creator_secret`
+    was retired in migration 123 and pre-Phase-E groups never had one
+    anyway. Authority is delegated to caller-side gates (signed-in +
+    group member); the function itself only enforces the
+    no-recorded-creator invariant.
+    """
+    row = conn.execute(
+        """
+        UPDATE groups
+           SET creator_user_id = %(uid)s::uuid
+         WHERE id = %(gid)s::uuid
+           AND creator_user_id IS NULL
+        RETURNING id
+        """,
+        {"gid": group_id, "uid": user_id},
+    ).fetchone()
+    return row is not None
+
+
 def is_caller_member_of_group(
     conn,
     group_id: str,

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -276,7 +276,7 @@ def group_name_phrase(conn, group_id: str, *, override: str | None) -> str:
     return f'"{name}"' if name else "your group"
 
 
-def claim_group(conn, group_id: str, user_id: str) -> bool:
+def claim_group(conn, group_id: str, user_id: str):
     """Phase I: atomically claim a group that has no recorded creator.
 
     Used to upgrade grandfathered (pre-Phase-E) groups and
@@ -285,11 +285,14 @@ def claim_group(conn, group_id: str, user_id: str) -> bool:
     approval, and invite-link minting that would otherwise be stranded
     on those groups forever.
 
-    Returns True iff the row was just claimed by this caller. False
-    when someone else already holds creator_user_id (race or
-    pre-claimed). The atomic `WHERE creator_user_id IS NULL` clause
-    serializes concurrent claims at row-lock granularity: whoever wins
-    the lock writes their user_id, the loser sees 0 rows updated.
+    Returns the row dict on success (with `id`, `short_id`, `privacy`,
+    `creator_user_id`) or None when someone else already holds
+    creator_user_id (race or pre-claimed) OR the group doesn't exist.
+    The atomic `WHERE creator_user_id IS NULL` clause serializes
+    concurrent claims at row-lock granularity: whoever wins the lock
+    writes their user_id, the loser sees 0 rows updated. RETURNING
+    pulls the full response payload in the same statement so callers
+    can skip a second SELECT.
 
     There's no "proof of original creation" check — `creator_secret`
     was retired in migration 123 and pre-Phase-E groups never had one
@@ -297,17 +300,16 @@ def claim_group(conn, group_id: str, user_id: str) -> bool:
     group member); the function itself only enforces the
     no-recorded-creator invariant.
     """
-    row = conn.execute(
+    return conn.execute(
         """
         UPDATE groups
            SET creator_user_id = %(uid)s::uuid
          WHERE id = %(gid)s::uuid
            AND creator_user_id IS NULL
-        RETURNING id
+        RETURNING id, short_id, privacy, creator_user_id
         """,
         {"gid": group_id, "uid": user_id},
     ).fetchone()
-    return row is not None
 
 
 def is_caller_member_of_group(

--- a/server/tests/test_claim_group.py
+++ b/server/tests/test_claim_group.py
@@ -1,0 +1,249 @@
+"""Phase I — claim an anonymous-created / grandfathered group.
+
+Covers `POST /api/groups/{route_id}/claim`:
+  * 401 anonymous caller.
+  * 404 unresolvable route.
+  * 403 signed-in non-member.
+  * 200 signed-in member of a NULL-creator group → claim succeeds,
+    response carries the new creator_user_id, DB row reflects the
+    write, privacy state is unchanged.
+  * 409 second-claim attempt (same caller OR a different signed-in
+    member) — the atomic UPDATE prevents takeover after the first
+    claim lands.
+  * Post-claim, the privacy endpoint accepts a flip from the new
+    creator (proves the claim actually unlocks creator-only
+    authorization downstream).
+
+Reuses the magic-link sign-in helper + direct-DB privacy seeder from
+`test_group_privacy.py`'s pattern.
+"""
+
+import uuid
+
+import psycopg
+import pytest
+
+from services.auth import (
+    generate_token,
+    hash_token,
+    normalize_email,
+)
+from tests.conftest import TEST_DB_URL
+
+
+@pytest.fixture
+def creator_browser():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def stranger_browser():
+    return str(uuid.uuid4())
+
+
+def _bid_headers(bid):
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+def _bearer_headers(bid, token):
+    h = _bid_headers(bid)
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _issue_known_magic_link(email, browser_id):
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO magic_link_tokens
+                  (token_hash, email, browser_id, expires_at)
+                VALUES
+                  (%s, %s, %s, NOW() + INTERVAL '15 minutes')
+                """,
+                (hash_token(token), normalize_email(email), browser_id),
+            )
+        conn.commit()
+    return token
+
+
+def _sign_in(client, browser_id, email=None):
+    email = email or f"phaseI-{uuid.uuid4().hex[:8]}@example.com"
+    token = _issue_known_magic_link(email, browser_id)
+    resp = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": token},
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    return body["session_token"], body["user"]["user_id"]
+
+
+def _create_anonymous_group(client, browser_id):
+    """Create a fresh group via the anonymous (no-bearer) path.
+    Result: privacy='public', creator_user_id=NULL — exactly the
+    'grandfathered / anonymous-created' shape claim is for.
+    """
+    resp = client.post(
+        "/api/groups",
+        headers=_bid_headers(browser_id),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _read_group_row(group_id):
+    with psycopg.connect(TEST_DB_URL) as conn:
+        row = conn.execute(
+            "SELECT privacy, creator_user_id FROM groups WHERE id = %s",
+            (group_id,),
+        ).fetchone()
+    if not row:
+        return None
+    privacy, creator_user_id = row
+    return {
+        "privacy": privacy,
+        "creator_user_id": str(creator_user_id) if creator_user_id else None,
+    }
+
+
+def test_claim_requires_sign_in(client, creator_browser):
+    group = _create_anonymous_group(client, creator_browser)
+    resp = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bid_headers(creator_browser),
+    )
+    assert resp.status_code == 401
+
+
+def test_claim_404_on_unknown_route(client, creator_browser):
+    _, _ = _sign_in(client, creator_browser)
+    # Look-alike uuid that doesn't exist
+    fake = "00000000-0000-0000-0000-000000000001"
+    token, _ = _sign_in(client, creator_browser, email="claim404@example.com")
+    resp = client.post(
+        f"/api/groups/{fake}/claim",
+        headers=_bearer_headers(creator_browser, token),
+    )
+    assert resp.status_code == 404
+
+
+def test_claim_403_when_not_a_member(
+    client, creator_browser, stranger_browser
+):
+    """A signed-in user who has never visited the group can't claim
+    it — the membership gate is the only proof-of-relevance we have."""
+    group = _create_anonymous_group(client, creator_browser)
+    token, _ = _sign_in(client, stranger_browser, email="stranger@example.com")
+    resp = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bearer_headers(stranger_browser, token),
+    )
+    assert resp.status_code == 403
+
+
+def test_claim_succeeds_for_signed_in_member(client, creator_browser):
+    group = _create_anonymous_group(client, creator_browser)
+    # Anonymous-create wrote the member row keyed on creator_browser.
+    # Sign in on the SAME browser so user_browsers links the session's
+    # user_id to that browser → the member walk finds the row.
+    token, user_id = _sign_in(client, creator_browser)
+    resp = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bearer_headers(creator_browser, token),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["group_id"] == group["id"]
+    assert body["creator_user_id"] == user_id
+    # Privacy state is preserved — claim doesn't auto-flip to private.
+    assert body["privacy"] == "public"
+    # DB write committed:
+    db = _read_group_row(group["id"])
+    assert db["creator_user_id"] == user_id
+    assert db["privacy"] == "public"
+
+
+def test_claim_409_when_already_claimed_by_same_user(
+    client, creator_browser
+):
+    group = _create_anonymous_group(client, creator_browser)
+    token, _ = _sign_in(client, creator_browser)
+    first = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bearer_headers(creator_browser, token),
+    )
+    assert first.status_code == 200, first.text
+    second = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bearer_headers(creator_browser, token),
+    )
+    assert second.status_code == 409
+
+
+def test_claim_409_when_already_claimed_by_someone_else(
+    client, creator_browser, stranger_browser
+):
+    """Once claimed, the row is no longer NULL → no other member can
+    re-claim. Even if the second signed-in user has membership, the
+    atomic UPDATE WHERE creator_user_id IS NULL bounces them with 409."""
+    group = _create_anonymous_group(client, creator_browser)
+    first_token, first_user_id = _sign_in(client, creator_browser)
+    resp = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bearer_headers(creator_browser, first_token),
+    )
+    assert resp.status_code == 200
+
+    # Second user joins via the read endpoint (auto-join writes a
+    # group_members row for their browser on the public group), then
+    # signs in and tries to claim.
+    second_user_browser = str(uuid.uuid4())
+    join = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bid_headers(second_user_browser),
+    )
+    assert join.status_code == 200
+    second_token, _ = _sign_in(
+        client, second_user_browser, email="second@example.com"
+    )
+    resp = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bearer_headers(second_user_browser, second_token),
+    )
+    assert resp.status_code == 409
+    # DB still reflects the FIRST user as creator — no takeover.
+    db = _read_group_row(group["id"])
+    assert db["creator_user_id"] == first_user_id
+
+
+def test_claim_unlocks_privacy_toggle(client, creator_browser):
+    """Smoke test that claiming actually unlocks downstream
+    creator-only authorization. Before claim, privacy flip 403s
+    (the legacy 'no recorded creator' branch). After claim, the
+    same caller's flip succeeds."""
+    group = _create_anonymous_group(client, creator_browser)
+    token, _ = _sign_in(client, creator_browser)
+    # Pre-claim flip is rejected — the group has no recorded creator.
+    pre = client.post(
+        f"/api/groups/{group['id']}/privacy",
+        json={"privacy": "private"},
+        headers=_bearer_headers(creator_browser, token),
+    )
+    assert pre.status_code == 403
+    # Claim, then re-attempt the flip.
+    claim = client.post(
+        f"/api/groups/{group['id']}/claim",
+        headers=_bearer_headers(creator_browser, token),
+    )
+    assert claim.status_code == 200
+    post = client.post(
+        f"/api/groups/{group['id']}/privacy",
+        json={"privacy": "private"},
+        headers=_bearer_headers(creator_browser, token),
+    )
+    assert post.status_code == 200, post.text
+    assert post.json()["privacy"] == "private"

--- a/server/tests/test_claim_group.py
+++ b/server/tests/test_claim_group.py
@@ -120,7 +120,6 @@ def test_claim_requires_sign_in(client, creator_browser):
 
 
 def test_claim_404_on_unknown_route(client, creator_browser):
-    _, _ = _sign_in(client, creator_browser)
     # Look-alike uuid that doesn't exist
     fake = "00000000-0000-0000-0000-000000000001"
     token, _ = _sign_in(client, creator_browser, email="claim404@example.com")
@@ -191,6 +190,12 @@ def test_claim_409_when_already_claimed_by_someone_else(
     re-claim. Even if the second signed-in user has membership, the
     atomic UPDATE WHERE creator_user_id IS NULL bounces them with 409."""
     group = _create_anonymous_group(client, creator_browser)
+    # Precondition for the auto-join path used below: the by-route-id
+    # read only writes a group_members row when privacy='public'. If a
+    # future schema flip changes the anonymous-create default, this
+    # assertion catches the regression rather than letting the test
+    # silently morph into a 403-not-a-member check.
+    assert group["privacy"] == "public"
     first_token, first_user_id = _sign_in(client, creator_browser)
     resp = client.post(
         f"/api/groups/{group['id']}/claim",


### PR DESCRIPTION
## Summary

`POST /api/groups/{route_id}/claim` lets any signed-in member of a group with `creator_user_id IS NULL` (anonymous-created or grandfathered pre-Phase-E) take over as the recorded creator — unlocking the privacy toggle, join-request approvals, and invite-link minting that would otherwise be stranded forever.

- **Server**: single atomic `UPDATE groups SET creator_user_id = ... WHERE id = ... AND creator_user_id IS NULL RETURNING ...` — first signed-in member wins; subsequent attempts (incl. from the same caller) 409. Endpoint auth ladder: 401 anonymous, 403 non-member, 409 already-claimed.
- **Membership is the only auth signal** (`creator_secret` was retired in migration 123; pre-Phase-E groups never had one anyway). It's load-bearing: visitors of a private group can't reach this endpoint at all (the by-route-id read 404s them); public-group visitors auto-join via the by-route-id read before this is callable.
- **Claim does NOT touch privacy** — the new creator can flip privacy normally via the existing endpoint once claimed.
- **FE**: `apiClaimGroup(routeId)` in `lib/api/groups.ts` (same `invalidateGroupPolls` pattern as `apiUpdateGroupPrivacy`); `<GroupPrivacySection>` renders a "Claim this group" button when `signedIn && !effectiveCreatorUserId && !claimRaced`. On success, fires `onCreatorClaimed(newUserId)` so `/info` lifts the value into a `claimedCreatorOverride` state — every downstream creator-only gate (JoinRequestsSection, InviteLinksSection) flips on the same render via `effectiveCreatorUserId = override ?? group.creatorUserId`. On 409, the button hides + a clear error renders (no infinite-retry loop on a stale-cache device).
- **Anonymous viewer copy** is context-aware: "Sign in to claim this group" on a claimable group, "Sign in to create private groups" otherwise.

## Test plan

- [x] 7 new server tests (`server/tests/test_claim_group.py`): 401 anon, 404 unknown route, 403 non-member, 200 success, 409 re-claim by same user, 409 second user wins-the-race-then-loser-409s, smoke that the privacy flip unlocks post-claim.
- [x] 624 existing server tests still pass.
- [x] Live demo on the `claude-todos-jfsob.dev.whoeverwants.com` branch dev server — anonymous group with 2 polls, instant-link to sign in as Sam and land on `/info`. Tap "Claim this group" → privacy toggle + empty Join-Requests + Invite-Links cards appear immediately on the same render (proves the parent-side override propagates).

## /simplify

`/simplify` ran with 9 finder angles + verifier consolidation. 7 fixes applied (commit `386b9c8`): single UPDATE RETURNING collapse (5 → 3 DB roundtrips per claim), `??` simplification, `claimInFlightRef` double-tap guard, `claimRaced` 409 button-hide, context-aware sign-in nudge, dead-`_sign_in` removal, `privacy='public'` precondition assertion. Skipped: shared-button extraction (2 uses below abstraction threshold), `claiming`/`saving` unification (separation reads clearer), `ClaimGroupResponse` vs `UpdateGroupPrivacyResponse` Pydantic dedup (nullability differs), generic `useOptimisticOverride` hook (single use, premature), `_require_signed_in_member` helper (endpoints differ enough), `invalidateGroupPolls` shape-vs-field issue (pre-existing across 4 other endpoints — out of scope here).

https://claude.ai/code/session_01JuPj9JH3HAFRgvdHhp33Jf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuPj9JH3HAFRgvdHhp33Jf)_