### PR TITLE
Tell late joiners a poll closed before they joined (instead of leaking/omitting it)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2087,28 +2087,56 @@ different FE origin, extend the allowlist.
 >
 > The closed-before-join filter still applies, so a brand-new member
 > sees open polls plus polls closed after their `joined_at` watermark
-> but NOT polls closed before. If the URL carries `?p=<closedPreJoin>`,
-> the linked poll is silently absent — the FE renders the rest of the
-> group (per the user spec: "if they received a direct link to a poll
-> closed before they joined, just show the group and don't try to show
-> the old poll"). `?p=` is purely cosmetic at the API level — it drives
-> FE auto-expand + scroll target + link-preview metadata, nothing else.
+> but NOT polls closed before. The closed-pre-join poll is omitted from
+> the group read's list; a direct LINK to such a poll is no longer
+> silently dropped — it surfaces a "Poll Closed — closed before you
+> joined" note (see the "Late-joiner closed-poll edge — SHIPPED" note
+> below). `?p=` is purely cosmetic at the API level — it drives FE
+> auto-expand + scroll target + link-preview metadata, nothing else.
 >
-> **TODO — don't silently omit a link-targeted poll the recipient can't see;
-> tell them it closed before they joined.** (Decision from the social-test
-> review, May 2026 — this refines the "just show the group, don't try to show
-> the old poll" spec above.) Silently dropping the targeted poll reads as a
-> broken link to whoever shared a just-closed result. Desired: when a direct
-> poll link (`/g/<g>/p/<poll>` or legacy `?p=<poll>`) targets a poll that's
-> hidden ONLY by the closed-before-join watermark (as opposed to genuinely not
-> existing), render the group plus a clear "this poll closed before you joined
-> the group" note where the poll would be — instead of nothing. Implementation:
-> the FE can't tell "filtered out" from "doesn't exist" today (the read returns
-> only the visible subset). Either (a) FE does a cheap existence check —
-> requested poll short_id resolves within this group but isn't in the visible
-> list — or (b) the read endpoint returns a small marker `{hidden_pre_join:
-> [pollShortId]}` for exactly this case. Return existence + closure timing
-> ONLY; never the hidden poll's contents — the visibility rule stands.
+> **Late-joiner closed-poll edge — SHIPPED (`hidden_pre_join` marker).**
+> A direct poll link (`/g/<g>/p/<poll>`; legacy `?p=<poll>` redirects to the
+> path form) that targets a poll hidden ONLY by the closed-before-join
+> watermark now shows a clear "Poll Closed — this poll closed {N} ago, before
+> you joined the group" note instead of either silently omitting it or (worse)
+> leaking its contents. The note renders on the poll DETAIL page (where the
+> link lands) with a "Back to Group" button — NOT as a phantom card injected
+> into the group list (closed-pre-join polls have no natural slot in the
+> sorted list, and reshaping the group read's `list[PollResponse]` to carry a
+> marker would break every consumer).
+>   * **The leak this also closed:** `GET /api/polls/{short_id}` /
+>     `/by-id/{poll_id}` are visibility-BLIND (they 200 the full poll
+>     regardless of membership/closure). The path-form detail page used to
+>     fetch the targeted poll through `apiGetPollByShortId` on a cache miss —
+>     so a late joiner tapping a closed-pre-join link saw the full contents.
+>     The detail page's cache-miss fetch now routes through the new
+>     visibility-aware endpoint instead.
+>   * **Backend:** `GET /api/groups/by-route-id/{route_id}/poll/{poll_ref}`
+>     (`routers/groups.py`, model `GroupPollResponse`). Resolves the group
+>     (404 on miss), gates private groups (404 non-members at the boundary,
+>     same as the group read), auto-joins public-group visitors (so the
+>     closed-before-join watermark is "now"), resolves `poll_ref` as a
+>     `polls.short_id` OR `polls.id` uuid SCOPED to that group (cross-group
+>     ref → 404), then runs `filter_visible_polls` on the single poll id.
+>     Visible → `{status:"visible", poll:<full PollResponse>}`; filtered out
+>     (the caller is now a member, so the only cause is closed-before-join) →
+>     `{status:"hidden_pre_join", poll:null, closed_at:<polls.updated_at>}` —
+>     existence + closure timing ONLY, never the contents. Tests:
+>     `server/tests/test_group_poll_visibility.py`.
+>   * **FE:** `apiGetGroupPoll(routeId, pollRef)` in `lib/api/groups.ts`
+>     returns `GroupPollResult` (`{status:"visible", poll}` |
+>     `{status:"hidden_pre_join", closedAt}`; throws ApiError 404 otherwise),
+>     caching the poll + priming `accessiblePollsCache` on visible (via the
+>     shared `hydrateAndCache`). `PollDetailView`'s cache-miss effect calls it
+>     and renders the `hiddenPreJoin` note branch. The cache-HIT path (slide
+>     overlay from the group, where the poll is already a visible cache entry)
+>     is unchanged — the new endpoint only fires on a direct-URL cache miss,
+>     which is exactly the late-joiner case.
+>   * **Why a dedicated endpoint vs reshaping the group read (spec option b):**
+>     the detail page doesn't call the group read; reshaping `list[PollResponse]`
+>     to a wrapper-with-markers would break every group-read consumer. The
+>     dedicated endpoint is the targeted realization of option (a)/(b) for the
+>     path-form-link architecture.
 >
 > `/by-route-id/{id}` only 404s when route resolution itself fails. An
 > empty visible-polls list returns 200 with `[]` so the group page can

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2138,6 +2138,46 @@ different FE origin, extend the allowlist.
 >     dedicated endpoint is the targeted realization of option (a)/(b) for the
 >     path-form-link architecture.
 >
+> **TODO — backdate `joined_at` to invite-SEND time for directly-invited
+> members (so they see polls that closed between invite and accept).** When
+> someone is invited to a group *directly* — via an invite link (Phase G), a
+> member-add (migration 126 `add_member_for_user`), or a join-request approval
+> (Phase F `decide_request`) — the `joined_at` watermark that drives the
+> closed-before-join filter should be the time the INVITATION WAS SENT, not the
+> time the recipient finally redeems / opens / is approved. Today every
+> membership-write site uses the `group_members.joined_at` default of `NOW()`
+> (redeem time / approve time / add time), so a poll that closed in the gap
+> between "invite sent" and "invite accepted" is hidden from the invitee —
+> wrong, since the inviter meant to share the whole group as it stood when they
+> reached out. Desired: the invitee can see polls that closed AFTER the invite
+> was sent even if they don't open/accept until later.
+>   * **Plain group-URL share is UNCHANGED:** when someone pastes a bare
+>     `/g/<id>` link and the recipient auto-joins on visit
+>     (`grant_group_membership_inline`), `joined_at = visit time` stays correct
+>     — there's no "send" event distinct from the visit, and an open invitation
+>     to anyone-with-the-URL shouldn't retroactively expose polls closed before
+>     they ever arrived. Only the *targeted* invite flows get the backdate.
+>   * **Per-flow send-time source:** invite link → `group_invites.created_at`
+>     (the moment the creator minted the link; thread it into `redeem_invite`'s
+>     membership INSERT). Member-add → effectively already correct (the add is
+>     instantaneous, so add time ≈ send time) — but if a future "invite, accept
+>     later" variant lands, record the add/send time. Join-request approval is
+>     the ambiguous one: the "invitation" is the creator's approval, so approve
+>     time is arguably right; OR, if we want the requester to see what existed
+>     when they asked, use the request's `requested_at`. Decide per-flow.
+>   * **Implementation caution:** the membership INSERTs all use
+>     `ON CONFLICT (group_id, browser_id) DO NOTHING` to PRESERVE the earliest
+>     `joined_at` across re-visits (load-bearing — advancing it would un-hide
+>     newly-closed polls). Backdating means passing an explicit older
+>     `joined_at` on the INSERT. Two wrinkles: (a) the conflict path must not
+>     overwrite an already-EARLIER watermark (a plain-URL visit that predates
+>     the invite should win — use `DO UPDATE SET joined_at = LEAST(group_members.joined_at, EXCLUDED.joined_at)`
+>     rather than DO NOTHING for the invite path); (b) `load_user_visibility`
+>     already takes `MIN(joined_at)` across linked browsers, so backdating one
+>     browser's row correctly makes the user's effective join the earliest.
+>     Backend-only change to the membership-write sites + the visibility
+>     watermark; no FE work and no new endpoint.
+>
 > `/by-route-id/{id}` only 404s when route resolution itself fails. An
 > empty visible-polls list returns 200 with `[]` so the group page can
 > still render its chrome (header + tappable title to /info + the

--- a/app/g/[groupShortId]/p/[pollShortId]/PollDetailPage.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/PollDetailPage.tsx
@@ -215,35 +215,27 @@ export function PollDetailView({ groupId, pollShortId, overlayCardsOffset }: Pol
 
   if (hiddenPreJoin && !poll) {
     return (
-      <SimpleFrame onBack={goBack}>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Poll Closed</h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-4">
-          {hiddenPreJoin.closedAt
+      <MessageFrame
+        onBack={goBack}
+        onBackToGroup={() => router.push(`/g/${groupId}`)}
+        heading="Poll Closed"
+        message={
+          hiddenPreJoin.closedAt
             ? `This poll closed ${relativeTime(hiddenPreJoin.closedAt)}, before you joined the group, so it's no longer available to view.`
-            : "This poll closed before you joined the group, so it's no longer available to view."}
-        </p>
-        <button
-          onClick={() => router.push(`/g/${groupId}`)}
-          className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
-        >
-          Back to Group
-        </button>
-      </SimpleFrame>
+            : "This poll closed before you joined the group, so it's no longer available to view."
+        }
+      />
     );
   }
 
   if (error || !poll) {
     return (
-      <SimpleFrame onBack={goBack}>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Poll Not Found</h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-4">This poll may have been removed.</p>
-        <button
-          onClick={() => router.push(`/g/${groupId}`)}
-          className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
-        >
-          Back to Group
-        </button>
-      </SimpleFrame>
+      <MessageFrame
+        onBack={goBack}
+        onBackToGroup={() => router.push(`/g/${groupId}`)}
+        heading="Poll Not Found"
+        message="This poll may have been removed."
+      />
     );
   }
 
@@ -269,6 +261,33 @@ function SimpleFrame({ onBack, children }: { onBack: () => void; children: React
         {children}
       </div>
     </>
+  );
+}
+
+/** Terminal "can't show the poll" frame (not-found / closed-before-join):
+ *  heading + message + a single "Back to Group" button. */
+function MessageFrame({
+  onBack,
+  onBackToGroup,
+  heading,
+  message,
+}: {
+  onBack: () => void;
+  onBackToGroup: () => void;
+  heading: string;
+  message: string;
+}) {
+  return (
+    <SimpleFrame onBack={onBack}>
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">{heading}</h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-4">{message}</p>
+      <button
+        onClick={onBackToGroup}
+        className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+      >
+        Back to Group
+      </button>
+    </SimpleFrame>
   );
 }
 

--- a/app/g/[groupShortId]/p/[pollShortId]/PollDetailPage.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/PollDetailPage.tsx
@@ -14,8 +14,8 @@ import { Fragment, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, u
 import { useParams, useRouter } from "next/navigation";
 import { flushSync } from "react-dom";
 import {
+  apiGetGroupPoll,
   apiGetPollById,
-  apiGetPollByShortId,
   apiGetQuestionResults,
   apiGetVotes,
   apiRecordPollView,
@@ -54,7 +54,6 @@ import {
   pollScrollKey,
   rememberCurrentScroll,
 } from "@/lib/scrollMemory";
-import { isUuidLike } from "@/lib/questionId";
 import {
   compactDurationSince,
   getCategoryIcon,
@@ -149,6 +148,12 @@ export function PollDetailView({ groupId, pollShortId, overlayCardsOffset }: Pol
   });
   const [loading, setLoading] = useState(!poll);
   const [error, setError] = useState(false);
+  // Set when the poll exists in this group but closed BEFORE the caller
+  // joined — its contents are withheld by the visibility rule, so we show
+  // a "closed before you joined" note instead of either the leaked
+  // contents or a misleading "not found". `closedAt` is the closure
+  // timestamp (ISO) or null. See `apiGetGroupPoll`.
+  const [hiddenPreJoin, setHiddenPreJoin] = useState<{ closedAt: string | null } | null>(null);
 
   useEffect(() => {
     if (poll) return;
@@ -157,11 +162,16 @@ export function PollDetailView({ groupId, pollShortId, overlayCardsOffset }: Pol
     (async () => {
       try {
         setLoading(true);
-        const fetched = isUuidLike(pollShortId)
-          ? await apiGetPollById(pollShortId)
-          : await apiGetPollByShortId(pollShortId);
+        // Visibility-aware read (NOT the visibility-blind
+        // apiGetPollByShortId): a closed-before-join poll returns a marker,
+        // never its contents.
+        const result = await apiGetGroupPoll(groupId, pollShortId);
         if (cancelled) return;
-        setPoll(fetched);
+        if (result.status === "visible") {
+          setPoll(result.poll);
+        } else {
+          setHiddenPreJoin({ closedAt: result.closedAt });
+        }
       } catch (err) {
         if (cancelled) return;
         if (!(err instanceof ApiError && err.status === 404)) {
@@ -175,7 +185,7 @@ export function PollDetailView({ groupId, pollShortId, overlayCardsOffset }: Pol
     return () => {
       cancelled = true;
     };
-  }, [poll, pollShortId]);
+  }, [poll, pollShortId, groupId]);
 
   // POLL_HYDRATED swaps a placeholder poll for the real one. Handles the
   // case where the user clicked through to a freshly-submitted poll before
@@ -202,6 +212,25 @@ export function PollDetailView({ groupId, pollShortId, overlayCardsOffset }: Pol
   }, [groupId, pollShortId]);
 
   if (loading && !poll) return <SimpleFrame onBack={goBack}><p className="text-gray-600 dark:text-gray-400">Loading poll...</p></SimpleFrame>;
+
+  if (hiddenPreJoin && !poll) {
+    return (
+      <SimpleFrame onBack={goBack}>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Poll Closed</h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-4">
+          {hiddenPreJoin.closedAt
+            ? `This poll closed ${relativeTime(hiddenPreJoin.closedAt)}, before you joined the group, so it's no longer available to view.`
+            : "This poll closed before you joined the group, so it's no longer available to view."}
+        </p>
+        <button
+          onClick={() => router.push(`/g/${groupId}`)}
+          className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+        >
+          Back to Group
+        </button>
+      </SimpleFrame>
+    );
+  }
 
   if (error || !poll) {
     return (

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -118,6 +118,40 @@ export async function apiGetGroupByRouteId(
   return hydrateAndCache(data);
 }
 
+/** Result of a visibility-aware single-poll read within a group.
+ *  - `{ status: 'visible', poll }` — the caller can see the poll.
+ *  - `{ status: 'hidden_pre_join', closedAt }` — the poll exists in the
+ *    group and the caller is a member, but it closed before they joined,
+ *    so its contents are withheld. `closedAt` is the closure timestamp
+ *    (ISO) or null. */
+export type GroupPollResult =
+  | { status: "visible"; poll: Poll }
+  | { status: "hidden_pre_join"; closedAt: string | null };
+
+/** Visibility-aware fetch of one poll within a group, used by the
+ *  direct-poll-link landing page (`/g/<group>/p/<poll>`).
+ *
+ *  Unlike `apiGetPollByShortId` (which hits the visibility-BLIND
+ *  `/api/polls/{short_id}` and would leak a closed-before-join poll's
+ *  contents to a late joiner), this enforces the group visibility rule.
+ *  Throws ApiError(404) when the poll doesn't exist in the group (or the
+ *  group is private and the caller isn't a member). On a `visible` result
+ *  the poll is cached (and the group's accessible-polls cache primed) just
+ *  like `apiGetGroupByRouteId`. */
+export async function apiGetGroupPoll(
+  routeId: string,
+  pollRef: string,
+): Promise<GroupPollResult> {
+  const data = await groupFetch<any>(
+    `/by-route-id/${encodeURIComponent(routeId)}/poll/${encodeURIComponent(pollRef)}`,
+  );
+  if (data?.status === "visible" && data.poll) {
+    const [poll] = hydrateAndCache([data.poll]);
+    return { status: "visible", poll };
+  }
+  return { status: "hidden_pre_join", closedAt: data?.closed_at ?? null };
+}
+
 /** Create a brand-new empty group and auto-join the caller as a member.
  *  Used by the home new group button. The next `getMyGroups()` call picks up the
  *  new group via the always-fresh `/api/groups/empty` parallel fetch;

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -40,6 +40,7 @@ export { apiGetQuestionResults } from "./results";
 export {
   apiGetMyGroups,
   apiGetGroupByRouteId,
+  apiGetGroupPoll,
   apiCreateGroup,
   apiGetMyEmptyGroups,
   apiGetGroupSummary,
@@ -64,6 +65,7 @@ export type {
   CreateGroupJoinRequestResult,
   GroupInvite,
   CreateGroupInviteOptions,
+  GroupPollResult,
   InvitableAccount,
 } from "./groups";
 

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -77,6 +77,7 @@ from services.groups import (
     load_user_visibility,
     poll_ids_for_group_ids,
     polls_for_poll_ids,
+    resolve_group_for_visit,
     resolve_group_id_from_route_id,
 )
 from services.push import fan_out_join_request, fan_out_member_added
@@ -444,24 +445,11 @@ def get_group_by_route_id(
     user_id = _user_id(request)
 
     with get_db() as conn:
-        group_id = resolve_group_id_from_route_id(conn, route_id)
+        group_id = resolve_group_for_visit(
+            conn, route_id, browser_id=browser_id, user_id=user_id
+        )
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-
-        meta = get_group_metadata(conn, group_id)
-        privacy = meta["privacy"] if meta else "public"
-
-        # Phase E: strangers don't auto-join private groups via URL and
-        # don't see any polls — 404 at the boundary instead.
-        if privacy == "private":
-            if not is_caller_member_of_group(
-                conn, group_id, browser_id=browser_id, user_id=user_id
-            ):
-                raise HTTPException(status_code=404, detail="Group not found")
-        else:
-            grant_group_membership_inline(
-                conn, group_id, browser_id, privacy=privacy
-            )
 
         visibility = load_user_visibility(conn, browser_id, user_id=user_id)
         group_pids = poll_ids_for_group_ids(conn, [group_id])
@@ -501,21 +489,11 @@ def get_group_poll(route_id: str, poll_ref: str, request: Request):
     user_id = _user_id(request)
 
     with get_db() as conn:
-        group_id = resolve_group_id_from_route_id(conn, route_id)
+        group_id = resolve_group_for_visit(
+            conn, route_id, browser_id=browser_id, user_id=user_id
+        )
         if not group_id:
             raise HTTPException(status_code=404, detail="Poll not found")
-
-        meta = get_group_metadata(conn, group_id)
-        privacy = meta["privacy"] if meta else "public"
-        if privacy == "private":
-            if not is_caller_member_of_group(
-                conn, group_id, browser_id=browser_id, user_id=user_id
-            ):
-                raise HTTPException(status_code=404, detail="Poll not found")
-        else:
-            grant_group_membership_inline(
-                conn, group_id, browser_id, privacy=privacy
-            )
 
         # Resolve the poll WITHIN this group (short_id, then uuid). Scoping
         # to group_id keeps a cross-group poll id from resolving here.

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -154,6 +154,28 @@ class GroupPreviewResponse(BaseModel):
     description: str | None = None
 
 
+class GroupPollResponse(BaseModel):
+    """Visibility-aware single-poll read for the direct-poll-link landing
+    (`GET /api/groups/by-route-id/{route_id}/poll/{poll_ref}`).
+
+    `status`:
+      - "visible": the caller can see this poll; `poll` carries the full
+        PollResponse (identical shape to the group read's entries).
+      - "hidden_pre_join": the poll exists in this group and the caller IS
+        a member, but it closed before the caller joined the group, so the
+        visibility rule withholds its contents. `poll` is null; `closed_at`
+        is the closure timestamp (the `polls.updated_at` close proxy) so the
+        FE can render a clear "this poll closed before you joined" note —
+        existence + closure timing ONLY, never the hidden poll's contents.
+
+    A poll that doesn't exist in this group (or a private group the caller
+    isn't a member of) returns 404, never this body."""
+
+    status: str
+    poll: PollResponse | None = None
+    closed_at: str | None = None
+
+
 class GroupImageRequest(BaseModel):
     """`POST /api/groups/{route_id}/image` body.
 
@@ -450,6 +472,91 @@ def get_group_by_route_id(
         return polls_for_poll_ids(
             conn, visible_pids, include_results=include_results,
             viewer_user_id=viewer_user_id,
+        )
+
+
+@router.get(
+    "/by-route-id/{route_id}/poll/{poll_ref}",
+    response_model=GroupPollResponse,
+)
+def get_group_poll(route_id: str, poll_ref: str, request: Request):
+    """Visibility-aware fetch of one poll within a group — the direct
+    poll-link landing path (`/g/<group>/p/<poll>`).
+
+    Unlike the visibility-blind `GET /api/polls/{short_id}`, this enforces
+    the group visibility rule (documented in `services/groups.py`) so a
+    late joiner who taps a link to a poll that closed BEFORE they joined
+    the group gets a `hidden_pre_join` marker — existence + closure timing
+    only, never the poll's contents — instead of either the leaked
+    contents or a misleading "not found". The visibility rule stands.
+
+    Auto-join semantics match the group read: landing on a public group's
+    poll link joins the caller (so the closed-before-join watermark is
+    "now"); private groups 404 non-members at the boundary.
+
+    `poll_ref` is resolved against THIS group as a `polls.short_id` or a
+    `polls.id` uuid — a poll id from a different group does not resolve
+    here (404)."""
+    browser_id = _browser_id(request)
+    user_id = _user_id(request)
+
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Poll not found")
+
+        meta = get_group_metadata(conn, group_id)
+        privacy = meta["privacy"] if meta else "public"
+        if privacy == "private":
+            if not is_caller_member_of_group(
+                conn, group_id, browser_id=browser_id, user_id=user_id
+            ):
+                raise HTTPException(status_code=404, detail="Poll not found")
+        else:
+            grant_group_membership_inline(
+                conn, group_id, browser_id, privacy=privacy
+            )
+
+        # Resolve the poll WITHIN this group (short_id, then uuid). Scoping
+        # to group_id keeps a cross-group poll id from resolving here.
+        poll_row = conn.execute(
+            "SELECT id, updated_at FROM polls "
+            "WHERE group_id = %(gid)s::uuid AND short_id = %(ref)s",
+            {"gid": group_id, "ref": poll_ref},
+        ).fetchone()
+        if not poll_row and _is_uuid_like(poll_ref):
+            poll_row = conn.execute(
+                "SELECT id, updated_at FROM polls "
+                "WHERE group_id = %(gid)s::uuid AND id = %(ref)s::uuid",
+                {"gid": group_id, "ref": poll_ref},
+            ).fetchone()
+        if not poll_row:
+            raise HTTPException(status_code=404, detail="Poll not found")
+
+        poll_id = str(poll_row["id"])
+        visibility = load_user_visibility(conn, browser_id, user_id=user_id)
+        visible = filter_visible_polls(conn, [poll_id], visibility)
+        if visible:
+            viewer_user_id = resolve_actor_user_id(
+                conn, user_id=user_id, browser_id=browser_id
+            )
+            polls = polls_for_poll_ids(
+                conn, visible, include_results=True,
+                viewer_user_id=viewer_user_id,
+            )
+            return GroupPollResponse(
+                status="visible", poll=polls[0] if polls else None,
+            )
+
+        # The caller is a member of this group (auto-joined above for
+        # public, confirmed for private), so the ONLY way the poll filtered
+        # out is the closed-before-join watermark. Return existence +
+        # closure timing; never the contents.
+        closed_at = poll_row.get("updated_at")
+        return GroupPollResponse(
+            status="hidden_pre_join",
+            poll=None,
+            closed_at=closed_at.isoformat() if closed_at else None,
         )
 
 

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -346,6 +346,41 @@ def is_caller_member_of_group(
     return row is not None
 
 
+def resolve_group_for_visit(
+    conn,
+    route_id: str,
+    *,
+    browser_id: str | None,
+    user_id: str | None,
+) -> str | None:
+    """Shared read-boundary gate for the `/by-route-id/{route_id}` endpoints:
+    resolve `route_id` → group_id, enforce Phase E privacy, and auto-join
+    public-group visitors inline.
+
+    Returns the group_id on success. Returns None when the route doesn't
+    resolve OR the group is private and the caller isn't a member — callers
+    raise their own 404 with whatever detail fits ("Group not found" for the
+    whole-group read, "Poll not found" for the single-poll read). Keeping the
+    privacy gate + auto-join in one place is load-bearing: the single-poll
+    read and the whole-group read can't drift on who's allowed in, so a
+    private group can't become readable through one endpoint but not the
+    other.
+    """
+    group_id = resolve_group_id_from_route_id(conn, route_id)
+    if not group_id:
+        return None
+    meta = get_group_metadata(conn, group_id)
+    privacy = meta["privacy"] if meta else "public"
+    if privacy == "private":
+        if not is_caller_member_of_group(
+            conn, group_id, browser_id=browser_id, user_id=user_id
+        ):
+            return None
+    else:
+        grant_group_membership_inline(conn, group_id, browser_id, privacy=privacy)
+    return group_id
+
+
 def polls_for_poll_ids(
     conn,
     poll_ids: list[str],

--- a/server/tests/test_group_poll_visibility.py
+++ b/server/tests/test_group_poll_visibility.py
@@ -1,0 +1,156 @@
+"""Visibility-aware single-poll read.
+
+`GET /api/groups/by-route-id/{route_id}/poll/{poll_ref}` is the direct
+poll-link landing path (`/g/<group>/p/<poll>`). Unlike the
+visibility-blind `GET /api/polls/{short_id}`, it enforces the group
+visibility rule so a late joiner who taps a link to a poll that closed
+BEFORE they joined gets a `hidden_pre_join` marker (existence + closure
+timing only — never the contents) instead of either the leaked contents
+or a misleading "not found".
+
+Companion to `test_groups_visibility.py` (the group-level read). Shared
+fixtures (`client`, `creator_secret`) and helpers (`create_poll`,
+`creator_headers`) live in `conftest.py`.
+"""
+
+import uuid
+
+import psycopg
+import pytest
+
+from tests.conftest import TEST_DB_URL, create_poll, creator_headers
+
+
+@pytest.fixture
+def creator_browser():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def stranger_browser():
+    return str(uuid.uuid4())
+
+
+def _close_poll(poll: dict, client):
+    resp = client.post(
+        f"/api/polls/{poll['id']}/close",
+        json={"close_reason": "manual"},
+        headers=creator_headers(poll),
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _set_poll_updated_at(poll_id: str, dt_iso: str):
+    """Backdate updated_at (the closed_at proxy) below a join watermark."""
+    with psycopg.connect(TEST_DB_URL) as conn:
+        conn.execute(
+            "UPDATE polls SET updated_at = %s WHERE id = %s",
+            (dt_iso, poll_id),
+        )
+
+
+def _set_group_private(group_id: str):
+    with psycopg.connect(TEST_DB_URL) as conn:
+        conn.execute(
+            "UPDATE groups SET privacy = 'private' WHERE id = %s",
+            (group_id,),
+        )
+
+
+def _get_poll(client, route_id, poll_ref, browser_id):
+    return client.get(
+        f"/api/groups/by-route-id/{route_id}/poll/{poll_ref}",
+        headers={"X-Browser-Id": browser_id},
+    )
+
+
+class TestGroupPollVisibility:
+    def test_member_sees_visible_poll(self, client, creator_secret, creator_browser):
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = _get_poll(client, poll["short_id"], poll["short_id"], creator_browser)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "visible"
+        assert body["poll"]["id"] == poll["id"]
+
+    def test_stranger_auto_joins_open_poll(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """Landing on a public group's poll link joins the caller (like the
+        group read) and surfaces the open poll."""
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = _get_poll(client, poll["short_id"], poll["short_id"], stranger_browser)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "visible"
+        assert body["poll"]["id"] == poll["id"]
+
+    def test_late_joiner_closed_pre_join_poll_is_hidden(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """The headline case: a poll closed BEFORE the caller joined returns
+        a hidden_pre_join marker with closure timing — never the contents."""
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+        _close_poll(poll, client)
+        _set_poll_updated_at(poll["id"], "2000-01-01T00:00:00Z")
+
+        resp = _get_poll(client, poll["short_id"], poll["short_id"], stranger_browser)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "hidden_pre_join"
+        assert body["poll"] is None
+        assert body["closed_at"] is not None
+
+    def test_member_sees_own_closed_poll(
+        self, client, creator_secret, creator_browser,
+    ):
+        """A poll the caller closed themselves stays visible — they joined
+        the group before it closed."""
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+        _close_poll(poll, client)
+        resp = _get_poll(client, poll["short_id"], poll["short_id"], creator_browser)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "visible"
+        assert body["poll"]["id"] == poll["id"]
+
+    def test_resolve_poll_by_uuid(self, client, creator_secret, creator_browser):
+        """poll_ref accepts a poll uuid as well as a short_id."""
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = _get_poll(client, poll["short_id"], poll["id"], creator_browser)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "visible"
+
+    def test_unknown_poll_in_group_404s(
+        self, client, creator_secret, creator_browser,
+    ):
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+        resp = _get_poll(
+            client, poll["short_id"], "zzznotreal", creator_browser,
+        )
+        assert resp.status_code == 404
+
+    def test_cross_group_poll_ref_404s(
+        self, client, creator_secret, creator_browser,
+    ):
+        """A poll id that belongs to a DIFFERENT group does not resolve under
+        this group's route — the lookup is scoped to the group."""
+        a = create_poll(client, creator_secret, browser_id=creator_browser)
+        b = create_poll(client, creator_secret, browser_id=creator_browser)
+        # Ask for b's poll under a's group route → not found in a's group.
+        resp = _get_poll(client, a["short_id"], b["short_id"], creator_browser)
+        assert resp.status_code == 404
+
+    def test_unknown_route_404s(self, client, creator_browser):
+        resp = _get_poll(client, "zzznotreal", "alsoreal", creator_browser)
+        assert resp.status_code == 404
+
+    def test_private_group_non_member_404s(
+        self, client, creator_secret, creator_browser, stranger_browser,
+    ):
+        """A non-member of a private group gets 404 at the boundary — same
+        as the group read — never a hidden_pre_join leak of existence."""
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+        _set_group_private(poll["group_id"])
+        resp = _get_poll(client, poll["short_id"], poll["short_id"], stranger_browser)
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

A direct poll link (`/g/<g>/p/<poll>`) targeting a poll hidden **only** by the closed-before-join visibility watermark previously fetched it through the visibility-**blind** `GET /api/polls/{short_id}` and rendered its full contents to a late joiner. Now it shows a clear **"Poll Closed — closed {N} ago, before you joined the group"** note with a Back to Group button, and never exposes the contents. (Resolves the Migration-106 "late-joiner closed-poll edge" TODO.)

- **Backend:** new visibility-aware endpoint `GET /api/groups/by-route-id/{route_id}/poll/{poll_ref}` (`server/routers/groups.py`, model `GroupPollResponse`). Resolves the group (404 on miss), gates private groups (404 non-members at the boundary), auto-joins public-group visitors (so the watermark is "now"), resolves `poll_ref` as a `polls.short_id` or `polls.id` uuid **scoped to that group** (cross-group ref → 404), then runs `filter_visible_polls` on the single poll. Visible → `{status:"visible", poll}`; filtered out (caller is now a member, so the only cause is closed-before-join) → `{status:"hidden_pre_join", closed_at}` — existence + closure timing only, never the contents.
- **Frontend:** `apiGetGroupPoll()` in `lib/api/groups.ts`; `PollDetailView`'s cache-miss fetch routes through it and renders the note. The cache-hit path (slide from the group, poll already a visible cache entry) is unchanged — the endpoint only fires on a direct-URL cache miss, which is exactly the late-joiner case.
- **Why a dedicated endpoint:** the detail page doesn't call the group read, and reshaping its `list[PollResponse]` to carry a marker would break every consumer. Making `/api/polls/{short_id}` visibility-aware would affect the create/vote flows that rely on it.

Also records a follow-up **TODO** in CLAUDE.md: backdate `joined_at` to the invite-**send** time for directly-invited members (invite link / member-add / join-request approval) so they see polls that closed between invite and accept; the plain group-URL share case stays `joined_at = visit time`.

## Test plan

- [x] `server/tests/test_group_poll_visibility.py` — 9 new cases (member-visible, stranger auto-join open poll, the headline hidden-pre-join, own-closed-poll-visible, uuid ref, unknown ref 404, cross-group ref 404, unknown route 404, private non-member 404). All pass.
- [x] Existing `test_groups_visibility.py` (19) still passes.
- [x] Live demo on the per-branch dev server + screenshot of the rendered "Poll Closed" note verified end-to-end as a fresh late-joiner browser.

https://claude.ai/code/session_01ByMjJ1rGPAbhqhMBcazL5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByMjJ1rGPAbhqhMBcazL5W)_