### PR TITLE
Long-press / click a user → profile modal (name, avatar, age, shared groups)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3204,6 +3204,24 @@ From `/g/<id>/info`, a member taps **"Add people"** (above the members list) to 
 
 ---
 
+## User Profile Modal (long-press / click another user)
+
+Long-pressing (touch) or **clicking (desktop)** another user's name/avatar anywhere a per-user identity renders — group members list (`/info`), poll respondents list (`/g/<g>/p/<p>/info`), poll creator (detail page), invite-members list — opens a modal with their name, a larger avatar, account age ("Joined X ago"), and the groups the **caller** shares with them (tappable → navigate). Never targets yourself.
+
+- **`lib/useUserProfile.ts`** — `useProfileLongPress(userId, name?)` returns handlers to spread onto the element. Mouse → plain `onClick` opens; touch → 500ms long-press (a plain tap falls through to the element's own onClick, e.g. an invite row's select-toggle); movement >10px cancels; it `stopPropagation`s when it acts so it can sit on an inner element (invite row's avatar+name div) without firing the row's onClick. Returns `{}` (no handlers) when `userId` is null/undefined → disabled for anonymous participants + the viewer's own rows. `openUserProfileCard(userId, name?)` fires `USER_PROFILE_OPEN_EVENT`; `<UserProfileModalHost>` (mounted once in `app/layout.tsx`) renders the modal and ignores opens targeting the caller's own `getCachedSessionUser().user_id`.
+- **`components/UserProfileModal.tsx`** fetches `apiGetUserProfileCard(userId)` (`GET /api/users/{user_id}/profile-card`). Uses the shared `useBodyScrollLock(true)`; z-`[80]` (above ConfirmationModal's z-70).
+- **`components/RosterRow.tsx`** is the shared one-person row (avatar + name + the long-press hook), used by BOTH the /info members list and the poll /info respondents list. Don't reintroduce per-page row duplicates. The invite-members row keeps its own `InvitableRow` (checkbox + select-toggle structure) with the hook on the inner avatar+name div.
+
+### Distinct-people rosters
+
+Both rosters render **one row per distinct PERSON**, account-deduped. The **group** members list already does this via `#683`'s `apiGetGroupMembers → GroupRoster` (`services/groups.py: load_group_members`, keyed on `COALESCE(user_id, browser_id)` so two same-named people are two rows and an account across N browsers/roles is one). This feature:
+- Threads each member's `user_id` (already on `GroupMember`) into the /info row so it's long-pressable (the viewer's own row, matched via `isCurrentUserName`, gets `userId=null`).
+- Adds **`services/groups.py: load_poll_voters(conn, poll_id)`** — the poll-scoped sibling of `load_group_members` (same `(named[{name,user_id}], anonymous_count)` shape, but from `votes` of one poll). Endpoint `GET /api/groups/by-route-id/{route_id}/poll/{poll_ref}/voter-identities` → `GroupMembersResponse` (reuses #683's model); FE `apiGetGroupPollVoters(routeId, pollRef) → GroupRoster` (reuses #683's type). The poll /info respondents list renders this roster (one row per voter person + long-press), falling back to `poll.voter_names` only until it loads.
+- **`get_profile_card`** (`services/profiles.py`) returns name + `created_at` (age) + shared groups = intersection of the caller's visible memberships (`load_user_visibility`) and the target's memberships (one `group_display_name` query per shared group — fine, modal-open only). Endpoint in `routers/users.py` (`GET /{user_id}/profile-card`, public-ish: user_id is the URL token; shared_groups is caller-scoped). FE `apiGetUserProfileCard` + `UserProfileCard` in `lib/api/users.ts`.
+- **Rule**: any new "list the distinct people in a group/poll" surface should consume `load_group_members` / `load_poll_voters` (account-deduped) rather than re-deriving from name aggregates. Tests: `server/tests/test_profiles.py` (poll roster + profile card; the group `/members` roster is covered by #683's tests).
+
+---
+
 ## Group Avatar Images
 
 Groups can have a custom uploaded image avatar that replaces the participant-initials graphic. **Storage**: inline on the `groups` row — migration 108 added `image_data BYTEA`, `image_mime_type TEXT`, `image_updated_at TIMESTAMPTZ` columns. Keeping bytes in Postgres (vs filesystem / object storage) means pg_dump captures them automatically, no second storage surface to provision per-branch on the Mac dev infrastructure, and "destroy + recreate dev DB" stays a one-step operation. Trade-off accepted for the current scale.

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -21,6 +21,7 @@ import GroupShareButton from "@/components/GroupShareButton";
 import GroupPrivacySection from "@/components/GroupPrivacySection";
 import HeaderPortal from "@/components/HeaderPortal";
 import InitialBubble from "@/components/InitialBubble";
+import RosterRow from "@/components/RosterRow";
 import InviteLinksSection from "@/components/InviteLinksSection";
 import JoinRequestsSection from "@/components/JoinRequestsSection";
 import NotificationSettingsCard from "@/components/NotificationSettingsCard";
@@ -119,7 +120,9 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   // people who share a name (two "Bob"s). `anonymousExtra` is the rolled-up
   // count of members with no resolvable name (drive-by URL visitors on a
   // public group).
-  let membersList: { name: string; key: string }[];
+  // `userId` is the account to long-press → profile modal (null = anonymous or
+  // the viewer's own row, which isn't long-pressable).
+  let membersList: { name: string; key: string; userId: string | null }[];
   let totalCount: number;
   let anonymousExtra = 0;
   if (roster) {
@@ -128,13 +131,15 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
     const rows = roster.members.map((m, i) => ({
       name: m.name,
       key: `member-${m.user_id ?? m.name}-${i}`,
+      // Don't long-press yourself; otherwise the resolved account.
+      userId: isCurrentUserName(m.name) ? null : m.user_id,
     }));
     // The viewer is always a member (visiting auto-joins / the creator is a
     // member). If they aren't a resolved named row, they're one of the
     // anonymous members — surface them as themselves and pull one out of the
     // anonymous roll-up so the headcount stays right.
     if (!rows.some((r) => isCurrentUserName(r.name))) {
-      rows.push({ name: viewerLabel, key: "__viewer__" });
+      rows.push({ name: viewerLabel, key: "__viewer__", userId: null });
       if (anon > 0) anon -= 1;
     }
     rows.sort((a, b) => a.name.localeCompare(b.name));
@@ -147,10 +152,10 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
       ...group.participantNames.flatMap((name) =>
         Array.from(
           { length: nameCount(group.participantNameCounts, name) },
-          (_, i) => ({ name, key: `${name}#${i}` }),
+          (_, i) => ({ name, key: `${name}#${i}`, userId: null }),
         ),
       ),
-      { name: viewerLabel, key: "__viewer__" },
+      { name: viewerLabel, key: "__viewer__", userId: null },
     ].sort((a, b) => a.name.localeCompare(b.name));
     totalCount = membersList.length;
   }
@@ -249,7 +254,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
 
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden">
           <ul className="divide-y divide-gray-200 dark:divide-gray-800">
-            {membersList.map(({ name, key }) => {
+            {membersList.map(({ name, key, userId }) => {
               // Viewer row resolves either as the literal "You" label
               // (no saved name) or as a real-name row matching the
               // current saved name. `name === "You"` passes `null` to
@@ -259,15 +264,13 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
               const imageUrl = isViewer ? myUserImageUrl : null;
               const bubbleName = name === "You" ? null : name;
               return (
-                <li key={key} className="flex items-center gap-3 px-4 py-3 text-gray-900 dark:text-white">
-                  <InitialBubble
-                    name={bubbleName}
-                    imageUrl={imageUrl}
-                    sizeClassName="w-8 h-8"
-                    className="shrink-0"
-                  />
-                  <span className="min-w-0 break-words">{name}</span>
-                </li>
+                <RosterRow
+                  key={key}
+                  displayName={name}
+                  bubbleName={bubbleName}
+                  imageUrl={imageUrl}
+                  userId={userId}
+                />
               );
             })}
             {anonymousExtra > 0 && (

--- a/app/g/[groupShortId]/invite-members/page.tsx
+++ b/app/g/[groupShortId]/invite-members/page.tsx
@@ -20,6 +20,7 @@ import {
   apiGetGroupInvitableAccounts,
   type InvitableAccount,
 } from "@/lib/api";
+import { useProfileLongPress } from "@/lib/useUserProfile";
 
 /** Prop-driven inner view. Exposed so the slide overlay can render this
  *  directly without going through useParams() (the overlay mounts the
@@ -184,49 +185,14 @@ function InviteMembers({ groupId }: { groupId: string }) {
         ) : (
           <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden">
             <ul className="divide-y divide-gray-200 dark:divide-gray-800">
-              {filtered.map((a) => {
-                const isSelected = selected.has(a.user_id);
-                const label = a.name ?? "Unnamed";
-                return (
-                  <li key={a.user_id}>
-                    <button
-                      type="button"
-                      onClick={() => toggle(a.user_id)}
-                      aria-pressed={isSelected}
-                      className="w-full flex items-center gap-3 px-4 py-3 text-left text-gray-900 dark:text-white active:bg-gray-50 dark:active:bg-gray-800/60"
-                    >
-                      <div
-                        role="checkbox"
-                        aria-checked={isSelected}
-                        className={`flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
-                          isSelected
-                            ? "bg-blue-600 border-blue-600 dark:bg-blue-500 dark:border-blue-500"
-                            : "border-gray-400 dark:border-gray-500 bg-white dark:bg-gray-900"
-                        }`}
-                      >
-                        {isSelected && (
-                          <svg
-                            className="w-4 h-4 text-white"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth={3}
-                            viewBox="0 0 24 24"
-                          >
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                          </svg>
-                        )}
-                      </div>
-                      <InitialBubble
-                        name={a.name}
-                        imageUrl={null}
-                        sizeClassName="w-8 h-8"
-                        className="shrink-0"
-                      />
-                      <span className="min-w-0 break-words">{label}</span>
-                    </button>
-                  </li>
-                );
-              })}
+              {filtered.map((a) => (
+                <InvitableRow
+                  key={a.user_id}
+                  account={a}
+                  isSelected={selected.has(a.user_id)}
+                  onToggle={toggle}
+                />
+              ))}
             </ul>
           </div>
         )}
@@ -240,6 +206,64 @@ function InviteMembers({ groupId }: { groupId: string }) {
         confirmText="Add"
       />
     </>
+  );
+}
+
+/** A single invitable-account row. Tap the checkbox/row toggles selection;
+ *  click (desktop) or long-press (touch) the avatar/name opens the profile
+ *  modal — the hook stops propagation so it doesn't also toggle. Extracted so
+ *  `useProfileLongPress` is a top-level hook (not called inside the .map). */
+function InvitableRow({
+  account,
+  isSelected,
+  onToggle,
+}: {
+  account: InvitableAccount;
+  isSelected: boolean;
+  onToggle: (userId: string) => void;
+}) {
+  const lp = useProfileLongPress(account.user_id, account.name);
+  const label = account.name ?? "Unnamed";
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onToggle(account.user_id)}
+        aria-pressed={isSelected}
+        className="w-full flex items-center gap-3 px-4 py-3 text-left text-gray-900 dark:text-white active:bg-gray-50 dark:active:bg-gray-800/60 select-none"
+      >
+        <div
+          role="checkbox"
+          aria-checked={isSelected}
+          className={`flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
+            isSelected
+              ? "bg-blue-600 border-blue-600 dark:bg-blue-500 dark:border-blue-500"
+              : "border-gray-400 dark:border-gray-500 bg-white dark:bg-gray-900"
+          }`}
+        >
+          {isSelected && (
+            <svg
+              className="w-4 h-4 text-white"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={3}
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          )}
+        </div>
+        <div className="flex items-center gap-3 min-w-0 cursor-pointer" {...lp}>
+          <InitialBubble
+            name={account.name}
+            imageUrl={null}
+            sizeClassName="w-8 h-8"
+            className="shrink-0"
+          />
+          <span className="min-w-0 break-words">{label}</span>
+        </div>
+      </button>
+    </li>
   );
 }
 

--- a/app/g/[groupShortId]/p/[pollShortId]/PollDetailPage.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/PollDetailPage.tsx
@@ -67,6 +67,7 @@ import {
 } from "@/lib/questionListUtils";
 import { formatCreationTimestamp } from "@/lib/timeUtils";
 import { useMyUserImageUrl } from "@/lib/useMyUserImageUrl";
+import { useProfileLongPress } from "@/lib/useUserProfile";
 import {
   loadVotedQuestions,
   parseYesNoChoice,
@@ -808,6 +809,12 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
     poll.viewer_is_creator === true ||
     isCurrentUserName(poll.creator_name);
   const creatorImageUrl = creatorIsMe ? myUserImageUrl : null;
+  // Long-press (touch) / click (desktop) the creator's avatar/name → their
+  // profile modal (disabled when it's the viewer's own poll or no account).
+  const creatorLongPress = useProfileLongPress(
+    creatorIsMe ? null : poll.creator_user_id ?? null,
+    poll.creator_name,
+  );
 
   // When a submit action fires without a saved name, the retry closure is
   // stashed here and replayed after AccountGateModal completes.
@@ -964,19 +971,26 @@ function PollDetail({ poll, setPoll, groupId, pollShortId, onBack, overlayCardsO
             surfaces the same information about the poll. */}
         {anchor && (
           <div className="mb-2 flex items-center gap-2 px-1 min-w-0">
-            <InitialBubble
-              name={poll.creator_name ?? null}
-              imageUrl={creatorImageUrl}
-              className="shrink-0"
-            />
-            <ClientOnly fallback={null}>
-              <span className="min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">
-                {poll.creator_name && <>{poll.creator_name} &middot; </>}
-                <span title={formatCreationTimestamp(anchor.created_at)}>
-                  {relativeTime(anchor.created_at)}
+            <div
+              className={`flex items-center gap-2 min-w-0 select-none${
+                creatorIsMe ? "" : " cursor-pointer"
+              }`}
+              {...creatorLongPress}
+            >
+              <InitialBubble
+                name={poll.creator_name ?? null}
+                imageUrl={creatorImageUrl}
+                className="shrink-0"
+              />
+              <ClientOnly fallback={null}>
+                <span className="min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">
+                  {poll.creator_name && <>{poll.creator_name} &middot; </>}
+                  <span title={formatCreationTimestamp(anchor.created_at)}>
+                    {relativeTime(anchor.created_at)}
+                  </span>
                 </span>
-              </span>
-            </ClientOnly>
+              </ClientOnly>
+            </div>
             <div className="flex-1 min-w-0 flex justify-end text-sm leading-tight text-gray-500 dark:text-gray-400">
               <ClientOnly fallback={null}>{statusEl}</ClientOnly>
             </div>

--- a/app/g/[groupShortId]/p/[pollShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/p/[pollShortId]/info/page.tsx
@@ -19,7 +19,9 @@ import {
   apiCutoffPollAvailability,
   apiCutoffPollSuggestions,
   apiGetGroupPoll,
+  apiGetGroupPollVoters,
   apiReopenPoll,
+  type GroupRoster,
 } from "@/lib/api";
 import type { Poll, Question } from "@/lib/types";
 import { hasAppHistory } from "@/lib/viewTransitions";
@@ -31,6 +33,7 @@ import {
 } from "@/lib/questionListUtils";
 import GroupHeader from "@/components/GroupHeader";
 import InitialBubble from "@/components/InitialBubble";
+import RosterRow from "@/components/RosterRow";
 import { namedVoterCount } from "@/components/VoterList";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import PollActionButton, { CutoffIcon } from "@/components/PollActionButton";
@@ -209,20 +212,56 @@ function Info({ poll, setPoll, groupId, onBack }: InfoProps) {
     isCreatorOrDev;
 
   const namedVoters = poll.voter_names ?? [];
-  const anonymousCount = poll.anonymous_count ?? 0;
   // Viewed-but-no-response viewers (opened >5 min ago, never voted/abstained).
   const ignoredCount = poll.viewed_ignored_count ?? 0;
-  // Sum the multiplicity map so two people sharing a name ("Alex" ×2) count as
-  // 2 responders — matches the turnout semantics used elsewhere.
-  const respondedCount =
-    namedVoterCount(namedVoters, poll.voter_name_counts) + anonymousCount;
-  // Total distinct viewers = everyone who opened the poll = responders +
-  // viewed-but-no-response.
-  const totalViewed = respondedCount + ignoredCount;
   const currentUserName = useMemo(
     () => getUserName()?.trim().toLowerCase() ?? null,
     [],
   );
+
+  // Per-person voter roster (account-deduped) so each respondent is one row +
+  // long-pressable to their profile. Same shape as the group members roster.
+  // Null until loaded; fall back to poll.voter_names (no-flash, no long-press).
+  const pollShortId = poll.short_id;
+  const [roster, setRoster] = useState<GroupRoster | null>(null);
+  useEffect(() => {
+    if (!pollShortId) return;
+    let cancelled = false;
+    apiGetGroupPollVoters(groupId, pollShortId)
+      .then((r) => {
+        if (!cancelled) setRoster(r);
+      })
+      .catch(() => {
+        /* keep the voter-name fallback on failure */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId, pollShortId]);
+
+  const anonymousCount = roster
+    ? roster.anonymous_count
+    : poll.anonymous_count ?? 0;
+  const namedCount = roster
+    ? roster.members.length
+    : namedVoterCount(namedVoters, poll.voter_name_counts);
+  const respondedCount = namedCount + anonymousCount;
+  const totalViewed = respondedCount + ignoredCount;
+
+  // One row per named respondent. `userId` = account to long-press (null for
+  // the viewer's own row / anonymous / pre-roster fallback).
+  const respondentRows: { name: string; key: string; userId: string | null }[] =
+    roster
+      ? roster.members.map((m, i) => ({
+          name: m.name,
+          key: `voter-${m.user_id ?? m.name}-${i}`,
+          userId: isCurrentUserName(m.name) ? null : m.user_id,
+        }))
+      : namedVoters.map((name, idx) => ({
+          name,
+          key: `${name}-${idx}`,
+          userId: null,
+        }));
 
   const [pendingAction, setPendingAction] = useState<PendingActionKind | null>(
     null,
@@ -391,23 +430,18 @@ function Info({ poll, setPoll, groupId, onBack }: InfoProps) {
             </div>
           ) : (
             <ul className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden divide-y divide-gray-200 dark:divide-gray-800">
-              {namedVoters.map((name, idx) => {
+              {respondentRows.map((row) => {
                 const isViewer =
                   currentUserName !== null &&
-                  name.trim().toLowerCase() === currentUserName;
+                  row.name.trim().toLowerCase() === currentUserName;
                 return (
-                  <li
-                    key={`${name}-${idx}`}
-                    className="flex items-center gap-3 px-4 py-3 text-gray-900 dark:text-white"
-                  >
-                    <InitialBubble
-                      name={name}
-                      imageUrl={isViewer ? myUserImageUrl : null}
-                      sizeClassName="w-8 h-8"
-                      className="shrink-0"
-                    />
-                    <span className="min-w-0 break-words">{name}</span>
-                  </li>
+                  <RosterRow
+                    key={row.key}
+                    displayName={row.name}
+                    bubbleName={row.name}
+                    imageUrl={isViewer ? myUserImageUrl : null}
+                    userId={row.userId}
+                  />
                 );
               })}
               {anonymousCount > 0 && (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { UniversalLinksHandler } from "@/components/UniversalLinksHandler";
 import { ClipboardLinkPrompt } from "@/components/ClipboardLinkPrompt";
 import { PushAutoRegister } from "@/components/PushAutoRegister";
 import { NativeIdentityHost } from "@/components/NativeIdentityHost";
+import UserProfileModalHost from "@/components/UserProfileModalHost";
 import { THEME_KEY } from "@/lib/theme";
 
 
@@ -186,6 +187,11 @@ export default function RootLayout({
             Inert on non-native platforms. Lives in the layout so the
             subscription survives client-side route changes. */}
         <NativeIdentityHost />
+
+        {/* Long-press (touch) / click (desktop) a user's name/avatar anywhere →
+            profile modal. Mounted once so the triggering surfaces just dispatch
+            the open event. */}
+        <UserProfileModalHost />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/components/RosterRow.tsx
+++ b/components/RosterRow.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import InitialBubble from "@/components/InitialBubble";
+import { useProfileLongPress } from "@/lib/useUserProfile";
+
+/**
+ * One person row in a group members / poll respondents roster: avatar + name,
+ * long-pressable (desktop: click) to open their profile modal. `userId` null
+ * (anonymous, or the viewer's own row) disables the trigger. `bubbleName` null
+ * → the gray anonymous-fallback avatar (used for the viewer's "You" row).
+ *
+ * Extracted so `useProfileLongPress` is a top-level hook (callers render this
+ * inside a `.map`, where the hook can't be called directly).
+ */
+export default function RosterRow({
+  displayName,
+  bubbleName,
+  imageUrl,
+  userId,
+}: {
+  displayName: string;
+  bubbleName: string | null;
+  imageUrl: string | null;
+  userId: string | null;
+}) {
+  const lp = useProfileLongPress(userId, bubbleName ?? displayName);
+  return (
+    <li
+      className={`flex items-center gap-3 px-4 py-3 text-gray-900 dark:text-white select-none${
+        userId ? " cursor-pointer" : ""
+      }`}
+      {...lp}
+    >
+      <InitialBubble
+        name={bubbleName}
+        imageUrl={imageUrl}
+        sizeClassName="w-8 h-8"
+        className="shrink-0"
+      />
+      <span className="min-w-0 break-words">{displayName}</span>
+    </li>
+  );
+}

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+/**
+ * The long-press → user profile modal. Shows another user's name, a larger
+ * avatar, their account age, and the groups the caller shares with them.
+ * Opened via `openUserProfileCard(userId)`; mounted once by
+ * <UserProfileModalHost> in the root layout.
+ */
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import ModalPortal from "@/components/ModalPortal";
+import InitialBubble from "@/components/InitialBubble";
+import { useBodyScrollLock } from "@/lib/useBodyScrollLock";
+import {
+  apiGetUserProfileCard,
+  buildUserImageUrl,
+  type UserProfileCard,
+} from "@/lib/api/users";
+import { relativeTime } from "@/lib/questionListUtils";
+
+interface UserProfileModalProps {
+  userId: string;
+  /** Shown immediately (header) while the card loads. */
+  fallbackName?: string | null;
+  onClose: () => void;
+}
+
+export default function UserProfileModal({
+  userId,
+  fallbackName,
+  onClose,
+}: UserProfileModalProps) {
+  const router = useRouter();
+  const [card, setCard] = useState<UserProfileCard | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCard(null);
+    setError(false);
+    (async () => {
+      try {
+        const result = await apiGetUserProfileCard(userId);
+        if (!cancelled) setCard(result);
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  // iOS-safe background-scroll lock (shared hook — see Document Scroll
+  // Architecture notes; overflow:hidden alone doesn't block iOS PTR).
+  useBodyScrollLock(true);
+  // Escape closes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const displayName = card?.name ?? fallbackName ?? null;
+  const imageUrl = card
+    ? buildUserImageUrl(card.user_id, card.image_updated_at)
+    : null;
+
+  const goToGroup = (routeId: string) => {
+    onClose();
+    router.push(`/g/${routeId}`);
+  };
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-[80] flex items-center justify-center p-4">
+        <div
+          className="absolute inset-0 bg-black/50 dark:bg-black/70"
+          onClick={onClose}
+        />
+        <div className="relative bg-white dark:bg-gray-800 rounded-2xl shadow-xl max-w-sm w-full max-h-[80vh] overflow-y-auto px-5 py-5">
+          <div className="flex flex-col items-center text-center">
+            <InitialBubble
+              name={displayName}
+              imageUrl={imageUrl}
+              sizeClassName="w-24 h-24"
+              textSizeClassName="text-3xl"
+            />
+            <h2 className="mt-3 text-xl font-bold text-gray-900 dark:text-white break-words">
+              {displayName ?? "Member"}
+            </h2>
+            {card && (
+              <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                Joined {relativeTime(card.created_at)}
+              </p>
+            )}
+          </div>
+
+          {error ? (
+            <p className="mt-5 text-center text-sm text-gray-500 dark:text-gray-400">
+              Couldn&apos;t load this profile.
+            </p>
+          ) : !card ? (
+            <p className="mt-5 text-center text-sm text-gray-500 dark:text-gray-400">
+              Loading…
+            </p>
+          ) : (
+            <div className="mt-5">
+              <h3 className="px-1 mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                {card.shared_groups.length}{" "}
+                {card.shared_groups.length === 1
+                  ? "Shared group"
+                  : "Shared groups"}
+              </h3>
+              {card.shared_groups.length === 0 ? (
+                <p className="px-1 text-sm text-gray-500 dark:text-gray-400">
+                  No groups in common.
+                </p>
+              ) : (
+                <ul className="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden divide-y divide-gray-200 dark:divide-gray-700">
+                  {card.shared_groups.map((g) => (
+                    <li key={g.routeId}>
+                      <button
+                        type="button"
+                        onClick={() => goToGroup(g.routeId)}
+                        className="w-full flex items-center justify-between gap-2 px-4 py-3 text-left text-sm text-gray-900 dark:text-white active:bg-gray-100 dark:active:bg-gray-700/50"
+                      >
+                        <span className="min-w-0 truncate">
+                          {g.name ?? "Group"}
+                        </span>
+                        <svg
+                          className="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M9 5l7 7-7 7"
+                          />
+                        </svg>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/UserProfileModalHost.tsx
+++ b/components/UserProfileModalHost.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * Mounts the user-profile modal once at the root layout level and opens it in
+ * response to `openUserProfileCard(...)` (USER_PROFILE_OPEN_EVENT). Living in
+ * the layout (not a per-route component) keeps the modal alive across the
+ * surfaces that trigger it. Ignores opens that target the viewer's own
+ * account (belt-and-suspenders — call sites already pass null for self).
+ */
+
+import { useEffect, useState } from "react";
+import UserProfileModal from "@/components/UserProfileModal";
+import {
+  USER_PROFILE_OPEN_EVENT,
+  type OpenUserProfileDetail,
+} from "@/lib/useUserProfile";
+import { getCachedSessionUser } from "@/lib/session";
+
+export default function UserProfileModalHost() {
+  const [target, setTarget] = useState<OpenUserProfileDetail | null>(null);
+
+  useEffect(() => {
+    const onOpen = (e: Event) => {
+      const detail = (e as CustomEvent<OpenUserProfileDetail>).detail;
+      if (!detail?.userId) return;
+      // Never open the modal on yourself.
+      if (getCachedSessionUser()?.user_id === detail.userId) return;
+      setTarget(detail);
+    };
+    window.addEventListener(USER_PROFILE_OPEN_EVENT, onOpen);
+    return () => window.removeEventListener(USER_PROFILE_OPEN_EVENT, onOpen);
+  }, []);
+
+  if (!target) return null;
+  return (
+    <UserProfileModal
+      key={target.userId}
+      userId={target.userId}
+      fallbackName={target.name}
+      onClose={() => setTarget(null)}
+    />
+  );
+}

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -677,6 +677,32 @@ export async function apiGetGroupMembers(
   }
 }
 
+/** A single poll's respondent roster — same shape as the group members roster
+ *  (one entry per distinct voter person + a rolled-up anonymous count). Drives
+ *  the poll /info respondents list (per-person rows + long-press to profile). */
+export async function apiGetGroupPollVoters(
+  routeId: string,
+  pollRef: string,
+): Promise<GroupRoster> {
+  try {
+    const data = await groupFetch<any>(
+      `/by-route-id/${encodeURIComponent(routeId)}/poll/${encodeURIComponent(pollRef)}/voter-identities`,
+    );
+    return {
+      members: Array.isArray(data?.members)
+        ? (data.members as GroupMember[])
+        : [],
+      anonymous_count:
+        typeof data?.anonymous_count === 'number' ? data.anonymous_count : 0,
+    };
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      return { members: [], anonymous_count: 0 };
+    }
+    throw err;
+  }
+}
+
 /** Encode an ArrayBuffer as base64. Chunked to avoid the `apply()`
  *  call-stack limit on big buffers — handles the 5 MiB max-image-size
  *  cap comfortably. */

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -66,6 +66,7 @@ export {
   apiGetGroupInvitableAccounts,
   apiAddGroupMembers,
   apiGetGroupMembers,
+  apiGetGroupPollVoters,
 } from "./groups";
 export type {
   GroupJoinRequest,
@@ -80,6 +81,7 @@ export type {
 
 export {
   apiGetMyUserProfile,
+  apiGetUserProfileCard,
   apiGetPollCategoryHistory,
   apiGetCategoryOptions,
   apiUploadMyUserImage,
@@ -91,7 +93,13 @@ export {
   getMyUserImageUrl,
   USER_PROFILE_CHANGED_EVENT,
 } from "./users";
-export type { UserProfile, PollCategoryHistory, CategoryOptionEntry } from "./users";
+export type {
+  UserProfile,
+  UserProfileCard,
+  SharedGroupSummary,
+  PollCategoryHistory,
+  CategoryOptionEntry,
+} from "./users";
 
 export {
   apiSearchLocations,

--- a/lib/api/users.ts
+++ b/lib/api/users.ts
@@ -102,6 +102,44 @@ export async function apiGetCategoryOptions(
   return { group: norm(data.group), general: norm(data.general) };
 }
 
+/** A group the caller shares with the profiled user. `routeId` builds the
+ *  `/g/<routeId>` link; `name` is the group's display name (may be null). */
+export interface SharedGroupSummary {
+  routeId: string;
+  name: string | null;
+}
+
+/** The long-press profile modal payload for another user. */
+export interface UserProfileCard {
+  user_id: string;
+  name: string | null;
+  image_updated_at: string | null;
+  /** ISO timestamp the account was created — drives the "joined X ago" age. */
+  created_at: string;
+  shared_groups: SharedGroupSummary[];
+}
+
+/** Fetch another user's profile card. Throws ApiError(404) when missing. */
+export async function apiGetUserProfileCard(
+  userId: string,
+): Promise<UserProfileCard> {
+  const data = await userFetch<any>(`/${encodeURIComponent(userId)}/profile-card`);
+  return {
+    user_id: data.user_id,
+    name: (data.name ?? null) as string | null,
+    image_updated_at: (data.image_updated_at ?? null) as string | null,
+    created_at: data.created_at,
+    shared_groups: Array.isArray(data.shared_groups)
+      ? data.shared_groups
+          .filter((g: any) => g && typeof g.route_id === 'string')
+          .map((g: any) => ({
+            routeId: g.route_id as string,
+            name: (g.name ?? null) as string | null,
+          }))
+      : [],
+  };
+}
+
 /**
  * Upload a profile image. `creatorName` is used ONLY when the caller has
  * no account yet — it names the lightweight account the server mints to

--- a/lib/useUserProfile.ts
+++ b/lib/useUserProfile.ts
@@ -1,0 +1,122 @@
+/**
+ * Long-press → user-profile-modal plumbing.
+ *
+ * `useProfileLongPress(userId, name?)` returns handlers to spread onto any
+ * element that renders ANOTHER user's name or avatar (group members list,
+ * poll respondents, poll creator, invite-members).
+ *   - Mouse (desktop): a simple CLICK opens the profile modal.
+ *   - Touch: a 500ms long-press opens it (a plain tap is left for the
+ *     element's own onClick, e.g. selecting an invite-members row); movement
+ *     >10px (a scroll) cancels.
+ * When it acts it stops propagation, so attaching it to an inner element
+ * (e.g. an invite row's avatar) won't also fire the row's onClick.
+ *
+ * Disabled (returns no handlers) when `userId` is null/undefined — used for
+ * anonymous/legacy participants and for the viewer's own entries, so you can
+ * never long-press yourself.
+ *
+ * The open event is consumed by <UserProfileModalHost> mounted once in the
+ * root layout — same module-level-event + host pattern as the slide overlay.
+ */
+
+import { useRef } from "react";
+import { haptic } from "@/lib/haptics";
+
+export const USER_PROFILE_OPEN_EVENT = "whoeverwants:open-user-profile";
+
+export interface OpenUserProfileDetail {
+  userId: string;
+  /** Optional name to show immediately while the card loads. */
+  name?: string | null;
+}
+
+export function openUserProfileCard(userId: string, name?: string | null): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<OpenUserProfileDetail>(USER_PROFILE_OPEN_EVENT, {
+      detail: { userId, name },
+    }),
+  );
+}
+
+const LONG_PRESS_MS = 500;
+const MOVE_CANCEL_PX = 10;
+
+type ProfileLongPressHandlers = {
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: () => void;
+  onPointerLeave: () => void;
+  onPointerCancel: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onClick: (e: React.MouseEvent) => void;
+};
+
+export function useProfileLongPress(
+  userId: string | null | undefined,
+  name?: string | null,
+): Partial<ProfileLongPressHandlers> {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const start = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const fired = useRef(false);
+  const lastPointerType = useRef<string>("");
+
+  // Hooks above the early return keep hook-order stable across enabled flips.
+  if (!userId) return {};
+
+  const clear = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+
+  return {
+    onPointerDown: (e: React.PointerEvent) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      lastPointerType.current = e.pointerType;
+      fired.current = false;
+      start.current = { x: e.clientX, y: e.clientY };
+      clear();
+      timer.current = setTimeout(() => {
+        timer.current = null;
+        fired.current = true;
+        haptic.medium();
+        openUserProfileCard(userId, name);
+      }, LONG_PRESS_MS);
+    },
+    onPointerMove: (e: React.PointerEvent) => {
+      if (
+        timer.current &&
+        Math.hypot(e.clientX - start.current.x, e.clientY - start.current.y) >
+          MOVE_CANCEL_PX
+      ) {
+        clear();
+      }
+    },
+    onPointerUp: clear,
+    onPointerLeave: clear,
+    onPointerCancel: clear,
+    // Suppress the OS context menu / iOS callout the long-press would trigger.
+    onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+    onClick: (e: React.MouseEvent) => {
+      // A long-press already opened the modal → swallow the trailing click so
+      // it doesn't also fire the element's own onClick (e.g. an invite row's
+      // toggle).
+      if (fired.current) {
+        fired.current = false;
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      // Desktop: a simple click opens the profile. (Touch taps fall through —
+      // the element's own onClick, if any, handles them; long-press is the
+      // touch gesture.) stopPropagation so a parent onClick doesn't also fire.
+      if (lastPointerType.current === "mouse") {
+        e.preventDefault();
+        e.stopPropagation();
+        openUserProfileCard(userId, name);
+      }
+    },
+  };
+}

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -75,6 +75,7 @@ from services.groups import (
     group_name_phrase,
     is_caller_member_of_group,
     load_group_members,
+    load_poll_voters,
     load_user_visibility,
     poll_ids_for_group_ids,
     polls_for_poll_ids,
@@ -1642,6 +1643,48 @@ def get_group_members(route_id: str, request: Request):
             ):
                 raise HTTPException(status_code=404, detail="Group not found")
         named, anon = load_group_members(conn, group_id)
+        return GroupMembersResponse(
+            members=[GroupMemberResponse(**m) for m in named],
+            anonymous_count=anon,
+        )
+
+
+@router.get(
+    "/by-route-id/{route_id}/poll/{poll_ref}/voter-identities",
+    response_model=GroupMembersResponse,
+)
+def get_poll_voters(route_id: str, poll_ref: str, request: Request):
+    """A single poll's respondent roster — one entry per distinct voter person
+    (account-deduped) + a rolled-up anonymous count, same shape as the group
+    members roster. Lets the poll /info respondents list render one row per
+    person and long-press the right account. Member-gated; 404 on unresolvable
+    route/poll."""
+    browser_id = _browser_id(request)
+    user_id = _user_id(request)
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        if not is_caller_member_of_group(
+            conn, group_id, browser_id=browser_id, user_id=user_id
+        ):
+            raise HTTPException(
+                status_code=404, detail="Group not found"
+            )
+        poll_row = conn.execute(
+            "SELECT id FROM polls "
+            "WHERE group_id = %(gid)s::uuid AND short_id = %(ref)s",
+            {"gid": group_id, "ref": poll_ref},
+        ).fetchone()
+        if not poll_row and _is_uuid_like(poll_ref):
+            poll_row = conn.execute(
+                "SELECT id FROM polls "
+                "WHERE group_id = %(gid)s::uuid AND id = %(ref)s::uuid",
+                {"gid": group_id, "ref": poll_ref},
+            ).fetchone()
+        if not poll_row:
+            raise HTTPException(status_code=404, detail="Poll not found")
+        named, anon = load_poll_voters(conn, str(poll_row["id"]))
         return GroupMembersResponse(
             members=[GroupMemberResponse(**m) for m in named],
             anonymous_count=anon,

--- a/server/routers/users.py
+++ b/server/routers/users.py
@@ -42,6 +42,7 @@ from services.auth import create_anonymous_user, resolve_actor_user_id
 from services.category_options import load_category_options
 from services.groups import require_uuid, resolve_group_id_from_route_id
 from services.poll_categories import load_category_recency
+from services.profiles import get_profile_card
 from services.validation import validate_user_name
 
 
@@ -88,6 +89,26 @@ class UserProfileResponse(BaseModel):
 
     user_id: str | None = None
     image_updated_at: str | None = None
+
+
+class SharedGroupResponse(BaseModel):
+    """One group the caller shares with the profiled user. `route_id` builds a
+    `/g/<route_id>` link; `name` is the group's display name (may be null)."""
+
+    route_id: str
+    name: str | None = None
+
+
+class UserProfileCardResponse(BaseModel):
+    """`GET /api/users/{user_id}/profile-card` — the long-press profile modal
+    data. `name`/`image_updated_at`/`created_at` are account-level;
+    `shared_groups` is computed per-caller (groups BOTH belong to)."""
+
+    user_id: str
+    name: str | None = None
+    image_updated_at: str | None = None
+    created_at: str
+    shared_groups: list[SharedGroupResponse]
 
 
 class PollCategoryHistoryResponse(BaseModel):
@@ -158,6 +179,42 @@ def get_my_profile(request: Request):
     return UserProfileResponse(
         user_id=user_id,
         image_updated_at=image_updated_at.isoformat() if image_updated_at else None,
+    )
+
+
+@router.get("/{user_id}/profile-card", response_model=UserProfileCardResponse)
+def get_user_profile_card(user_id: str, request: Request):
+    """Profile card for another user: name, avatar timestamp, account age
+    (`created_at`), and the groups the caller shares with them. The user_id is
+    the URL token (name + image are already broadly exposed); shared_groups is
+    intersected with the caller's own visible memberships. 404 when the target
+    account doesn't exist.
+    """
+    require_uuid(user_id, "user_id")
+    browser_id = _browser_id(request)
+    caller_user_id = _user_id(request)
+    with get_db() as conn:
+        card = get_profile_card(
+            conn,
+            user_id,
+            caller_browser_id=browser_id,
+            caller_user_id=resolve_actor_user_id(
+                conn, user_id=caller_user_id, browser_id=browser_id
+            ),
+        )
+    if card is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return UserProfileCardResponse(
+        user_id=card.user_id,
+        name=card.name,
+        image_updated_at=card.image_updated_at.isoformat()
+        if card.image_updated_at
+        else None,
+        created_at=card.created_at.isoformat(),
+        shared_groups=[
+            SharedGroupResponse(route_id=g.route_id, name=g.name)
+            for g in card.shared_groups
+        ],
     )
 
 

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -453,6 +453,49 @@ def load_group_members(conn, group_id: str) -> tuple[list[dict], int]:
     return named, anonymous_count
 
 
+def load_poll_voters(conn, poll_id: str) -> tuple[list[dict], int]:
+    """A single poll's voter roster, same shape + account-dedup as
+    `load_group_members` but scoped to who VOTED on `poll_id`. Returns
+    ``(named_voters, anonymous_count)`` — one entry per distinct voter person
+    (account-aware), plus a rolled-up count of voters with no resolvable name.
+    Used by the poll /info respondents list (per-person rows + long-press)."""
+    rows = conn.execute(
+        """
+        SELECT
+            COALESCE(ub.user_id::text, v.browser_id::text) AS person_key,
+            ub.user_id::text AS user_id,
+            NULLIF(BTRIM(v.voter_name), '') AS name,
+            v.created_at AS ts
+          FROM votes v
+          JOIN questions q ON v.question_id = q.id
+          LEFT JOIN user_browsers ub ON ub.browser_id = v.browser_id
+         WHERE q.poll_id = %(p)s::uuid
+         ORDER BY v.created_at
+        """,
+        {"p": poll_id},
+    ).fetchall()
+
+    by_person: dict[str, dict] = {}
+    for r in rows:
+        # Legacy votes (pre-migration-120) can carry neither account nor
+        # browser_id — treat each as its own anonymous person.
+        key = r["person_key"] or f"legacy:{r['ts']}"
+        existing = by_person.get(key)
+        if existing is None:
+            by_person[key] = {"user_id": r.get("user_id"), "name": r.get("name")}
+        elif not existing["name"] and r.get("name"):
+            existing["name"] = r["name"]
+
+    named = [
+        {"name": p["name"], "user_id": p["user_id"]}
+        for p in by_person.values()
+        if p["name"]
+    ]
+    anonymous_count = sum(1 for p in by_person.values() if not p["name"])
+    named.sort(key=lambda m: m["name"].lower())
+    return named, anonymous_count
+
+
 def resolve_group_for_visit(
     conn,
     route_id: str,

--- a/server/services/profiles.py
+++ b/server/services/profiles.py
@@ -1,0 +1,95 @@
+"""User profile card for the long-press → profile modal.
+
+`get_profile_card` returns another user's display name, avatar timestamp,
+account age (`created_at`), and the groups the CALLER shares with them
+(computed per-caller). Account-aware: the caller's visible memberships come
+from `load_user_visibility` (unions every browser linked to their account);
+the target's memberships union every browser linked to theirs — mirroring
+`services/contacts.py`. The group/poll member ROSTERS live in
+`services/groups.py` (`load_group_members` / `load_poll_voters`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from services.groups import group_display_name, load_user_visibility
+
+
+@dataclass
+class SharedGroup:
+    route_id: str
+    name: str | None
+
+
+@dataclass
+class ProfileCard:
+    user_id: str
+    name: str | None
+    image_updated_at: datetime | None
+    created_at: datetime
+    shared_groups: list[SharedGroup]
+
+
+def get_profile_card(
+    conn,
+    target_user_id: str,
+    *,
+    caller_browser_id: str | None,
+    caller_user_id: str | None,
+) -> ProfileCard | None:
+    """The profile card for `target_user_id` from the CALLER's perspective.
+
+    Returns None when the target account doesn't exist. Name + image are
+    account-level (already broadly exposed — the image endpoint is public, the
+    name surfaces in invitable-accounts / the members roster to any member).
+    `shared_groups` is the intersection of the caller's visible memberships and
+    the target's memberships, so it never reveals a group the caller can't see.
+    """
+    urow = conn.execute(
+        "SELECT display_name, created_at FROM users WHERE id = %(id)s::uuid",
+        {"id": target_user_id},
+    ).fetchone()
+    if not urow:
+        return None
+    prow = conn.execute(
+        "SELECT image_updated_at FROM user_profiles WHERE user_id = %(id)s::uuid",
+        {"id": target_user_id},
+    ).fetchone()
+    image_updated_at = prow.get("image_updated_at") if prow else None
+
+    # Caller's visible group set (account-aware union of their browsers).
+    vis = load_user_visibility(conn, caller_browser_id, user_id=caller_user_id)
+    caller_gids = list(vis.joined_by_group.keys())
+    shared: list[SharedGroup] = []
+    if caller_gids:
+        grows = conn.execute(
+            """
+            SELECT g.id::text AS id, g.short_id AS short_id, g.title AS title
+              FROM groups g
+             WHERE g.id = ANY(%(gids)s::uuid[])
+               AND EXISTS (
+                 SELECT 1 FROM group_members gm
+                  WHERE gm.group_id = g.id
+                    AND gm.browser_id IN (
+                          SELECT browser_id FROM user_browsers
+                           WHERE user_id = %(target)s::uuid
+                        )
+               )
+             ORDER BY g.created_at DESC
+            """,
+            {"gids": caller_gids, "target": target_user_id},
+        ).fetchall()
+        for g in grows:
+            route_id = g.get("short_id") or g["id"]
+            name = group_display_name(conn, g["id"], override=g.get("title"))
+            shared.append(SharedGroup(route_id=route_id, name=name))
+
+    return ProfileCard(
+        user_id=target_user_id,
+        name=urow.get("display_name"),
+        image_updated_at=image_updated_at,
+        created_at=urow["created_at"],
+        shared_groups=shared,
+    )

--- a/server/tests/test_profiles.py
+++ b/server/tests/test_profiles.py
@@ -1,0 +1,136 @@
+"""Profile card + poll voter-roster coverage.
+
+Exercises `GET /api/users/{user_id}/profile-card` and
+`GET /api/groups/by-route-id/{route_id}/poll/{poll_ref}/voter-identities`:
+
+  * profile-card returns name + account age + the groups BOTH the caller and
+    the target belong to (caller-scoped intersection).
+  * the poll voter roster returns one entry per distinct VOTER person
+    (account-deduped, so two same-named voters are two entries), plus a
+    rolled-up anonymous count — same shape as the group `/members` roster.
+
+(The group `/members` roster itself is covered by the #683 tests.)
+
+Creators auto-mint an account (display_name = creator_name) keyed on the
+creating browser_id, so two polls created by two browsers give us two named
+accounts that share a group — no magic-link sign-in needed.
+"""
+
+import uuid
+
+import pytest
+
+from tests.conftest import create_poll
+
+
+def _bid(uid):
+    return {"X-Browser-Id": uid}
+
+
+def _vote(client, poll, qid, browser, name, choice):
+    r = client.post(
+        f"/api/polls/{poll['id']}/votes",
+        json={
+            "voter_name": name,
+            "items": [
+                {"question_id": qid, "vote_type": "yes_no", "yes_no_choice": choice}
+            ],
+        },
+        headers=_bid(browser),
+    )
+    assert r.status_code == 201, r.text
+
+
+@pytest.fixture
+def browsers():
+    return {k: str(uuid.uuid4()) for k in ("a", "b", "c", "d")}
+
+
+def test_poll_voters_distinct_and_scoped(client, browsers):
+    p1 = create_poll(client, browser_id=browsers["a"], creator_name="Alice")
+    g = p1["group_id"]
+    qid = p1["questions"][0]["id"]
+    # Bob + Cara have accounts (they create polls in the group) and vote.
+    create_poll(client, browser_id=browsers["b"], creator_name="Bob", group_id=g)
+    create_poll(client, browser_id=browsers["c"], creator_name="Cara", group_id=g)
+    _vote(client, p1, qid, browsers["b"], "Bob", "yes")
+    _vote(client, p1, qid, browsers["c"], "Cara", "no")
+
+    resp = client.get(
+        f"/api/groups/by-route-id/{p1['group_short_id']}/poll/{p1['short_id']}/voter-identities",
+        headers=_bid(browsers["a"]),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    by_name = {m["name"]: m for m in body["members"]}
+    assert set(by_name) == {"Bob", "Cara"}  # Alice (creator, no vote) excluded
+    assert by_name["Bob"]["user_id"] is not None
+
+
+def test_poll_voters_distinguish_duplicate_names(client, browsers):
+    # Two different accounts both named "Sam" vote → two entries, distinct ids.
+    p1 = create_poll(client, browser_id=browsers["a"], creator_name="Alice")
+    g = p1["group_id"]
+    qid = p1["questions"][0]["id"]
+    s1 = create_poll(client, browser_id=browsers["b"], creator_name="Sam", group_id=g)
+    s2 = create_poll(client, browser_id=browsers["c"], creator_name="Sam", group_id=g)
+    _vote(client, p1, qid, browsers["b"], "Sam", "yes")
+    _vote(client, p1, qid, browsers["c"], "Sam", "no")
+
+    resp = client.get(
+        f"/api/groups/by-route-id/{p1['group_short_id']}/poll/{p1['short_id']}/voter-identities",
+        headers=_bid(browsers["a"]),
+    )
+    assert resp.status_code == 200, resp.text
+    sams = [m for m in resp.json()["members"] if m["name"] == "Sam"]
+    ids = {m["user_id"] for m in sams}
+    assert ids == {s1["creator_user_id"], s2["creator_user_id"]}
+    assert len(sams) == 2
+
+
+def test_poll_voters_non_member_404(client, browsers):
+    p1 = create_poll(client, browser_id=browsers["a"], creator_name="Alice")
+    resp = client.get(
+        f"/api/groups/by-route-id/{p1['group_short_id']}/poll/{p1['short_id']}/voter-identities",
+        headers=_bid(browsers["d"]),  # never participated → not a member
+    )
+    assert resp.status_code == 404, resp.text
+
+
+def test_poll_voters_unknown_poll_404(client, browsers):
+    p1 = create_poll(client, browser_id=browsers["a"], creator_name="Alice")
+    resp = client.get(
+        f"/api/groups/by-route-id/{p1['group_short_id']}/poll/ZZZZ/voter-identities",
+        headers=_bid(browsers["a"]),
+    )
+    assert resp.status_code == 404
+
+
+def test_profile_card_shows_shared_groups(client, browsers):
+    # Shared group G (A + B); A-only group G2.
+    p1 = create_poll(client, browser_id=browsers["a"], creator_name="Alice")
+    g = p1["group_id"]
+    g_route = p1["group_short_id"]
+    p2 = create_poll(client, browser_id=browsers["b"], creator_name="Bob", group_id=g)
+    bob_id = p2["creator_user_id"]
+    create_poll(client, browser_id=browsers["a"], creator_name="Alice")  # G2
+
+    resp = client.get(
+        f"/api/users/{bob_id}/profile-card",
+        headers=_bid(browsers["a"]),
+    )
+    assert resp.status_code == 200, resp.text
+    card = resp.json()
+    assert card["user_id"] == bob_id
+    assert card["name"] == "Bob"
+    assert card["created_at"]  # account age source
+    routes = {sg["route_id"] for sg in card["shared_groups"]}
+    assert g_route in routes
+
+
+def test_profile_card_unknown_user_404(client, browsers):
+    resp = client.get(
+        f"/api/users/{uuid.uuid4()}/profile-card",
+        headers=_bid(browsers["a"]),
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Long-pressing (touch) or **clicking (desktop)** another user's name/avatar anywhere a per-user identity renders opens a modal with their **name, a larger avatar, account age** ("Joined X ago"), and **the groups you share with them** (tappable → navigate). Never targets yourself.

Surfaces: group members list (`/info`), poll respondents list (`/g/<g>/p/<p>/info`), poll creator (detail page), invite-members list.

Built on top of #683's membership-based members roster.

## How it works
- `lib/useUserProfile.ts` — `useProfileLongPress(userId, name?)`: mouse → plain click opens; touch → 500ms long-press (a plain tap still falls through to the element's own action, e.g. an invite row's select-toggle); movement cancels; stops propagation so it can sit on an inner element. Disabled (no handlers) for anonymous participants + the viewer's own rows.
- `components/UserProfileModal.tsx` + `UserProfileModalHost.tsx` (mounted once in the layout, opened via an event). `components/RosterRow.tsx` — shared one-person row used by both /info lists.
- Backend: `GET /api/users/{id}/profile-card` (`services/profiles.py: get_profile_card` — name + `created_at` + caller∩target shared groups) and `GET /api/groups/by-route-id/{route_id}/poll/{poll_ref}/voter-identities` (`services/groups.py: load_poll_voters`, the poll-scoped sibling of #683's `load_group_members`).

## Distinct people
Distinct people are always separate rows regardless of a shared name, including same-named creators — the /info members list reuses #683's account-deduped `group_members` roster (threading each member's `user_id` for the long-press), and the poll respondents list now renders a per-person poll-voter roster.

## Test plan
- [x] `server/tests/test_profiles.py` (poll voter roster: distinct voters, duplicate-name resolution, member-gating; profile card: shared groups + 404). Full backend suite green except 3 pre-existing `test_showtimes_cache.py` failures unrelated to this PR (a `Showtime` dataclass mock missing `brand`/`group_key`).
- [x] Verified on the branch dev server: desktop click opens the modal; two same-named people (creators and voters) open two different profiles (2 vs 1 shared groups).

https://claude.ai/code/session_01UA6zsuKtvi51mP3koin2c5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA6zsuKtvi51mP3koin2c5)_