### PR TITLE
Move Next.js dev indicator to bottom-right corner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4360,7 +4360,7 @@ When reviewing each screenshot, check:
 - No overflow, clipping, or unexpected wrapping?
 - No regressions in adjacent UI elements?
 
-**Dev-only artifact: the bottom-left "N" circle is the Next.js dev-server indicator** (the floating Next.js logo / build-status button `next dev` injects). It appears on EVERY dev-server screenshot (`*.dev.whoeverwants.com`), is NOT part of the app, and does NOT exist in production (Vercel build). Don't chase it as a layout bug or reposition app chrome to avoid it — if a fixed bottom-left element overlaps it in a screenshot, that overlap is invisible to real users.
+**Dev-only artifact: the bottom-right "N" circle is the Next.js dev-server indicator** (the floating Next.js logo / build-status button `next dev` injects). It appears on EVERY dev-server screenshot (`*.dev.whoeverwants.com`), is NOT part of the app, and does NOT exist in production (Vercel build). Don't chase it as a layout bug or reposition app chrome to avoid it — if a fixed element (e.g. the bottom-right "+ Group" button) overlaps it in a screenshot, that overlap is invisible to real users. Position is set to `bottom-right` via `devIndicators.position` in `next.config.ts` (default is `bottom-left`); the setting is dev-only.
 
 #### Measure DOM Spacing Programmatically
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -62,6 +62,13 @@ function apiRewriteRules(dest: string, host?: string) {
 
 const nextConfig: NextConfig = {
   trailingSlash: true,
+  // Move the Next.js dev indicator (the "N" build-status logo) to the
+  // bottom-right corner. Next.js defaults it to bottom-left, which on dev
+  // servers overlaps the home-page settings gear / back-arrow chrome.
+  // Dev-only — has no effect in the Vercel production build.
+  devIndicators: {
+    position: "bottom-right",
+  },
   // Prevent trailingSlash from issuing 308 redirects on API routes.
   // Rewrites handle the proxy; the redirect breaks POST request bodies.
   skipTrailingSlashRedirect: true,


### PR DESCRIPTION
The Next.js dev build-status indicator defaults to bottom-left, which
overlaps the home-page settings gear / back-arrow chrome on dev servers.
Set devIndicators.position to bottom-right. Dev-only; no effect in the
Vercel production build.

https://claude.ai/code/session_01TuQsQfGWjWmmtWkVhrA1e3