### PR TITLE
Ballot privacy: enforce browser-ownership on vote edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1565,12 +1565,22 @@ helper mirrors the visibility query's `OR browser_id IN (SELECT
     all already scoped to the caller's stored `vote_id`, so they're unchanged.
   - **VoteResponse audit (the other emitter):** `POST /api/polls/{id}/votes`
     returns only the caller's just-inserted/edited rows — no cross-voter
-    leak. `_edit_vote_on_question` edits by `vote_id` without a browser
-    ownership check, but vote UUIDs are no longer discoverable cross-voter
-    once `get_votes` is scoped, so it's a capability gated by possession; a
-    belt-and-suspenders browser-ownership gate on edit is a possible
-    follow-up but was left alone to avoid regressing legacy (pre-120,
-    NULL-browser_id) votes.
+    leak. **The edit path now ALSO enforces browser-ownership (SHIPPED).**
+    `_edit_vote_on_question(conn, qid, vote_id, req, now, *, caller_browser_ids=None)`
+    takes the editing caller's account-aware browser set (`caller_browser_ids`
+    from `services/auth.py`, computed once per request in `submit_poll_votes`
+    and threaded in); when provided, the vote's own `browser_id` must be in
+    that set or the edit 403s — so possession of a vote_id alone can't let one
+    voter overwrite another's ballot. Legacy votes cast before migration 120
+    have a NULL `browser_id` (unattributable) and stay editable by possession
+    so they don't regress; an empty/None set skips the gate (preserves prior
+    behavior — this only ever adds protection). The seeded plus-one editable
+    votes pass cleanly: they're attributed to the represented account's browser,
+    which is in that signed-in account's `caller_browser_ids` when they edit.
+    Vote UUIDs were already non-discoverable cross-voter once `get_votes` was
+    scoped; this is the belt-and-suspenders on top. Tests:
+    `test_ballot_privacy.py::test_cannot_edit_another_voters_ballot` +
+    `::test_owner_can_edit_their_own_ballot`.
   - This is the foundation for a future opt-in hidden ballot (which would
     additionally withhold the name from the roster). Tests:
     `server/tests/test_ballot_privacy.py`.

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -15,7 +15,11 @@ from middleware import (
     browser_id_from_request as _browser_id,
     user_id_from_request as _user_id,
 )
-from services.auth import create_anonymous_user, resolve_actor_user_id
+from services.auth import (
+    caller_browser_ids,
+    create_anonymous_user,
+    resolve_actor_user_id,
+)
 from models import (
     CloseQuestionRequest,
     CreatePollRequest,
@@ -1656,6 +1660,13 @@ def submit_poll_votes(
                     detail=f"Sub-question {question_id} does not belong to this poll",
                 )
 
+        # Account-aware browser set of the editing caller — passed to the edit
+        # path so possession of a vote_id alone can't let one voter overwrite
+        # another's ballot (ballot-privacy backstop). Computed once per request.
+        caller_bids = caller_browser_ids(
+            conn, browser_id=browser_id, user_id=_user_id(request)
+        )
+
         result_rows: list[dict] = []
         for item in req.items:
             if item.vote_id:
@@ -1665,6 +1676,7 @@ def submit_poll_votes(
                     item.vote_id,
                     _vote_item_to_edit_req(item, req.voter_name, plus_one_names),
                     now,
+                    caller_browser_ids=caller_bids,
                 )
             else:
                 row = _submit_vote_to_question(

--- a/server/services/questions.py
+++ b/server/services/questions.py
@@ -514,16 +514,38 @@ def _merge_suggestion_metadata(conn, question_id: str, options_metadata, suggest
         )
 
 
-def _edit_vote_on_question(conn, question_id: str, vote_id: str, req: EditVoteRequest, now: datetime) -> dict:
+def _edit_vote_on_question(
+    conn,
+    question_id: str,
+    vote_id: str,
+    req: EditVoteRequest,
+    now: datetime,
+    *,
+    caller_browser_ids: list[str] | None = None,
+) -> dict:
     """Update a vote row inside an existing transaction. Shared by the per-question
     `edit_vote` endpoint and the poll batch-vote endpoint. Returns the
-    updated row. Raises HTTPException on validation failures."""
+    updated row. Raises HTTPException on validation failures.
+
+    Ballot-privacy belt-and-suspenders (see the Auth & Access Model TODO in
+    CLAUDE.md): when `caller_browser_ids` is provided (the account-aware browser
+    set of whoever is editing), the vote's own `browser_id` must be in that set
+    — so possession of a vote_id alone can't let one voter edit another's ballot.
+    Legacy votes cast before migration 120 have a NULL `browser_id` (can't be
+    attributed to any caller) and stay editable by possession so we don't
+    regress them. When the set is empty/None (no resolvable identity) the gate is
+    skipped, preserving prior behavior — this only ever adds protection."""
     existing = conn.execute(
-        "SELECT id FROM votes WHERE id = %(vote_id)s AND question_id = %(question_id)s",
+        "SELECT id, browser_id FROM votes WHERE id = %(vote_id)s AND question_id = %(question_id)s",
         {"vote_id": vote_id, "question_id": question_id},
     ).fetchone()
     if not existing:
         raise HTTPException(status_code=404, detail="Vote not found")
+
+    if caller_browser_ids:
+        owner = existing["browser_id"]
+        if owner is not None and str(owner) not in caller_browser_ids:
+            raise HTTPException(status_code=403, detail="You can only edit your own vote")
 
     question = conn.execute(
         """SELECT p.question_type,

--- a/server/tests/test_ballot_privacy.py
+++ b/server/tests/test_ballot_privacy.py
@@ -111,6 +111,67 @@ def test_stranger_browser_sees_nothing():
     assert _get_votes(client, qid) == []
 
 
+def _edit_vote(client, poll, question_id, vote_id, *, name, choice, browser_id):
+    return client.post(
+        f"/api/polls/{poll['id']}/votes",
+        json={
+            "voter_name": name,
+            "items": [
+                {
+                    "question_id": question_id,
+                    "vote_id": vote_id,
+                    "vote_type": "yes_no",
+                    "yes_no_choice": choice,
+                }
+            ],
+        },
+        headers={"X-Browser-Id": browser_id},
+    )
+
+
+def test_cannot_edit_another_voters_ballot():
+    """Possession of a vote_id alone must not let one voter overwrite another's
+    ballot — the belt-and-suspenders edit-ownership gate. (Vote UUIDs aren't
+    cross-voter discoverable now that /votes is scoped, but the edit path
+    enforces ownership too.)"""
+    client = _client()
+    poll = _create_yes_no_poll(client, _bid())
+    qid = poll["questions"][0]["id"]
+
+    alice = _bid()
+    alice_vote = _vote(client, poll, qid, name="Alice", choice="yes", browser_id=alice)
+    alice_vote_id = alice_vote[0]["id"]
+
+    # Bob, somehow holding Alice's vote_id, tries to overwrite her ballot.
+    bob = _bid()
+    resp = _edit_vote(
+        client, poll, qid, alice_vote_id, name="Bob", choice="no", browser_id=bob
+    )
+    assert resp.status_code == 403, resp.text
+
+    # Alice's ballot is untouched.
+    alice_votes = _get_votes(client, qid, browser_id=alice)
+    assert len(alice_votes) == 1
+    assert alice_votes[0]["yes_no_choice"] == "yes"
+
+
+def test_owner_can_edit_their_own_ballot():
+    """The gate only blocks cross-voter edits — the owner still edits freely."""
+    client = _client()
+    poll = _create_yes_no_poll(client, _bid())
+    qid = poll["questions"][0]["id"]
+
+    alice = _bid()
+    alice_vote = _vote(client, poll, qid, name="Alice", choice="yes", browser_id=alice)
+    vote_id = alice_vote[0]["id"]
+
+    resp = _edit_vote(
+        client, poll, qid, vote_id, name="Alice", choice="no", browser_id=alice
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()[0]["yes_no_choice"] == "no"
+
+
 def test_roster_and_results_still_expose_aggregates():
     """The render-necessary cross-voter data is unaffected: the poll roster
     (names only) and the aggregate results remain available to anyone."""


### PR DESCRIPTION
## Summary

Closes the "possible follow-up" flagged in the Auth & Access Model ballot-privacy TODO: the vote **edit** path now enforces browser-ownership, so possession of a `vote_id` alone can no longer overwrite another voter's ballot.

Previously `_edit_vote_on_question` updated a vote purely by `vote_id` with no ownership check. That was safe only because vote UUIDs stopped being cross-voter discoverable once `GET /api/questions/{id}/votes` was scoped — a capability gated by possession. This adds the belt-and-suspenders gate on top.

- `_edit_vote_on_question(..., *, caller_browser_ids=None)` rejects (403) any edit where the vote's own `browser_id` isn't in the editing caller's **account-aware** browser set.
- The poll batch-vote endpoint computes the set once per request via the existing `caller_browser_ids` helper and threads it in.
- **No regressions:** legacy pre-migration-120 votes (NULL `browser_id`) stay editable by possession; an empty/None set skips the gate. Seeded plus-one editable votes still work — they're attributed to the represented account's browser, which is in that account's set when they edit.

## Test plan
- [x] 2 new cases in `server/tests/test_ballot_privacy.py` (cross-voter edit → 403; owner edit → 201)
- [x] Full server suite green (718 passed), incl. plus-ones + options-metadata edit paths
- [x] Live demo on dev server: Bob using Alice's `vote_id` → HTTP 403; Alice editing her own → HTTP 201

https://claude.ai/code/session_0148SMcDrzzt425AvhxTRugQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0148SMcDrzzt425AvhxTRugQ)_