### PR TITLE
Restyle new-poll search bar outline and plus/X icons

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -2595,11 +2595,11 @@ export function CreateQuestionContent() {
             className="w-[42.24px] h-[42.24px] shrink-0 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 border-[0.5px] border-gray-500 dark:border-gray-400 shadow-lg text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
           >
             {searchFocused ? (
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
+              <svg className="w-5 h-5 text-gray-700 dark:text-gray-200" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             ) : (
-              <svg className="w-6 h-6 text-gray-700 dark:text-gray-200" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24" aria-hidden="true">
+              <svg className="w-6 h-6 text-gray-700 dark:text-gray-200" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" d="M12 5v14M5 12h14" />
               </svg>
             )}

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -2592,20 +2592,20 @@ export function CreateQuestionContent() {
             onClick={searchFocused ? dismissSearch : () => chooseSuggestion({ category: 'custom' })}
             aria-label={searchFocused ? 'Cancel' : 'New poll'}
             disabled={isLoading}
-            className="w-[42.24px] h-[42.24px] shrink-0 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 shadow-lg text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
+            className="w-[42.24px] h-[42.24px] shrink-0 flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 border-[0.5px] border-gray-500 dark:border-gray-400 shadow-lg text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 disabled:opacity-50"
           >
             {searchFocused ? (
               <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             ) : (
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden="true">
+              <svg className="w-6 h-6 text-gray-700 dark:text-gray-200" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" d="M12 5v14M5 12h14" />
               </svg>
             )}
           </button>
           {/* Text box — to the right of the button, no inner + symbol. */}
-          <div className="flex-1 min-w-0 flex items-center h-[42.24px] rounded-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 px-4 shadow-lg">
+          <div className="flex-1 min-w-0 flex items-center h-[42.24px] rounded-full bg-gray-100 dark:bg-gray-800 border-[0.5px] border-gray-500 dark:border-gray-400 px-4 shadow-lg">
           <input
             ref={searchInputRef}
             type="text"


### PR DESCRIPTION
## Summary
Tweaks the always-visible new-poll search bar at the bottom of group-like pages (`app/create-poll/page.tsx`):

- **Outline** on both the plus button and the text box: `border border-gray-300/600` → `border-[0.5px] border-gray-500/400` — more intense color at half the thickness.
- **Plus icon**: explicit `text-gray-700 dark:text-gray-200` (less faint), stroke thinned `2.5` → `1.5`.
- **X icon** (the plus's focused state): color + stroke weight matched to the plus (`1.5`).

## Test plan
- [x] Verified on dev server `/g/` placeholder — outline is crisp/fine, plus reads as a darker thin glyph, X matches.

https://claude.ai/code/session_01V9mV9PgDJ4uhLTqBAjWtVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9mV9PgDJ4uhLTqBAjWtVh)_