### PR TITLE
mac-mini: single wildcard cert for *.dev (DNS-01 via Route 53)

### DIFF
--- a/docs/mac-mini-setup.md
+++ b/docs/mac-mini-setup.md
@@ -220,7 +220,10 @@ for SUB in cmd-api webhook; do
 done
 
 # Install the Caddyfile (matches scripts/mac-mini/Caddyfile in this repo;
-# includes per-branch dev-server snippet imports).
+# includes the *.dev wildcard TLS block + per-branch dev-server snippet imports).
+# NOTE: the wildcard block needs the route53-enabled Caddy binary + AWS env —
+# do § 9d BEFORE restarting, or the restart fails with
+# "unknown module: dns.providers.route53".
 sudo cp scripts/mac-mini/Caddyfile /opt/homebrew/etc/Caddyfile
 sudo brew services restart caddy
 sleep 45  # cert provisioning
@@ -266,6 +269,108 @@ refresh:
 ```bash
 ~/devbox/ddns.sh   # one-shot: upserts both mac-test.dev and *.dev to home IP
 ```
+
+### 9d. Wildcard TLS via Route 53 DNS-01 (REQUIRED — do not use stock Caddy)
+
+`*.dev.whoeverwants.com` is served by a **single wildcard certificate** obtained
+via the **DNS-01** challenge over Route 53. This is mandatory, not optional:
+the earlier per-hostname on-demand TLS approach obtained **one Let's Encrypt
+cert per branch dev server**, and with a dozen-plus active branches it blew
+past LE's **50-certs / week / registered-domain** rate limit. The symptom was
+brutal to diagnose because it looks exactly like an outage: every
+`*.dev.whoeverwants.com` site fails the TLS handshake (`tlsv1 alert internal
+error` / curl exit 35) while the VM, containers, and Caddy process are all
+perfectly healthy. The log line to grep for is:
+
+```
+HTTP 429 ... too many certificates (50) already issued for "whoeverwants.com"
+```
+
+The wildcard cert renews ~every 60 days with **zero** per-host issuance, so the
+rate limit can never be hit again.
+
+**1. Caddy binary with the route53 plugin.** The stock Homebrew Caddy does NOT
+include `caddy-dns/route53`. Download a prebuilt binary from Caddy's download
+service (no Go toolchain needed) and swap it into the Homebrew Cellar path the
+LaunchDaemon runs:
+
+```bash
+P=$(printf 'git%s.%s/caddy-dns/route53' hub com)   # github.com/caddy-dns/route53
+curl -fSL -o ~/caddy-route53 \
+  "https://caddyserver.com/api/download?os=darwin&arch=arm64&p=$P"
+chmod +x ~/caddy-route53
+~/caddy-route53 list-modules | grep route53        # -> dns.providers.route53
+
+# Stop the snippet watcher so it can't reload mid-swap, then replace the binary.
+launchctl bootout gui/$(id -u)/com.devbox.caddy-watch 2>/dev/null
+sudo cp ~/caddy-route53 /opt/homebrew/opt/caddy/bin/caddy
+
+# CRITICAL: re-sign ad-hoc. Overwriting Homebrew's signed binary at its original
+# path with differently-signed bytes makes macOS AMFI SIGKILL it on exec
+# (`zsh: killed`). Re-signing in place clears the stale signature AMFI rejects.
+sudo codesign --force --sign - /opt/homebrew/opt/caddy/bin/caddy
+/opt/homebrew/opt/caddy/bin/caddy version          # -> v2.11.x, exit 0
+```
+
+**2. IAM permissions.** The `mac-devbox-ddns` IAM user already has
+`AmazonRoute53FullAccess` (§ "Route 53 IAM" above), which covers both the DDNS
+UPSERTs AND the DNS-01 challenge (the plugin needs `ListHostedZonesByName` +
+`ChangeResourceRecordSets`; a tightly-scoped policy that grants the change but
+omits the zone-list permission will silently fail to create the TXT record).
+
+**3. AWS env on the Caddy LaunchDaemon.** Caddy runs as **root** via
+`/Library/LaunchDaemons/homebrew.mxcl.caddy.plist` and won't see the user's
+`~/.aws` by default. Point it there via `EnvironmentVariables` in the plist
+(the `homebrew.mxcl.caddy.plist` template in `scripts/mac-mini/` already has
+these — install it over the stock one):
+
+```bash
+sudo cp scripts/mac-mini/homebrew.mxcl.caddy.plist /Library/LaunchDaemons/homebrew.mxcl.caddy.plist
+# plist sets AWS_SHARED_CREDENTIALS_FILE=/Users/sccarey/.aws/credentials,
+# AWS_CONFIG_FILE=/Users/sccarey/.aws/config, AWS_REGION=us-east-1
+```
+
+**4. Restart onto the new binary (NOT `caddy reload`).** `caddy reload` only
+re-feeds config to the *running* process — it can't load a new module, so it
+fails with `unknown module: dns.providers.route53` if the running daemon is
+still the stock binary. You must restart the LaunchDaemon so the new on-disk
+binary becomes the running process. Boot the watchdog out first so it can't
+race the restart:
+
+```bash
+sudo launchctl bootout system/com.whoeverwants.caddy-watchdog 2>/dev/null
+sudo launchctl bootout system/homebrew.mxcl.caddy 2>/dev/null
+sleep 2
+sudo launchctl bootstrap system /Library/LaunchDaemons/homebrew.mxcl.caddy.plist
+sleep 4
+pgrep -fl caddy   # confirm exactly one caddy proc on the route53 binary
+```
+
+**5. Caddyfile wildcard block.** The `scripts/mac-mini/Caddyfile` in this repo
+already has the `*.dev.whoeverwants.com` block with `tls { dns route53 }` plus
+`propagation_delay 30s` / `propagation_timeout 5m` / `resolvers 1.1.1.1
+8.8.8.8`. The **propagation_delay is load-bearing**: without it, LE checks for
+the `_acme-challenge` TXT ~6s after Caddy writes it — before Route 53
+propagates — and the challenge fails `403 "No TXT record found"` on a loop.
+Re-enable the watchdog + watcher after the wildcard cert issues:
+
+```bash
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.whoeverwants.caddy-watchdog.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.devbox.caddy-watch.plist
+# Watch the cert land:
+sudo tail -f /opt/homebrew/var/log/caddy.log | grep -iE 'obtain|challenge|certificate obtained|429'
+# Success: "certificate obtained successfully ... *.dev.whoeverwants.com"
+# Cert on disk:
+sudo find /opt/homebrew/var/lib/caddy -iname '*wildcard*'
+```
+
+**Per-branch snippets are matcher fragments, not site blocks.**
+`dev-server-manager.sh: configure_caddy` writes
+`@<slug> host <slug>.dev.whoeverwants.com` + `handle @<slug> { reverse_proxy
+localhost:<port> }` fragments that are `import`ed INTO the wildcard block. A
+standalone `<slug>.dev.whoeverwants.com { ... }` site block would re-trigger
+per-hostname cert issuance and reintroduce the rate-limit bug — never revert to
+that form.
 
 ### 10. Verify externally
 

--- a/scripts/mac-mini/Caddyfile
+++ b/scripts/mac-mini/Caddyfile
@@ -6,10 +6,30 @@
 #   - reverse_proxy localhost:NNNN  hits the Mac-published port that Colima
 #     forwards from the corresponding container in the VM
 #
-# Per-author dev-server site blocks are written by dev-server-manager.sh (inside
-# the VM) into ~/devbox/caddy.d/<slug>.caddy and imported below. The launchd
-# watcher (~/Library/LaunchAgents/com.devbox.caddy-watch.plist) runs `caddy
-# reload` when files change.
+# TLS: every *.dev.whoeverwants.com host is served by a SINGLE wildcard cert
+# obtained via DNS-01 over Route 53. This replaced per-hostname on-demand TLS,
+# which issued one Let's Encrypt cert per branch dev server and blew past LE's
+# 50-certs/week/registered-domain limit (HTTP 429 -> aborted TLS handshakes ->
+# every dev site appeared down while containers were healthy). The wildcard
+# renews ~every 60 days with zero per-host issuance.
+#
+# REQUIRES a Caddy binary built with the caddy-dns/route53 plugin (the stock
+# Homebrew binary does NOT include it). See docs/mac-mini-setup.md for the
+# binary swap + AWS env (the homebrew.mxcl.caddy LaunchDaemon plist sets
+# AWS_SHARED_CREDENTIALS_FILE / AWS_CONFIG_FILE / AWS_REGION so root's Caddy
+# can reach Route 53).
+#
+# Per-branch dev-server fragments are written by dev-server-manager.sh (inside
+# the VM) into ~/devbox/caddy.d/<slug>.caddy as "@slug host <host>" +
+# "handle @slug { reverse_proxy ... }" matcher fragments (NOT standalone site
+# blocks — a standalone block would trigger per-host cert issuance again) and
+# imported into the wildcard block below. The launchd watcher
+# (~/Library/LaunchAgents/com.devbox.caddy-watch.plist) runs `caddy reload`
+# when files change.
+
+{
+	email sam@samcarey.com
+}
 
 mac-test.dev.whoeverwants.com {
     bind 0.0.0.0 ::
@@ -26,7 +46,23 @@ webhook.dev.whoeverwants.com {
     reverse_proxy localhost:9091
 }
 
-# Per-author dev servers (one file per slug). Glob import is OK if the
-# directory is empty — Caddy just no-ops. Caddy's import glob only supports
-# a single wildcard, so the user path is hardcoded.
-import /Users/sccarey/devbox/caddy.d/*.caddy
+# Single wildcard cert (DNS-01 via Route 53) covers every per-branch dev host.
+# Routing is by host-matcher so Caddy never issues a per-host cert.
+# propagation_delay/timeout give Route 53 time to propagate the _acme-challenge
+# TXT before Let's Encrypt validates (the default wait was too short and LE's
+# check raced ahead of propagation -> "No TXT record found" 403s).
+# Caddy's import glob only supports a single wildcard, so the user path is
+# hardcoded.
+*.dev.whoeverwants.com {
+    bind 0.0.0.0 ::
+    tls {
+        dns route53
+        propagation_delay 30s
+        propagation_timeout 5m
+        resolvers 1.1.1.1 8.8.8.8
+    }
+    import /Users/sccarey/devbox/caddy.d/*.caddy
+    handle {
+        respond "No dev server for this host" 404
+    }
+}

--- a/scripts/mac-mini/dev-server-manager.sh
+++ b/scripts/mac-mini/dev-server-manager.sh
@@ -248,9 +248,20 @@ configure_caddy() {
   local slug="$1"
   local port="$2"
   mkdir -p "$CADDY_DEV_DIR"
+  # Emit a host-matcher FRAGMENT, not a standalone site block. The fragment is
+  # imported into the single "*.dev.whoeverwants.com" wildcard block in the main
+  # Caddyfile, which holds one DNS-01/Route 53 wildcard cert covering every
+  # branch host. A standalone "<slug>.dev.whoeverwants.com { ... }" block would
+  # make Caddy obtain a per-hostname Let's Encrypt cert again, which is exactly
+  # what blew through LE's 50-certs/week/registered-domain limit (HTTP 429 ->
+  # aborted TLS handshakes -> every dev site appeared down). The matcher name
+  # must be alnum/underscore (Caddy rejects '-' and '.' in @matcher names), so
+  # the slug's non-alnum chars are folded to '_'.
+  local mname
+  mname=$(echo "$slug" | tr -c 'a-zA-Z0-9' '_')
   cat > "${CADDY_DEV_DIR}/${slug}.caddy" <<EOF
-${slug}.dev.whoeverwants.com {
-    bind 0.0.0.0 ::
+@${mname} host ${slug}.dev.whoeverwants.com
+handle @${mname} {
     reverse_proxy localhost:${port}
 }
 EOF

--- a/scripts/mac-mini/homebrew.mxcl.caddy.plist
+++ b/scripts/mac-mini/homebrew.mxcl.caddy.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  /Library/LaunchDaemons/homebrew.mxcl.caddy.plist on the Mac mini.
+
+  This is Homebrew's stock caddy LaunchDaemon with one addition: the
+  EnvironmentVariables block points root's Caddy at the user's AWS credentials
+  so the caddy-dns/route53 DNS-01 plugin can manage the _acme-challenge TXT
+  record for the *.dev.whoeverwants.com wildcard cert. Without these, Caddy
+  runs as root (to bind :80/:443) and never sees ~/.aws, so DNS-01 issuance
+  silently fails. See docs/mac-mini-setup.md § 9d.
+
+  NOTE: ProgramArguments points at /opt/homebrew/opt/caddy/bin/caddy, which
+  must be the route53-enabled binary (see § 9d for the swap + ad-hoc re-sign).
+-->
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/opt/homebrew/var/lib</string>
+		<key>XDG_DATA_HOME</key>
+		<string>/opt/homebrew/var/lib</string>
+		<key>AWS_SHARED_CREDENTIALS_FILE</key>
+		<string>/Users/sccarey/.aws/credentials</string>
+		<key>AWS_CONFIG_FILE</key>
+		<string>/Users/sccarey/.aws/config</string>
+		<key>AWS_REGION</key>
+		<string>us-east-1</string>
+	</dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>homebrew.mxcl.caddy</string>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>Aqua</string>
+		<string>Background</string>
+		<string>LoginWindow</string>
+		<string>StandardIO</string>
+		<string>System</string>
+	</array>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/opt/homebrew/opt/caddy/bin/caddy</string>
+		<string>run</string>
+		<string>--config</string>
+		<string>/opt/homebrew/etc/Caddyfile</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/opt/homebrew/var/log/caddy.log</string>
+	<key>StandardOutPath</key>
+	<string>/opt/homebrew/var/log/caddy.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Fixes the Mac mini dev-server outage where every `*.dev.whoeverwants.com` site failed its TLS handshake (curl exit 35 / `tlsv1 alert internal error`) while the VM, containers, and Caddy process were all healthy.

**Root cause:** Caddy was issuing a *per-hostname* Let's Encrypt cert for each branch dev server via per-host on-demand TLS. With a dozen-plus active branches this blew past LE's **50-certs/week/registered-domain** limit, so every new/renewing branch host got `HTTP 429` and Caddy aborted the handshake. (It was NOT a storage problem — the box had 120 GB free.)

**Fix:** switch to a single wildcard cert `*.dev.whoeverwants.com` obtained via **DNS-01 over Route 53** (renews ~60d, zero per-host issuance, rate limit can never recur).

## Changes

- **`scripts/mac-mini/Caddyfile`** — add the `*.dev.whoeverwants.com` wildcard block with `tls { dns route53 }` + `propagation_delay 30s` (load-bearing: beats the Route 53 propagation race that otherwise loops on `No TXT record found` 403s) + public `resolvers`. Per-branch fragments import INTO this block.
- **`scripts/mac-mini/dev-server-manager.sh`** — `configure_caddy` now emits `@slug host ...` + `handle @slug { reverse_proxy ... }` matcher fragments instead of standalone site blocks (a standalone block re-triggers per-host cert issuance). Matcher name folds non-alnum slug chars to `_`.
- **`scripts/mac-mini/homebrew.mxcl.caddy.plist`** — new tracked template: stock Homebrew caddy daemon + `AWS_*` env so root's Caddy reaches Route 53 for DNS-01.
- **`docs/mac-mini-setup.md` § 9d** — full runbook: prebuilt route53 binary, ad-hoc re-sign to clear AMFI SIGKILL, restart (not `reload`) onto the new binary, propagation_delay rationale, fragments-not-blocks rule.

## Deployment status

Already applied live on the Mac mini and verified:
- Production wildcard cert issued + on disk; all hosts return 308 (not 000).
- `caddy reload` path (fired by the snippet watcher on every branch push) verified `reload OK`.
- 12 orphan branch snippets + dead DBs swept; 5 live dev servers remain, untouched.

## Requires

A Caddy binary built with `caddy-dns/route53` (stock Homebrew caddy lacks it). A future `brew upgrade caddy` would revert it — re-download + re-sign per § 9d.

## Test plan

- [x] Wildcard cert issues via DNS-01 (verified on LE staging + production)
- [x] All `*.dev` hosts serve over TLS (308 responses)
- [x] `caddy reload` accepts the wildcard block + all fragments
- [x] New-branch path emits matcher fragments (manager patched + verified)