### PR TITLE
Show requester name, photo, and request date in join requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1871,8 +1871,20 @@ without blocking re-requests after a denial. Three endpoints in
     bullet below). Idempotent via the partial unique index —
     second call doesn't re-fire the creator push.
   * `GET /api/groups/<route_id>/join-requests` — creator-only.
-    Returns pending oldest first, with `requester_email` joined
-    in (NULL for passkey-only requesters). 401/403/404.
+    Returns pending oldest first. Each row carries `requester_email`
+    (NULL for passkey-only requesters), `requester_name`
+    (`users.display_name`, LEFT JOIN), `requester_image_updated_at`
+    (`user_profiles.image_updated_at`, LEFT JOIN — the profile-photo
+    cache-buster, NULL when no photo), and `requested_at`. The two
+    LEFT JOINs select ONLY scalar columns (display_name, the timestamp)
+    — never `user_profiles.image_data` (the BYTEA blob) — so the join
+    stays cheap. The FE (`JoinRequestsSection`) renders an avatar
+    (`InitialBubble` fed `buildUserImageUrl(requester_user_id,
+    requester_image_updated_at)`, falling back to a name-initials disc)
+    + name (primary) + email (secondary) + "Requested <relativeTime>".
+    Name is the primary label because instant-link / browser-tied
+    accounts (and passkey-only ones) have no email — `requester_email`
+    is frequently NULL in practice. 401/403/404.
   * `POST /api/groups/<route_id>/join-requests/<id>/decide` (body
     `{action: 'approve' | 'deny'}`) — creator-only. Approve writes
     a `group_members` row keyed on the requester's

--- a/components/JoinRequestsSection.tsx
+++ b/components/JoinRequestsSection.tsx
@@ -19,13 +19,15 @@
  *   3. On success, leave the row removed. On failure, restore + show
  *      a transient error message above the section.
  *
- * Requester identity display:
- *   - Email when available (most users — magic-link sign-in always
- *     records one, OAuth merges via verified email).
- *   - "Passkey user" fallback for Phase D no-email accounts.
- *   - Message (if any) renders below the identity line in lighter
- *     text. Long messages truncate to 3 lines with an expandable
- *     "more" link (deferred — for v1, line-clamp-3 is enough).
+ * Requester identity display (avatar + stacked text):
+ *   - Profile photo when uploaded, else a name-initials disc
+ *     (`InitialBubble`).
+ *   - Name (account display_name) as the primary label; falls back to
+ *     email, then "Passkey user" (Phase D no-email accounts).
+ *   - Email as a secondary line under the name (when both exist).
+ *   - "Requested <relative time>" so the creator sees how long it's
+ *     been waiting.
+ *   - Message (if any) renders below in lighter text.
  */
 
 "use client";
@@ -38,8 +40,11 @@ import {
   apiListGroupJoinRequests,
 } from "@/lib/api";
 import type { GroupJoinRequest } from "@/lib/api";
+import { buildUserImageUrl } from "@/lib/api";
+import InitialBubble from "@/components/InitialBubble";
 import { haptic } from "@/lib/haptics";
 import { isPathPrefix } from "@/lib/questionId";
+import { relativeTime } from "@/lib/questionListUtils";
 import {
   SW_NOTIFICATION_CLICK_EVENT,
   SW_PUSH_RECEIVED_EVENT,
@@ -200,18 +205,45 @@ export default function JoinRequestsSection({
         <ul className="divide-y divide-gray-200 dark:divide-gray-800">
           {requests.map((r) => {
             const deciding = decidingIds.has(r.id);
-            const identity = r.requester_email ?? "Passkey user";
+            const displayName = r.requester_name?.trim() || null;
+            // Primary label is the requester's name; fall back to their
+            // email, then the passkey-only placeholder.
+            const identity =
+              displayName ?? r.requester_email ?? "Passkey user";
+            // Secondary line: show the email under the name (only when we
+            // actually have a name above it, so it isn't duplicated).
+            const subLabel = displayName ? r.requester_email : null;
+            const imageUrl = buildUserImageUrl(
+              r.requester_user_id,
+              r.requester_image_updated_at,
+            );
             return (
               <li key={r.id} className="px-4 py-3 flex flex-col gap-2">
-                <div className="flex flex-col min-w-0">
-                  <span className="text-gray-900 dark:text-white break-words">
-                    {identity}
-                  </span>
-                  {r.message && (
-                    <span className="mt-0.5 text-sm text-gray-600 dark:text-gray-400 break-words whitespace-pre-wrap">
-                      {r.message}
+                <div className="flex items-start gap-3 min-w-0">
+                  <InitialBubble
+                    name={displayName ?? r.requester_email ?? null}
+                    imageUrl={imageUrl}
+                    sizeClassName="w-9 h-9 shrink-0"
+                    textSizeClassName="text-sm"
+                  />
+                  <div className="flex flex-col min-w-0 flex-1">
+                    <span className="text-gray-900 dark:text-white break-words">
+                      {identity}
                     </span>
-                  )}
+                    {subLabel && (
+                      <span className="text-xs text-gray-500 dark:text-gray-400 break-words">
+                        {subLabel}
+                      </span>
+                    )}
+                    <span className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                      Requested {relativeTime(r.requested_at)}
+                    </span>
+                    {r.message && (
+                      <span className="mt-1 text-sm text-gray-600 dark:text-gray-400 break-words whitespace-pre-wrap">
+                        {r.message}
+                      </span>
+                    )}
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   <button

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -452,6 +452,12 @@ export interface GroupJoinRequest {
   group_id: string;
   requester_user_id: string;
   requester_email: string | null;
+  /** Account display_name. Populated for real requests (a name is
+   *  required to request access); may be null for legacy/edge rows. */
+  requester_name: string | null;
+  /** Profile-photo cache-buster; null when the requester has no
+   *  uploaded photo. Feed into `buildUserImageUrl(requester_user_id, ...)`. */
+  requester_image_updated_at: string | null;
   message: string | null;
   requested_at: string;
 }

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -1040,12 +1040,17 @@ class JoinRequestSummaryResponse(BaseModel):
     """Per-request shape returned to the creator (list endpoint) and
     echoed by the create endpoint. `requester_email` is NULL for
     passkey-only users (Phase D registration permits no-email accounts)
-    — the FE renders a "Passkey user" fallback."""
+    — the FE renders a "Passkey user" fallback. `requester_name` is the
+    requester's account display_name; `requester_image_updated_at` is the
+    profile-photo cache-buster (NULL when no photo) the FE feeds into the
+    public `/by-user-id/<id>/image?v=<ts>` URL."""
 
     id: str
     group_id: str
     requester_user_id: str
     requester_email: str | None
+    requester_name: str | None = None
+    requester_image_updated_at: str | None = None
     message: str | None
     requested_at: str
 
@@ -1079,6 +1084,12 @@ def _summary_to_response(s, fallback_email: str | None = None) -> JoinRequestSum
         group_id=s.group_id,
         requester_user_id=s.requester_user_id,
         requester_email=s.requester_email if s.requester_email is not None else fallback_email,
+        requester_name=getattr(s, "requester_name", None),
+        requester_image_updated_at=(
+            s.requester_image_updated_at.isoformat()
+            if getattr(s, "requester_image_updated_at", None)
+            else None
+        ),
         message=s.message,
         requested_at=s.requested_at.isoformat() if s.requested_at else "",
     )

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -1049,8 +1049,8 @@ class JoinRequestSummaryResponse(BaseModel):
     group_id: str
     requester_user_id: str
     requester_email: str | None
-    requester_name: str | None = None
-    requester_image_updated_at: str | None = None
+    requester_name: str | None
+    requester_image_updated_at: str | None
     message: str | None
     requested_at: str
 
@@ -1084,10 +1084,10 @@ def _summary_to_response(s, fallback_email: str | None = None) -> JoinRequestSum
         group_id=s.group_id,
         requester_user_id=s.requester_user_id,
         requester_email=s.requester_email if s.requester_email is not None else fallback_email,
-        requester_name=getattr(s, "requester_name", None),
+        requester_name=s.requester_name,
         requester_image_updated_at=(
             s.requester_image_updated_at.isoformat()
-            if getattr(s, "requester_image_updated_at", None)
+            if s.requester_image_updated_at
             else None
         ),
         message=s.message,

--- a/server/services/join_requests.py
+++ b/server/services/join_requests.py
@@ -38,12 +38,21 @@ class JoinRequestSummary:
     """Creator-facing view of a pending request. `requester_email` is
     null for passkey-only users — Phase D registration permits accounts
     with no email at all. UI falls back to a "Passkey user" placeholder
-    in that case."""
+    in that case.
+
+    `requester_name` is the requester's account `display_name` (a name
+    is required to request access, so it's populated for real requests).
+    `requester_image_updated_at` is the cache-buster for the requester's
+    profile image (NULL when they have no uploaded photo) — the FE builds
+    the public `/by-user-id/<id>/image?v=<ts>` URL from it +
+    `requester_user_id`."""
 
     id: str
     group_id: str
     requester_user_id: str
     requester_email: str | None
+    requester_name: str | None
+    requester_image_updated_at: datetime | None
     message: str | None
     requested_at: datetime
 
@@ -95,6 +104,8 @@ def create_join_request(
         group_id=str(row["group_id"]),
         requester_user_id=str(row["requester_user_id"]),
         requester_email=None,
+        requester_name=None,
+        requester_image_updated_at=None,
         message=row.get("message"),
         requested_at=row["requested_at"],
     )
@@ -137,7 +148,9 @@ def is_member_or_creator(
 def list_pending_requests(conn, group_id: str) -> list[JoinRequestSummary]:
     """Pending requests for a group, oldest first. The email column is
     the requester's most-recently-verified email across their identity
-    rows (NULL for passkey-only)."""
+    rows (NULL for passkey-only). `requester_name` is the account
+    display_name; `requester_image_updated_at` is the profile-photo
+    cache-buster (NULL when no photo)."""
     rows = conn.execute(
         """
         SELECT r.id,
@@ -145,6 +158,8 @@ def list_pending_requests(conn, group_id: str) -> list[JoinRequestSummary]:
                r.requester_user_id,
                r.message,
                r.requested_at,
+               u.display_name AS requester_name,
+               up.image_updated_at AS requester_image_updated_at,
                (
                    SELECT ui.email
                      FROM user_identities ui
@@ -154,6 +169,8 @@ def list_pending_requests(conn, group_id: str) -> list[JoinRequestSummary]:
                     LIMIT 1
                ) AS requester_email
           FROM group_join_requests r
+          LEFT JOIN users u ON u.id = r.requester_user_id
+          LEFT JOIN user_profiles up ON up.user_id = r.requester_user_id
          WHERE r.group_id = %(g)s::uuid
            AND r.status = 'pending'
          ORDER BY r.requested_at ASC
@@ -166,6 +183,8 @@ def list_pending_requests(conn, group_id: str) -> list[JoinRequestSummary]:
             group_id=str(r["group_id"]),
             requester_user_id=str(r["requester_user_id"]),
             requester_email=r.get("requester_email"),
+            requester_name=r.get("requester_name"),
+            requester_image_updated_at=r.get("requester_image_updated_at"),
             message=r.get("message"),
             requested_at=r["requested_at"],
         )

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -391,6 +391,39 @@ def test_list_join_requests_creator_sees_pending_in_order(
     assert body[1]["requester_email"] == e2
 
 
+def test_list_join_requests_surfaces_name_and_image_fields(
+    client, creator_browser
+):
+    """The creator-facing list carries the requester's display_name and
+    the profile-photo cache-buster (NULL when no photo) so the FE can
+    render an avatar + name + email + request date."""
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    rb = str(uuid.uuid4())
+    rtoken, _, remail = _sign_in(client, rb, name="Alice Requester")
+    client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": None},
+        headers=_bearer_headers(rb, rtoken),
+    )
+
+    resp = client.get(
+        f"/api/groups/{group['id']}/join-requests",
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    row = body[0]
+    assert row["requester_name"] == "Alice Requester"
+    assert row["requester_email"] == remail
+    # No uploaded photo → null cache-buster (FE falls back to initials).
+    assert row["requester_image_updated_at"] is None
+    # requested_at is an ISO timestamp the FE renders as "Requested Xm ago".
+    assert row["requested_at"]
+
+
 def test_list_join_requests_anon_created_group_returns_403(
     client, creator_browser
 ):


### PR DESCRIPTION
## Summary
Group owners reviewing pending join requests now see each requester's **name**, **profile photo**, and **request date** — not just an email (which is frequently null for browser-tied / passkey-only accounts).

- **Backend** (`services/join_requests.py`, `routers/groups.py`): `list_pending_requests` `LEFT JOIN`s `users.display_name` + `user_profiles.image_updated_at` (scalar columns only — never the `image_data` BYTEA blob). Surfaced on `JoinRequestSummaryResponse` as `requester_name` + `requester_image_updated_at`. `requested_at` was already in the payload — it just wasn't displayed.
- **Frontend** (`lib/api/groups.ts`, `components/JoinRequestsSection.tsx`): each row renders an `InitialBubble` avatar (uploaded photo via `buildUserImageUrl`, falling back to a name-initials disc) + name (primary) + email (secondary) + "Requested <relative time>".

Display priority: name → email → "Passkey user". A name is required to request access, so real requesters always show one.

## Test plan
- [x] `server/tests/test_join_requests.py` — all 22 pass, incl. new `test_list_join_requests_surfaces_name_and_image_fields`
- [x] Live demo: creator with a private group + 3 named requesters (one with an uploaded photo) — verified avatar/name/email/date render correctly

https://claude.ai/code/session_018tXwh1ic63eykL7CmqoByc