### PR TITLE
Fix clipped selection highlight in emoji picker

### DIFF
--- a/components/EmojiPickerModal.tsx
+++ b/components/EmojiPickerModal.tsx
@@ -127,7 +127,7 @@ export default function EmojiPickerModal({
                   aria-pressed={selected}
                   className={`shrink-0 w-9 h-9 flex items-center justify-center rounded-lg text-xl select-none ${
                     selected
-                      ? 'bg-blue-100 dark:bg-blue-900/40 ring-1 ring-blue-400 dark:ring-blue-500'
+                      ? 'bg-blue-100 dark:bg-blue-900/40 ring-1 ring-inset ring-blue-400 dark:ring-blue-500'
                       : 'hover:bg-gray-100 dark:hover:bg-gray-700'
                   }`}
                 >


### PR DESCRIPTION
## Summary
The emoji picker's selected-emoji blue highlight was clipped along the top and left edges when the selected emoji sat in the top-left of the grid.

**Cause:** the grid uses `overflow-y-auto`, and per CSS rules a non-`visible` value on one axis makes the other axis compute to `auto` too — so the grid clips on both axes. The selection `ring-1` is drawn 1px *outside* the button box, so for buttons flush against the scroll-container edges the ring got clipped.

**Fix:** switched the selection ring to `ring-inset` so the highlight renders *inside* the button box. One-line change, no layout impact — the header/grid flush alignment is preserved.

## Test plan
- [x] Verified on the dev server by opening the picker and selecting the 🎟️ emoji (lands top-left, the reported case): the blue box now renders fully with no clipping.

https://claude.ai/code/session_01DXKgM7uaa3KkrmvTCMtwLw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXKgM7uaa3KkrmvTCMtwLw)_