### PR TITLE
Honest "Private Group" copy when the group actually exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1710,6 +1710,36 @@ viewers on the same page get a "Sign in to request access" CTA
 that opens `SignInModal`; signing in fires
 `SESSION_CHANGED_EVENT` and the button surfaces without remount.
 
+**`<GroupNotFound>` probes `/preview` to switch from ambiguous to
+honest copy when the group actually exists.** A private-group 404
+from `/by-route-id` looks identical to a truly-missing route at the
+FE layer, so saying "this group may not exist" was misleading for
+the common case where the friend just doesn't have access yet. On
+mount with a `routeId`, `apiGetGroupPreview(routeId)` (in
+`lib/api/groups.ts`) hits the public `/preview` endpoint — same one
+Open Graph crawlers already get on URL share, so no new info is
+disclosed. On 200 (group exists), the heading swaps to "Private
+Group" + body "Request access to view this group." On 404 the
+original "Group Not Found / may not exist or you don't have access"
+copy stays — we truly don't know. Tri-state `groupExists: null |
+true | false` (null = probe in flight) is load-bearing: during the
+<100ms probe window we keep the ambiguous copy rather than flashing
+a wrong claim. Don't add caching for this probe — GroupNotFound is
+rare enough that the extra request is a non-issue, and a stale
+cache would be worse than re-probing.
+
+**`/preview` returns 200 for empty groups (no polls), not 404.**
+The endpoint was originally 404'ing whenever `target is None` (no
+polls picked), but that mis-classified any private empty group as
+missing — breaking the `GroupNotFound` probe described above.
+Empty-group branch in `get_group_preview` returns
+`GroupPreviewResponse(title=<groups.title override> or
+"WhoeverWants", description=None)` instead. Unlike the populated
+case, the `groups.title` override IS honored here (there's no poll
+subject to defer to). When adding a new "does this group exist"
+client probe, route through `/preview` — it's the canonical
+identity-free existence check.
+
 **Pitfall: requester-email surfaces are NULL for passkey-only
 accounts.** Phase D permits accounts with no email at all
 (`user_identities` carries only a passkey row). The

--- a/components/GroupLoadState.tsx
+++ b/components/GroupLoadState.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import {
   ApiError,
   apiCreateGroupJoinRequest,
+  apiGetGroupPreview,
 } from "@/lib/api";
 import SignInModal from "@/components/SignInModal";
 import { haptic } from "@/lib/haptics";
@@ -41,7 +42,13 @@ export function GroupLoading({ label = "Loading group..." }: { label?: string })
  * page: per Phase E, /by-route-id 404s strangers on private groups
  * with no leak of title/avatar. So the 404 page IS the only surface a
  * signed-in non-member ever reaches when given a private group's URL.
- * We don't try to look up the group here — that would be the leak.
+ *
+ * To avoid pretending the group "may not exist" when it actually does,
+ * we probe the public `/preview` endpoint (same one Open Graph
+ * crawlers hit on URL share — no new info disclosed). If preview
+ * returns 200 the group exists; we swap to the "Private Group" copy.
+ * Preview 404 keeps the ambiguous original copy ("may not exist or
+ * you don't have access") since the group really might be missing.
  *
  * UX states:
  *   * Anonymous viewer → only the "Go Home" button (signing in alone
@@ -61,6 +68,10 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
     | { kind: "error"; message: string }
   >({ kind: "idle" });
   const [signInOpen, setSignInOpen] = useState(false);
+  // null = not yet known (probe in flight or no routeId); true = preview
+  // returned 200 so the group exists (private + no access); false =
+  // preview 404'd, group truly may not exist.
+  const [groupExists, setGroupExists] = useState<boolean | null>(null);
 
   // Same session-tracking pattern as GroupPrivacySection — seed from
   // the localStorage cache then subscribe to live changes so the
@@ -72,6 +83,20 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
     window.addEventListener(SESSION_CHANGED_EVENT, update);
     return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
   }, []);
+
+  // Probe /preview to find out whether the group exists. Cancelled on
+  // unmount so a late response can't setState on a dead component.
+  useEffect(() => {
+    if (!routeId) return;
+    let cancelled = false;
+    apiGetGroupPreview(routeId).then((preview) => {
+      if (cancelled) return;
+      setGroupExists(preview !== null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [routeId]);
 
   const requestAccess = () => {
     if (!routeId || submitting) return;
@@ -124,9 +149,13 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
     <>
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center max-w-sm px-6">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Group Not Found</h2>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            {groupExists ? "Private Group" : "Group Not Found"}
+          </h2>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            This group may not exist or you don&apos;t have access.
+            {groupExists
+              ? "Request access to view this group."
+              : "This group may not exist or you don’t have access."}
           </p>
           <button
             onClick={() => router.push("/")}

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -168,6 +168,32 @@ export async function apiGetGroupSummary(routeId: string): Promise<GroupSummary 
   }
 }
 
+/** Public link-preview metadata for a group (title + description).
+ *  Identity-free, visibility-free — the same endpoint Open Graph
+ *  crawlers hit on URL share. Returns null on 404 (route_id doesn't
+ *  resolve to a group at all), so consumers can distinguish "group
+ *  exists but you don't have access" from "group truly doesn't exist".
+ *
+ *  Used by `GroupNotFound` to swap the "may not exist or you don't have
+ *  access" copy for an honest "this group is private — request access"
+ *  message when the group does exist. */
+export async function apiGetGroupPreview(
+  routeId: string,
+): Promise<{ title: string; description: string | null } | null> {
+  try {
+    const data = await groupFetch<any>(
+      `/by-route-id/${encodeURIComponent(routeId)}/preview`,
+    );
+    return {
+      title: typeof data?.title === "string" ? data.title : "",
+      description:
+        typeof data?.description === "string" ? data.description : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Explicit "leave group" action — DELETE the caller's `group_members`
  * row for the resolved group. Idempotent server-side and fire-and-forget

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -43,6 +43,7 @@ export {
   apiCreateGroup,
   apiGetMyEmptyGroups,
   apiGetGroupSummary,
+  apiGetGroupPreview,
   apiLeaveGroup,
   apiUpdateGroupTitle,
   apiUpdateGroupPrivacy,

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -502,8 +502,28 @@ def get_group_preview(route_id: str, p: str | None = None):
                 {"t": group_id},
             ).fetchone()
 
+        # Empty group (no polls yet): return a minimal preview using the
+        # group's `title` override (or a default) instead of 404'ing. The
+        # GroupNotFound page uses this endpoint to distinguish "group is
+        # private + you don't have access" from "group genuinely doesn't
+        # exist" — 404'ing here would mis-classify any private empty group
+        # as missing, leaving the user with the "may not exist" copy on a
+        # group that actually does. Unlike the populated case, the
+        # `groups.title` override IS used here (no poll subject to defer
+        # to), falling back to "WhoeverWants" so crawlers always have
+        # something renderable.
         if target is None:
-            raise HTTPException(status_code=404, detail="Group not found")
+            group_row = conn.execute(
+                "SELECT title FROM groups WHERE id = %(gid)s::uuid",
+                {"gid": group_id},
+            ).fetchone()
+            override = (
+                (group_row.get("title") or "").strip() if group_row else ""
+            )
+            return GroupPreviewResponse(
+                title=override or "WhoeverWants",
+                description=None,
+            )
 
         question_rows = conn.execute(
             """SELECT title, category, question_type, details, options

--- a/server/tests/test_groups_api.py
+++ b/server/tests/test_groups_api.py
@@ -289,6 +289,56 @@ class TestGroupPreview:
         # we care about: not empty.
         assert title
 
+    def test_empty_group_returns_200_with_default_title(
+        self, client, browser_id,
+    ):
+        """An empty group (no polls) must NOT 404 on /preview — the
+        GroupNotFound page uses /preview to distinguish "private + no
+        access" from "doesn't exist". Returning 404 here would
+        mis-classify a private empty group as missing."""
+        resp = client.post("/api/groups", headers=bid_headers(browser_id))
+        assert resp.status_code == 201, resp.text
+        group = resp.json()
+
+        resp = client.get(
+            f"/api/groups/by-route-id/{group['short_id']}/preview"
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"]  # default fallback when no override is set
+        assert body["description"] is None
+
+    def test_empty_group_uses_title_override(
+        self, client, browser_id,
+    ):
+        """When the empty group has a `groups.title` override (set via
+        /edit-title), the preview surfaces it. Unlike the populated case,
+        the override is honored here because there's no poll subject to
+        defer to."""
+        resp = client.post("/api/groups", headers=bid_headers(browser_id))
+        assert resp.status_code == 201, resp.text
+        group = resp.json()
+
+        title_resp = client.post(
+            f"/api/groups/{group['short_id']}/title",
+            json={"group_title": "Movie Night 2026"},
+            headers=bid_headers(browser_id),
+        )
+        assert title_resp.status_code == 200, title_resp.text
+
+        resp = client.get(
+            f"/api/groups/by-route-id/{group['short_id']}/preview"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Movie Night 2026"
+
+    def test_unknown_route_still_returns_404(self, client):
+        """Sanity: a truly nonexistent group must still 404. The
+        empty-group fallback only activates AFTER `resolve_group_id_from_route_id`
+        succeeds."""
+        resp = client.get("/api/groups/by-route-id/zzznotreal/preview")
+        assert resp.status_code == 404
+
 
 class TestBrowserIdMiddleware:
     def test_response_carries_browser_id_header(self, client, creator_secret):


### PR DESCRIPTION
## Summary

- `<GroupNotFound>` now probes the public `/preview` endpoint (same one Open Graph crawlers hit on URL share — no new info disclosed). On 200, swap copy from the ambiguous "Group Not Found / may not exist or you don't have access" to "Private Group / Request access to view this group." On 404, keep the original copy since the group really might be missing.
- Fix `/preview` 404'ing on empty groups (no polls). Empty-group branch returns 200 with the `groups.title` override (or "WhoeverWants" default), so the FE probe can tell an empty private group apart from a truly-missing route.
- 3 new backend tests cover empty-group preview behavior (default fallback, title override, unknown-route still 404).

## Test plan
- [x] `tests/test_groups_api.py::TestGroupPreview` — 6/6 pass (3 new + 3 existing)
- [x] Broader `test_groups_api.py` + `test_groups_visibility.py` + `test_empty_groups.py` — 60/60 pass
- [x] Live demo on dev: stranger visit to a private populated group (`/g/~1`), private empty group (`/g/~2`), and truly-nonexistent route (`/g/zzznotreal`) — first two show "Private Group" copy, third keeps "Group Not Found"

https://claude.ai/code/session_017FyADBHJtjSvHa9QwWT6n1

---
_Generated by [Claude Code](https://claude.ai/code/session_017FyADBHJtjSvHa9QwWT6n1)_