### PR TITLE
Fix confusing group privacy switch label

### DIFF
--- a/components/GroupPrivacySection.tsx
+++ b/components/GroupPrivacySection.tsx
@@ -184,7 +184,15 @@ export default function GroupPrivacySection({
       });
   };
 
-  const stateLabel = isPrivate ? "Private" : "Public";
+  // Label rules:
+  //   * Creator (switch shown): a FIXED label "Private group" that
+  //     describes what the ON position means. The switch position alone
+  //     conveys the state — a label that changed with the toggle (the old
+  //     "Private"/"Public" readout) made it impossible to tell what the
+  //     switch *does* versus what it currently *is*.
+  //   * Non-creator (no switch): the read-only current state, since there
+  //     is no switch to convey it.
+  const rowLabel = isCreator ? "Private group" : isPrivate ? "Private" : "Public";
   // Base description by state; creator gets the invite-link nudge as a
   // suffix when private (Phase F/G will deliver the actual invite UI).
   const helpText =
@@ -218,17 +226,13 @@ export default function GroupPrivacySection({
                 if (isCreator && !saving) onToggle(!isPrivate);
               }}
             >
-              <span className="text-base font-normal">{stateLabel}</span>
+              <span className="text-base font-normal">{rowLabel}</span>
               {isCreator ? (
                 <SliderSwitch
                   checked={isPrivate}
                   onChange={onToggle}
                   disabled={saving}
-                  aria-label={
-                    isPrivate
-                      ? "Make this group public"
-                      : "Make this group private"
-                  }
+                  aria-label="Private group"
                 />
               ) : null}
             </div>


### PR DESCRIPTION
## Summary
The privacy row on `/g/<id>/info` showed the **current state** ("Private"/"Public") as the label right next to the toggle, so flipping the switch flipped the label too — making it impossible to tell what the switch *does* versus what state it is *in*.

Now the creator's switch uses a **fixed** label "Private group" (describing the ON position); the switch position + the help text below convey the state:
- ON (blue) → "Only members can see this group. Share an invite link to add others."
- OFF (gray) → "Anyone with the URL can see this group."

Non-creators (no switch) still see the read-only current state. The switch `aria-label` is also fixed to "Private group" so `aria-checked` carries the state for screen readers.

## Test plan
- [x] Verified live: creator sees fixed "Private group" label with switch ON when private, OFF when public

https://claude.ai/code/session_01DwrfJZMZ1BcA9vLx75NwGV