### PR TITLE
Add bottom padding to showtime create flow card

### DIFF
--- a/app/create-poll/ShowtimeCreateFlow.tsx
+++ b/app/create-poll/ShowtimeCreateFlow.tsx
@@ -181,7 +181,7 @@ export default function ShowtimeCreateFlow({
   }
 
   return (
-    <div className="space-y-3 pt-2 pb-4">
+    <div className="space-y-3 pt-2 pb-[0.9rem]">
       <div>
         <ReferenceLocationInput
           latitude={refLatitude}

--- a/app/create-poll/ShowtimeCreateFlow.tsx
+++ b/app/create-poll/ShowtimeCreateFlow.tsx
@@ -181,7 +181,7 @@ export default function ShowtimeCreateFlow({
   }
 
   return (
-    <div className="space-y-3 pt-2">
+    <div className="space-y-3 pt-2 pb-4">
       <div>
         <ReferenceLocationInput
           latitude={refLatitude}


### PR DESCRIPTION
## Summary
The location UI ("Near …") and the "Find theaters" button in the Showtime poll create card rendered flush against the card's bottom rounded edge. The card (`<section data-draft-poll-card>`) only has horizontal padding (`px-4`) — the divide-y rows above provide their own vertical spacing via `h-12`, but the `ShowtimeCreateFlow` complex widget had only `pt-2` and no bottom padding.

Added `pb-[0.9rem]` (14.4px) to the `ShowtimeCreateFlow` root wrapper, giving breathing room under the "Find theaters" button (location set), the "Pick a location…" hint (location unset), and the final curation content in later steps.

## Test plan
- [x] Verified live on the dev server — opened the Showtime poll modal with a seeded location; the "Find theaters" button now has comfortable space below it before the card's bottom edge.

https://claude.ai/code/session_01X25thxPZndoPR2di2YxpsM

---
_Generated by [Claude Code](https://claude.ai/code/session_01X25thxPZndoPR2di2YxpsM)_