### PR TITLE
Reword time-poll availability hint

### DIFF
--- a/components/QuestionBallot/TimeBallotSection.tsx
+++ b/components/QuestionBallot/TimeBallotSection.tsx
@@ -245,7 +245,7 @@ export default function TimeBallotSection({
               <h3 className="text-lg font-semibold mb-3 text-center">Mark Your Preferences</h3>
               {inAvailabilityPhase && (
                 <p className="mb-3 text-xs text-amber-600 dark:text-amber-400 text-center">
-                  Tentative slots — list may shift as more voters submit availability.
+                  Options may change as more voters submit availability.
                 </p>
               )}
               <TimeSlotBubbles

--- a/components/QuestionBallot/TimeBallotSection.tsx
+++ b/components/QuestionBallot/TimeBallotSection.tsx
@@ -245,7 +245,7 @@ export default function TimeBallotSection({
               <h3 className="text-lg font-semibold mb-3 text-center">Mark Your Preferences</h3>
               {inAvailabilityPhase && (
                 <p className="mb-3 text-xs text-amber-600 dark:text-amber-400 text-center">
-                  Options may change as more voters submit availability.
+                  Options may change during availability phase
                 </p>
               )}
               <TimeSlotBubbles


### PR DESCRIPTION
Changes the amber hint shown in the time-poll preferences phase (pre-ranking) from "Tentative slots — list may shift as more voters submit availability." to "Options may change during availability phase".

https://claude.ai/code/session_01NgsHEdNBuB4ar8Wb4whPQ3