### PR TITLE
Show To Do/New/Old tabs on groups whose polls are all hidden pre-join

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2317,6 +2317,28 @@ different FE origin, extend the allowlist.
 > transition (when a placeholder/real poll lands via POLL_PENDING /
 > POLL_HYDRATED).
 >
+> **`GroupSummary.has_polls` + `Group.hasHiddenPolls` distinguish a
+> genuinely-empty group from one whose polls are all hidden pre-join.**
+> The closed-before-join filter (Migration 106) makes `/by-route-id/{id}`
+> return `[]` for a late joiner to an all-closed group — identical to a
+> brand-new empty group at the FE layer, so the group page rendered
+> **totally blank** (no To Do/New/Old tabs, no message: both were gated
+> on `groupedGroupQuestions.length > 0`). Fix: `GET /by-route-id/{id}/summary`
+> now returns a **visibility-blind** `has_polls` (`EXISTS (SELECT 1 FROM
+> polls WHERE group_id = g.id)`, folded into the one summary SELECT — not
+> a second round-trip). The FE threads it `GroupSummary.has_polls` →
+> `buildEmptyGroup` → `Group.hasHiddenPolls` (always false for populated
+> groups + genuinely-empty new groups). `GroupContent` renders the tabs +
+> a short per-tab empty message ("No to-dos" / "Nothing new" / "Nothing
+> ignored") when `showFollowTabs = groupedGroupQuestions.length > 0 ||
+> group.hasHiddenPolls`; a genuinely-empty group keeps the
+> create-first-poll flow (no tabs). This mirrors, at the group level, the
+> per-poll `hidden_pre_join` marker that direct poll links already use.
+> NOTE the deeper cause is per-viewer: an anonymous browser (not signed
+> into the creator's account) joins "now", so account-aware visibility
+> doesn't union the creator's old membership — signing in surfaces the
+> full history. The blank-page fix is independent of that.
+>
 > **`Group.groupTitleOverride` carries the raw `groups.title`** (or
 > null) so the edit-title page input can pre-fill with the raw value
 > rather than showing the computed "New Group" default. For populated

--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -1949,6 +1949,13 @@ export function GroupContent({ groupId, overlayCardsOffset, inOverlay }: GroupCo
   const cardsTransformOffset =
     overlayCardsOffset ?? (overlayShouldBottomPin ? overlayBottomOffset : undefined);
 
+  // Show the To Do/New/Old follow tabs whenever the group has polls — either
+  // visible ones, or polls that are all hidden from this viewer pre-join
+  // (`hasHiddenPolls`), so a late joiner to an all-closed group sees the tabs
+  // + an empty message instead of a blank page. A genuinely-new empty group
+  // (no polls at all) keeps the create-first-poll flow with no tabs.
+  const showFollowTabs = groupedGroupQuestions.length > 0 || group.hasHiddenPolls;
+
   return (
     <>
       <GroupHeader
@@ -2055,8 +2062,12 @@ export function GroupContent({ groupId, overlayCardsOffset, inOverlay }: GroupCo
             never in the steady-state real route. If that transform ever becomes
             persistent, this would stick to the transformed box instead of the
             viewport; hoist the control out of the transformed wrapper then (it's
-            page chrome, not card content). */}
-        {groupedGroupQuestions.length > 0 && (
+            page chrome, not card content).
+            Also shown when the group has polls that are all hidden from this
+            viewer by the closed-before-join filter (`hasHiddenPolls`) — so a
+            late joiner to an all-closed group sees the tabs + an empty message
+            instead of a blank page. */}
+        {showFollowTabs && (
           <div
             ref={filterSwitchRef}
             className="sticky z-[5] bg-[var(--background)] px-2 pt-1 pb-2"
@@ -2161,15 +2172,16 @@ export function GroupContent({ groupId, overlayCardsOffset, inOverlay }: GroupCo
               />
             );
           })}
-        {/* Gap 1: empty-state when the active tab has no polls (the group has
-            polls, just none in this filter). */}
-        {groupedGroupQuestions.length > 0 && visibleGroupedQuestions.length === 0 && (
+        {/* Gap 1: short empty-state when the active tab has no polls — either
+            because the group's polls are all in other tabs, or because every
+            poll is hidden from this viewer pre-join (`hasHiddenPolls`). */}
+        {showFollowTabs && visibleGroupedQuestions.length === 0 && (
           <div className="px-4 py-10 text-center text-sm text-gray-400 dark:text-gray-500">
             {effectiveTab === "todo"
-              ? "Nothing needs you right now — you're all caught up."
+              ? "No to-dos"
               : effectiveTab === "old"
-              ? "No ignored polls. Tap the ✕ on a poll to file it here."
-              : "No followed polls."}
+              ? "Nothing ignored"
+              : "Nothing new"}
           </div>
         )}
       </div>

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -46,6 +46,7 @@ function toGroupSummary(data: any): GroupSummary {
     image_updated_at: data.image_updated_at ?? null,
     privacy: data.privacy ?? null,
     creator_user_id: data.creator_user_id ?? null,
+    has_polls: data.has_polls ?? false,
   };
 }
 

--- a/lib/groupUtils.ts
+++ b/lib/groupUtils.ts
@@ -169,6 +169,14 @@ export interface Group {
   /** True iff the group has no polls yet — distinguishes the brand-new
    *  empty-group case from a normal group with `polls.length === 1`. */
   isEmpty: boolean;
+  /** True iff the group is `isEmpty` from the viewer's perspective (no
+   *  visible polls) BUT the group genuinely has polls on the server — every
+   *  one hidden by the closed-before-join filter (a late joiner to a group
+   *  whose polls all closed before they joined). Drives showing the
+   *  To Do/New/Old tabs + empty messages instead of a blank page or the
+   *  brand-new-group create flow. Always false for populated groups, and
+   *  false for genuinely-empty new groups. */
+  hasHiddenPolls: boolean;
   /** The latest question in the group (most recently created). Null for
    *  empty groups. */
   latestQuestion: Question | null;
@@ -410,6 +418,7 @@ function buildGroupFromPolls(
     unvotedDeadlineKind,
     latestActivityMs,
     isEmpty: false,
+    hasHiddenPolls: false,
     latestQuestion: questions[questions.length - 1],
     latestPoll,
     anonymousRespondentCount,
@@ -451,6 +460,7 @@ export function buildEmptyGroup(summary: GroupSummary): Group {
     unvotedDeadlineKind: undefined,
     latestActivityMs: createdMs,
     isEmpty: true,
+    hasHiddenPolls: summary.has_polls ?? false,
     latestQuestion: null,
     latestPoll: null,
     anonymousRespondentCount: 0,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -199,6 +199,15 @@ export interface GroupSummary {
   // in — null for anonymous-created groups (which are always public).
   privacy?: string | null;
   creator_user_id?: string | null;
+  // True iff the group has any polls at all, regardless of the caller's
+  // visibility. The closed-before-join filter can hide every poll from a
+  // late joiner, so `/by-route-id` returns [] (and the FE treats the group
+  // as "empty") even though the group genuinely has history. This flag lets
+  // the group page distinguish a brand-new empty group (create-first-poll
+  // flow) from one whose polls are all hidden pre-join (show the tabs +
+  // empty messages). Only set by `/summary`; defaults false/undefined
+  // elsewhere.
+  has_polls?: boolean | null;
 }
 
 // Poll wrapper. Mirrors PollResponse in server/models.py.

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -109,6 +109,15 @@ class GroupSummary(BaseModel):
     image_updated_at: str | None = None
     privacy: str | None = None
     creator_user_id: str | None = None
+    # True iff the group has ANY polls at all, regardless of the caller's
+    # visibility (the closed-before-join filter can hide every poll from a
+    # late joiner, so `/by-route-id` returns [] while the group is not
+    # actually empty). Lets the FE distinguish a brand-new empty group
+    # (show the create-first-poll flow) from a group whose history is all
+    # hidden pre-join (show the To Do/New/Old tabs with empty messages).
+    # Only `get_group_summary` computes a real value; the /empty + create
+    # paths are genuinely poll-less so they keep the False default.
+    has_polls: bool = False
 
 
 class UpdateGroupPrivacyRequest(BaseModel):
@@ -321,7 +330,7 @@ def get_my_empty_groups(request: Request):
         return [_row_to_group_summary(r) for r in rows]
 
 
-def _row_to_group_summary(row) -> GroupSummary:
+def _row_to_group_summary(row, has_polls: bool = False) -> GroupSummary:
     created_at = row.get("created_at")
     image_updated_at = row.get("image_updated_at")
     creator_user_id = row.get("creator_user_id")
@@ -333,6 +342,7 @@ def _row_to_group_summary(row) -> GroupSummary:
         image_updated_at=image_updated_at.isoformat() if image_updated_at else None,
         privacy=row.get("privacy"),
         creator_user_id=str(creator_user_id) if creator_user_id else None,
+        has_polls=has_polls,
     )
 
 
@@ -407,13 +417,19 @@ def get_group_summary(route_id: str, request: Request):
                 conn, group_id, browser_id=browser_id, user_id=user_id
             ):
                 raise HTTPException(status_code=404, detail="Group not found")
+        # `has_polls` (visibility-blind) lets the FE tell "all my history is
+        # hidden pre-join" apart from "brand-new empty group" — folded into
+        # the one SELECT so the summary stays a single round-trip. See
+        # GroupSummary.has_polls.
         row = conn.execute(
-            f"SELECT {_GROUP_SUMMARY_COLUMNS} FROM groups WHERE id = %(id)s",
+            f"""SELECT {_GROUP_SUMMARY_COLUMNS},
+                       EXISTS (SELECT 1 FROM polls WHERE group_id = g.id) AS has_polls
+                  FROM groups g WHERE g.id = %(id)s""",
             {"id": group_id},
         ).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Group not found")
-        return _row_to_group_summary(row)
+        return _row_to_group_summary(row, has_polls=row["has_polls"])
 
 
 @router.get("/by-route-id/{route_id}", response_model=list[PollResponse])

--- a/server/tests/test_empty_groups.py
+++ b/server/tests/test_empty_groups.py
@@ -153,6 +153,9 @@ class TestGroupSummary:
         assert body["short_id"] == new_group["short_id"]
         assert body["title"] is None
         assert body["created_at"]
+        # A brand-new group has no polls — the FE uses this to show the
+        # create-first-poll flow rather than the To Do/New/Old tabs.
+        assert body["has_polls"] is False
 
     def test_returns_metadata_for_populated_group(
         self, client, creator_secret, browser_id,
@@ -165,6 +168,26 @@ class TestGroupSummary:
         body = resp.json()
         assert body["id"] == poll["group_id"]
         assert body["short_id"] == poll["group_short_id"]
+        assert body["has_polls"] is True
+
+    def test_has_polls_true_even_when_all_hidden_pre_join(
+        self, client, creator_secret, browser_id,
+    ):
+        """A late joiner whose visibility hides every poll still gets
+        `has_polls: True` from the summary — so the group page shows the
+        To Do/New/Old tabs (with empty messages) rather than a blank page.
+
+        The summary endpoint is visibility-blind for public groups, so a
+        fresh browser that has never joined still sees `has_polls: True`
+        as long as the group has any poll at all."""
+        poll = create_poll(client, creator_secret, browser_id=browser_id)
+        stranger = str(uuid.uuid4())
+        resp = client.get(
+            f"/api/groups/by-route-id/{poll['group_short_id']}/summary",
+            headers=bid_headers(stranger),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["has_polls"] is True
 
     def test_unknown_route_id_returns_404(self, client):
         resp = client.get("/api/groups/by-route-id/zzznotreal/summary")


### PR DESCRIPTION
## Summary

A group whose polls are **all closed before the viewer joined** renders **totally blank** under the top bar — no To Do/New/Old tabs, no message. Reported on `latest.whoeverwants.com/g/~6`.

Root cause: the closed-before-join filter (Migration 106) makes `GET /by-route-id/{id}` return `[]` for a late joiner to an all-closed group. At the FE layer this is indistinguishable from a brand-new empty group (both return `[]` + a valid `/summary`), and `GroupContent` gates both the tabs and the empty-tab message on `groupedGroupQuestions.length > 0`, so it renders nothing.

(The deeper, per-viewer reason it triggered for the group's own creator: the browser was anonymous — not signed into the creator's account — so it joined "now" and account-aware visibility didn't union the creator's older membership. Signing in surfaces the full history. The blank-page fix here is independent of that.)

## Changes

- **Server:** added a **visibility-blind** `has_polls` to `GroupSummary`, computed as `EXISTS (SELECT 1 FROM polls WHERE group_id = g.id)` folded into the single `/by-route-id/{id}/summary` SELECT (no extra round-trip). `/empty` + `POST /api/groups` keep the `False` default (genuinely poll-less).
- **Frontend:** threaded it through `GroupSummary.has_polls` → `buildEmptyGroup` → `Group.hasHiddenPolls`. `GroupContent` now shows the **To Do · New · Old** tabs + a short per-tab empty message ("No to-dos" / "Nothing new" / "Nothing ignored") when `showFollowTabs = groupedGroupQuestions.length > 0 || group.hasHiddenPolls`. A genuinely-empty new group still gets the create-first-poll flow (no tabs).
- Shortened the per-tab empty-state copy.

Mirrors, at the group level, the per-poll `hidden_pre_join` marker that direct poll links already use.

## Test plan

- [x] `server/tests/test_empty_groups.py` — 13 pass, incl. a new `has_polls`-true-when-all-hidden assertion + `has_polls: false` for a brand-new group.
- [x] Live demo on the branch dev server: an all-hidden group shows the tabs with "Nothing new"; a genuinely-empty new group shows no tabs (create-first-poll flow).

https://claude.ai/code/session_01AxMwRTkujvQvHBruFkxZay

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxMwRTkujvQvHBruFkxZay)_