### PR TITLE
test: regression guard for effectiveCategoryIcon on stale localStorage drafts

### DIFF
--- a/tests/__tests__/effective-category-icon.test.ts
+++ b/tests/__tests__/effective-category-icon.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  effectiveCategoryIcon,
+  emptyDraft,
+  type QuestionDraft,
+} from "@/app/create-poll/createPollHelpers";
+
+/**
+ * Regression guard for the production-Safari poll-submission crash
+ * (PR #647): `effectiveCategoryIcon` ran `d.categoryIcon.trim()`, which threw
+ * `TypeError: undefined is not an object` when a draft was restored from a
+ * localStorage `questionFormState` (or staged `drafts[]`) saved BEFORE the
+ * `categoryIcon` field shipped (migration 127). Those old-shaped drafts are
+ * replayed verbatim by the create-poll restore paths, so the helper must
+ * tolerate a missing `categoryIcon` and never throw mid-submit.
+ *
+ * `QuestionDraft` requires `categoryIcon: string` at compile time, but the
+ * whole point is that RUNTIME data (old localStorage) can violate that — so
+ * the stale shapes are deliberately cast.
+ */
+describe("effectiveCategoryIcon", () => {
+  it("does not throw and returns null for a draft missing categoryIcon (stale localStorage shape)", () => {
+    const { categoryIcon, ...rest } = emptyDraft();
+    const stale = rest as unknown as QuestionDraft; // pre-migration-127 draft: no categoryIcon key
+    expect(() => effectiveCategoryIcon(stale)).not.toThrow();
+    expect(effectiveCategoryIcon(stale)).toBeNull();
+  });
+
+  it("does not throw and returns null when categoryIcon is explicitly undefined", () => {
+    const stale = { ...emptyDraft(), categoryIcon: undefined } as unknown as QuestionDraft;
+    expect(() => effectiveCategoryIcon(stale)).not.toThrow();
+    expect(effectiveCategoryIcon(stale)).toBeNull();
+  });
+
+  it("returns null for an empty / whitespace-only categoryIcon", () => {
+    expect(effectiveCategoryIcon({ ...emptyDraft(), categoryIcon: "" })).toBeNull();
+    expect(effectiveCategoryIcon({ ...emptyDraft(), categoryIcon: "   " })).toBeNull();
+  });
+
+  it("returns the trimmed chosen emoji when one is set", () => {
+    expect(effectiveCategoryIcon({ ...emptyDraft(), categoryIcon: "🎬" })).toBe("🎬");
+    expect(effectiveCategoryIcon({ ...emptyDraft(), categoryIcon: "  🍕 " })).toBe("🍕");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a unit test that would have caught the production-Safari poll-submission crash fixed in #647.

`effectiveCategoryIcon` used to call `d.categoryIcon.trim()`, which threw `TypeError: undefined is not an object` for a draft restored from a localStorage `questionFormState` (or staged `drafts[]`) saved **before** the emoji `categoryIcon` field shipped (migration 127). Those old-shaped drafts are replayed verbatim by the create-poll restore paths, so the helper must tolerate a missing field and never throw mid-submit.

The test pins that contract:
- a draft with **no `categoryIcon` key** (the stale-localStorage shape) → no throw, returns `null`
- `categoryIcon: undefined` → no throw, returns `null`
- empty / whitespace-only → `null`
- a real emoji (incl. surrounding whitespace) → trimmed emoji

`QuestionDraft` requires `categoryIcon: string` at compile time, but the whole point is that **runtime** data (old localStorage) violates that — so the stale shapes are deliberately cast in the test.

## Test plan
- [x] CI (vitest) runs the new `tests/__tests__/effective-category-icon.test.ts`.

https://claude.ai/code/session_01Fx2RvN46aLhACg3ukTCfaT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fx2RvN46aLhACg3ukTCfaT)_