### PR TITLE
Fix hairline gap between sticky tabs and group header

### DIFF
--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -2070,8 +2070,13 @@ export function GroupContent({ groupId, overlayCardsOffset, inOverlay }: GroupCo
         {showFollowTabs && (
           <div
             ref={filterSwitchRef}
-            className="sticky z-[5] bg-[var(--background)] px-2 pt-1 pb-2"
-            style={{ top: `${headerHeight}px` }}
+            className="sticky z-[5] bg-[var(--background)] px-2 pb-2"
+            // Overlap the fixed header by 1px (added back to pt) so a subpixel
+            // rounding gap — headerHeight is an integer offsetHeight, but the
+            // header's real bottom can land on a fractional pixel — can't show
+            // scrolling polls through a hairline seam. The header (z-20,
+            // opaque bg-background) covers the 1px overlap.
+            style={{ top: `${headerHeight - 1}px`, paddingTop: "calc(0.25rem + 1px)" }}
           >
             <div className="flex rounded-full bg-gray-100 dark:bg-gray-800 p-0.5 text-sm font-medium">
               {([


### PR DESCRIPTION
## Summary
The sticky To Do · New · Old filter bar on the group page left a ~1px seam below the fixed header where scrolling polls peeked through.

**Root cause:** the bar's `top` was set to `${headerHeight}px`, where `headerHeight` is the header's `offsetHeight` (an integer). The fixed header's real rendered bottom can land on a fractional pixel (safe-area inset / borders), so the integer `top` left a hairline gap.

**Fix:** pull the sticky bar up 1px (`top: headerHeight - 1`) so it tucks under the opaque, higher-z-index header (z-20 vs the bar's z-5), and add that 1px back to the bar's top padding so content doesn't shift. The header's `bg-background` covers the overlap, closing the seam.

## Test plan
- [ ] Scroll the poll list on a group page and confirm no content bleeds through the tab/header boundary
- Demo: https://claude-poll-list-scroll-gap-3ttjx.dev.whoeverwants.com/g/~1

https://claude.ai/code/session_01494sVUAXZfvkrNpepgGv6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01494sVUAXZfvkrNpepgGv6A)_