### PR TITLE
Fix ITMS-90626: remove 'Siri' from QuickPollIntent description

### DIFF
--- a/docs/siri-integration-plan.md
+++ b/docs/siri-integration-plan.md
@@ -343,6 +343,19 @@ plan's "start in-process" decision.** What shipped (all colocated in
   server — native-iOS-only. The minimal payload shape is the only thing mirrored to
   the FE, and that mirroring is documented inline.
 
+**PITFALL — App Intent `IntentDescription` (and any App-Store-facing intent
+metadata) MUST NOT contain the literal word "siri" (case-insensitive).** Apple's
+App Store automated review rejects the binary at upload with **ITMS-90626: Invalid
+Siri Support — App Intent description '…' cannot contain 'siri'**. The first
+`QuickPollIntent.description` read "…Siri reads back a confirmation…" and was bounced
+on the `1.0` build (Apple Apple ID 6762459339, build 1780588944, 2026-06-04).
+Reworded to "…You'll hear a spoken confirmation…". This applies to the
+`IntentDescription` string and intent/parameter `title`s — NOT to code comments (not
+shipped as metadata) and NOT to the spoken `AppShortcut` phrases (those use
+`\(.applicationName)` and never embed "Siri"). When adding a new `AppIntent`, keep
+"Siri" out of every user/metadata-facing string; describe the behavior generically
+("spoken confirmation", "hands-free", "without opening the app").
+
 **WWDC re-check still owed (Phase 0).** This is the most keynote-sensitive phase; the
 in-process-vs-extension shape + the "headless in-app action" idiom should be
 re-validated against WWDC 2026 before this ships to **prod** (canary `latest` is fine

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -512,7 +512,7 @@ enum QuickPollService {
 struct QuickPollIntent: AppIntent {
     static var title: LocalizedStringResource = "Quick poll"
     static var description = IntentDescription(
-        "Create a yes/no poll without opening the app. Siri reads back a confirmation; open WhoeverWants to see and share it."
+        "Create a yes/no poll without opening the app. You'll hear a spoken confirmation; open WhoeverWants to see and share it."
     )
     // NOT openAppWhenRun — this runs headless; the app stays closed.
 


### PR DESCRIPTION
## Summary

Apple's App Store automated review rejected the `1.0` prod build (Apple ID 6762459339, build 1780588944) with:

> **ITMS-90626: Invalid Siri Support** — App Intent description '…' cannot contain 'siri'

The `QuickPollIntent` (Phase 3 headless poll creation) `IntentDescription` read *"…Siri reads back a confirmation…"*. Apple forbids the literal word "siri" in App Intent metadata.

## Change

- `ios/App/App/AppDelegate.swift` — reword the description: *"Siri reads back a confirmation"* → *"You'll hear a spoken confirmation"*. This was the only App Store-facing string containing "Siri":
  - `CreatePollIntent` (Phase 1) has no `IntentDescription`.
  - Shortcut phrases use `\(.applicationName)`, never a literal "Siri".
  - Remaining "Siri" mentions are in code comments (not shipped as metadata).
- `docs/siri-integration-plan.md` — document the constraint so a future `AppIntent` doesn't reintroduce it.

## Test plan

- [ ] Native string change — needs a fresh prod iOS build (`com.whoeverwants.app`) triggered by a GitHub Release, then re-upload to App Store Connect; confirm ITMS-90626 no longer fires.

https://claude.ai/code/session_01PwEkjihiajhccBcvzNfZoJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwEkjihiajhccBcvzNfZoJ)_