### PR TITLE
Fix space after bold "other" in merge-account copy

### DIFF
--- a/components/MergeAccountModal.tsx
+++ b/components/MergeAccountModal.tsx
@@ -73,8 +73,8 @@ export default function MergeAccountModal({
 
           <h2 className="text-lg font-semibold mb-2 pr-6">Combine another account</h2>
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-            Sign in to your <strong>other</strong> account below. Its polls,
-            groups, and sign-in methods move into this one, and the other
+            Sign in to your <strong>other</strong>{" "}account below. Its
+            polls, groups, and sign-in methods move into this one, and the other
             account is permanently removed. This can&apos;t be undone.
           </p>
 


### PR DESCRIPTION
## Summary
- The merge-account modal copy (Settings → "Combine another account") read "Sign in to your **other** account below…". Made the space after the bolded `other` an explicit `{" "}` JSX token so it can't be lost to a formatter reflow that moves `account` onto its own line and collapses the inter-element whitespace.

## Test plan
- [x] Verified the modal renders with a clear space after **other** (screenshot via signed-in dev session)

https://claude.ai/code/session_01WiWRURA4UPcZ2yhyfHxtNC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiWRURA4UPcZ2yhyfHxtNC)_