### PR TITLE
Backdate joined_at to invite-send time for directly-invited members

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2147,45 +2147,46 @@ different FE origin, extend the allowlist.
 >     dedicated endpoint is the targeted realization of option (a)/(b) for the
 >     path-form-link architecture.
 >
-> **TODO — backdate `joined_at` to invite-SEND time for directly-invited
-> members (so they see polls that closed between invite and accept).** When
-> someone is invited to a group *directly* — via an invite link (Phase G), a
-> member-add (migration 126 `add_member_for_user`), or a join-request approval
-> (Phase F `decide_request`) — the `joined_at` watermark that drives the
-> closed-before-join filter should be the time the INVITATION WAS SENT, not the
-> time the recipient finally redeems / opens / is approved. Today every
-> membership-write site uses the `group_members.joined_at` default of `NOW()`
-> (redeem time / approve time / add time), so a poll that closed in the gap
-> between "invite sent" and "invite accepted" is hidden from the invitee —
-> wrong, since the inviter meant to share the whole group as it stood when they
-> reached out. Desired: the invitee can see polls that closed AFTER the invite
-> was sent even if they don't open/accept until later.
->   * **Plain group-URL share is UNCHANGED:** when someone pastes a bare
->     `/g/<id>` link and the recipient auto-joins on visit
->     (`grant_group_membership_inline`), `joined_at = visit time` stays correct
->     — there's no "send" event distinct from the visit, and an open invitation
->     to anyone-with-the-URL shouldn't retroactively expose polls closed before
->     they ever arrived. Only the *targeted* invite flows get the backdate.
->   * **Per-flow send-time source:** invite link → `group_invites.created_at`
->     (the moment the creator minted the link; thread it into `redeem_invite`'s
->     membership INSERT). Member-add → effectively already correct (the add is
->     instantaneous, so add time ≈ send time) — but if a future "invite, accept
->     later" variant lands, record the add/send time. Join-request approval is
->     the ambiguous one: the "invitation" is the creator's approval, so approve
->     time is arguably right; OR, if we want the requester to see what existed
->     when they asked, use the request's `requested_at`. Decide per-flow.
->   * **Implementation caution:** the membership INSERTs all use
->     `ON CONFLICT (group_id, browser_id) DO NOTHING` to PRESERVE the earliest
->     `joined_at` across re-visits (load-bearing — advancing it would un-hide
->     newly-closed polls). Backdating means passing an explicit older
->     `joined_at` on the INSERT. Two wrinkles: (a) the conflict path must not
->     overwrite an already-EARLIER watermark (a plain-URL visit that predates
->     the invite should win — use `DO UPDATE SET joined_at = LEAST(group_members.joined_at, EXCLUDED.joined_at)`
->     rather than DO NOTHING for the invite path); (b) `load_user_visibility`
->     already takes `MIN(joined_at)` across linked browsers, so backdating one
->     browser's row correctly makes the user's effective join the earliest.
->     Backend-only change to the membership-write sites + the visibility
->     watermark; no FE work and no new endpoint.
+> **Backdated `joined_at` for directly-invited members — SHIPPED.** When
+> someone is invited to a group *directly*, the `joined_at` watermark that
+> drives the closed-before-join filter is the time the INVITATION WAS SENT,
+> not the time the recipient redeems / is approved — so a poll that closed in
+> the gap between "invite sent" and "invite accepted" stays visible (the
+> inviter meant to share the whole group as it stood when they reached out).
+> Per-flow send-time source:
+>   * **Invite link (`redeem_invite`)** → `group_invites.created_at` (when the
+>     creator minted the link). Backdate applies even on an already-member
+>     re-click (it can only pull the watermark earlier, never later).
+>   * **Join-request approval (`decide_request`)** → `group_join_requests.requested_at`
+>     (when the requester asked). The owner picked request-time over the
+>     approve-time status quo (`NOW()` was a no-op) so a poll that closed while
+>     the request sat pending stays visible to the new member.
+>   * **Member-add (`add_member_for_user`)** → UNCHANGED. The add is
+>     instantaneous (add time ≈ send time), so the `NOW()` default is already
+>     correct. If a future "invite, accept later" member-add variant lands,
+>     record the send time then.
+>   * **Plain group-URL share** → UNCHANGED. A bare `/g/<id>` auto-join on
+>     visit (`grant_group_membership_inline`) keeps `joined_at = visit time` —
+>     there's no "send" event distinct from the visit, and an open
+>     anyone-with-the-URL invitation shouldn't retroactively expose polls
+>     closed before the recipient ever arrived.
+>   * **Mechanism:** both flows call the shared
+>     `services/groups.py: backdate_membership_for_user(conn, group_id, user_id, joined_at)`
+>     (caller's-connection sibling of `grant_group_membership_inline`) — it
+>     finds the user's earliest-linked browser and INSERTs with an explicit
+>     `joined_at` using `ON CONFLICT (group_id, browser_id) DO UPDATE SET
+>     joined_at = LEAST(group_members.joined_at, EXCLUDED.joined_at)` (not
+>     `DO NOTHING`) so the conflict path PRESERVES an even-earlier watermark
+>     (e.g. a prior plain-URL visit) and never advances it.
+>     `load_user_visibility` already takes `MIN(joined_at)` across linked
+>     browsers, so backdating one browser's row makes the user's effective join
+>     the earliest. Backend-only — no FE work, no new endpoint, no migration
+>     (`group_members.joined_at` already existed; we just stop relying on its
+>     `NOW()` default for these two flows). Tests:
+>     `test_invites.py::test_redeem_backdates_joined_at_to_invite_creation`,
+>     `test_join_requests.py::test_approve_backdates_joined_at_to_request_time`
+>     (both fail without the fix — the closed-in-the-gap poll is absent from the
+>     post-redeem/post-approve `/by-route-id` list).
 >
 > `/by-route-id/{id}` only 404s when route resolution itself fails. An
 > empty visible-polls list returns 200 with `[]` so the group page can

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -209,6 +209,48 @@ def grant_group_membership_inline(
     )
 
 
+def backdate_membership_for_user(conn, group_id, user_id, joined_at) -> None:
+    """Establish (or back-date) `user_id`'s membership in `group_id`, keyed
+    on their earliest-linked browser, with `joined_at` set to when the
+    invitation was SENT (an invite-link's `created_at`, a join-request's
+    `requested_at`) rather than the accept time. Runs on the caller's
+    transaction so it commits atomically with the redeem / approve.
+
+    The closed-before-join filter hides polls that closed before
+    `joined_at`; back-dating to send-time keeps polls that closed in the
+    gap between invite-send and accept visible to the invitee.
+
+    ON CONFLICT ... LEAST can only pull an existing watermark EARLIER
+    (a re-clicked older invite, or preserving a prior plain-URL visit) —
+    never later, so it never reduces visibility. `load_user_visibility`
+    takes MIN(joined_at) across linked browsers, so writing ONE row makes
+    the user's effective join the earliest. No-op when the user has no
+    linked browser to key the row on.
+    """
+    bid_row = conn.execute(
+        """
+        SELECT browser_id FROM user_browsers
+         WHERE user_id = %(u)s::uuid
+         ORDER BY linked_at ASC
+         LIMIT 1
+        """,
+        {"u": user_id},
+    ).fetchone()
+    if not bid_row:
+        return
+    conn.execute(
+        """
+        INSERT INTO group_members (group_id, browser_id, joined_at)
+        VALUES (%(g)s::uuid, %(b)s::uuid, %(j)s)
+        ON CONFLICT (group_id, browser_id)
+            DO UPDATE SET joined_at = LEAST(
+                group_members.joined_at, EXCLUDED.joined_at
+            )
+        """,
+        {"g": str(group_id), "b": str(bid_row["browser_id"]), "j": joined_at},
+    )
+
+
 def get_group_metadata(conn, group_id: str) -> dict | None:
     """Read a group's privacy + creator_user_id in a single round-trip.
     Used by the read-side endpoints (Phase E) to decide whether to

--- a/server/services/invites.py
+++ b/server/services/invites.py
@@ -8,8 +8,10 @@ Four operations:
   * `redeem_invite(conn, token, user_id)` walks the redemption
     transaction: validates the token + use_count + expiry + revoked
     state, bumps use_count, writes a `group_members` row for the
-    requester's earliest-linked browser_id, returns the resolved
-    group_id + target poll info for the FE redirect.
+    requester's earliest-linked browser_id (with `joined_at` backdated
+    to the invite's `created_at` so the joiner sees polls that closed
+    between invite-send and redeem), returns the resolved group_id +
+    target poll info for the FE redirect.
   * `revoke_invite(conn, invite_id, by_user_id)` stamps `revoked_at`
     on a creator-owned invite. Idempotent.
 
@@ -29,6 +31,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from services.auth import generate_token, hash_token
+from services.groups import backdate_membership_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +259,7 @@ def redeem_invite(
            AND revoked_at IS NULL
            AND (expires_at IS NULL OR expires_at > NOW())
            AND (max_uses IS NULL OR use_count < max_uses)
-        RETURNING id, group_id, target_poll_id
+        RETURNING id, group_id, target_poll_id, created_at
         """,
         {"h": hash_token(token)},
     ).fetchone()
@@ -267,6 +270,12 @@ def redeem_invite(
     target_poll_id = (
         str(invite["target_poll_id"]) if invite.get("target_poll_id") else None
     )
+    # Backdate the joiner's membership watermark to the moment the invite
+    # was MINTED (`created_at`), not the redeem time. The closed-before-join
+    # filter (services/groups.py) hides polls that closed before joined_at;
+    # an invite is the creator sharing "the group as it stands now", so the
+    # joiner should see polls that closed between invite-send and redeem.
+    invite_created_at = invite["created_at"]
 
     # Check existing membership across every browser linked to the
     # requesting user_id. Same logic as
@@ -299,28 +308,14 @@ def redeem_invite(
             """,
             {"i": str(invite["id"])},
         )
-    else:
-        # Write membership keyed on the requester's earliest-linked
-        # browser_id — same pattern as Phase F's approve. ONE row is
-        # enough; load_user_visibility expands across user_browsers.
-        bid_row = conn.execute(
-            """
-            SELECT browser_id FROM user_browsers
-             WHERE user_id = %(u)s::uuid
-             ORDER BY linked_at ASC
-             LIMIT 1
-            """,
-            {"u": user_id},
-        ).fetchone()
-        if bid_row:
-            conn.execute(
-                """
-                INSERT INTO group_members (group_id, browser_id)
-                VALUES (%(g)s::uuid, %(b)s::uuid)
-                ON CONFLICT (group_id, browser_id) DO NOTHING
-                """,
-                {"g": group_id, "b": str(bid_row["browser_id"])},
-            )
+
+    # Write (or backdate) membership keyed on the requester's
+    # earliest-linked browser_id. Runs even for an already-member: the
+    # LEAST-upsert can only pull the watermark earlier, never later (see
+    # backdate_membership_for_user).
+    backdate_membership_for_user(
+        conn, group_id, user_id, invite_created_at
+    )
 
     # Resolve short_ids in one round-trip so the FE can build the
     # redirect URL without a follow-up call.

--- a/server/services/join_requests.py
+++ b/server/services/join_requests.py
@@ -28,6 +28,8 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 
+from services.groups import backdate_membership_for_user
+
 logger = logging.getLogger(__name__)
 
 
@@ -197,8 +199,9 @@ def decide_request(
     On approve, writes a `group_members` row keyed on the requester's
     earliest-linked browser_id. Picking one browser is sufficient —
     `load_user_visibility` expands membership across every linked
-    browser via `user_browsers` — and picking the earliest gives the
-    most-permissive `joined_at` for the closed-before-join filter.
+    browser via `user_browsers`. `joined_at` is backdated to the
+    request's `requested_at` (not approval time) so a poll that closed
+    while the request was pending stays visible to the new member.
 
     The decision row's `decided_at` is set to NOW(); `decided_by_user_id`
     records who clicked the button so the audit history is intact even
@@ -218,7 +221,7 @@ def decide_request(
                decided_by_user_id = %(d)s::uuid
          WHERE id = %(r)s::uuid
            AND status = 'pending'
-        RETURNING id, group_id, requester_user_id
+        RETURNING id, group_id, requester_user_id, requested_at
         """,
         {"s": decision, "r": request_id, "d": deciding_user_id},
     ).fetchone()
@@ -226,30 +229,20 @@ def decide_request(
         return None
 
     if decision == "approved":
-        # Pick the requester's earliest-linked browser_id. They must
-        # have at least one (the request endpoint required user_id,
-        # which requires a session, which requires linked browser),
-        # but defensive: skip the membership write if none exist (the
-        # row stays approved; next browser link picks it up via the
-        # auto-claim path described in docs/auth-access-model.md).
-        bid_row = conn.execute(
-            """
-            SELECT browser_id FROM user_browsers
-             WHERE user_id = %(u)s::uuid
-             ORDER BY linked_at ASC
-             LIMIT 1
-            """,
-            {"u": str(row["requester_user_id"])},
-        ).fetchone()
-        if bid_row:
-            conn.execute(
-                """
-                INSERT INTO group_members (group_id, browser_id)
-                VALUES (%(g)s::uuid, %(b)s::uuid)
-                ON CONFLICT (group_id, browser_id) DO NOTHING
-                """,
-                {"g": str(row["group_id"]), "b": str(bid_row["browser_id"])},
-            )
+        # Establish membership keyed on the requester's earliest-linked
+        # browser. `joined_at` is back-dated to when the request was MADE
+        # (`requested_at`), not approval time, so a poll that closed while
+        # the request sat pending stays visible to the new member — they
+        # reached out expecting to see the group as it stood then. A
+        # requester with no linked browser is a no-op (the row stays
+        # approved; the next browser link picks it up via the auto-claim
+        # path in docs/auth-access-model.md).
+        backdate_membership_for_user(
+            conn,
+            str(row["group_id"]),
+            str(row["requester_user_id"]),
+            row["requested_at"],
+        )
 
     return DecidedRequest(
         request_id=str(row["id"]),

--- a/server/tests/test_invites.py
+++ b/server/tests/test_invites.py
@@ -510,6 +510,80 @@ def test_redeem_already_member_is_noop_no_use_count_bump(
     assert items[0]["use_count"] == 1
 
 
+def test_redeem_backdates_joined_at_to_invite_creation(
+    client, creator_browser, joiner_browser
+):
+    """A poll that closed AFTER the invite was minted but BEFORE the
+    joiner redeemed must remain visible to the joiner. `joined_at` is
+    backdated to the invite's `created_at`, not the redeem time, so the
+    closed-before-join filter doesn't hide polls that closed in the gap.
+    """
+    ctoken, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    create = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "multi"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    invite = create.json()
+    raw_token = invite["token"]
+
+    # A poll created in the group, then closed.
+    poll_resp = client.post(
+        "/api/polls",
+        json={
+            "creator_name": "Creator",
+            "group_id": group["id"],
+            "questions": [{"question_type": "yes_no", "category": "yes_no"}],
+        },
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert poll_resp.status_code == 201, poll_resp.text
+    poll = poll_resp.json()
+    close = client.post(
+        f"/api/polls/{poll['id']}/close",
+        json={"close_reason": "manual"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert close.status_code == 200, close.text
+
+    # Pin the timeline deterministically: invite minted 2h ago, poll
+    # closed 1h ago, redeem "now". Without the backdate joined_at would
+    # be "now" and the poll (closed_at = now - 1h) would fall outside the
+    # closed-before-join window.
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE group_invites SET created_at = NOW() - INTERVAL "
+                "'2 hours' WHERE id = %s",
+                (invite["id"],),
+            )
+            cur.execute(
+                "UPDATE polls SET updated_at = NOW() - INTERVAL '1 hour' "
+                "WHERE id = %s",
+                (poll["id"],),
+            )
+        conn.commit()
+
+    jtoken, _ = _sign_in(client, joiner_browser)
+    redeem = client.post(
+        f"/api/auth/invites/{raw_token}/redeem",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert redeem.status_code == 200, redeem.text
+
+    listed = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bearer_headers(joiner_browser, jtoken),
+    )
+    assert listed.status_code == 200, listed.text
+    ids = [p["id"] for p in listed.json()]
+    assert poll["id"] in ids, (
+        "poll closed between invite-send and redeem must be visible"
+    )
+
+
 def test_redeem_returns_target_poll_short_id(
     client, creator_browser, joiner_browser
 ):

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -562,6 +562,80 @@ def test_approve_writes_membership_and_grants_visibility(
     assert post.status_code == 200, post.text
 
 
+def test_approve_backdates_joined_at_to_request_time(
+    client, creator_browser, requester_browser
+):
+    """A poll that closed while the request sat pending must stay
+    visible to the newly-approved member. `joined_at` is backdated to
+    the request's `requested_at`, not the approval time, so the
+    closed-before-join filter doesn't hide polls that closed in the gap.
+    """
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    rtoken, _, _ = _sign_in(client, requester_browser)
+    create = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "let me in"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    request_id = create.json()["request"]["id"]
+
+    # A poll created in the group, then closed while the request pends.
+    poll_resp = client.post(
+        "/api/polls",
+        json={
+            "creator_name": "Creator",
+            "group_id": group["id"],
+            "questions": [{"question_type": "yes_no", "category": "yes_no"}],
+        },
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert poll_resp.status_code == 201, poll_resp.text
+    poll = poll_resp.json()
+    close = client.post(
+        f"/api/polls/{poll['id']}/close",
+        json={"close_reason": "manual"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert close.status_code == 200, close.text
+
+    # Pin the timeline: requested 2h ago, poll closed 1h ago, approve
+    # "now". Without the backdate joined_at would be "now" and the poll
+    # (closed_at = now - 1h) would fall outside the closed-before-join
+    # window.
+    with psycopg.connect(TEST_DB_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE group_join_requests SET requested_at = NOW() - "
+                "INTERVAL '2 hours' WHERE id = %s",
+                (request_id,),
+            )
+            cur.execute(
+                "UPDATE polls SET updated_at = NOW() - INTERVAL '1 hour' "
+                "WHERE id = %s",
+                (poll["id"],),
+            )
+        conn.commit()
+
+    decide = client.post(
+        f"/api/groups/{group['id']}/join-requests/{request_id}/decide",
+        json={"action": "approve"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert decide.status_code == 200, decide.text
+
+    listed = client.get(
+        f"/api/groups/by-route-id/{group['id']}",
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert listed.status_code == 200, listed.text
+    ids = [p["id"] for p in listed.json()]
+    assert poll["id"] in ids, (
+        "poll closed while request pending must be visible after approve"
+    )
+
+
 def test_approve_schedules_member_added_push(
     client, creator_browser, requester_browser, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Implements the "backdate `joined_at` to invite-SEND time" TODO from CLAUDE.md. Directly-invited members now get a `group_members.joined_at` watermark set to when the invitation was **sent** rather than when they accepted, so the closed-before-join visibility filter no longer hides polls that closed in the gap between invite and accept (the inviter meant to share the whole group as it stood when they reached out).

Per-flow send-time source:
- **Invite link** (`redeem_invite`) → `group_invites.created_at` (when the creator minted the link). Applies even on an already-member re-click — the LEAST-upsert can only pull the watermark earlier, never later.
- **Join-request approval** (`decide_request`) → `group_join_requests.requested_at` (when the requester asked). Chosen over the approve-time status quo (`NOW()`, a no-op) so a poll that closed while the request sat pending stays visible to the new member.
- **Member-add** (`add_member_for_user`) and **plain group-URL share** → **unchanged** (add/visit time ≈ send time; the `NOW()` default is already correct).

## Mechanism

Both flows now call a new shared helper `services/groups.py: backdate_membership_for_user(conn, group_id, user_id, joined_at)` — the caller's-connection sibling of `grant_group_membership_inline`. It finds the user's earliest-linked browser and INSERTs with an explicit `joined_at` using `ON CONFLICT (group_id, browser_id) DO UPDATE SET joined_at = LEAST(group_members.joined_at, EXCLUDED.joined_at)` (not `DO NOTHING`), so the conflict path preserves an even-earlier watermark (e.g. a prior plain-URL visit) and never advances it. `load_user_visibility` already takes `MIN(joined_at)` across linked browsers, so writing one row makes the user's effective join the earliest.

Backend-only — no FE work, no new endpoint, **no migration** (`group_members.joined_at` already existed; we just stop relying on its `NOW()` default for these two flows).

## Test plan
- [x] `test_invites.py::test_redeem_backdates_joined_at_to_invite_creation` — a poll closed between invite-send and redeem is visible after redeem
- [x] `test_join_requests.py::test_approve_backdates_joined_at_to_request_time` — a poll closed while the request was pending is visible after approve
- [x] Both new tests **fail without the change** (the closed-in-the-gap poll is absent from the post-redeem/post-approve `/by-route-id` list) — verified by stashing the fix
- [x] Full server suite: 678 passed

https://claude.ai/code/session_01WvQ3r2cj1xCCGU6zE3kqmX

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvQ3r2cj1xCCGU6zE3kqmX)_