### PR TITLE
Reduce Duration field vertical padding by 50%

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -2196,7 +2196,7 @@ export function CreateQuestionContent() {
                       <label className="block text-[17.5px] font-medium text-gray-500 dark:text-gray-400 mb-1 px-1">
                         Duration
                       </label>
-                      <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-3">
+                      <section className="rounded-3xl bg-white dark:bg-gray-800 px-4 py-1.5">
                         <MinMaxCounter
                           minValue={durationMinValue}
                           maxValue={durationMaxValue}


### PR DESCRIPTION
## Summary
- Halved the vertical padding on the Duration card in the create-poll form (`py-3` → `py-1.5`, 12px → 6px top/bottom). Horizontal padding (`px-4`) is unchanged.

## Test plan
- [x] Open the Time category from a group's bubble bar → the Duration card now hugs the min/max counter row more tightly.

https://claude.ai/code/session_0198JUm1rUJgTHJ6WiJ1ZR9L

---
_Generated by [Claude Code](https://claude.ai/code/session_0198JUm1rUJgTHJ6WiJ1ZR9L)_