### PR TITLE
Round calendar day cells and add spacing between them

### DIFF
--- a/components/DaysSelector.tsx
+++ b/components/DaysSelector.tsx
@@ -273,7 +273,7 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                 data-date={dateStr}
                 data-testid={`calendar-day-${dateStr}`}
                 className={`
-                  aspect-[5/4] text-sm flex items-center justify-center
+                  aspect-[5/4] text-sm flex items-center justify-center rounded-lg
                   ${isDisabled
                     ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
                     : !isCurrentMonth
@@ -281,11 +281,11 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                       : 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
                   }
                   ${isSelected
-                    ? 'bg-blue-500 text-white hover:bg-blue-600'
+                    ? 'bg-blue-400/70 dark:bg-blue-500/50 text-white hover:bg-blue-400/80 dark:hover:bg-blue-500/60'
                     : ''
                   }
                   ${isToday && !isSelected && !isDisabled
-                    ? 'border-2 border-blue-500'
+                    ? 'border-2 border-blue-400/70 dark:border-blue-500/60'
                     : ''
                   }
                 `}

--- a/components/DaysSelector.tsx
+++ b/components/DaysSelector.tsx
@@ -244,7 +244,7 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
   );
 
   const weekdayHeader = (
-    <div className="grid grid-cols-7 mb-2">
+    <div className="grid grid-cols-7 gap-1 mb-2">
       {WEEK_DAYS.map(day => (
         <div key={day} className="text-center text-xs font-medium text-gray-500 dark:text-gray-400 py-1">
           {day}
@@ -254,7 +254,7 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
   );
 
   const daysGrid = (
-    <div className="grid grid-cols-7">
+    <div className="grid grid-cols-7 gap-1">
       {(() => {
         const todayStr = formatLocalDateISO(new Date());
         return calendarDays.map(({ dateStr, isCurrentMonth, day }, index) => {
@@ -281,11 +281,11 @@ export default function DaysSelector({ selectedDays, onChange, disabled = false,
                       : 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
                   }
                   ${isSelected
-                    ? 'bg-blue-400/70 dark:bg-blue-500/50 text-white hover:bg-blue-400/80 dark:hover:bg-blue-500/60'
+                    ? 'bg-blue-500 text-white hover:bg-blue-600'
                     : ''
                   }
                   ${isToday && !isSelected && !isDisabled
-                    ? 'border-2 border-blue-400/70 dark:border-blue-500/60'
+                    ? 'border-2 border-blue-500'
                     : ''
                   }
                 `}


### PR DESCRIPTION
## Summary
- Round the corners of the day cells in the new-time-poll calendar field (`rounded-lg`), including the today/selected rectangles
- Add a small gap between day cells (`gap-1` on both the weekday header and days grids) so the rectangles no longer touch

## Test plan
- [ ] Open the new-poll form, tap the **Time** bubble, and confirm the Days calendar shows rounded, spaced day cells with the today/selected highlight in the standard `blue-500`

https://claude.ai/code/session_01DoEVGuNT5zC4oTf3VsarWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoEVGuNT5zC4oTf3VsarWx)_