### PR TITLE
Default app-icon badge to the to-do model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3198,9 +3198,9 @@ Real-device feedback after shipping surfaced four refinements. All four (1–4) 
 
 ### The two badge meanings + the three switches
 
-Settings exposes three `SliderSwitch`es (account-synced — see storage below) under the **"Unread polls"** header. Sensible defaults chosen so a casual user who never touches Settings gets the "opening marks read" behavior:
+Settings exposes three `SliderSwitch`es (account-synced — see storage below) under the **"Unread polls"** header. **As of migration 139 the default is the to-do model** (the badge counts open, votable, not-yet-responded polls) — flipped from the original unread default per the owner's "iOS badges should count to-dos, not New" directive. Migration 139 also `UPDATE`d existing accounts (which all held the old `FALSE`) to the to-do model so the change is observable for current users; a user can switch back via the headline switch below.
 
-1. **`badge_todo_mode`** (default **OFF**). The headline switch — UI label **"Stay unread until I respond"** (the user's framing: "does viewing mark it read, or must I respond?"). The wire/DB field name stays `badge_todo_mode` (no migration); only the label changed.
+1. **`badge_todo_mode`** (default **ON**, migration 139; was OFF in migration 121). The headline switch — UI label **"Stay unread until I respond"** (the user's framing: "does viewing mark it read, or must I respond?"). The wire/DB field name stays `badge_todo_mode`; only the default + label evolved.
    - **OFF = opening marks read** (casual default): a poll is unread when it has *activity you haven't looked at*. **Opening its detail page clears it.** This is the "open the app, the number goes away" behavior casual users expect.
    - **ON = stay unread until I respond** (power users): a poll is unread while it's *open, votable, and you haven't voted/abstained*. **Only voting or abstaining clears it** — merely seeing it never does. Forces an explicit abstain rather than look-and-ignore.
 2. **`badge_on_voting_open`** (default **ON**). UI label **"Mark unread when voting opens"** — a prephase→voting transition re-lights a poll. **Applies to the opening-marks-read model only**; inert (and rendered disabled/grayed) when `badge_todo_mode` is ON, where unread is purely the open + un-responded set.
@@ -3229,8 +3229,8 @@ New polls always contribute (no switch) — in unread they're a never-opened pol
 
 ### Storage (per account, synced)
 
-- Authoritative location: `users.badge_todo_mode` / `users.badge_on_voting_open` / `users.badge_on_results` (BOOLEAN, defaults false/true/true). Surfaced on `UserSummary` (rides every sign-in response + `/api/auth/me`) and `SessionUser` (FE). Written via `POST /api/auth/me/badge-settings` (signed-in only). On sign-in the account values are authoritative; mirrored to a localStorage cache for the client-side badge resync.
-- **Anonymous fallback**: anonymous users have no `users` row, so their preference lives in localStorage only and shapes the **client-side** badge (web/PWA `setAppBadge`). Their **server push** badge uses the defaults (unread, both re-light ON) — once they sign in, the account settings apply to pushes too. Documented limitation, mirrors the display-name local↔account pattern.
+- Authoritative location: `users.badge_todo_mode` / `users.badge_on_voting_open` / `users.badge_on_results` (BOOLEAN, defaults **true**/true/true as of migration 139 — was false/true/true under migration 121). Surfaced on `UserSummary` (rides every sign-in response + `/api/auth/me`) and `SessionUser` (FE). Written via `POST /api/auth/me/badge-settings` (signed-in only). On sign-in the account values are authoritative; mirrored to a localStorage cache for the client-side badge resync. The `DEFAULT_BADGE_SETTINGS.todoMode` (FE), the `_badge_settings_for_browser` anonymous fallback + `get_badge_count` query default + the two `badge_todo_mode` request-model/dataclass defaults (server) all carry the matching `true` — flip them together if the default ever changes again.
+- **Anonymous fallback**: anonymous users have no `users` row, so their preference lives in localStorage only and shapes the **client-side** badge (web/PWA `setAppBadge`). Their **server push** badge uses the defaults (to-do model; the re-light switches are unread-only so inert) — once they sign in, the account settings apply to pushes too. Documented limitation, mirrors the display-name local↔account pattern.
 
 ### Badge computation — where the number comes from
 

--- a/database/migrations/139_badge_default_todo_down.sql
+++ b/database/migrations/139_badge_default_todo_down.sql
@@ -1,0 +1,8 @@
+-- Restore the unread-model default for badge_todo_mode (migration 121's value).
+-- Cannot recover per-account choices overwritten by the up migration's UPDATE.
+
+BEGIN;
+
+ALTER TABLE users ALTER COLUMN badge_todo_mode SET DEFAULT FALSE;
+
+COMMIT;

--- a/database/migrations/139_badge_default_todo_up.sql
+++ b/database/migrations/139_badge_default_todo_up.sql
@@ -1,0 +1,23 @@
+-- App-icon badge defaults to the to-do model.
+--
+-- Migration 121 introduced badge_todo_mode defaulting to FALSE (the unread /
+-- "New"-since-last-view model). The owner wants the iOS app-icon badge to count
+-- TO-DO polls instead (open, votable, not-yet-responded). This flips the column
+-- default for new accounts AND migrates existing accounts to the to-do model so
+-- the change is observable for current users (whose rows already hold FALSE).
+--
+-- The badge_on_voting_open / badge_on_results switches are unread-only and stay
+-- as-is; they're inert while badge_todo_mode is ON. A user can switch back to
+-- the unread model from Settings → "Stay unread until I respond".
+--
+-- NOTE: this UPDATE overwrites any account that had deliberately chosen the
+-- unread model. The feature is recent and the behavior change is intentional;
+-- such users can re-toggle. The down migration restores the FALSE default for
+-- new rows but cannot recover per-account choices.
+
+BEGIN;
+
+ALTER TABLE users ALTER COLUMN badge_todo_mode SET DEFAULT TRUE;
+UPDATE users SET badge_todo_mode = TRUE WHERE badge_todo_mode = FALSE;
+
+COMMIT;

--- a/lib/badgeSettings.ts
+++ b/lib/badgeSettings.ts
@@ -12,7 +12,7 @@
 import { getCachedSessionUser, getSessionToken } from "@/lib/session";
 
 export interface BadgeSettings {
-  /** OFF (default) = unread model; ON = to-do model. */
+  /** ON (default, migration 139) = to-do model; OFF = unread model. */
   todoMode: boolean;
   /** Unread-only: a prephase→voting transition re-lights the poll. */
   onVotingOpen: boolean;
@@ -21,7 +21,7 @@ export interface BadgeSettings {
 }
 
 export const DEFAULT_BADGE_SETTINGS: BadgeSettings = {
-  todoMode: false,
+  todoMode: true,
   onVotingOpen: true,
   onResults: true,
 };
@@ -62,7 +62,7 @@ function writeLocal(s: BadgeSettings): void {
 /**
  * The settings to act on right now. Account values win when signed in (they're
  * synced and authoritative); otherwise the localStorage copy; otherwise the
- * sensible defaults (unread, both re-lights on).
+ * sensible defaults (to-do model).
  */
 export function getEffectiveBadgeSettings(): BadgeSettings {
   const user = getCachedSessionUser();

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -128,7 +128,7 @@ class UserSummary(BaseModel):
     # Account-synced app-icon badge preferences (migration 121). Ride every
     # sign-in response + /me so the FE's local cache + client-side badge
     # resync stay in lockstep with the account.
-    badge_todo_mode: bool = False
+    badge_todo_mode: bool = True
     badge_on_voting_open: bool = True
     badge_on_results: bool = True
     # Migration 123: drives the home-page "add a recovery method" banner.
@@ -752,7 +752,7 @@ def update_my_name(req: UpdateNameBody, request: Request):
 
 
 class UpdateBadgeSettingsBody(BaseModel):
-    badge_todo_mode: bool = False
+    badge_todo_mode: bool = True
     badge_on_voting_open: bool = True
     badge_on_results: bool = True
 

--- a/server/routers/notifications.py
+++ b/server/routers/notifications.py
@@ -101,7 +101,7 @@ class BadgeCountResponse(BaseModel):
 @router.get("/badge", response_model=BadgeCountResponse)
 def get_badge_count(
     request: Request,
-    todo_mode: bool = False,
+    todo_mode: bool = True,
     on_voting_open: bool = True,
     on_results: bool = True,
 ):

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -1014,8 +1014,9 @@ class UserProfile:
     providers: list[str]  # distinct provider names linked to this user
     created_at: datetime
     display_name: str | None  # account-tied display name (None when unset)
-    # Account-synced app-icon badge preferences (migration 121).
-    badge_todo_mode: bool = False
+    # Account-synced app-icon badge preferences (migration 121; default flipped
+    # to the to-do model in migration 139).
+    badge_todo_mode: bool = True
     badge_on_voting_open: bool = True
     badge_on_results: bool = True
     # Migration 123: per-account "stop nagging me to add a recovery method"

--- a/server/services/push.py
+++ b/server/services/push.py
@@ -279,9 +279,10 @@ def _fetch_subscriptions(conn, browser_ids: Iterable[str]) -> list[dict]:
 
 def _badge_settings_for_browser(conn, browser_id: str) -> tuple[bool, bool, bool]:
     """(todo_mode, on_voting_open, on_results) for a browser. Signed-in →
-    account columns; anonymous (no user_browsers row) → defaults (unread, both
-    re-light on). The push path can only see account/default settings — an
-    anonymous user's localStorage preference shapes only the client-side badge.
+    account columns; anonymous (no user_browsers row) → defaults (to-do model;
+    the on_voting_open/on_results re-lights are unread-only so inert here). The
+    push path can only see account/default settings — an anonymous user's
+    localStorage preference shapes only the client-side badge.
     """
     row = conn.execute(
         """
@@ -293,7 +294,7 @@ def _badge_settings_for_browser(conn, browser_id: str) -> tuple[bool, bool, bool
         {"b": browser_id},
     ).fetchone()
     if not row:
-        return (False, True, True)
+        return (True, True, True)
     return (
         bool(row["badge_todo_mode"]),
         bool(row["badge_on_voting_open"]),


### PR DESCRIPTION
## Summary

The iOS app-icon badge counted **"New"** (unread-since-last-view) polls by default. This flips the default to the **to-do** model so the badge counts polls that are open, votable, and not-yet-responded-to (only voting/abstaining clears them).

The per-account toggle (Settings → "Stay unread until I respond") stays, so anyone can switch back to the unread model.

## Changes

- **Migration 139** — flips the `users.badge_todo_mode` column default to `TRUE` **and** `UPDATE`s existing accounts (which all held the old `FALSE`) so the change is observable for current users, not just new sign-ups.
- Mirrors the new default across every default site so they can't drift: FE `DEFAULT_BADGE_SETTINGS.todoMode`, the anonymous-fallback in `_badge_settings_for_browser` (push path), the `GET /api/notifications/badge` query default, and the two `badge_todo_mode` request-model/dataclass defaults.
- CLAUDE.md "App-Icon Badge Model" section updated.

The client-side gold "unread" bar + home-list emphasis already honor `badge_todo_mode`, so they switch to to-do semantics in lockstep with the badge — no divergence. The `on_voting_open`/`on_results` re-light switches are unread-only and become inert under the to-do default.

> Note: the migration's `UPDATE` also flips any account that had *deliberately* chosen the unread model — acceptable since the feature is recent and the change is intentional; they can re-toggle from Settings. The down migration restores the `FALSE` default for new rows but can't recover per-account choices.

## Test plan

- [x] Verified on the per-branch dev server: a poll **viewed but not voted** reads badge `1` under the new default (no params) and `0` under `?todo_mode=false` (old unread model) — proving the default flipped to to-do.
- [x] Existing badge tests pass explicit `todo_mode` params, so the default change doesn't affect them.

https://claude.ai/code/session_01RrBPptVHJj89ofgsusumAj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrBPptVHJj89ofgsusumAj)_