### PR TITLE
Retry home group-fetch on transient failures + Try again button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The Supabase-to-Python migration and infrastructure improvements (Phases 1-10) a
 WhoeverWants runs on **two** DigitalOcean droplets that are software-identical (same `scripts/provision-droplet.sh`, same Docker stack, same migrations). Only the public hostnames and deploy trigger differ — see "Development Workflow" below for the gating.
 
 - **`whoeverwants` (prod)** — `142.93.60.29`, fronts `api.whoeverwants.com` + `hooks.api.whoeverwants.com`. Deploys when a GitHub Release is published, pinned to the release's tag.
-- **`latest` (pre-prod canary)** — `67.207.94.93`, fronts `api.latest.whoeverwants.com` + `hooks.api.latest.whoeverwants.com`. Deploys on every push to `main` so the latest code is exercised in its final configuration (release-mode build, droplet, Caddy, Postgres) before a production release.
+- **`latest` (pre-prod canary)** — `104.248.61.202`, fronts `api.latest.whoeverwants.com` + `hooks.api.latest.whoeverwants.com`. Deploys on every push to `main` so the latest code is exercised in its final configuration (release-mode build, droplet, Caddy, Postgres) before a production release.
 
 Behavior is driven by `/etc/droplet-label` on each droplet (`""` = prod, `"latest"` = canary). `scripts/dev-webhook.py` reads it at startup. `scripts/provision-droplet.sh` accepts `DROPLET_LABEL=latest` to provision a canary; default behavior is prod.
 
@@ -78,7 +78,7 @@ Behavior is driven by `/etc/droplet-label` on each droplet (`""` = prod, `"lates
 | Hostname | IP | Tier | Public hosts |
 |----------|----|----|--------------|
 | `whoeverwants` | `142.93.60.29` | prod | `api.whoeverwants.com`, `hooks.api.whoeverwants.com` |
-| `latest` | `67.207.94.93` | canary | `api.latest.whoeverwants.com`, `hooks.api.latest.whoeverwants.com` |
+| `latest` | `104.248.61.202` | canary | `api.latest.whoeverwants.com`, `hooks.api.latest.whoeverwants.com` |
 
 ### Remote Command Execution
 
@@ -108,7 +108,7 @@ The following environment variables must be available. In the Claude Code web en
 ```
 DROPLET_API_URL=https://142-93-60-29.sslip.io
 DROPLET_API_TOKEN=<bearer token>
-LATEST_DROPLET_API_URL=https://67-207-94-93.sslip.io
+LATEST_DROPLET_API_URL=https://104-248-61-202.sslip.io
 LATEST_DROPLET_API_TOKEN=<bearer token for latest droplet>
 DIGITAL_OCEAN_TOKEN=<DO API v2 token>
 VERCEL_API_TOKEN=<vercel api token>
@@ -1160,6 +1160,27 @@ linked browser for signed-in users), so the previous
 had to carve out signed-in users to avoid hiding server-side
 membership — is simply gone. In-flight coalescing
 (`myGroupsInFlight`) still prevents per-render fetch piling.
+
+**Home `fetchQuestions` retries on transient failures + offers "Try
+again" (`app/page.tsx`).** The iOS WebView cold-launch routinely
+fires the home fetch before the network path is up, and a single
+`getMyGroups()` attempt that throws a network `TypeError` would paint
+a permanent dead-end error card with no recovery (the only escape was
+force-quitting the app — a real TestFlight report). The fetch is now a
+`useCallback` that retries with backoff (`[500, 1000, 2000]ms` before
+attempts 2/3/4) before surfacing an error, and the error card carries
+a "Try again" button that re-runs it (`fetchQuestions({ isRetry: true })`).
+Diagnostic tell for this class: the in-app Logs tab showed `Unexpected
+error: {}` for EVERY `/api/*` call — an empty `{}` is a network
+`fetch` TypeError (an `ApiError` would serialize `{"status":...}`), so
+the requests never connected vs. came back 4xx/5xx. When debugging
+"main page error card" reports, check whether the error is `{}` (can't
+connect — transient/network) vs. carries a status (server-side). The
+callback's deps are the STABLE `useState`-initializer snapshots
+(`initialPolls`/`initialEmptyGroups`), so the callback identity is
+constant and the mount `useEffect([fetchQuestions])` runs once;
+`getMyGroups`'s `myGroupsInFlight` coalescing makes a retry that races
+an in-flight fetch join it rather than double-fire.
 
 **Pitfall: `cachedToken` in `lib/session.ts` is module-cached.**
 The first call to `getSessionToken()` reads localStorage and stores

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { GroupSummary, Poll } from "@/lib/types";
 import { getCachedEmptyGroups, getMyGroups } from "@/lib/simpleQuestionQueries";
 import { getCachedAccessiblePolls } from "@/lib/questionCache";
@@ -199,19 +199,28 @@ export default function Home() {
     }
   }, [fontSize, displayedPhrase]);
 
-  // Fetch questions
-  useEffect(() => {
-    async function fetchQuestions() {
-      try {
-        // Only show the spinner when there's no cached data to render —
-        // otherwise mounting home (e.g. after a swipe-back from a group)
-        // would flash the GroupList off-screen for one render cycle while
-        // the refetch round-trips, then flash it back when the same data
-        // returns from the cache-warmed endpoint.
-        const hasCached = initialPolls.length > 0 || initialEmptyGroups.length > 0;
-        if (!hasCached) setLoading(true);
-        setError(null);
+  // Fetch the caller's groups, retrying on transient failures. Cold-launch
+  // (esp. the iOS WebView) routinely fires this before the network path is
+  // fully up, so a single attempt would turn a sub-second blip into a
+  // permanent dead-end error card with no recovery. Back off a few times
+  // before surfacing an error, and expose `fetchQuestions` so the error
+  // card's "Try again" button can re-run it.
+  const fetchQuestions = useCallback(async (opts?: { isRetry?: boolean }) => {
+    // Only show the spinner when there's no cached data to render —
+    // otherwise mounting home (e.g. after a swipe-back from a group) would
+    // flash the GroupList off-screen for one render cycle while the refetch
+    // round-trips, then flash it back when the same data returns from the
+    // cache-warmed endpoint. A manual retry always shows feedback.
+    const hasCached = initialPolls.length > 0 || initialEmptyGroups.length > 0;
+    if (!hasCached || opts?.isRetry) setLoading(true);
+    setError(null);
 
+    // Delays before attempts 2/3/4 — attempt 1 fires immediately.
+    const retryDelaysMs = [500, 1000, 2000];
+    let lastError: unknown = null;
+
+    for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
+      try {
         // One round-trip pair — the server returns every group the caller
         // is a member of (populated + empty), with results inline.
         // Membership (`group_members`) is the single source of truth.
@@ -228,16 +237,24 @@ export default function Home() {
             ? prev
             : nextEmptyGroups,
         );
-      } catch (error) {
-        console.error("Unexpected error:", error);
-        setError("An unexpected error occurred");
-      } finally {
         setLoading(false);
+        return;
+      } catch (error) {
+        lastError = error;
+        if (attempt < retryDelaysMs.length) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelaysMs[attempt]));
+        }
       }
     }
 
+    console.error("Unexpected error:", lastError);
+    setError("Couldn't load your groups. Check your connection and try again.");
+    setLoading(false);
+  }, [initialPolls, initialEmptyGroups]);
+
+  useEffect(() => {
     fetchQuestions();
-  }, []);
+  }, [fetchQuestions]);
 
   // Live-refresh the polls list on poll creation. User submits from /g
   // (empty placeholder), router.replace lands them on /g/<short_id>, and
@@ -279,7 +296,14 @@ export default function Home() {
 
       {error && (
         <div className="p-4 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-300 rounded-md text-center">
-          {error}
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={() => fetchQuestions({ isRetry: true })}
+            className="mt-3 inline-flex items-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-medium rounded-lg transition-colors"
+          >
+            Try again
+          </button>
         </div>
       )}
 

--- a/docs/droplet-setup.md
+++ b/docs/droplet-setup.md
@@ -39,12 +39,12 @@ Note the IP address (e.g., `142.93.60.29`).
 | `*.api.whoeverwants.com` | A | `142.93.60.29` | Preview API environments + webhook handler (`hooks.api.whoeverwants.com`) |
 | `whoeverwants.com` | CNAME | `cname.vercel-dns.com` (or Vercel IP) | Production frontend |
 
-### Latest droplet (`latest`, 67.207.94.93)
+### Latest droplet (`latest`, 104.248.61.202)
 
 | Record | Type | Value | Purpose |
 |--------|------|-------|---------|
-| `api.latest.whoeverwants.com` | A | `67.207.94.93` | Latest-tier API |
-| `hooks.api.latest.whoeverwants.com` | A | `67.207.94.93` | Latest-tier GitHub webhook handler |
+| `api.latest.whoeverwants.com` | A | `104.248.61.202` | Latest-tier API |
+| `hooks.api.latest.whoeverwants.com` | A | `104.248.61.202` | Latest-tier GitHub webhook handler |
 | `latest.whoeverwants.com` | CNAME | `cname.vercel-dns.com` | Latest-tier frontend (Vercel alias) |
 
 ### Mac mini dev box


### PR DESCRIPTION
## Summary

Fixes a TestFlight report: the **WhoeverWants Latest** app opened to a red **"An unexpected error occurred"** card on the home page; closing and reopening fixed it.

### Root cause
On cold launch (especially the iOS WebView), the home page's `getMyGroups()` fires before the network path is fully up. The single attempt threw a network `fetch` `TypeError`, which painted a **permanent dead-end error card with no recovery** — the only escape was force-quitting the app. The backend was healthy throughout (verified: `api.latest.whoeverwants.com` returns fast 200s, valid E7 cert, correct CORS, no server-side 500s).

Diagnostic tell: the in-app Logs tab showed `Unexpected error: {}` for **every** `/api/*` call. An empty `{}` is a network `TypeError` (an `ApiError` would serialize `{"status":...}`), so the requests never connected vs. came back 4xx/5xx — i.e. a transient connection blip, not a server fault.

### Changes
- **`app/page.tsx`**: lift `fetchQuestions` into a stable `useCallback` that **retries with backoff** (500/1000/2000 ms before attempts 2/3/4) before surfacing an error, and render a **"Try again"** button in the error card that re-runs it. Cached groups still render underneath (the existing mount cache-seed is unchanged), and `getMyGroups`'s in-flight coalescing keeps a retry from double-firing.
- **`CLAUDE.md` + `docs/droplet-setup.md`**: correct the stale `latest` droplet IP (`67.207.94.93` → `104.248.61.202`, per the DigitalOcean API and the live `LATEST_DROPLET_API_URL`).

### Not in scope (follow-up)
`GroupPage`'s initial load (`apiGetGroupByRouteId`) has the same cold-launch vulnerability and shows an error card with no retry button. Retry was deliberately **not** pushed into `fetchWithBase` — auto-retrying user-initiated mutations (votes, poll creation) would be wrong UX.

## Test plan
- [x] Home renders normally (no regression) when the API is up.
- [x] Transient first-attempt failure now retries silently before showing the card.
- [x] Error card exposes a working "Try again" button.

https://claude.ai/code/session_01SBm49ocPugUcUbP4QaZqbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBm49ocPugUcUbP4QaZqbT)_