### PR TITLE
Copy time slots from latest selected day when adding a new day

### DIFF
--- a/lib/useDayTimeWindowsState.ts
+++ b/lib/useDayTimeWindowsState.ts
@@ -38,10 +38,11 @@ export function useDayTimeWindowsState(
         working.push({ day: d, windows: cached });
         continue;
       }
-      // Inherit windows from the chronologically previous day in the
-      // working list; fall back to 8am–5pm when there is no prior day.
+      // Inherit windows from the latest (chronologically last) already-selected
+      // day, regardless of whether it sorts before or after the new day; fall
+      // back to 8am–5pm when no other day has windows.
       const prev = working
-        .filter(x => x.day < d && x.windows.length > 0)
+        .filter(x => x.day !== d && x.windows.length > 0)
         .sort((a, b) => a.day.localeCompare(b.day))
         .pop();
       const inheritedWindows: TimeWindow[] = prev


### PR DESCRIPTION
## Summary
- When adding a day to a time-poll creation form, the new day now inherits its time windows from the **latest** (chronologically last) already-selected day, regardless of whether the new day sorts before or after it.
- Previously the inheritance only looked at a day sorting before the new one (`x.day < d`), so adding a day earlier than every existing day fell through to the 8am-5pm default instead of copying.
- The change is in the shared `useDayTimeWindowsState` hook, so both consumers (the create-poll form and the voter-facing `TimeQuestionFields`) get it. The removed-day cache (re-adds restore their own windows) and the `DEFAULT_TIME_WINDOW` fallback are unchanged.

## Test plan
- [ ] In the time-poll create flow, add a day and set it to e.g. 6pm-9pm, then add a day that sorts earlier -> new day copies 6pm-9pm (not the default).
- [ ] Add a day later than existing days -> still copies the latest day's windows.
- [ ] Remove a day and re-add it -> restores its own previous windows (cache path unchanged).

https://claude.ai/code/session_01QbGz5miwQNPAB4FwHfFXPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbGz5miwQNPAB4FwHfFXPu)_