### PR TITLE
Add confirmation modal before removing a passkey

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -122,6 +122,8 @@ export default function SettingsPage() {
   const [platformAuthAvailable, setPlatformAuthAvailable] = useState<boolean | null>(null);
   const [passkeyRegisterInFlight, setPasskeyRegisterInFlight] = useState(false);
   const [passkeyDeletePending, setPasskeyDeletePending] = useState<string | null>(null);
+  // The passkey the user has tapped "Remove" on, awaiting confirmation.
+  const [passkeyToDelete, setPasskeyToDelete] = useState<PasskeySummary | null>(null);
   const [passkeyError, setPasskeyError] = useState<string | null>(null);
 
   // Name + reference location are read-only here (edited on /settings/edit).
@@ -452,7 +454,7 @@ export default function SettingsPage() {
                     </div>
                     <button
                       type="button"
-                      onClick={() => handleDeletePasskey(p.credential_id)}
+                      onClick={() => setPasskeyToDelete(p)}
                       disabled={passkeyDeletePending === p.credential_id}
                       className="text-sm text-red-600 dark:text-red-400 hover:underline disabled:opacity-50 shrink-0"
                     >
@@ -651,6 +653,20 @@ export default function SettingsPage() {
           await handleSignOut();
         }}
         onCancel={() => setShowSignOutConfirm(false)}
+      />
+
+      <ConfirmationModal
+        isOpen={passkeyToDelete !== null}
+        title="Remove passkey?"
+        message={`Remove "${passkeyToDelete?.name || "Passkey"}"? You won't be able to sign in with it anymore.`}
+        confirmText="Remove"
+        confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
+        onConfirm={() => {
+          const target = passkeyToDelete;
+          setPasskeyToDelete(null);
+          if (target) void handleDeletePasskey(target.credential_id);
+        }}
+        onCancel={() => setPasskeyToDelete(null)}
       />
 
       <SignInModal


### PR DESCRIPTION
## Summary
- Removing a passkey from Settings was immediate and unrecoverable. This adds a confirmation step.
- Tapping "Remove" now opens a `ConfirmationModal` (the same component used for sign-out) reading: `Remove "<name>"? You won't be able to sign in with it anymore.` with a red Remove button.
- The existing optimistic-delete + rollback `handleDeletePasskey` runs only after confirm; backdrop/Escape cancels.

## Test plan
- [x] Verified live on the dev server with a WebAuthn virtual authenticator: register a passkey → tap Remove → confirmation modal appears → confirm deletes, cancel dismisses.

https://claude.ai/code/session_01JHKFWjudPB7KrQgc21a6zD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHKFWjudPB7KrQgc21a6zD)_