### PR TITLE
Center and titlecase time-poll preferences legend

### DIFF
--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -95,6 +95,15 @@ export default function TimeSlotBubbles({
     if (disabled) clearSelection();
   }, [disabled, clearSelection]);
 
+  // Whether any slot would render an orange "excludes N voter(s)" badge — used
+  // to gate the matching legend entry.
+  const hasExcluded = useMemo(() => {
+    if (maxAvailability == null || availabilityCounts == null) return false;
+    return options.some(
+      (slot) => maxAvailability - (availabilityCounts[slot] ?? 0) > 0,
+    );
+  }, [options, maxAvailability, availabilityCounts]);
+
   const days = useMemo(
     () =>
       groupSlotsByDay(options).map(([dateStr, slots]) => ({
@@ -312,19 +321,19 @@ export default function TimeSlotBubbles({
       ))}
 
       {/* Legend */}
-      <div className="flex items-center gap-3 pt-1 text-xs text-gray-400 dark:text-gray-500">
+      <div className="flex flex-wrap items-center justify-center gap-3 pt-1 text-xs text-gray-400 dark:text-gray-500">
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-full bg-green-500" /> liked
+          <span className="inline-block w-3 h-3 rounded-full bg-green-500" /> Liked
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-full bg-red-500" /> disliked
+          <span className="inline-block w-3 h-3 rounded-full bg-red-500" /> Disliked
         </span>
         <span className="flex items-center gap-1">
-          <span className="inline-block w-3 h-3 rounded-full border border-gray-300 dark:border-gray-600" /> neutral
+          <span className="inline-block w-3 h-3 rounded-full border border-gray-300 dark:border-gray-600" /> Neutral
         </span>
-        {maxAvailability != null && maxAvailability > 0 && (
+        {hasExcluded && (
           <span className="flex items-center gap-1">
-            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-orange-500 text-[9px] font-bold text-white">N</span> excludes N voter(s)
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-orange-500 text-[9px] font-bold text-white">N</span> Excludes N Voter(s)
           </span>
         )}
       </div>

--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -333,7 +333,7 @@ export default function TimeSlotBubbles({
         </span>
         {hasExcluded && (
           <span className="flex items-center gap-1">
-            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-orange-500 text-[9px] font-bold text-white">N</span> Excludes N Voter(s)
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-orange-500 text-[9px] font-bold text-white">N</span> Excludes Voters
           </span>
         )}
       </div>

--- a/components/TimeSlotBubbles.tsx
+++ b/components/TimeSlotBubbles.tsx
@@ -95,14 +95,21 @@ export default function TimeSlotBubbles({
     if (disabled) clearSelection();
   }, [disabled, clearSelection]);
 
+  // How many voters a slot excludes (max availability minus its own count).
+  const excludedCount = useCallback(
+    (slot: string) =>
+      maxAvailability != null && availabilityCounts != null
+        ? maxAvailability - (availabilityCounts[slot] ?? 0)
+        : 0,
+    [maxAvailability, availabilityCounts],
+  );
+
   // Whether any slot would render an orange "excludes N voter(s)" badge — used
   // to gate the matching legend entry.
-  const hasExcluded = useMemo(() => {
-    if (maxAvailability == null || availabilityCounts == null) return false;
-    return options.some(
-      (slot) => maxAvailability - (availabilityCounts[slot] ?? 0) > 0,
-    );
-  }, [options, maxAvailability, availabilityCounts]);
+  const hasExcluded = useMemo(
+    () => options.some((slot) => excludedCount(slot) > 0),
+    [options, excludedCount],
+  );
 
   const days = useMemo(
     () =>
@@ -237,10 +244,7 @@ export default function TimeSlotBubbles({
     }
     const state = getState(cell.slot);
     const isSelected = selection.has(cell.slot);
-    const excluded =
-      maxAvailability != null && availabilityCounts != null
-        ? maxAvailability - (availabilityCounts[cell.slot] ?? 0)
-        : 0;
+    const excluded = excludedCount(cell.slot);
     return (
       <button
         key={cell.slot}


### PR DESCRIPTION
## Summary
- Horizontally center the time-poll preferences legend (`flex-wrap justify-center`).
- Titlecase the legend labels: `Liked`, `Disliked`, `Neutral`, `Excludes Voters`.
- Only show the "Excludes Voters" entry when at least one slot actually renders an exclusion badge (was previously shown whenever `maxAvailability > 0`, even with no excluded slots).
- Extract a shared `excludedCount(slot)` helper so the legend gate and the per-slot orange badge compute exclusion the same way.

All in `components/TimeSlotBubbles.tsx`.

## Test plan
- [x] Preferences ballot with varying availability → legend centered, titlecased, and shows "Excludes Voters" (orange badges present).
- [x] Single-phase time poll with no availability data → legend ends at "Neutral", no exclude entry.

https://claude.ai/code/session_01NjfJjA2dRuVPRKJvhg3f2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjfJjA2dRuVPRKJvhg3f2S)_