### PR TITLE
Refetch groups on sign-in so home list updates without navigating away

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1182,6 +1182,36 @@ constant and the mount `useEffect([fetchQuestions])` runs once;
 `getMyGroups`'s `myGroupsInFlight` coalescing makes a retry that races
 an in-flight fetch join it rather than double-fire.
 
+**Home re-fetches groups on `SESSION_CHANGED_EVENT`, not just on
+mount (`app/page.tsx`).** Signing in from the home empty-state's
+"Sign In" modal completes IN PLACE (no remount) — `persistSignIn` →
+`saveSession` fires `SESSION_CHANGED_EVENT`. The home page's original
+session listener only used that event to swap away the "Sign In"
+button (toggling `session` state), so the membership-driven group list
+stayed empty until the user navigated away and back (e.g. to settings),
+which remounted home and re-ran the mount fetch. Symptom (real iOS
+report): "after signing in from the main page, groups don't appear
+until I go to settings and come back." Fix: a SECOND effect listens to
+`SESSION_CHANGED_EVENT` and re-runs `fetchQuestions()` — kept separate
+from the button-state effect (which has `[]` deps) so it can carry
+`[fetchQuestions]` deps cleanly; mirrors the adjacent `POLL_HYDRATED_EVENT`
+listener. The new bearer is already in `lib/session`'s `cachedToken`
+module cache by the time the event fires (saveSession sets it
+synchronously before dispatching), so the refetch's `getMyGroups()`
+carries it. General rule: any surface that renders identity-dependent
+data AND can have a sign-in/out complete WITHOUT a remount (a modal,
+not a nav) must listen to `SESSION_CHANGED_EVENT` and re-fetch — don't
+assume a remount will pick up the new session. Verifying this needs a
+real in-place sign-in: a passkey ceremony via the CDP virtual
+authenticator (register account → seed a group as it → simulate a
+fresh signed-out device by LOCALLY clearing `session_token`/
+`session_user`/`browser_id` in localStorage, NOT a server sign-out
+which `unlink_browser`s the account's member browser → reload → sign in
+with the resident passkey on the home modal → assert the empty-state
+detaches with `page.url()` unchanged). A server sign-out can't be used
+for the "fresh device" setup because it unlinks the only browser
+holding the seeded group's membership.
+
 **Pitfall: `cachedToken` in `lib/session.ts` is module-cached.**
 The first call to `getSessionToken()` reads localStorage and stores
 the result; subsequent calls return the cached value without

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -256,6 +256,21 @@ export default function Home() {
     fetchQuestions();
   }, [fetchQuestions]);
 
+  // Re-fetch groups when the session changes (sign-in / sign-out). Signing
+  // in from the home empty-state's "Sign In" button fires
+  // SESSION_CHANGED_EVENT but doesn't remount this page, so without an
+  // explicit refetch the membership-driven group list stays empty until the
+  // user navigates away and back (e.g. to settings). The new bearer token is
+  // already in lib/session's module cache by the time the event fires, so
+  // getMyGroups() carries it and the server returns the account's groups.
+  useEffect(() => {
+    const refetch = () => {
+      void fetchQuestions();
+    };
+    window.addEventListener(SESSION_CHANGED_EVENT, refetch);
+    return () => window.removeEventListener(SESSION_CHANGED_EVENT, refetch);
+  }, [fetchQuestions]);
+
   // Live-refresh the polls list on poll creation. User submits from /g
   // (empty placeholder), router.replace lands them on /g/<short_id>, and
   // when they navigate home the list would otherwise be stale until refresh.


### PR DESCRIPTION
## Problem

On iOS (and any browser), after signing in from the main page's empty-state **Sign In** modal, groups don't appear until you navigate to settings and come back.

## Cause

The home page (`app/page.tsx`) only fetched groups **on mount**. Signing in from the modal completes *in place* (no remount) — `persistSignIn` → `saveSession` fires `SESSION_CHANGED_EVENT`. The home page used that event only to swap away the "Sign In" button, never to re-fetch the membership-driven group list. Navigating to settings and back remounted home, which re-ran the mount fetch and finally surfaced the groups.

## Fix

Add a `SESSION_CHANGED_EVENT` listener that re-runs `fetchQuestions()`. Kept separate from the button-state effect (so it can carry `[fetchQuestions]` deps cleanly) and mirrors the adjacent `POLL_HYDRATED_EVENT` listener. The new bearer is already in `lib/session`'s `cachedToken` module cache by the time the event fires, so the refetch carries it and the server returns the account's groups.

## Verification

Drove a faithful in-place sign-in on the dev server with a real passkey ceremony (CDP virtual authenticator): created an account + seeded a group for it, simulated a fresh signed-out device, then signed in with the resident passkey on the home modal. Result:
- empty-state visible **before** sign-in: `true`
- empty-state visible **after** sign-in: `false` (group loaded)
- **navigation occurred: `false`** (URL stayed on `/`)

## Test plan
- [x] Group appears on home immediately after in-place sign-in, no navigation
- [x] No regression to the existing mount fetch / retry path

https://claude.ai/code/session_0159jFNQbdwwS6txVKPSc5pM

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jFNQbdwwS6txVKPSc5pM)_