### PR TITLE
Exclude closed-before-join polls from the app-icon badge count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3184,9 +3184,10 @@ Settings exposes three `SliderSwitch`es (account-synced — see storage below) u
 
 New polls always contribute (no switch) — in unread they're a never-opened poll, in to-do they're a fresh awaiting poll. Switches 2/3 are the Q4 "re-light" fork turned into user-tunable knobs.
 
-**Badge set, precisely.** A poll P contributes to browser B's badge iff B is a `group_members` row for P's group AND:
+**Badge set, precisely.** A poll P contributes to browser B's badge iff B is a `group_members` row for P's group, P is **visible** to B (NOT closed-before-join — see next bullet), AND:
 - **To-do mode**: P is not closed, votable now (`prephase_deadline` IS NULL or passed), deadline not passed, AND B has no `votes` row on any of P's questions (vote OR abstain — both insert a row). Views never matter.
 - **Unread mode** (any of, gated by the toggles): (a) P never viewed-since-created (`poll_views.last_viewed_at` IS NULL or `< P.created_at`); (b) `badge_on_voting_open` AND P transitioned (`prephase_deadline` passed) since last view; (c) `badge_on_results` AND P closed (`updated_at` close-proxy) since last view. Opening P's detail page bumps `last_viewed_at`, clearing all three.
+- **Closed-before-join filter (load-bearing — fixed June 2026):** `compute_badge_count` MUST apply the same visibility rule as `filter_visible_polls` (`services/groups.py`): a poll counts only if `p.is_closed = false OR p.updated_at >= gm.joined_at`. Without it, a poll that closed BEFORE the member joined the group — hidden in-app — was never-viewed → counted as unread, so the iOS app-icon badge read HIGHER than the visible poll count (reported as "badge 3, but 2 new inside"). The filter joins per-`gm`-row + `DISTINCT p.id`, which gives the most-permissive (MIN `joined_at`) account-union semantics. Only the unread branch needs it (the to-do branch already requires `is_closed = false`, so closed-before-join can't reach it). Regression: `server/tests/test_badge_account.py::test_closed_before_join_poll_does_not_inflate_unread_badge`. Whenever you touch the badge query, keep it in lockstep with `filter_visible_polls`.
 
 ### "Seen" + "Ignored" + the Viewed (N) list
 

--- a/server/services/push.py
+++ b/server/services/push.py
@@ -383,6 +383,11 @@ def compute_badge_count(
             ) seen ON TRUE
            WHERE gm.browser_id = ANY(%(bids)s::uuid[])
              AND p.id <> ALL(%(old)s::uuid[])
+             -- Closed-before-join filter (mirrors filter_visible_polls): a poll
+             -- closed before this member joined is hidden in the app, so it must
+             -- not inflate the badge. updated_at is the close_at proxy; gm.joined_at
+             -- per-row + DISTINCT gives the most-permissive (MIN joined_at) rule.
+             AND (p.is_closed = false OR p.updated_at >= gm.joined_at)
              AND (
                (seen.last_viewed_at IS NULL OR seen.last_viewed_at < p.created_at)
                OR (%(voting)s AND p.prephase_deadline IS NOT NULL

--- a/server/tests/test_badge_account.py
+++ b/server/tests/test_badge_account.py
@@ -90,6 +90,47 @@ def test_view_on_one_device_clears_unread_badge_on_another(client):
     assert _badge(client, bid_a, token_a, todo_mode=False) == 0
 
 
+def _close_poll_before_join(group_id, poll_id, member_bid):
+    """Mark the poll closed with its close-proxy (updated_at) one hour BEFORE the
+    member joined the group — i.e. a poll the app hides via the closed-before-join
+    visibility filter."""
+    with psycopg.connect(TEST_DB_URL) as conn:
+        # Close the poll first; the close trigger stamps updated_at = NOW()
+        # (we can't write updated_at directly — the trigger overrides it).
+        conn.execute(
+            "UPDATE polls SET is_closed = true, close_reason = 'manual' WHERE id = %s",
+            (poll_id,),
+        )
+        # The member joined an hour AFTER the close → closed-before-join.
+        conn.execute(
+            "UPDATE group_members SET joined_at = NOW() + INTERVAL '1 hour' "
+            "WHERE group_id = %s AND browser_id = %s",
+            (group_id, member_bid),
+        )
+        conn.commit()
+
+
+def test_closed_before_join_poll_does_not_inflate_unread_badge(client):
+    """A poll closed before the member joined is hidden in-app (closed-before-join
+    filter) and must NOT count toward the unread badge — even though it was never
+    viewed. Regression for badge > visible-poll-count on the iOS app icon."""
+    bid = str(uuid.uuid4())
+    creator = str(uuid.uuid4())
+
+    poll = create_poll(client, browser_id=creator)
+    group_id = poll["group_id"]
+    _add_member(group_id, bid)
+
+    # Never-viewed open poll → unread badge counts it.
+    assert _badge(client, bid, None, todo_mode=False) == 1
+
+    # Same poll, now closed before this member joined → hidden in-app, so 0.
+    _close_poll_before_join(group_id, poll["id"], bid)
+    assert _badge(client, bid, None, todo_mode=False) == 0
+    # And it never enters the to-do badge either (it's closed).
+    assert _badge(client, bid, None, todo_mode=True) == 0
+
+
 def test_vote_on_one_device_clears_todo_badge_on_another(client):
     email = f"badge-{uuid.uuid4().hex[:8]}@example.com"
     bid_a, bid_b = str(uuid.uuid4()), str(uuid.uuid4())


### PR DESCRIPTION
## Summary

The iOS app-icon badge read higher than the visible poll count (reported: badge says **3**, but the group has **2 new** inside).

**Root cause:** `compute_badge_count` (`server/services/push.py`) joined `group_members` to `polls` purely on `group_id` with **no closed-before-join filter** — but the group reads (`filter_visible_polls`) hide any poll that closed *before* the member joined the group. So a poll closed before you joined is invisible in-app, yet — because you never viewed it — it counted as "unread" and inflated the badge.

**Fix:** mirror `filter_visible_polls`' rule in the unread badge query — a poll counts only if `p.is_closed = false OR p.updated_at >= gm.joined_at`. Per-`gm`-row join + `DISTINCT p.id` gives the most-permissive (MIN `joined_at`) account-union semantics, consistent with the rest of the badge query. The to-do branch already requires `is_closed = false`, so closed-before-join can't reach it (no change there).

The native iOS icon badge resyncs to this corrected count on app open/focus (`GET /api/notifications/badge` → `AppBadgePlugin`), so the stale count self-corrects once this ships.

## Test plan
- [x] New regression test `test_closed_before_join_poll_does_not_inflate_unread_badge` (server/tests/test_badge_account.py) — passes.
- [x] Existing badge / notification-event / follow-state / mute / visibility suites stay green.
- [x] Reproduced live on the dev server: a group where the member joined *after* the lake-house poll closed → old query returns **3**, fixed `/api/notifications/badge` returns **2** (matching the visible polls).

Push *delivery* of the new count can't be scripted (needs a real subscription/device); the recipient count — the actual bug — is what the test + demo pin down.

https://claude.ai/code/session_01GwGRB4z5aJTqCehjEwkHfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwGRB4z5aJTqCehjEwkHfT)_