### PR TITLE
Require account name to request group access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1665,8 +1665,9 @@ without blocking re-requests after a denial. Three endpoints in
   * `POST /api/groups/<route_id>/join-requests` (body `{message?}`)
     — signed-in caller. Returns 200 + status discriminator
     (`pending` | `already_pending` | `already_member`). 401
-    anonymous, 404 unknown group. Idempotent via the partial
-    unique index — second call doesn't re-fire the creator push.
+    anonymous, 404 unknown group, 400 nameless account (see name-gate
+    bullet below). Idempotent via the partial unique index —
+    second call doesn't re-fire the creator push.
   * `GET /api/groups/<route_id>/join-requests` — creator-only.
     Returns pending oldest first, with `requester_email` joined
     in (NULL for passkey-only requesters). 401/403/404.
@@ -1710,6 +1711,27 @@ and shows a "Request sent" / "Group not found" result. Anonymous
 viewers on the same page get a "Sign in to request access" CTA
 that opens `SignInModal`; signing in fires
 `SESSION_CHANGED_EVENT` and the button surfaces without remount.
+
+**Account name is required to request access (server backstop + FE
+gate).** `POST /api/groups/<route_id>/join-requests` runs
+`validate_user_name(users.display_name)` AFTER the member-or-creator
+short-circuit but before `create_join_request`, returning 400 "name
+is required" when the caller's `display_name` is NULL/blank. The
+member-check goes first so a nameless existing-member tapping retry
+gets the friendly `already_member` response — the name only matters
+when a request would actually be created (the creator needs
+SOMETHING to recognize the requester by, and `requester_email` is
+NULL for passkey-only accounts → "Passkey user" UI fallback reads
+as anonymous). FE primary gate is in `GroupNotFound.requestAccess`
+(in `components/GroupLoadState.tsx`): when `!isValidUserName(getUserName())`
+it opens the shared `<AccountGateModal message="to request access">`
+instead of POSTing; the modal's `onSubmit` retries the request
+inline via the extracted `submitJoinRequest` helper. Pattern matches
+the other 4 AccountGateModal callsites (CreateGroupButtonHost / vote
+Submit / create-poll bubble / settings/edit). Mirror this rule any
+time a new endpoint produces a creator-visible artifact tagged with
+the caller's identity — name-required, ordered after any short-
+circuit that doesn't actually create the artifact.
 
 **`<GroupNotFound>` probes `/preview` to switch from ambiguous to
 honest copy when the group actually exists.** A private-group 404

--- a/components/GroupLoadState.tsx
+++ b/components/GroupLoadState.tsx
@@ -9,8 +9,11 @@ import {
   apiGetGroupPreview,
 } from "@/lib/api";
 import SignInModal from "@/components/SignInModal";
+import AccountGateModal from "@/components/AccountGateModal";
 import { haptic } from "@/lib/haptics";
+import { isValidUserName } from "@/lib/nameValidation";
 import { isPathPrefix } from "@/lib/questionId";
+import { getUserName } from "@/lib/userProfile";
 import {
   getCachedSessionUser,
   SESSION_CHANGED_EVENT,
@@ -74,6 +77,7 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
     | { kind: "error"; message: string }
   >({ kind: "idle" });
   const [signInOpen, setSignInOpen] = useState(false);
+  const [nameModalOpen, setNameModalOpen] = useState(false);
   // null = not yet known (probe in flight or no routeId); true = preview
   // returned 200 so the group exists (private + no access); false =
   // preview 404'd, group truly may not exist.
@@ -145,9 +149,8 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
     };
   }, [routeId]);
 
-  const requestAccess = () => {
+  const submitJoinRequest = () => {
     if (!routeId || submitting) return;
-    haptic.medium();
     setSubmitting(true);
     setStatus({ kind: "idle" });
     apiCreateGroupJoinRequest(routeId, null)
@@ -181,6 +184,20 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
         setStatus({ kind: "error", message: msg });
       })
       .finally(() => setSubmitting(false));
+  };
+
+  const requestAccess = () => {
+    if (!routeId || submitting) return;
+    haptic.medium();
+    // The server requires the account to have a `display_name` so the
+    // creator can recognize who's asking ("Approve request from <name>?").
+    // Surface the shared AccountGateModal when missing so the user can
+    // set a name without leaving the page; on submit, retry the request.
+    if (!isValidUserName(getUserName())) {
+      setNameModalOpen(true);
+      return;
+    }
+    submitJoinRequest();
   };
 
   // The "Request to join" CTA only renders when we have a routeId to
@@ -253,6 +270,15 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
         </div>
       </div>
       <SignInModal isOpen={signInOpen} onClose={() => setSignInOpen(false)} />
+      <AccountGateModal
+        isOpen={nameModalOpen}
+        message="to request access"
+        onSubmit={() => {
+          setNameModalOpen(false);
+          submitJoinRequest();
+        }}
+        onCancel={() => setNameModalOpen(false)}
+      />
     </>
   );
 }

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -1043,21 +1043,6 @@ def create_group_join_request(
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
 
-        # Name gate: the creator needs SOMETHING to recognize the requester
-        # by ("Approve / deny request from <who>?"). `requester_email` is
-        # null for passkey-only accounts and the UI's "Passkey user"
-        # placeholder reads as anonymous to creators — a display name closes
-        # that gap. Validated here as the backstop; the FE's
-        # AccountGateModal is the primary gate at the click.
-        name_row = conn.execute(
-            "SELECT display_name FROM users WHERE id = %(u)s::uuid",
-            {"u": user_id},
-        ).fetchone()
-        validate_user_name(
-            name_row["display_name"] if name_row else None,
-            field="name",
-        )
-
         # Already-member / creator short-circuit. We return 200 (not 201)
         # so the FE can show "you're already in this group" instead of
         # "request sent". The row in group_members might be keyed on a
@@ -1067,6 +1052,23 @@ def create_group_join_request(
             return JoinRequestCreateResponse(
                 status="already_member", request=None
             )
+
+        # Name gate: the creator needs SOMETHING to recognize the requester
+        # by ("Approve / deny request from <who>?"). `requester_email` is
+        # null for passkey-only accounts and the UI's "Passkey user"
+        # placeholder reads as anonymous to creators — a display name closes
+        # that gap. Validated here as the backstop; the FE's
+        # AccountGateModal is the primary gate at the click. Runs AFTER
+        # the member check so a nameless existing-member tapping retry
+        # gets the friendly already_member response, not 400.
+        name_row = conn.execute(
+            "SELECT display_name FROM users WHERE id = %(u)s::uuid",
+            {"u": user_id},
+        ).fetchone()
+        validate_user_name(
+            name_row["display_name"] if name_row else None,
+            field="name",
+        )
 
         # Snapshot existence BEFORE the create so we know whether this
         # call inserted a new row or returned an existing pending one.

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -65,6 +65,7 @@ from services.contacts import (
     reconcile_contacts_safe,
 )
 from services.memberships import leave_group as _leave_group_row
+from services.validation import validate_user_name
 from services.groups import (
     _is_uuid_like,
     claim_group as _claim_group_row,
@@ -1041,6 +1042,21 @@ def create_group_join_request(
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
+
+        # Name gate: the creator needs SOMETHING to recognize the requester
+        # by ("Approve / deny request from <who>?"). `requester_email` is
+        # null for passkey-only accounts and the UI's "Passkey user"
+        # placeholder reads as anonymous to creators — a display name closes
+        # that gap. Validated here as the backstop; the FE's
+        # AccountGateModal is the primary gate at the click.
+        name_row = conn.execute(
+            "SELECT display_name FROM users WHERE id = %(u)s::uuid",
+            {"u": user_id},
+        ).fetchone()
+        validate_user_name(
+            name_row["display_name"] if name_row else None,
+            field="name",
+        )
 
         # Already-member / creator short-circuit. We return 200 (not 201)
         # so the FE can show "you're already in this group" instead of

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -87,11 +87,17 @@ def _issue_known_magic_link(email, browser_id):
     return token
 
 
-def _sign_in(client, browser_id, email=None):
+def _sign_in(client, browser_id, email=None, name="Test User"):
     """Run a full magic-link verify and return (session_token, user_id,
     email). The email is the server-normalized (lowercase, trimmed)
     form so tests can compare against `requester_email` from list /
-    create endpoint responses without surface mismatches."""
+    create endpoint responses without surface mismatches.
+
+    `name` defaults to a non-empty display name so the join-request
+    name gate (which requires `users.display_name`) is satisfied. Pass
+    `name=None` to leave the account nameless — useful for testing
+    that gate's 400 path.
+    """
     raw_email = email or f"phasef-{uuid.uuid4().hex[:8]}@example.com"
     token = _issue_known_magic_link(raw_email, browser_id)
     resp = client.post(
@@ -101,7 +107,15 @@ def _sign_in(client, browser_id, email=None):
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    return body["session_token"], body["user"]["user_id"], normalize_email(raw_email)
+    session_token = body["session_token"]
+    if name is not None:
+        named = client.post(
+            "/api/auth/me/name",
+            json={"name": name},
+            headers=_bearer_headers(browser_id, session_token),
+        )
+        assert named.status_code == 200, named.text
+    return session_token, body["user"]["user_id"], normalize_email(raw_email)
 
 
 def _create_private_group(client, browser_id, token):
@@ -155,6 +169,25 @@ def test_create_join_request_unknown_group_returns_404(
         headers=_bearer_headers(requester_browser, rtoken),
     )
     assert resp.status_code == 404
+
+
+def test_create_join_request_requires_account_name(
+    client, creator_browser, requester_browser
+):
+    """A signed-in caller whose account has no `display_name` is rejected
+    with 400 — the creator wouldn't be able to recognize who's asking."""
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    # Sign in without setting a name so users.display_name stays NULL.
+    rtoken, _, _ = _sign_in(client, requester_browser, name=None)
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "Hi"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 400, resp.text
+    assert "name" in resp.json()["detail"].lower()
 
 
 def test_create_join_request_new_returns_pending(

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -190,6 +190,52 @@ def test_create_join_request_requires_account_name(
     assert "name" in resp.json()["detail"].lower()
 
 
+def test_create_join_request_nameless_existing_member_short_circuits(
+    client, creator_browser, requester_browser
+):
+    """A nameless caller who's ALREADY a member gets the friendly
+    `already_member` response — the name gate only fires when a new
+    request would actually be created. Pins the name-check-after-member-
+    check ordering."""
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    # Sign in the requester with a name + approve them so they become a
+    # member, then clear the name to simulate a member whose display_name
+    # was wiped (legacy data / manual clear).
+    rtoken, ruid, _ = _sign_in(client, requester_browser)
+    pending = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "join me"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = pending.json()["request"]["id"]
+    decided = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert decided.status_code == 200, decided.text
+
+    # Wipe the requester's display_name now that they're a member.
+    cleared = client.post(
+        "/api/auth/me/name",
+        json={"name": None},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert cleared.status_code == 200, cleared.text
+
+    # Re-tap "Request to join" — should short-circuit on membership
+    # BEFORE hitting the name gate.
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "?"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "already_member"
+
+
 def test_create_join_request_new_returns_pending(
     client, creator_browser, requester_browser
 ):


### PR DESCRIPTION
## Summary
- `POST /api/groups/<route_id>/join-requests` runs `validate_user_name(users.display_name)` AFTER the member-or-creator short-circuit and before `create_join_request` — returns 400 "name is required" for nameless callers, but lets nameless existing-members keep their friendly `already_member` response. Creators need *something* to recognize the requester by (passkey-only accounts have no email, so the "Passkey user" UI fallback reads as anonymous).
- FE: `GroupNotFound.requestAccess` (in `components/GroupLoadState.tsx`) gates on `isValidUserName(getUserName())` and opens the shared `<AccountGateModal message="to request access">` when missing — same modal the create-group / vote / create-poll flows use. `onSubmit` retries the request inline via an extracted `submitJoinRequest` helper.

## Demo
Live on the branch's dev tier: https://claude-account-name-group-access-xq6h9.dev.whoeverwants.com/

Instant-sign-in URL for a fresh nameless requester landing on the private group's "Private Group" page (tap "Request to join" to see the gate):
https://claude-account-name-group-access-xq6h9.dev.whoeverwants.com/auth/instant?token=yFohdk6hMvL4Oc4hG7Ldo2Wjf6YKjoiH3innvnL3rc0&next=%2Fg%2F~1

Screenshot of the modal: https://claude-account-name-group-access-xq6h9.dev.whoeverwants.com/screenshots/join-request-name-gate.png

## Test plan
- [x] `server/tests/test_join_requests.py` — 20 tests pass locally (was 19 + 1 new `test_create_join_request_requires_account_name` + 1 new `test_create_join_request_nameless_existing_member_short_circuits` regression for the ordering)
- [x] `test_group_privacy.py` + `test_groups_api.py` + `test_groups_visibility.py` (96 total) all pass
- [x] End-to-end demo: nameless POST → 400, then `/auth/me/name` → 200, then retry POST → 200 `pending`

https://claude.ai/code/session_01KnGXx2qXWDQNmasteRgiqT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnGXx2qXWDQNmasteRgiqT)_