### PR TITLE
Match duration field unit placement in time ballot to poll creation form

### DIFF
--- a/components/TimeQuestionFields.tsx
+++ b/components/TimeQuestionFields.tsx
@@ -80,7 +80,7 @@ export default function TimeQuestionFields({
       {onDurationMinChange && onDurationMaxChange && onDurationMinEnabledChange && onDurationMaxEnabledChange && (
         <div>
           <label className="block text-sm font-medium mb-1">
-            Duration (hours)
+            Duration
           </label>
           <MinMaxCounter
             minValue={durationMinValue}
@@ -98,6 +98,7 @@ export default function TimeQuestionFields({
             formatValue={formatDurationValue}
             minCheckboxEnabled={durationMinEnabled}
             onMinCheckboxChange={onDurationMinEnabledChange}
+            suffix="h"
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- The voter-facing time ballot rendered the duration unit as a `Duration (hours)` header label with bare counters, while the poll creation form puts `h` inside each counter field with a plain `Duration` header.
- Made the ballot match: dropped `(hours)` from the label and passed `suffix="h"` to `MinMaxCounter` in `components/TimeQuestionFields.tsx` (reusing the existing prop the create-poll form already uses).

## Test plan
- [x] Availability ballot on a time poll shows `Duration` header with `1 h` — `3 h` fields, matching the create-poll form
- Demo: https://claude-time-poll-duration-label-jitjq.dev.whoeverwants.com/g/~1/p/1

https://claude.ai/code/session_01JLiaBwHAwU2bASdYUDNxYR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLiaBwHAwU2bASdYUDNxYR)_