### PR TITLE
Adjust new-poll text box and plus button height

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -2447,7 +2447,7 @@ export function CreateQuestionContent() {
             onClick={searchFocused ? dismissSearch : () => chooseSuggestion({ category: 'custom' })}
             aria-label={searchFocused ? 'Cancel' : 'New poll'}
             disabled={isLoading}
-            className="w-12 h-12 shrink-0 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow-lg text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
+            className="w-[38.4px] h-[38.4px] shrink-0 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow-lg text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
           >
             {searchFocused ? (
               <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
@@ -2460,7 +2460,7 @@ export function CreateQuestionContent() {
             )}
           </button>
           {/* Text box — to the right of the button, no inner + symbol. */}
-          <div className="flex-1 min-w-0 flex items-center h-12 rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 px-4 shadow-lg">
+          <div className="flex-1 min-w-0 flex items-center h-[38.4px] rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 px-4 shadow-lg">
           <input
             ref={searchInputRef}
             type="text"

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -2447,7 +2447,7 @@ export function CreateQuestionContent() {
             onClick={searchFocused ? dismissSearch : () => chooseSuggestion({ category: 'custom' })}
             aria-label={searchFocused ? 'Cancel' : 'New poll'}
             disabled={isLoading}
-            className="w-[38.4px] h-[38.4px] shrink-0 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow-lg text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
+            className="w-[42.24px] h-[42.24px] shrink-0 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow-lg text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
           >
             {searchFocused ? (
               <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
@@ -2460,7 +2460,7 @@ export function CreateQuestionContent() {
             )}
           </button>
           {/* Text box — to the right of the button, no inner + symbol. */}
-          <div className="flex-1 min-w-0 flex items-center h-[38.4px] rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 px-4 shadow-lg">
+          <div className="flex-1 min-w-0 flex items-center h-[42.24px] rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 px-4 shadow-lg">
           <input
             ref={searchInputRef}
             type="text"


### PR DESCRIPTION
## Summary
- Shrank the bottom new-poll text box and the circular **+** button from `h-12` (48px) to a shorter height, then bumped that up 10% — landing at `42.24px` for both.
- The **+** button keeps its round shape (both width and height set), and the pill text box height matches it.

## Test plan
- [x] Verified on the dev server at `/g/` — pill and button align, plus icon and placeholder stay vertically centered, no spacing regressions.

https://claude.ai/code/session_014VUJqpeab8jtnA9suFpBsM

---
_Generated by [Claude Code](https://claude.ai/code/session_014VUJqpeab8jtnA9suFpBsM)_