### PR TITLE
Drop the seconding instruction from the suggestion ballot header

### DIFF
--- a/components/SuggestionVotingInterface.tsx
+++ b/components/SuggestionVotingInterface.tsx
@@ -277,7 +277,7 @@ export default function SuggestionVotingInterface({
         {filteredExistingSuggestions.length > 0 && (
           <div className="mb-3">
             <h5 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              {isEditingVote ? 'All suggestions (select to second/unsecond):' : 'Existing suggestions (select to second):'}
+              {isEditingVote ? 'All suggestions:' : 'Existing suggestions:'}
             </h5>
             <div className="space-y-2">
               {filteredExistingSuggestions.map((suggestion, index) => {


### PR DESCRIPTION
## Summary
The existing-suggestions section header on a suggestion ballot read `Existing suggestions (select to second):` / `All suggestions (select to second/unsecond):`. The parenthetical is a call-to-action instruction that reads as out of place when a voter is looking at their ballot rather than actively seconding — the seconding checkboxes are self-evidently tappable, so the instruction just adds noise.

Keep the descriptive label, drop the instruction; the checkboxes are unchanged:
- `Existing suggestions (select to second):` → `Existing suggestions:`
- `All suggestions (select to second/unsecond):` → `All suggestions:`

Removed from both header branches rather than gating on edit state: once a voter has submitted, the seconding checkboxes only render with `isEditingVote=true`, and there's no separate flag distinguishing "viewing my checked ballot" from "actively editing" — so a conditional gate can't cleanly target the viewing case. Stripping the instruction works in every state and keeps the checkboxes.

## Test plan
- [x] Verified on the branch dev server (`/g/~3/p/3`): header now reads "Existing suggestions:", 3 seconding checkboxes still present, and no "select to second" text anywhere on the page.

https://claude.ai/code/session_017QoiQ7YwgraQtB5LDn68Na

---
_Generated by [Claude Code](https://claude.ai/code/session_017QoiQ7YwgraQtB5LDn68Na)_