### PR TITLE
Group admin system (migration 142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3183,6 +3183,91 @@ Bob → list still says only Sam). Shipped on
 
 ---
 
+## Group Admin System (migration 142)
+
+Every group has ≥1 **admin** at all times (when it has ≥1 account member). Admins
+generalize the old single `groups.creator_user_id` into a set. An admin can:
+toggle privacy, edit title/avatar, approve join requests, mint/revoke invite
+links, add people directly, **promote** members to admin, and **boot** non-admin
+members. Design decisions (owner-confirmed): **no demotion and no owner
+hierarchy** (Q4 — once an admin, you stay one until you LEAVE the group, which is
+the only event that shrinks the admin set); **boot is PRIVATE-groups-only** (Q3 —
+booting a public-group member is futile, they auto-rejoin on visit) and revokes
+the specific invite link the booted member joined through; **admins are
+account-keyed** (`group_members` is browser-keyed, but admin powers need a real
+account).
+
+- **Schema:** `group_admins(group_id, user_id, granted_at)` PK `(group_id,
+  user_id)`, both FKs CASCADE, index on `user_id`. `group_members.joined_via_invite_id`
+  (FK → `group_invites`, SET NULL) records which invite a member joined through
+  (set in `redeem_invite`, only on a genuine first join) so boot can revoke it.
+  The migration WIPED all legacy NULL-creator groups (owner: disposable
+  anonymous-era data — prod was ~97% NULL-creator since group creator was
+  deliberately NULL for anonymous creators) and seeded surviving creators as
+  admin #1.
+- **`creator_user_id` is now vestigial historical data, NOT an authorization
+  signal.** It is NOT NOT-NULL (its FK is ON DELETE SET NULL, so a creator
+  deleting their account legitimately nulls it). The "every group has an admin"
+  invariant lives in `group_admins` (seeded on create + auto-promotion), not a
+  column constraint. Don't reintroduce creator-based auth gates.
+- **No more NULL-creator groups going forward.** Both create paths always record
+  a creator: `POST /api/polls` (`_resolve_or_create_group` uses the poll's
+  always-set `creator_user_id` — the auto-account for anonymous creators —
+  DECOUPLED from privacy, which still keys on genuine sign-in so anonymous groups
+  stay public/URL-shareable) and `POST /api/groups` (resolves the actor, or
+  auto-mints a nameless account for a bare browser). Both seed the `group_admins`
+  row. The **claim** endpoint/flow is obsolete (every group already has a
+  creator → claim always 409s); kept as harmless dead code, FE claim UI removed.
+- **`_require_admin(conn, group_id, *, browser_id, user_id) → admin_user_id`**
+  (`routers/groups.py`) is the single authorization gate. It resolves the actor
+  via `resolve_actor_user_id` (bearer OR the browser→account link — so a
+  browser-tied auto-account admin qualifies WITHOUT a bearer; 401 only when NO
+  account resolves) then requires a `group_admins` row (403 otherwise). It
+  REPLACED the per-endpoint `creator_user_id == user_id` gate on privacy /
+  join-requests / invites, and NEWLY gates title + image edits + add-people (Q6:
+  admin-only; these had no check before). `revoke_invite` is now group-scoped (any
+  admin revokes any of the group's invites, not just the minter).
+- **Service helpers (`services/groups.py`):** `is_group_admin` / `is_caller_admin`
+  / `add_group_admin` / `remove_group_admin` / `group_admin_user_ids` /
+  `promote_oldest_member_if_adminless` / `boot_member`. **Auto-promotion** runs
+  whenever the admin set could empty: `leave_group` endpoint (leaving drops your
+  admin row, then promotes the oldest remaining account-member by
+  `MIN(joined_at)`), and `delete_user_account` (captures the user's admin groups
+  before the cascade, promotes after). `merge_accounts` repoints `group_admins`
+  (dest keeps its row on collision) so a sign-in absorb / explicit merge never
+  silently demotes. No account member to promote ⇒ group stays admin-less (the
+  accepted "≥1 account member" condition).
+- **New endpoints:** `POST /{route}/admins {user_id}` (promote a member; target
+  must be a member), `POST /{route}/members/{user_id}/boot` (private-only,
+  non-admin target, not self → removes membership across linked browsers +
+  revokes their `joined_via_invite_id`). Both admin-only.
+- **`GET /{route}/members`** now returns `viewer_is_admin` (top-level) +
+  per-member `is_admin`. Anonymous (nameless) members roll into `anonymous_count`
+  and are never admins (account-keyed); a nameless admin (no display_name) is an
+  admin but rolls up anonymously — FE admins always have a name via the name-gate.
+- **FE:** `apiGetGroupMembers` surfaces `viewer_is_admin` + `is_admin`;
+  `apiPromoteGroupAdmin` / `apiBootGroupMember`. The `/info` page gates ALL admin
+  chrome on `roster.viewer_is_admin` (replacing the old
+  `session.user_id === group.creatorUserId` computation): Privacy toggle (via
+  `GroupPrivacySection`'s new `viewerIsAdmin` prop — its claim flow is removed),
+  JoinRequestsSection/InviteLinksSection `enabled`, Add-people, Edit-title, and
+  per-member Make-admin / Remove buttons (behind a `ConfirmationModal`; Remove
+  only when `group.privacy === 'private'`). The per-POLL info page is UNCHANGED —
+  its close/reopen/cutoff actions gate on POLL authorship (`poll.viewer_is_creator`),
+  a separate concept from group admin.
+- **Pitfall (the NOT NULL trap):** an early version made `creator_user_id` NOT
+  NULL as a guardrail — it broke account deletion (FK SET NULL → NOT NULL
+  violation) AND cascaded failures in instant-link / follow-state / account tests.
+  The invariant must live in `group_admins` + app code, never a NOT NULL on a
+  SET-NULL-FK column.
+- **Tests:** `server/tests/test_group_admins.py` (13: create-seeds-admin signed-in
+  + anon auto-account, roster flags, promote + guards, boot + revoke + all
+  negatives, auto-promote-on-leave, title/image admin-gating). Updated
+  group-privacy / claim / invite / join-request tests for the creator→admin +
+  auto-account-creator behavior changes.
+
+---
+
 ## Invite Members (In-App Address Book)
 
 From `/g/<id>/info`, a member taps **"Add people"** (above the members list) to open `/g/<id>/invite-members` — a screen that searches the caller's contacts, selects accounts with round checkboxes (whole row tappable), and adds them on **Update** (gated on ≥1 selection, behind a `ConfirmationModal`). Added accounts get a push. Shipped on `claude/group-member-invitations-DuZXc` (migration 126).

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -10,8 +10,13 @@ import {
 } from "@/lib/slideOverlay";
 import { useGroup } from "@/lib/useGroup";
 import { nameCount } from "@/lib/groupUtils";
-import { apiGetGroupMembers } from "@/lib/api";
+import {
+  apiGetGroupMembers,
+  apiPromoteGroupAdmin,
+  apiBootGroupMember,
+} from "@/lib/api";
 import type { GroupRoster } from "@/lib/api";
+import ConfirmationModal from "@/components/ConfirmationModal";
 import {
   GROUP_MEMBERS_CHANGED_EVENT,
   type GroupMembersChangedDetail,
@@ -58,19 +63,12 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
     window.addEventListener(SESSION_CHANGED_EVENT, update);
     return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
   }, []);
-  // Phase I: when the viewer claims the group, GroupPrivacySection
-  // fires `onCreatorClaimed(newUserId)` and we lift the value here so
-  // every downstream creator-only gate (Join Requests, Invite Links)
-  // flips on the same render. The cache-backed `group.creatorUserId`
-  // remains stale until the next group fetch — bounded by the
-  // questionCache TTL — which is harmless since the override always
-  // wins.
-  const [claimedCreatorOverride, setClaimedCreatorOverride] = useState<
-    string | null
+  // Migration 142: a pending promote/boot the admin must confirm (both are
+  // consequential — promote is permanent, boot removes a member + revokes
+  // their invite link).
+  const [pendingAction, setPendingAction] = useState<
+    { kind: "promote" | "boot"; userId: string; name: string } | null
   >(null);
-  const effectiveCreatorUserId = claimedCreatorOverride ?? group.creatorUserId;
-  const viewerIsCreator =
-    !!session && !!effectiveCreatorUserId && session.user_id === effectiveCreatorUserId;
 
   const goBack = () => {
     // Slide overlay: mount the group root above the current page and slide
@@ -90,6 +88,22 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   const viewerLabel = currentUserName ?? "You";
   const [roster, setRoster] = useState<GroupRoster | null>(null);
   const [rosterTick, setRosterTick] = useState(0);
+  const viewerIsAdmin = roster?.viewer_is_admin ?? false;
+  const isPrivateGroup = group.privacy === "private";
+
+  const runPendingAction = () => {
+    if (!pendingAction) return;
+    const { kind, userId } = pendingAction;
+    setPendingAction(null);
+    const call =
+      kind === "promote"
+        ? apiPromoteGroupAdmin(groupId, userId)
+        : apiBootGroupMember(groupId, userId);
+    // Refetch the roster on success so the badge / removal reflects.
+    call.then(() => setRosterTick((t) => t + 1)).catch(() => {
+      setRosterTick((t) => t + 1);
+    });
+  };
   useEffect(() => {
     let cancelled = false;
     const load = () => {
@@ -121,25 +135,40 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   // count of members with no resolvable name (drive-by URL visitors on a
   // public group).
   // `userId` is the account to long-press → profile modal (null = anonymous or
-  // the viewer's own row, which isn't long-pressable).
-  let membersList: { name: string; key: string; userId: string | null }[];
+  // the viewer's own row, which isn't long-pressable). `isAdmin` drives the
+  // Admin badge + gates the promote/boot actions.
+  type MemberRow = {
+    name: string;
+    key: string;
+    userId: string | null;
+    isAdmin: boolean;
+  };
+  let membersList: MemberRow[];
   let totalCount: number;
   let anonymousExtra = 0;
   if (roster) {
     totalCount = roster.members.length + roster.anonymous_count;
     let anon = roster.anonymous_count;
-    const rows = roster.members.map((m, i) => ({
+    const rows: MemberRow[] = roster.members.map((m, i) => ({
       name: m.name,
       key: `member-${m.user_id ?? m.name}-${i}`,
       // Don't long-press yourself; otherwise the resolved account.
       userId: isCurrentUserName(m.name) ? null : m.user_id,
+      isAdmin: m.is_admin,
     }));
     // The viewer is always a member (visiting auto-joins / the creator is a
     // member). If they aren't a resolved named row, they're one of the
     // anonymous members — surface them as themselves and pull one out of the
     // anonymous roll-up so the headcount stays right.
     if (!rows.some((r) => isCurrentUserName(r.name))) {
-      rows.push({ name: viewerLabel, key: "__viewer__", userId: null });
+      // Viewer's own row isn't long-pressable (userId null); isAdmin still
+      // drives the Admin badge on your own row.
+      rows.push({
+        name: viewerLabel,
+        key: "__viewer__",
+        userId: null,
+        isAdmin: viewerIsAdmin,
+      });
       if (anon > 0) anon -= 1;
     }
     rows.sort((a, b) => a.name.localeCompare(b.name));
@@ -152,10 +181,10 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
       ...group.participantNames.flatMap((name) =>
         Array.from(
           { length: nameCount(group.participantNameCounts, name) },
-          (_, i) => ({ name, key: `${name}#${i}`, userId: null }),
+          (_, i) => ({ name, key: `${name}#${i}`, userId: null, isAdmin: false }),
         ),
       ),
-      { name: viewerLabel, key: "__viewer__", userId: null },
+      { name: viewerLabel, key: "__viewer__", userId: null, isAdmin: false },
     ].sort((a, b) => a.name.localeCompare(b.name));
     totalCount = membersList.length;
   }
@@ -188,14 +217,16 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <button
-          onClick={() => slideToGroupEditTitle({ groupId, direction: 'forward' })}
-          className="fixed right-3 z-30 h-10 px-4 flex items-center justify-center rounded-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 active:opacity-70 text-blue-600 dark:text-blue-400 text-sm font-medium"
-          style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}
-          aria-label="Edit group title"
-        >
-          Edit
-        </button>
+        {viewerIsAdmin && (
+          <button
+            onClick={() => slideToGroupEditTitle({ groupId, direction: 'forward' })}
+            className="fixed right-3 z-30 h-10 px-4 flex items-center justify-center rounded-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 active:opacity-70 text-blue-600 dark:text-blue-400 text-sm font-medium"
+            style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.5rem)' }}
+            aria-label="Edit group title"
+          >
+            Edit
+          </button>
+        )}
       </HeaderPortal>
 
       <div className="max-w-4xl mx-auto px-4" style={{ paddingTop: 'calc(env(safe-area-inset-top, 0px) + 1.05rem)' }}>
@@ -220,33 +251,34 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         <GroupPrivacySection
           group={group}
           groupId={groupId}
-          effectiveCreatorUserId={effectiveCreatorUserId}
-          onCreatorClaimed={setClaimedCreatorOverride}
+          viewerIsAdmin={viewerIsAdmin}
         />
 
         <JoinRequestsSection
           groupId={groupId}
-          enabled={viewerIsCreator}
+          enabled={viewerIsAdmin}
           onDecided={(action) => {
             if (action === "approve") setRosterTick((t) => t + 1);
           }}
         />
 
-        <InviteLinksSection groupId={groupId} enabled={viewerIsCreator} />
+        <InviteLinksSection groupId={groupId} enabled={viewerIsAdmin} />
 
         <NotificationSettingsCard groupRouteId={groupId} className="mt-[0.96rem]" />
 
-        <button
-          type="button"
-          onClick={() => slideToGroupInviteMembers({ groupId, direction: 'forward' })}
-          className="mt-6 w-full h-12 rounded-xl bg-blue-600 hover:bg-blue-700 active:scale-[0.99] text-white text-sm font-medium flex items-center justify-center gap-2 transition-transform"
-          aria-label="Add people to this group"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3M9 12a4 4 0 100-8 4 4 0 000 8zm0 0c-2.761 0-5 2.239-5 5v1h7" />
-          </svg>
-          Add people
-        </button>
+        {viewerIsAdmin && (
+          <button
+            type="button"
+            onClick={() => slideToGroupInviteMembers({ groupId, direction: 'forward' })}
+            className="mt-6 w-full h-12 rounded-xl bg-blue-600 hover:bg-blue-700 active:scale-[0.99] text-white text-sm font-medium flex items-center justify-center gap-2 transition-transform"
+            aria-label="Add people to this group"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3M9 12a4 4 0 100-8 4 4 0 000 8zm0 0c-2.761 0-5 2.239-5 5v1h7" />
+            </svg>
+            Add people
+          </button>
+        )}
 
         <h2 className="mt-4 px-1 mb-2 text-sm font-semibold text-gray-500 dark:text-gray-400">
           {totalCount} {totalCount === 1 ? 'Member' : 'Members'}
@@ -254,7 +286,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
 
         <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden">
           <ul className="divide-y divide-gray-200 dark:divide-gray-800">
-            {membersList.map(({ name, key, userId }) => {
+            {membersList.map(({ name, key, userId, isAdmin }) => {
               // Viewer row resolves either as the literal "You" label
               // (no saved name) or as a real-name row matching the
               // current saved name. `name === "You"` passes `null` to
@@ -263,6 +295,12 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
               const isViewer = name === viewerLabel || isCurrentUserName(name);
               const imageUrl = isViewer ? myUserImageUrl : null;
               const bubbleName = name === "You" ? null : name;
+              // Admins can act on non-admin, account-backed members other
+              // than themselves (Q4: admins can't demote/boot each other).
+              // `userId` is the member's real account id (main's RosterRow
+              // long-press path nulls it only for the viewer's own / anonymous
+              // rows, which `!isViewer` / `!!userId` already exclude).
+              const canManage = viewerIsAdmin && !!userId && !isViewer && !isAdmin;
               return (
                 <RosterRow
                   key={key}
@@ -270,6 +308,35 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                   bubbleName={bubbleName}
                   imageUrl={imageUrl}
                   userId={userId}
+                  isAdmin={isAdmin}
+                  actions={
+                    canManage ? (
+                      <>
+                        <button
+                          type="button"
+                          onPointerDown={(e) => e.stopPropagation()}
+                          onClick={() =>
+                            setPendingAction({ kind: "promote", userId: userId!, name })
+                          }
+                          className="shrink-0 text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline active:opacity-70"
+                        >
+                          Make admin
+                        </button>
+                        {isPrivateGroup && (
+                          <button
+                            type="button"
+                            onPointerDown={(e) => e.stopPropagation()}
+                            onClick={() =>
+                              setPendingAction({ kind: "boot", userId: userId!, name })
+                            }
+                            className="shrink-0 text-xs font-medium text-red-600 dark:text-red-400 hover:underline active:opacity-70"
+                          >
+                            Remove
+                          </button>
+                        )}
+                      </>
+                    ) : null
+                  }
                 />
               );
             })}
@@ -288,6 +355,25 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
           </ul>
         </div>
       </div>
+
+      {pendingAction && (
+        <ConfirmationModal
+          isOpen={true}
+          onConfirm={runPendingAction}
+          onCancel={() => setPendingAction(null)}
+          message={
+            pendingAction.kind === "promote"
+              ? `Make ${pendingAction.name} an admin? Admins can manage members, invites, and group settings. This can't be undone.`
+              : `Remove ${pendingAction.name} from the group? The invite link they joined with will stop working.`
+          }
+          confirmText={pendingAction.kind === "promote" ? "Make admin" : "Remove"}
+          confirmButtonClass={
+            pendingAction.kind === "promote"
+              ? "bg-blue-600 hover:bg-blue-700 text-white"
+              : "bg-red-600 hover:bg-red-700 text-white"
+          }
+        />
+      )}
     </>
   );
 }

--- a/components/GroupPrivacySection.tsx
+++ b/components/GroupPrivacySection.tsx
@@ -1,46 +1,28 @@
 /**
- * Phase E (group privacy) — info-page privacy controls.
+ * Group privacy controls (info page).
  *
  * Surfaces:
- *   * The group's current privacy state ("Public" / "Private") as the
- *     primary readout.
- *   * For the recorded creator (and only when signed in), a toggle to
- *     flip between public and private. Backed by
- *     `POST /api/groups/{id}/privacy`, which checks the session's
- *     user_id against the group's `creator_user_id` server-side.
- *   * For non-creator viewers: a help line describing what the state
- *     means. Anonymous viewers on a public group get a sign-in nudge
- *     ("Sign in to create private groups in the future") wired to the
- *     existing `<SignInModal>`.
+ *   * The group's current privacy state ("Public" / "Private").
+ *   * For ADMINS (migration 142), a toggle to flip between public and
+ *     private. Backed by `POST /api/groups/{id}/privacy`, which checks
+ *     `group_admins` server-side.
+ *   * For non-admin / anonymous viewers: a read-only state line, plus a
+ *     "Sign in to create private groups" nudge for anonymous viewers on a
+ *     public group.
  *
- * Why a toggle in Phase E: signed-in users create private groups by
- * default, but Phase F/G (join requests + invite links) haven't shipped
- * yet. Without a toggle, a signed-in user's group is unsharable. The
- * toggle gives them an escape hatch — flip public until the invite UI
- * arrives.
- *
- * Pre-Phase-E (grandfathered) groups have `privacy='public'` and no
- * `creator_user_id`, so no one can flip them. They stay public; the
- * read-only display is the only thing rendered for those.
- *
- * Anonymous-created groups (post-Phase-E) also have NULL
- * `creator_user_id` and are equally immutable; Phase I will add an
- * "anonymous → claim" upgrade. Until then, the toggle simply doesn't
- * appear for non-creators.
+ * (The Phase I "claim" affordance was retired by migration 142 — every group
+ * now has a creator/admin from the moment it's created, so there's nothing to
+ * claim.)
  */
 
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import SliderSwitch from "@/components/SliderSwitch";
 import SignInModal from "@/components/SignInModal";
 import { haptic } from "@/lib/haptics";
-import {
-  apiClaimGroup,
-  apiUpdateGroupPrivacy,
-  ApiError,
-} from "@/lib/api";
+import { apiUpdateGroupPrivacy, ApiError } from "@/lib/api";
 import {
   getCachedSessionUser,
   SESSION_CHANGED_EVENT,
@@ -52,55 +34,26 @@ interface Props {
   group: Group;
   groupId: string;
   className?: string;
-  /** Optional override for the group's creator_user_id. When the parent
-   *  has lifted an optimistic post-claim state, pass it here so the
-   *  isCreator computation matches what the rest of /info sees (Join-
-   *  Requests / Invite-Links sections gate on the same value). A null or
-   *  undefined value falls back to `group.creatorUserId` — there's no
-   *  way to "explicitly override to no-creator" because the cached value
-   *  already conveys that. */
-  effectiveCreatorUserId?: string | null;
-  /** Fires after a successful Phase I "claim" — the parent should
-   *  store the new creator_user_id so its own `viewerIsCreator`
-   *  computation flips true on the next render and the other
-   *  creator-only sections appear without a page refresh. */
-  onCreatorClaimed?: (newCreatorUserId: string) => void;
+  /** Migration 142: is the viewer an admin of this group? Gates the toggle.
+   *  Resolved by the parent from the members roster (`viewer_is_admin`). */
+  viewerIsAdmin: boolean;
 }
 
 export default function GroupPrivacySection({
   group,
   groupId,
   className = "mt-[0.96rem]",
-  effectiveCreatorUserId,
-  onCreatorClaimed,
+  viewerIsAdmin,
 }: Props) {
-  // Initialize as null to match SSR (no localStorage on the server);
-  // the mount effect below seeds from the localStorage-cached profile
-  // AND subscribes to live session changes. Eagerly reading via
-  // `useState(() => getCachedSessionUser())` would produce a hydration
-  // mismatch when signed in — server renders the no-toggle branch,
-  // client's first render reads localStorage and renders the toggle.
+  // Initialize as null to match SSR (no localStorage on the server); the
+  // mount effect seeds from the cached profile and tracks live changes. Used
+  // only for the anonymous-viewer sign-in nudge now.
   const [session, setSession] = useState<SessionUser | null>(null);
   const [privacy, setPrivacy] = useState<string | null>(group.privacy);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [signInOpen, setSignInOpen] = useState(false);
-  const [claiming, setClaiming] = useState(false);
-  // 409-on-claim means a concurrent device beat us to it. Surface the
-  // error and hide the button — keeping it tappable just produces an
-  // infinite retry loop with stale local state until the user navigates
-  // away. The next group fetch (cache TTL bounded) will resync
-  // `group.creatorUserId` from the server.
-  const [claimRaced, setClaimRaced] = useState(false);
-  // In-flight guard for the claim POST: state-based `claiming` is read
-  // from the closure and a double-tap within the same render batch
-  // sees the old `false`. A ref flips synchronously, so the second tap
-  // bails before firing a second request that would 409.
-  const claimInFlightRef = useRef(false);
 
-  // Mount + subscribe: seed `session` from the localStorage cache and
-  // listen for live changes (sign-in via SignInModal, sign-out
-  // elsewhere) so toggle visibility tracks without a remount.
   useEffect(() => {
     setSession(getCachedSessionUser());
     const update = () => setSession(getCachedSessionUser());
@@ -108,34 +61,16 @@ export default function GroupPrivacySection({
     return () => window.removeEventListener(SESSION_CHANGED_EVENT, update);
   }, []);
 
-  // Re-sync local state when the parent's group flips (e.g. background
-  // refresh after a different surface flipped the group). Without this,
-  // a creator who flipped on Device A would still see the old state on
-  // Device B's already-mounted /info page until they navigated away.
+  // Re-sync local state when the parent's group flips (e.g. background refresh
+  // after a different surface / device flipped the group).
   useEffect(() => {
     setPrivacy(group.privacy);
   }, [group.privacy]);
 
-  // Prefer the parent's lifted override (post-claim optimistic state)
-  // over the stale `group.creatorUserId` from the cache — keeps every
-  // creator-only surface on /info in lockstep. `??` falls back on
-  // null/undefined identically; a string override always wins.
-  const creatorUserId = effectiveCreatorUserId ?? group.creatorUserId;
-  const isCreator =
-    !!session && !!creatorUserId && session.user_id === creatorUserId;
   const isPrivate = privacy === "private";
-  // Phase I claim affordance: signed-in user, group has NO recorded
-  // creator, AND we haven't already lost a claim race. Anonymous
-  // viewers fall through to the sign-in nudge (which surfaces a
-  // claim-specific message when the group is also claimable). The
-  // membership gate is enforced server-side — visiting /info implies
-  // membership for private groups already, and public-group visitors
-  // auto-join via the /by-route-id read endpoint before this section
-  // renders.
-  const canClaim = !!session && !creatorUserId && !claimRaced;
 
   const onToggle = (next: boolean) => {
-    if (saving || !isCreator) return;
+    if (saving || !viewerIsAdmin) return;
     const target: "public" | "private" = next ? "private" : "public";
     if (target === privacy) return;
     haptic.medium();
@@ -146,69 +81,27 @@ export default function GroupPrivacySection({
     apiUpdateGroupPrivacy(groupId, target)
       .then((result) => setPrivacy(result.privacy))
       .catch((e) => {
-        // Roll back optimistic update on failure.
         setPrivacy(previous);
-        const msg =
-          e instanceof ApiError ? e.message : "Failed to update privacy";
-        setError(msg);
+        setError(e instanceof ApiError ? e.message : "Failed to update privacy");
       })
       .finally(() => setSaving(false));
   };
 
-  const onClaim = () => {
-    if (claimInFlightRef.current || !canClaim) return;
-    claimInFlightRef.current = true;
-    haptic.medium();
-    setError(null);
-    setClaiming(true);
-    apiClaimGroup(groupId)
-      .then((result) => {
-        onCreatorClaimed?.(result.creator_user_id);
-      })
-      .catch((e) => {
-        if (e instanceof ApiError && e.status === 409) {
-          // Someone else claimed first. Hide the button + show a clear
-          // explanation; the next group fetch will resync the creator
-          // server-side.
-          setClaimRaced(true);
-          setError("Another member just claimed this group.");
-        } else {
-          const msg =
-            e instanceof ApiError ? e.message : "Failed to claim group";
-          setError(msg);
-        }
-      })
-      .finally(() => {
-        claimInFlightRef.current = false;
-        setClaiming(false);
-      });
-  };
-
-  // Label rules:
-  //   * Creator (switch shown): a FIXED label "Private group" that
-  //     describes what the ON position means. The switch position alone
-  //     conveys the state — a label that changed with the toggle (the old
-  //     "Private"/"Public" readout) made it impossible to tell what the
-  //     switch *does* versus what it currently *is*.
-  //   * Non-creator (no switch): the read-only current state, since there
-  //     is no switch to convey it.
-  const rowLabel = isCreator ? "Private group" : isPrivate ? "Private" : "Public";
-  // Base description by state; creator gets the invite-link nudge as a
-  // suffix when private (Phase F/G will deliver the actual invite UI).
+  // Admin (switch shown): a FIXED label "Private group" that describes what
+  // the ON position means. Non-admin (no switch): the read-only current state.
+  const rowLabel = viewerIsAdmin
+    ? "Private group"
+    : isPrivate
+      ? "Private"
+      : "Public";
   const helpText =
-    (isPrivate ? "Only members can see this group." : "Anyone with the URL can see this group.")
-    + (isCreator && isPrivate ? " Share an invite link to add others." : "");
+    (isPrivate
+      ? "Only members can see this group."
+      : "Anyone with the URL can see this group.") +
+    (viewerIsAdmin && isPrivate ? " Share an invite link to add others." : "");
 
   // Sign-in nudge: anonymous viewer on a public group gets a quiet CTA.
-  // Copy is context-aware — on a CLAIMABLE group (no recorded creator)
-  // the actionable hint is "Sign in to claim THIS group"; otherwise it's
-  // the general "Sign in to create private groups" pitch for future
-  // group creation. Doesn't fire for anonymous viewers on private groups
-  // (they wouldn't be here — the /info read 404s non-members).
   const showSignInNudge = !session && privacy !== "private";
-  const signInNudgeText = !creatorUserId
-    ? " to claim this group."
-    : " to create private groups.";
 
   return (
     <>
@@ -220,14 +113,14 @@ export default function GroupPrivacySection({
           <div className="divide-y divide-gray-200 dark:divide-gray-700">
             <div
               className={`flex items-center justify-between gap-3 h-12 ${
-                isCreator && !saving ? "cursor-pointer" : ""
+                viewerIsAdmin && !saving ? "cursor-pointer" : ""
               }`}
               onClick={() => {
-                if (isCreator && !saving) onToggle(!isPrivate);
+                if (viewerIsAdmin && !saving) onToggle(!isPrivate);
               }}
             >
               <span className="text-base font-normal">{rowLabel}</span>
-              {isCreator ? (
+              {viewerIsAdmin ? (
                 <SliderSwitch
                   checked={isPrivate}
                   onChange={onToggle}
@@ -258,25 +151,8 @@ export default function GroupPrivacySection({
             >
               Sign in
             </button>
-            {signInNudgeText}
+            {" to create private groups."}
           </p>
-        )}
-        {canClaim && (
-          <div className="mt-3">
-            <button
-              type="button"
-              onClick={onClaim}
-              disabled={claiming}
-              className="w-full h-12 rounded-xl bg-blue-600 hover:bg-blue-700 active:scale-[0.99] disabled:opacity-60 text-white text-sm font-medium flex items-center justify-center transition-transform"
-              aria-label="Claim this group as creator"
-            >
-              {claiming ? "Claiming…" : "Claim this group"}
-            </button>
-            <p className="px-1 mt-2 text-xs text-gray-500 dark:text-gray-400">
-              This group has no recorded creator. Claim it to unlock
-              privacy, invite links, and join-request approvals.
-            </p>
-          </div>
         )}
       </section>
       <SignInModal isOpen={signInOpen} onClose={() => setSignInOpen(false)} />

--- a/components/RosterRow.tsx
+++ b/components/RosterRow.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import InitialBubble from "@/components/InitialBubble";
 import { useProfileLongPress } from "@/lib/useUserProfile";
 
@@ -9,6 +11,11 @@ import { useProfileLongPress } from "@/lib/useUserProfile";
  * (anonymous, or the viewer's own row) disables the trigger. `bubbleName` null
  * → the gray anonymous-fallback avatar (used for the viewer's "You" row).
  *
+ * `isAdmin` (migration 142) renders an "Admin" badge; `actions` is an optional
+ * right-aligned slot (the group /info page passes promote/boot buttons for
+ * admins). Action buttons should `stopPropagation` on pointerdown so a press on
+ * them doesn't also fire the row's long-press → profile.
+ *
  * Extracted so `useProfileLongPress` is a top-level hook (callers render this
  * inside a `.map`, where the hook can't be called directly).
  */
@@ -17,11 +24,15 @@ export default function RosterRow({
   bubbleName,
   imageUrl,
   userId,
+  isAdmin = false,
+  actions,
 }: {
   displayName: string;
   bubbleName: string | null;
   imageUrl: string | null;
   userId: string | null;
+  isAdmin?: boolean;
+  actions?: ReactNode;
 }) {
   const lp = useProfileLongPress(userId, bubbleName ?? displayName);
   return (
@@ -37,7 +48,13 @@ export default function RosterRow({
         sizeClassName="w-8 h-8"
         className="shrink-0"
       />
-      <span className="min-w-0 break-words">{displayName}</span>
+      <span className="min-w-0 break-words flex-1">{displayName}</span>
+      {isAdmin && (
+        <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 rounded-full px-2 py-0.5">
+          Admin
+        </span>
+      )}
+      {actions}
     </li>
   );
 }

--- a/database/migrations/142_group_admin_system_down.sql
+++ b/database/migrations/142_group_admin_system_down.sql
@@ -1,0 +1,12 @@
+-- Down-migration for 142.
+--
+-- NOTE: the destructive DELETE FROM groups WHERE creator_user_id IS NULL in the
+-- up-migration CANNOT be reversed — those groups/polls/votes are gone. This
+-- down only undoes the schema changes.
+
+BEGIN;
+
+ALTER TABLE group_members DROP COLUMN IF EXISTS joined_via_invite_id;
+DROP TABLE IF EXISTS group_admins;
+
+COMMIT;

--- a/database/migrations/142_group_admin_system_up.sql
+++ b/database/migrations/142_group_admin_system_up.sql
@@ -1,0 +1,46 @@
+-- 142: Group admin system.
+--
+-- Generalizes the single `groups.creator_user_id` into a multi-admin role.
+--   * `group_admins` — account-keyed admin roster (membership is browser-keyed,
+--     but admin powers require a real account). The original creator is admin #1.
+--   * `group_members.joined_via_invite_id` — which invite a member joined through,
+--     so booting that member can revoke the specific link they used.
+--   * DESTRUCTIVE: wipes legacy NULL-creator groups. These are pre-account
+--     anonymous-era groups with no account anywhere to administer them; per the
+--     owner's decision (CLAUDE.md group-admin design) this data is disposable.
+--     Cascades to polls/questions/votes/members/invites/... (verified FK chain).
+--   * Backfills the surviving groups' creators as admin #1.
+--
+-- The "every group has an admin" invariant lives in `group_admins` (seeded on
+-- create, auto-promoted on vacancy), NOT a NOT NULL on `groups.creator_user_id`:
+-- that column's FK is ON DELETE SET NULL, so a creator deleting their account
+-- legitimately nulls it while `group_admins` keeps the real (auto-promoted)
+-- admin. `creator_user_id` is now vestigial historical data — authorization
+-- reads `group_admins`, not it.
+
+BEGIN;
+
+-- 1. Admin roster.
+CREATE TABLE group_admins (
+    group_id   UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id    UUID NOT NULL REFERENCES users(id)  ON DELETE CASCADE,
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (group_id, user_id)
+);
+CREATE INDEX group_admins_user_id_idx ON group_admins (user_id);
+
+-- 2. Track the invite a member joined through (NULL when they joined via a
+--    join-request approval, "add people", or a plain public-link visit).
+ALTER TABLE group_members
+    ADD COLUMN joined_via_invite_id UUID REFERENCES group_invites(id) ON DELETE SET NULL;
+
+-- 3. Destructive wipe of legacy NULL-creator groups. The down-migration CANNOT
+--    restore these rows.
+DELETE FROM groups WHERE creator_user_id IS NULL;
+
+-- 4. Seed every surviving group's creator as admin #1.
+INSERT INTO group_admins (group_id, user_id)
+SELECT id, creator_user_id FROM groups WHERE creator_user_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -641,6 +641,9 @@ export interface GroupMember {
   name: string;
   /** Account id when this member is signed in; null for anonymous browsers. */
   user_id: string | null;
+  /** Migration 142: is this member a group admin? (always false for anonymous
+   *  members — admins are account-keyed). */
+  is_admin: boolean;
 }
 
 export interface GroupRoster {
@@ -648,6 +651,10 @@ export interface GroupRoster {
   members: GroupMember[];
   /** Distinct members with no resolvable name (drive-by public-group joins). */
   anonymous_count: number;
+  /** Migration 142: is the viewer an admin of this group? Gates the /info
+   *  admin chrome (privacy toggle, invites, join requests, add-people,
+   *  promote/boot, title/avatar edits). */
+  viewer_is_admin: boolean;
 }
 
 /** The group's ACTUAL roster from `group_members` — named members plus a
@@ -664,14 +671,19 @@ export async function apiGetGroupMembers(
     );
     return {
       members: Array.isArray(data?.members)
-        ? (data.members as GroupMember[])
+        ? (data.members as any[]).map((m) => ({
+            name: m.name,
+            user_id: m.user_id ?? null,
+            is_admin: !!m.is_admin,
+          }))
         : [],
       anonymous_count:
         typeof data?.anonymous_count === 'number' ? data.anonymous_count : 0,
+      viewer_is_admin: !!data?.viewer_is_admin,
     };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
-      return { members: [], anonymous_count: 0 };
+      return { members: [], anonymous_count: 0, viewer_is_admin: false };
     }
     throw err;
   }
@@ -679,7 +691,9 @@ export async function apiGetGroupMembers(
 
 /** A single poll's respondent roster — same shape as the group members roster
  *  (one entry per distinct voter person + a rolled-up anonymous count). Drives
- *  the poll /info respondents list (per-person rows + long-press to profile). */
+ *  the poll /info respondents list (per-person rows + long-press to profile).
+ *  `is_admin` / `viewer_is_admin` are not meaningful here (it's a voter roster,
+ *  not group membership) — defaulted false to satisfy the shared types. */
 export async function apiGetGroupPollVoters(
   routeId: string,
   pollRef: string,
@@ -690,17 +704,45 @@ export async function apiGetGroupPollVoters(
     );
     return {
       members: Array.isArray(data?.members)
-        ? (data.members as GroupMember[])
+        ? (data.members as any[]).map((m) => ({
+            name: m.name,
+            user_id: m.user_id ?? null,
+            is_admin: false,
+          }))
         : [],
       anonymous_count:
         typeof data?.anonymous_count === 'number' ? data.anonymous_count : 0,
+      viewer_is_admin: false,
     };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
-      return { members: [], anonymous_count: 0 };
+      return { members: [], anonymous_count: 0, viewer_is_admin: false };
     }
     throw err;
   }
+}
+
+/** Migration 142: promote a member to admin (admin-only). */
+export async function apiPromoteGroupAdmin(
+  routeId: string,
+  userId: string,
+): Promise<void> {
+  await groupFetch<any>(`/${encodeURIComponent(routeId)}/admins`, {
+    method: 'POST',
+    body: JSON.stringify({ user_id: userId }),
+  });
+}
+
+/** Migration 142: remove a non-admin member from a PRIVATE group and revoke
+ *  the invite they joined through (admin-only). */
+export async function apiBootGroupMember(
+  routeId: string,
+  userId: string,
+): Promise<void> {
+  await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/members/${encodeURIComponent(userId)}/boot`,
+    { method: 'POST' },
+  );
 }
 
 /** Encode an ArrayBuffer as base64. Chunked to avoid the `apply()`

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -67,6 +67,8 @@ export {
   apiAddGroupMembers,
   apiGetGroupMembers,
   apiGetGroupPollVoters,
+  apiPromoteGroupAdmin,
+  apiBootGroupMember,
 } from "./groups";
 export type {
   GroupJoinRequest,

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -56,7 +56,7 @@ from services.join_requests import (
     is_member_or_creator,
     list_pending_requests,
 )
-from services.auth import resolve_actor_user_id
+from services.auth import create_anonymous_user, resolve_actor_user_id
 from services.contacts import (
     add_member_for_user,
     is_contact,
@@ -68,17 +68,24 @@ from services.memberships import leave_group as _leave_group_row
 from services.validation import validate_user_name
 from services.groups import (
     _is_uuid_like,
+    add_group_admin,
+    boot_member,
     claim_group as _claim_group_row,
     filter_visible_polls,
     get_group_metadata,
     grant_group_membership_inline,
+    group_admin_user_ids,
     group_name_phrase,
+    is_caller_admin,
     is_caller_member_of_group,
+    is_group_admin,
     load_group_members,
     load_poll_voters,
     load_user_visibility,
     poll_ids_for_group_ids,
     polls_for_poll_ids,
+    promote_oldest_member_if_adminless,
+    remove_group_admin,
     resolve_group_for_visit,
     resolve_group_id_from_route_id,
 )
@@ -353,6 +360,31 @@ _GROUP_SUMMARY_COLUMNS = (
 )
 
 
+def _require_admin(
+    conn, group_id: str, *, browser_id: str | None, user_id: str | None
+) -> str:
+    """Authorize an admin-only group action (migration 142). Resolves the
+    caller's account via `resolve_actor_user_id` (bearer session OR the account
+    linked to this browser, so a browser-tied auto-account admin qualifies),
+    then requires a `group_admins` row. Returns the resolved admin user_id.
+
+    Replaces the old single-creator gate on privacy / join-requests / invites,
+    and newly gates title + avatar edits + add-people (Q6: admin-only).
+      * 401 when the caller has no resolvable account.
+      * 403 when signed in / resolved but not an admin of this group.
+    """
+    actor = resolve_actor_user_id(conn, user_id=user_id, browser_id=browser_id)
+    if not actor:
+        raise HTTPException(
+            status_code=401, detail="Sign in to manage this group"
+        )
+    if not is_group_admin(conn, group_id, actor):
+        raise HTTPException(
+            status_code=403, detail="Only a group admin can do this"
+        )
+    return actor
+
+
 @router.post("", response_model=GroupSummary, status_code=201)
 def create_group(request: Request):
     """Create an empty group + auto-join the caller as a member.
@@ -361,28 +393,38 @@ def create_group(request: Request):
     the group would be created but unreachable, so return 400 and let
     the FE retry after the middleware mints an id.
 
-    Phase E: privacy + creator_user_id are derived from the caller's
-    auth state. Signed-in callers get `privacy='private'` with
-    `creator_user_id` recorded; anonymous callers always get
-    `privacy='public'`. There's no body param for this — anonymous
-    browsers can't create private groups (the spec invariant: approval
-    authority can't be stranded on a wiped browser).
+    Migration 142: every group records a creator (= admin #1). The caller's
+    account is resolved via `resolve_actor_user_id` (bearer OR browser-tied
+    auto-account); a bare browser with no account yet gets a lightweight
+    auto-account minted on the spot (same pattern as an anonymous poll-create),
+    so the new group always has an admin. Privacy still keys on genuine
+    sign-in: bearer-signed-in → 'private', anything else → 'public'
+    (URL-shareable).
     """
     browser_id = _browser_id(request)
     if not browser_id:
         raise HTTPException(status_code=400, detail="Missing browser identity")
-    user_id = _user_id(request)
-    privacy = "private" if user_id else "public"
+    signed_in_uid = _user_id(request)
+    privacy = "private" if signed_in_uid else "public"
 
     with get_db() as conn:
+        creator_user_id = resolve_actor_user_id(
+            conn, user_id=signed_in_uid, browser_id=browser_id
+        )
+        if not creator_user_id:
+            creator_user_id = create_anonymous_user(
+                conn, browser_id=browser_id, display_name=None
+            )
         row = conn.execute(
             f"""
             INSERT INTO groups (privacy, creator_user_id)
             VALUES (%(privacy)s, %(creator_user_id)s)
             RETURNING {_GROUP_SUMMARY_COLUMNS}
             """,
-            {"privacy": privacy, "creator_user_id": user_id},
+            {"privacy": privacy, "creator_user_id": creator_user_id},
         ).fetchone()
+        # Creator is admin #1.
+        add_group_admin(conn, str(row["id"]), creator_user_id)
         # Bypass the helper's private-skip — creators are always members.
         grant_group_membership_inline(
             conn, str(row["id"]), browser_id, privacy="public"
@@ -671,13 +713,12 @@ def get_group_preview(route_id: str, p: str | None = None):
 
 
 @router.post("/{route_id}/title", response_model=GroupTitleResponse)
-def update_group_title(route_id: str, req: UpdateGroupTitleRequest):
+def update_group_title(route_id: str, req: UpdateGroupTitleRequest, request: Request):
     """Set or clear a group's title override.
 
     Migration 105 moved the override from `polls.group_title` (per-poll)
-    to `groups.title` (one row per group). Anyone with the URL can
-    rename the group — there's no creator-secret check today, matching
-    the prior `/api/polls/<id>/group-title` semantics.
+    to `groups.title` (one row per group). Migration 142: admin-only (Q6) —
+    editing group identity is a group-administration power.
 
     Empty / whitespace-only `group_title` clears the override (NULL).
 
@@ -690,6 +731,10 @@ def update_group_title(route_id: str, req: UpdateGroupTitleRequest):
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
         row = conn.execute(
             """
             UPDATE groups
@@ -709,7 +754,7 @@ def update_group_title(route_id: str, req: UpdateGroupTitleRequest):
 
 
 @router.post("/{route_id}/image", response_model=GroupImageResponse)
-def upload_group_image(route_id: str, req: GroupImageRequest):
+def upload_group_image(route_id: str, req: GroupImageRequest, request: Request):
     """Set the group's avatar image (migration 108).
 
     Body: base64-encoded JPEG or PNG bytes (already square-cropped by the
@@ -717,8 +762,7 @@ def upload_group_image(route_id: str, req: GroupImageRequest):
     on the group. Stamps `image_updated_at` so the FE knows to invalidate
     its `/api/groups/by-route-id/<id>/image?v=<ts>` cache.
 
-    Anyone with the URL can change the group's image — same trust model
-    as `POST /api/groups/{route_id}/title`. No creator-secret check today.
+    Migration 142: admin-only (Q6) — same as the title edit.
 
     `route_id` accepts the same four forms as `/by-route-id/{route_id}`:
     `groups.short_id`, `groups.id`, `polls.short_id`, `polls.id`.
@@ -745,6 +789,10 @@ def upload_group_image(route_id: str, req: GroupImageRequest):
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
         row = conn.execute(
             """
             UPDATE groups
@@ -767,15 +815,21 @@ def upload_group_image(route_id: str, req: GroupImageRequest):
 
 
 @router.delete("/{route_id}/image", response_model=GroupImageResponse)
-def delete_group_image(route_id: str):
+def delete_group_image(route_id: str, request: Request):
     """Clear the group's avatar image. Idempotent — a 200 is returned
     even if no image was set, so the FE doesn't have to distinguish
     "was set" from "wasn't set" to reset state. `image_updated_at` is
-    set to NULL so the FE falls back to the initials avatar."""
+    set to NULL so the FE falls back to the initials avatar.
+
+    Migration 142: admin-only (Q6)."""
     with get_db() as conn:
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
         row = conn.execute(
             """
             UPDATE groups
@@ -854,50 +908,21 @@ def update_group_privacy(
 ):
     """Phase E: flip a group between 'public' and 'private'.
 
-    Authorization: must be signed in AND match the group's
-    `creator_user_id`. Groups created anonymously (creator_user_id NULL)
-    and grandfathered pre-Phase-E groups can NOT be flipped — they stay
-    public forever. Phase I will add an "anonymous → claim → private"
-    upgrade path; deferred until then.
-
-    Without this endpoint, signed-in users who create a group get a
-    private group with no way to share it (Phase F/G aren't shipped
-    yet). The toggle is the escape hatch: flip to public until invites
-    land, then optionally flip back to private once the group is
-    bootstrapped.
+    Migration 142: admin-only (Q6). Any admin of the group can flip privacy.
     """
     if req.privacy not in ("public", "private"):
         raise HTTPException(
             status_code=400,
             detail="privacy must be 'public' or 'private'",
         )
-    user_id = _user_id(request)
-    if not user_id:
-        raise HTTPException(
-            status_code=401,
-            detail="Sign in to change group privacy",
-        )
     with get_db() as conn:
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        meta = get_group_metadata(conn, group_id)
-        if not meta:
-            raise HTTPException(status_code=404, detail="Group not found")
-        # Anonymous-created or pre-Phase-E groups can't be re-keyed by
-        # any signed-in caller: there's no creator to authorize against.
-        # Returning 403 distinguishes "not your group" from "no such
-        # group" (404).
-        if not meta["creator_user_id"]:
-            raise HTTPException(
-                status_code=403,
-                detail="Group has no recorded creator; cannot change privacy",
-            )
-        if meta["creator_user_id"] != user_id:
-            raise HTTPException(
-                status_code=403,
-                detail="Only the group's creator can change privacy",
-            )
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
         row = conn.execute(
             """
             UPDATE groups
@@ -1008,7 +1033,16 @@ def leave_group(route_id: str, request: Request):
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
+        # Migration 142: leaving the group also drops admin status. If that
+        # empties the admin set, the oldest remaining account-member is
+        # auto-promoted so every group always has an admin.
+        actor = resolve_actor_user_id(
+            conn, user_id=user_id, browser_id=browser_id
+        )
         _leave_group_row(conn, group_id, browser_id, user_id=user_id)
+        if actor:
+            remove_group_admin(conn, group_id, actor)
+            promote_oldest_member_if_adminless(conn, group_id)
 
 
 # ---------------------------------------------------------------------------
@@ -1271,38 +1305,19 @@ def create_group_join_request(
     response_model=list[JoinRequestSummaryResponse],
 )
 def list_group_join_requests(route_id: str, request: Request):
-    """Phase F: list pending requests for a group. Creator-only.
+    """Phase F: list pending requests for a group. Migration 142: admin-only.
 
-    Authorization: must be signed in AND match the group's recorded
-    `creator_user_id`. Anonymous-created / pre-Phase-E groups have
-    NULL creator and can't have a creator viewer either, so they 403
-    here for everyone — the join-request system simply isn't available
-    on those groups.
-
-    404 on route resolution failure; 401 when not signed in; 403 when
-    signed in but not the creator (distinguishes "not your group" from
-    "no such group" — same convention as the privacy toggle).
+    404 on route resolution failure; 401 when the caller has no account;
+    403 when resolved but not an admin of the group.
     """
-    user_id = _user_id(request)
-    if not user_id:
-        raise HTTPException(
-            status_code=401, detail="Sign in to view join requests"
-        )
     with get_db() as conn:
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        meta = get_group_metadata(conn, group_id)
-        if not meta or not meta["creator_user_id"]:
-            raise HTTPException(
-                status_code=403,
-                detail="Group has no recorded creator",
-            )
-        if meta["creator_user_id"] != user_id:
-            raise HTTPException(
-                status_code=403,
-                detail="Only the group's creator can view join requests",
-            )
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
         summaries = list_pending_requests(conn, group_id)
     return [_summary_to_response(s) for s in summaries]
 
@@ -1345,11 +1360,6 @@ def decide_group_join_request(
         raise HTTPException(
             status_code=400, detail="action must be 'approve' or 'deny'"
         )
-    user_id = _user_id(request)
-    if not user_id:
-        raise HTTPException(
-            status_code=401, detail="Sign in to decide join requests"
-        )
     decision = "approved" if body.action == "approve" else "denied"
     notify_payload: dict | None = None
     notify_user_id: str | None = None
@@ -1358,16 +1368,12 @@ def decide_group_join_request(
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        meta = get_group_metadata(conn, group_id)
-        if not meta or not meta["creator_user_id"]:
-            raise HTTPException(
-                status_code=403, detail="Group has no recorded creator"
-            )
-        if meta["creator_user_id"] != user_id:
-            raise HTTPException(
-                status_code=403,
-                detail="Only the group's creator can decide join requests",
-            )
+        # Migration 142: admin-only. The resolved admin id is recorded as the
+        # decider.
+        decider = _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
         # Existence + group-scoping guard: the route-id MUST match the
         # request's group_id. Without this, a creator of group A could
         # decide on a request that belongs to group B by guessing
@@ -1389,7 +1395,7 @@ def decide_group_join_request(
                 status_code=404,
                 detail="Request not found or already decided",
             )
-        decided = decide_request(conn, request_id, decision, user_id)
+        decided = decide_request(conn, request_id, decision, decider)
         if decided and decision == "approved":
             # Build the approval-push payload while we still hold the
             # connection; same shape as the invite-members fan-out so
@@ -1478,16 +1484,12 @@ def list_group_invitable_accounts(route_id: str, request: Request):
     """Accounts the caller can add to this group: people they've encountered
     (the `user_contacts` address book) who aren't already members here.
 
-    Authorization: caller must be a member of the group (any member can
-    invite). 404 on unresolvable route; 403 when the caller isn't a member.
-    An account-less caller (no resolvable user_id — e.g. a pure lurker who
-    never created or voted) has no contacts, so this returns an empty list
-    rather than erroring.
+    Migration 142: admin-only — adding people directly is an "allow users to
+    join" power. 404 on unresolvable route; 401/403 from `_require_admin`.
 
     Reconciles the caller's contacts inline first so the list reflects
-    everyone they currently share a group with, even on the first open after
-    this feature shipped. Sorted: most shared groups first, then most
-    recently seen together.
+    everyone they currently share a group with. Sorted: most shared groups
+    first, then most recently seen together.
     """
     browser_id = _browser_id(request)
     user_id = _user_id(request)
@@ -1495,15 +1497,9 @@ def list_group_invitable_accounts(route_id: str, request: Request):
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        if not is_caller_member_of_group(
+        me = _require_admin(
             conn, group_id, browser_id=browser_id, user_id=user_id
-        ):
-            raise HTTPException(
-                status_code=403, detail="Join the group to invite people"
-            )
-        me = resolve_actor_user_id(conn, user_id=user_id, browser_id=browser_id)
-        if not me:
-            return []
+        )
         reconcile_contacts(conn, me)
         accounts = list_invitable_accounts(conn, me, group_id)
     return [
@@ -1524,11 +1520,11 @@ def add_group_members(
     request: Request,
     background_tasks: BackgroundTasks,
 ):
-    """Add one or more accounts to a group. Any member can invite.
+    """Add one or more accounts to a group. Migration 142: admin-only.
 
     Each requested user_id must be one of the caller's contacts (in the
-    `user_contacts` address book) — non-contacts are silently skipped so a
-    member can't add an arbitrary stranger by guessing ids. Accounts already
+    `user_contacts` address book) — non-contacts are silently skipped so an
+    admin can't add an arbitrary stranger by guessing ids. Accounts already
     in the group (via any of their browsers) are skipped too (no duplicate
     membership, no notification). Each newly-added account gets an 'added to
     a group' push.
@@ -1542,18 +1538,9 @@ def add_group_members(
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        if not is_caller_member_of_group(
+        me = _require_admin(
             conn, group_id, browser_id=browser_id, user_id=user_id
-        ):
-            raise HTTPException(
-                status_code=403, detail="Join the group to invite people"
-            )
-        me = resolve_actor_user_id(conn, user_id=user_id, browser_id=browser_id)
-        if not me:
-            raise HTTPException(
-                status_code=403,
-                detail="Create or join a poll first so we can invite from your account",
-            )
+        )
 
         added_user_ids: list[str] = []
         # dict.fromkeys dedupes while preserving order. Skip the caller, any
@@ -1603,15 +1590,22 @@ def add_group_members(
 class GroupMemberResponse(BaseModel):
     name: str
     user_id: str | None
+    # migration 142: is this member an admin? (account-keyed, so a member with
+    # no resolvable user_id is never an admin)
+    is_admin: bool = False
 
 
 class GroupMembersResponse(BaseModel):
     """The group's actual roster. `members` are the named people (one entry
     per distinct person, account-aware); `anonymous_count` rolls up members
-    with no resolvable name (drive-by URL visitors on public groups)."""
+    with no resolvable name (drive-by URL visitors on public groups).
+    `viewer_is_admin` (migration 142) gates the FE's admin chrome (privacy
+    toggle, invites, join requests, add-people, promote/boot, title/avatar
+    edits)."""
 
     members: list[GroupMemberResponse]
     anonymous_count: int
+    viewer_is_admin: bool = False
 
 
 @router.get("/{route_id}/members", response_model=GroupMembersResponse)
@@ -1643,10 +1637,111 @@ def get_group_members(route_id: str, request: Request):
             ):
                 raise HTTPException(status_code=404, detail="Group not found")
         named, anon = load_group_members(conn, group_id)
-        return GroupMembersResponse(
-            members=[GroupMemberResponse(**m) for m in named],
-            anonymous_count=anon,
+        admin_ids = group_admin_user_ids(conn, group_id)
+        viewer_is_admin = is_caller_admin(
+            conn, group_id, browser_id=browser_id, user_id=user_id
         )
+        return GroupMembersResponse(
+            members=[
+                GroupMemberResponse(
+                    name=m["name"],
+                    user_id=m["user_id"],
+                    is_admin=bool(m["user_id"]) and m["user_id"] in admin_ids,
+                )
+                for m in named
+            ],
+            anonymous_count=anon,
+            viewer_is_admin=viewer_is_admin,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Admin roster management (migration 142)
+# ---------------------------------------------------------------------------
+
+
+class PromoteAdminRequest(BaseModel):
+    user_id: str
+
+
+class PromoteAdminResponse(BaseModel):
+    user_id: str
+    is_admin: bool = True
+
+
+class BootMemberResponse(BaseModel):
+    booted: bool
+
+
+@router.post("/{route_id}/admins", response_model=PromoteAdminResponse)
+def promote_group_admin(
+    route_id: str, body: PromoteAdminRequest, request: Request
+):
+    """Promote an existing member to admin. Admin-only. The target must be a
+    member of the group (account-keyed). There is no demotion (Q4): once
+    promoted, an admin stays one until they leave the group."""
+    target = body.user_id
+    if not _is_uuid_like(target):
+        raise HTTPException(status_code=400, detail="Invalid user_id")
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
+        if not is_caller_member_of_group(
+            conn, group_id, browser_id=None, user_id=target
+        ):
+            raise HTTPException(
+                status_code=400, detail="User is not a member of this group"
+            )
+        add_group_admin(conn, group_id, target)
+    return PromoteAdminResponse(user_id=target)
+
+
+@router.post(
+    "/{route_id}/members/{user_id}/boot", response_model=BootMemberResponse
+)
+def boot_group_member(route_id: str, user_id: str, request: Request):
+    """Remove a member from the group and revoke the invite link they joined
+    through. Admin-only, PRIVATE groups only (Q3 — booting a public-group
+    member is futile since they auto-rejoin on the next visit). The target
+    must be a NON-admin member (admins can't be booted — Q4)."""
+    target = user_id
+    if not _is_uuid_like(target):
+        raise HTTPException(status_code=400, detail="Invalid user_id")
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        admin = _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
+        meta = get_group_metadata(conn, group_id)
+        if not meta or meta["privacy"] != "private":
+            raise HTTPException(
+                status_code=400,
+                detail="Members can only be booted from private groups",
+            )
+        if target == admin:
+            raise HTTPException(
+                status_code=400, detail="Leave the group instead of booting yourself"
+            )
+        if is_group_admin(conn, group_id, target):
+            raise HTTPException(
+                status_code=403, detail="Admins can't be booted"
+            )
+        if not is_caller_member_of_group(
+            conn, group_id, browser_id=None, user_id=target
+        ):
+            raise HTTPException(
+                status_code=404, detail="User is not a member of this group"
+            )
+        boot_member(conn, group_id, target)
+    return BootMemberResponse(booted=True)
 
 
 @router.get(
@@ -1781,26 +1876,6 @@ def _issued_to_invite_response(
     )
 
 
-def _require_creator(conn, group_id: str, user_id: str | None) -> None:
-    """Raise 401/403 unless the caller is signed in AND matches the
-    group's recorded `creator_user_id`. Shared 3-way authorization
-    gate for every invite-management endpoint."""
-    if not user_id:
-        raise HTTPException(
-            status_code=401, detail="Sign in to manage invites"
-        )
-    meta = get_group_metadata(conn, group_id)
-    if not meta or not meta["creator_user_id"]:
-        raise HTTPException(
-            status_code=403, detail="Group has no recorded creator"
-        )
-    if meta["creator_user_id"] != user_id:
-        raise HTTPException(
-            status_code=403,
-            detail="Only the group's creator can manage invites",
-        )
-
-
 @router.post(
     "/{route_id}/invites",
     response_model=InviteResponse,
@@ -1811,7 +1886,7 @@ def create_group_invite(
     body: CreateInviteRequest,
     request: Request,
 ):
-    """Phase G: mint a new invite link. Creator-only.
+    """Phase G: mint a new invite link. Migration 142: admin-only.
 
     The response is the ONLY time the raw token + URL are returned —
     sha256(token) is what hits the DB. If the creator loses the URL,
@@ -1819,12 +1894,14 @@ def create_group_invite(
     """
     from services.fe_origin import resolve_fe_origin
 
-    user_id = _user_id(request)
     with get_db() as conn:
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        _require_creator(conn, group_id, user_id)
+        admin = _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
 
         if body.mode not in ("single", "multi"):
             raise HTTPException(
@@ -1857,7 +1934,7 @@ def create_group_invite(
         issued = issue_invite(
             conn,
             group_id=group_id,
-            created_by_user_id=user_id,
+            created_by_user_id=admin,
             mode=body.mode,
             target_poll_id=target_poll_id,
             max_uses=body.max_uses,
@@ -1877,17 +1954,19 @@ def create_group_invite(
     response_model=list[InviteResponse],
 )
 def list_group_invites(route_id: str, request: Request):
-    """Phase G: list a group's active invites. Creator-only.
+    """Phase G: list a group's active invites. Migration 142: admin-only.
 
     "Active" = not revoked, not expired, has remaining uses. Revoked
     or fully-used invites are excluded — the UI doesn't need them.
     """
-    user_id = _user_id(request)
     with get_db() as conn:
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        _require_creator(conn, group_id, user_id)
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
         summaries = list_active_invites(conn, group_id)
     return [_summary_to_invite_response(s) for s in summaries]
 
@@ -1899,20 +1978,22 @@ def list_group_invites(route_id: str, request: Request):
 def revoke_group_invite(
     route_id: str, invite_id: str, request: Request
 ):
-    """Phase G: revoke an active invite. Creator-only.
+    """Phase G: revoke an active invite. Migration 142: admin-only — any
+    admin of the group can revoke any of its invites (revoke is group-scoped,
+    not limited to the admin who minted it).
 
-    Returns 204 on successful revoke. 404 when the invite doesn't
-    exist OR isn't owned by the caller OR was already revoked —
-    indistinguishable to the caller, no information leak about
-    invites belonging to other creators.
+    Returns 204 on successful revoke. 404 when the invite doesn't exist in
+    this group OR was already revoked.
     """
-    user_id = _user_id(request)
     with get_db() as conn:
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        _require_creator(conn, group_id, user_id)
-        ok = revoke_invite(conn, invite_id, user_id)
+        _require_admin(
+            conn, group_id,
+            browser_id=_browser_id(request), user_id=_user_id(request),
+        )
+        ok = revoke_invite(conn, invite_id, group_id)
     if not ok:
         raise HTTPException(
             status_code=404, detail="Invite not found or already revoked"

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -45,7 +45,13 @@ from services.contacts import (
     user_responded_to_poll,
 )
 from services.invites import issue_invite
-from services.groups import NIL_UUID, _is_uuid_like, group_name_phrase, require_uuid
+from services.groups import (
+    NIL_UUID,
+    _is_uuid_like,
+    add_group_admin,
+    group_name_phrase,
+    require_uuid,
+)
 from services.memberships import join_group, join_group_for_poll
 from services.poll_categories import record_poll_categories
 from services.push import (
@@ -203,6 +209,7 @@ def _resolve_or_create_group(
     initial_title: str | None,
     *,
     creator_user_id: str | None,
+    signed_in: bool,
 ) -> str:
     """Resolve `req.group_id` to an existing group, or mint a fresh one.
 
@@ -213,11 +220,14 @@ def _resolve_or_create_group(
     (optionally with `title` set on creation so first-poll-with-name
     flows are a single transaction).
 
-    Phase E: minting a fresh group sets `privacy` from the caller's
-    auth state — signed-in (`creator_user_id` set) → 'private' + records
-    the creator; anonymous → 'public' (forced) + creator_user_id NULL.
-    Resolving to an existing group doesn't touch privacy or
-    creator_user_id; those are set-at-create-time fields.
+    Migration 142: a freshly-minted group ALWAYS records a creator —
+    `creator_user_id` is the poll's creator, which is always set now (the
+    signed-in user, or the auto-minted anonymous account) — and seeds it as
+    admin #1, so no group is ever admin-less (`groups.creator_user_id` is
+    NOT NULL). Privacy is DECOUPLED from the creator: it still keys on genuine
+    sign-in (`signed_in`), so an anonymous creator gets a public, URL-shareable
+    group even though their auto-account is the recorded creator/admin.
+    Resolving to an existing group doesn't touch privacy, creator, or admins.
 
     Unknown / malformed group ids fall through to "mint a fresh group"
     rather than 404 — the request still succeeds, it just lands in a new
@@ -240,7 +250,7 @@ def _resolve_or_create_group(
             "create_poll: requested group_id=%s not found; minting a fresh group",
             requested_group_id,
         )
-    privacy = "private" if creator_user_id else "public"
+    privacy = "private" if signed_in else "public"
     row = conn.execute(
         "INSERT INTO groups (title, privacy, creator_user_id) "
         "VALUES (%(title)s, %(privacy)s, %(creator_user_id)s) RETURNING id",
@@ -250,7 +260,10 @@ def _resolve_or_create_group(
             "creator_user_id": creator_user_id,
         },
     ).fetchone()
-    return str(row["id"])
+    group_id = str(row["id"])
+    if creator_user_id:
+        add_group_admin(conn, group_id, creator_user_id)
+    return group_id
 
 
 def _attach_group_fields(conn, row) -> dict:
@@ -315,7 +328,8 @@ def _insert_poll(
         conn,
         req.group_id,
         req.group_title,
-        creator_user_id=group_creator_user_id,
+        creator_user_id=creator_user_id,
+        signed_in=group_creator_user_id is not None,
     )
     # The prephase (suggestion / availability) countdown starts at creation —
     # there is no deferral to the first submission. A preset duration

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -538,6 +538,25 @@ def merge_accounts(conn, *, source_user_id: str, dest_user_id: str) -> None:
         p,
     )
 
+    # --- group_admins (PK (group_id, user_id), migration 142): dest keeps its
+    # admin row on collision; otherwise the source's admin status moves over so
+    # a merge never silently demotes the keeper.
+    conn.execute(
+        """
+        DELETE FROM group_admins s
+         WHERE s.user_id = %(src)s::uuid
+           AND EXISTS (
+             SELECT 1 FROM group_admins d
+              WHERE d.user_id = %(dst)s::uuid AND d.group_id = s.group_id
+           )
+        """,
+        p,
+    )
+    conn.execute(
+        "UPDATE group_admins SET user_id = %(dst)s::uuid WHERE user_id = %(src)s::uuid",
+        p,
+    )
+
     # --- user_contacts (PK (owner_user_id, contact_user_id)): move both
     # directions, dedupe via ON CONFLICT (newest watermark wins), and never
     # create a self-contact (owner == contact).
@@ -994,12 +1013,28 @@ def delete_user_account(conn, user_id: str) -> bool:
     that's now the sole poll-mutation authority (migration 123 retired
     `creator_secret`), a deleted creator's polls become immutable
     (close/reopen/cutoff no longer authorize). Returns True if a row was
-    deleted, False if the user was already gone (idempotent)."""
+    deleted, False if the user was already gone (idempotent).
+
+    Migration 142: `group_admins.user_id` cascades, so deleting a user drops
+    their admin rows. For any group that leaves admin-less, auto-promote the
+    oldest remaining account-member — same rule as "the last admin left"."""
+    # Capture the user's admin groups BEFORE the delete cascades the rows away.
+    admin_group_rows = conn.execute(
+        "SELECT group_id::text AS g FROM group_admins WHERE user_id = %(u)s::uuid",
+        {"u": user_id},
+    ).fetchall()
     row = conn.execute(
         "DELETE FROM users WHERE id = %(u)s::uuid RETURNING id",
         {"u": user_id},
     ).fetchone()
-    return row is not None
+    if row is None:
+        return False
+    # Local import avoids a top-level services.auth → services.groups cycle.
+    from services.groups import promote_oldest_member_if_adminless
+
+    for r in admin_group_rows:
+        promote_oldest_member_if_adminless(conn, r["g"])
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -496,6 +496,147 @@ def load_poll_voters(conn, poll_id: str) -> tuple[list[dict], int]:
     return named, anonymous_count
 
 
+# ---------------------------------------------------------------------------
+# Admin roster (migration 142)
+# ---------------------------------------------------------------------------
+#
+# `group_admins(group_id, user_id)` is the authorization source of truth for
+# every group-administration power (privacy toggle, title/avatar edits,
+# join-request approval, invite minting, promoting members, booting). It's
+# ACCOUNT-keyed: `group_members` is browser-keyed, but admin powers require a
+# real account. The original creator is admin #1 (seeded at create time and by
+# the migration backfill). There is no demotion and no owner hierarchy — the
+# only event that shrinks the admin set is an admin LEAVING the group (or
+# having their account deleted), which triggers auto-promotion below.
+
+
+def is_group_admin(conn, group_id: str, user_id: str | None) -> bool:
+    """True iff `user_id` (already resolved) is an admin of `group_id`."""
+    if not user_id:
+        return False
+    row = conn.execute(
+        "SELECT 1 FROM group_admins "
+        "WHERE group_id = %(g)s::uuid AND user_id = %(u)s::uuid LIMIT 1",
+        {"g": group_id, "u": user_id},
+    ).fetchone()
+    return row is not None
+
+
+def is_caller_admin(
+    conn,
+    group_id: str,
+    *,
+    browser_id: str | None,
+    user_id: str | None,
+) -> bool:
+    """True iff the caller is an admin of `group_id`. Resolves the actor via
+    `resolve_actor_user_id` (bearer session OR the account linked to this
+    browser) so browser-tied auto-account admins can exercise their powers,
+    not just bearer-signed-in users."""
+    from services.auth import resolve_actor_user_id
+
+    actor = resolve_actor_user_id(conn, user_id=user_id, browser_id=browser_id)
+    return is_group_admin(conn, group_id, actor)
+
+
+def group_admin_user_ids(conn, group_id: str) -> set[str]:
+    """The set of admin user_ids for a group (for member-list badging)."""
+    rows = conn.execute(
+        "SELECT user_id::text AS u FROM group_admins WHERE group_id = %(g)s::uuid",
+        {"g": group_id},
+    ).fetchall()
+    return {r["u"] for r in rows}
+
+
+def add_group_admin(conn, group_id: str, user_id: str) -> None:
+    """Grant admin. Idempotent (ON CONFLICT DO NOTHING preserves the original
+    `granted_at`). Caller authorizes (admin-only at the router, or seeded at
+    group-create time)."""
+    conn.execute(
+        """
+        INSERT INTO group_admins (group_id, user_id)
+        VALUES (%(g)s::uuid, %(u)s::uuid)
+        ON CONFLICT (group_id, user_id) DO NOTHING
+        """,
+        {"g": group_id, "u": user_id},
+    )
+
+
+def remove_group_admin(conn, group_id: str, user_id: str) -> None:
+    """Drop an admin row (used when an admin leaves the group). Does NOT
+    auto-promote — call `promote_oldest_member_if_adminless` afterward."""
+    conn.execute(
+        "DELETE FROM group_admins "
+        "WHERE group_id = %(g)s::uuid AND user_id = %(u)s::uuid",
+        {"g": group_id, "u": user_id},
+    )
+
+
+def promote_oldest_member_if_adminless(conn, group_id: str) -> str | None:
+    """If `group_id` has no admins, promote its oldest member that resolves to
+    an account (MIN(joined_at) across the group, account-aware). Returns the
+    promoted user_id, or None when there's already an admin OR no member has an
+    account (a legacy edge — the group stays admin-less rather than inventing
+    one). This is both the "last admin left" rule and the legacy backfill."""
+    if conn.execute(
+        "SELECT 1 FROM group_admins WHERE group_id = %(g)s::uuid LIMIT 1",
+        {"g": group_id},
+    ).fetchone():
+        return None
+    row = conn.execute(
+        """
+        SELECT ub.user_id::text AS uid
+          FROM group_members gm
+          JOIN user_browsers ub ON ub.browser_id = gm.browser_id
+         WHERE gm.group_id = %(g)s::uuid
+         GROUP BY ub.user_id
+         ORDER BY MIN(gm.joined_at) ASC
+         LIMIT 1
+        """,
+        {"g": group_id},
+    ).fetchone()
+    if not row:
+        return None
+    add_group_admin(conn, group_id, row["uid"])
+    return row["uid"]
+
+
+def boot_member(conn, group_id: str, target_user_id: str) -> None:
+    """Remove `target_user_id` from `group_id` and revoke the invite link(s)
+    they joined through. Deletes their `group_members` rows across every linked
+    browser, then stamps `revoked_at` on each `joined_via_invite_id` they used
+    so that link can't re-admit them. Caller authorizes (admin-only, private
+    group, target is a non-admin member)."""
+    invite_rows = conn.execute(
+        """
+        SELECT DISTINCT gm.joined_via_invite_id AS iid
+          FROM group_members gm
+         WHERE gm.group_id = %(g)s::uuid
+           AND gm.joined_via_invite_id IS NOT NULL
+           AND gm.browser_id IN (
+               SELECT browser_id FROM user_browsers WHERE user_id = %(u)s::uuid
+           )
+        """,
+        {"g": group_id, "u": target_user_id},
+    ).fetchall()
+    for r in invite_rows:
+        conn.execute(
+            "UPDATE group_invites SET revoked_at = NOW() "
+            "WHERE id = %(i)s::uuid AND revoked_at IS NULL",
+            {"i": r["iid"]},
+        )
+    conn.execute(
+        """
+        DELETE FROM group_members
+         WHERE group_id = %(g)s::uuid
+           AND browser_id IN (
+               SELECT browser_id FROM user_browsers WHERE user_id = %(u)s::uuid
+           )
+        """,
+        {"g": group_id, "u": target_user_id},
+    )
+
+
 def resolve_group_for_visit(
     conn,
     route_id: str,

--- a/server/services/invites.py
+++ b/server/services/invites.py
@@ -199,27 +199,26 @@ def list_active_invites(conn, group_id: str) -> list[InviteSummary]:
     ]
 
 
-def revoke_invite(conn, invite_id: str, by_user_id: str) -> bool:
-    """Mark a creator-owned invite as revoked. Returns True iff the
-    UPDATE affected a row (i.e. the invite existed, was owned by
-    `by_user_id`, and wasn't already revoked).
+def revoke_invite(conn, invite_id: str, group_id: str) -> bool:
+    """Mark an invite as revoked. Returns True iff the UPDATE affected a row
+    (the invite existed in `group_id` and wasn't already revoked).
 
-    The `created_by_user_id` check in the WHERE clause is the
-    authorization gate. A non-creator hitting the revoke endpoint
-    surfaces as a no-op (False return → 404 at the router). We don't
-    need a separate ownership lookup because the UPDATE's predicate
-    enforces it atomically.
+    Migration 142: scoped to `group_id` rather than the minting user, so ANY
+    admin of the group (gated at the router) can revoke any of its invites —
+    invite management is a shared admin power. The group_id check keeps a
+    guessed invite_id from another group from being revoked through this
+    group's route.
     """
     row = conn.execute(
         """
         UPDATE group_invites
            SET revoked_at = NOW()
          WHERE id = %(i)s::uuid
-           AND created_by_user_id = %(u)s::uuid
+           AND group_id = %(g)s::uuid
            AND revoked_at IS NULL
         RETURNING id
         """,
-        {"i": invite_id, "u": by_user_id},
+        {"i": invite_id, "g": group_id},
     ).fetchone()
     return row is not None
 
@@ -316,6 +315,25 @@ def redeem_invite(
     backdate_membership_for_user(
         conn, group_id, user_id, invite_created_at
     )
+
+    # Record which invite this member joined through (migration 142) so a
+    # future boot can revoke this specific link. Only on a genuine first join
+    # (not an already-member re-click — they didn't join via this link) and
+    # only when not already attributed, on the earliest-linked browser's row
+    # (the one backdate_membership_for_user wrote).
+    if not already_member:
+        conn.execute(
+            """
+            UPDATE group_members
+               SET joined_via_invite_id = %(i)s::uuid
+             WHERE group_id = %(g)s::uuid
+               AND joined_via_invite_id IS NULL
+               AND browser_id IN (
+                   SELECT browser_id FROM user_browsers WHERE user_id = %(u)s::uuid
+               )
+            """,
+            {"i": str(invite["id"]), "g": group_id, "u": user_id},
+        )
 
     # Resolve short_ids in one round-trip so the FE can build the
     # redirect URL without a follow-up call.

--- a/server/tests/test_claim_group.py
+++ b/server/tests/test_claim_group.py
@@ -84,8 +84,9 @@ def _sign_in(client, browser_id, email=None):
 
 def _create_anonymous_group(client, browser_id):
     """Create a fresh group via the anonymous (no-bearer) path.
-    Result: privacy='public', creator_user_id=NULL — exactly the
-    'grandfathered / anonymous-created' shape claim is for.
+    Migration 142: this now yields privacy='public' but with an auto-account
+    creator (no more NULL-creator groups), so claim is effectively obsolete —
+    see test_claim_obsolete_group_always_has_creator.
     """
     resp = client.post(
         "/api/groups",
@@ -144,111 +145,18 @@ def test_claim_403_when_not_a_member(
     assert resp.status_code == 403
 
 
-def test_claim_succeeds_for_signed_in_member(client, creator_browser):
-    group = _create_anonymous_group(client, creator_browser)
-    # Anonymous-create wrote the member row keyed on creator_browser.
-    # Sign in on the SAME browser so user_browsers links the session's
-    # user_id to that browser → the member walk finds the row.
-    token, user_id = _sign_in(client, creator_browser)
-    resp = client.post(
-        f"/api/groups/{group['id']}/claim",
-        headers=_bearer_headers(creator_browser, token),
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["group_id"] == group["id"]
-    assert body["creator_user_id"] == user_id
-    # Privacy state is preserved — claim doesn't auto-flip to private.
-    assert body["privacy"] == "public"
-    # DB write committed:
-    db = _read_group_row(group["id"])
-    assert db["creator_user_id"] == user_id
-    assert db["privacy"] == "public"
-
-
-def test_claim_409_when_already_claimed_by_same_user(
-    client, creator_browser
-):
+def test_claim_obsolete_group_always_has_creator(client, creator_browser):
+    """Migration 142 made claim obsolete: every group is minted with a creator
+    (= admin #1), so the atomic `UPDATE ... WHERE creator_user_id IS NULL`
+    never matches and claim always 409s. The endpoint is retained as harmless
+    (a future caller can't take over a group that already has an admin)."""
     group = _create_anonymous_group(client, creator_browser)
     token, _ = _sign_in(client, creator_browser)
-    first = client.post(
-        f"/api/groups/{group['id']}/claim",
-        headers=_bearer_headers(creator_browser, token),
-    )
-    assert first.status_code == 200, first.text
-    second = client.post(
-        f"/api/groups/{group['id']}/claim",
-        headers=_bearer_headers(creator_browser, token),
-    )
-    assert second.status_code == 409
-
-
-def test_claim_409_when_already_claimed_by_someone_else(
-    client, creator_browser, stranger_browser
-):
-    """Once claimed, the row is no longer NULL → no other member can
-    re-claim. Even if the second signed-in user has membership, the
-    atomic UPDATE WHERE creator_user_id IS NULL bounces them with 409."""
-    group = _create_anonymous_group(client, creator_browser)
-    # Precondition for the auto-join path used below: the by-route-id
-    # read only writes a group_members row when privacy='public'. If a
-    # future schema flip changes the anonymous-create default, this
-    # assertion catches the regression rather than letting the test
-    # silently morph into a 403-not-a-member check.
-    assert group["privacy"] == "public"
-    first_token, first_user_id = _sign_in(client, creator_browser)
     resp = client.post(
         f"/api/groups/{group['id']}/claim",
-        headers=_bearer_headers(creator_browser, first_token),
-    )
-    assert resp.status_code == 200
-
-    # Second user joins via the read endpoint (auto-join writes a
-    # group_members row for their browser on the public group), then
-    # signs in and tries to claim.
-    second_user_browser = str(uuid.uuid4())
-    join = client.get(
-        f"/api/groups/by-route-id/{group['id']}",
-        headers=_bid_headers(second_user_browser),
-    )
-    assert join.status_code == 200
-    second_token, _ = _sign_in(
-        client, second_user_browser, email="second@example.com"
-    )
-    resp = client.post(
-        f"/api/groups/{group['id']}/claim",
-        headers=_bearer_headers(second_user_browser, second_token),
+        headers=_bearer_headers(creator_browser, token),
     )
     assert resp.status_code == 409
-    # DB still reflects the FIRST user as creator — no takeover.
+    # The auto-account creator is recorded; claiming didn't change it.
     db = _read_group_row(group["id"])
-    assert db["creator_user_id"] == first_user_id
-
-
-def test_claim_unlocks_privacy_toggle(client, creator_browser):
-    """Smoke test that claiming actually unlocks downstream
-    creator-only authorization. Before claim, privacy flip 403s
-    (the legacy 'no recorded creator' branch). After claim, the
-    same caller's flip succeeds."""
-    group = _create_anonymous_group(client, creator_browser)
-    token, _ = _sign_in(client, creator_browser)
-    # Pre-claim flip is rejected — the group has no recorded creator.
-    pre = client.post(
-        f"/api/groups/{group['id']}/privacy",
-        json={"privacy": "private"},
-        headers=_bearer_headers(creator_browser, token),
-    )
-    assert pre.status_code == 403
-    # Claim, then re-attempt the flip.
-    claim = client.post(
-        f"/api/groups/{group['id']}/claim",
-        headers=_bearer_headers(creator_browser, token),
-    )
-    assert claim.status_code == 200
-    post = client.post(
-        f"/api/groups/{group['id']}/privacy",
-        json={"privacy": "private"},
-        headers=_bearer_headers(creator_browser, token),
-    )
-    assert post.status_code == 200, post.text
-    assert post.json()["privacy"] == "private"
+    assert db["creator_user_id"] is not None

--- a/server/tests/test_group_admins.py
+++ b/server/tests/test_group_admins.py
@@ -1,0 +1,364 @@
+"""Group admin system (migration 142) end-to-end coverage.
+
+Covers:
+  * Group create seeds the creator as admin #1 (signed-in AND the anonymous
+    auto-account path).
+  * GET /members surfaces `viewer_is_admin` + per-member `is_admin`.
+  * POST /{route}/admins promotes a member; admin-only; target must be a member.
+  * POST /{route}/members/{user_id}/boot removes a non-admin from a PRIVATE
+    group and revokes the invite they joined through; rejects public groups,
+    admins, and self.
+  * Auto-promotion: when the last admin leaves, the oldest remaining
+    account-member is promoted so the group always has an admin.
+  * Title/image edits are admin-gated (Q6).
+"""
+
+import uuid
+
+import psycopg
+import pytest
+
+from services.auth import generate_token, hash_token, normalize_email
+from tests.conftest import PNG_B64, TEST_DB_URL
+
+
+@pytest.fixture
+def creator_browser():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def member_browser():
+    return str(uuid.uuid4())
+
+
+def _bid(bid):
+    return {"X-Browser-Id": bid} if bid else {}
+
+
+def _auth(bid, token):
+    h = _bid(bid)
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _sign_in(client, browser_id, email=None, name=None):
+    """Sign in via magic link AND set a display name, so the account appears in
+    the named roster (where per-member is_admin is observable). FE-created
+    accounts always have a name; magic-link verify alone leaves it NULL."""
+    email = email or f"admin-{uuid.uuid4().hex[:8]}@example.com"
+    token = generate_token()
+    with psycopg.connect(TEST_DB_URL) as conn:
+        conn.execute(
+            "INSERT INTO magic_link_tokens (token_hash, email, browser_id, expires_at) "
+            "VALUES (%s, %s, %s, NOW() + INTERVAL '15 minutes')",
+            (hash_token(token), normalize_email(email), browser_id),
+        )
+        conn.commit()
+    resp = client.post(
+        "/api/auth/magic-link/verify",
+        json={"token": token},
+        headers=_bid(browser_id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    session_token = body["session_token"]
+    user_id = body["user"]["user_id"]
+    name = name or f"User-{uuid.uuid4().hex[:6]}"
+    named = client.post(
+        "/api/auth/me/name",
+        json={"name": name},
+        headers=_auth(browser_id, session_token),
+    )
+    assert named.status_code == 200, named.text
+    return session_token, user_id
+
+
+def _create_private_group(client, bid, token):
+    resp = client.post("/api/groups", headers=_auth(bid, token))
+    assert resp.status_code == 201, resp.text
+    g = resp.json()
+    assert g["privacy"] == "private"
+    return g
+
+
+def _members(client, route_id, bid, token=None):
+    resp = client.get(
+        f"/api/groups/{route_id}/members", headers=_auth(bid, token)
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _mint_invite(client, route_id, bid, token):
+    resp = client.post(
+        f"/api/groups/{route_id}/invites",
+        json={"mode": "single"},
+        headers=_auth(bid, token),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()  # carries id + token
+
+
+def _redeem(client, raw_token, bid, token):
+    resp = client.post(
+        f"/api/auth/invites/{raw_token}/redeem", headers=_auth(bid, token)
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _add_member_via_invite(client, group, admin_bid, admin_token, member_bid):
+    """Sign a fresh account in on member_bid and join `group` via an invite.
+    Returns (member_token, member_user_id, invite_id)."""
+    invite = _mint_invite(client, group["id"], admin_bid, admin_token)
+    member_token, member_uid = _sign_in(client, member_bid)
+    _redeem(client, invite["token"], member_bid, member_token)
+    return member_token, member_uid, invite["id"]
+
+
+# --------------------------------------------------------------------- create
+
+
+def test_signed_in_creator_is_admin(client, creator_browser):
+    token, user_id = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    roster = _members(client, g["short_id"], creator_browser, token)
+    assert roster["viewer_is_admin"] is True
+    me = [m for m in roster["members"] if m["user_id"] == user_id]
+    assert me and me[0]["is_admin"] is True
+
+
+def test_anonymous_creator_auto_account_is_admin(client, creator_browser):
+    # No bearer → public group with an auto-account creator who is admin #1.
+    resp = client.post("/api/groups", headers=_bid(creator_browser))
+    assert resp.status_code == 201, resp.text
+    g = resp.json()
+    roster = _members(client, g["short_id"], creator_browser)
+    assert roster["viewer_is_admin"] is True
+
+
+# -------------------------------------------------------------------- promote
+
+
+def test_promote_member_to_admin(client, creator_browser, member_browser):
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    member_token, member_uid, _ = _add_member_via_invite(
+        client, g, creator_browser, token, member_browser
+    )
+    # Before: member is not an admin.
+    roster = _members(client, g["short_id"], creator_browser, token)
+    member_row = [m for m in roster["members"] if m["user_id"] == member_uid]
+    assert member_row and member_row[0]["is_admin"] is False
+
+    resp = client.post(
+        f"/api/groups/{g['short_id']}/admins",
+        json={"user_id": member_uid},
+        headers=_auth(creator_browser, token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    # After: member is an admin and can do an admin action (mint an invite).
+    roster2 = _members(client, g["short_id"], member_browser, member_token)
+    assert roster2["viewer_is_admin"] is True
+    minted = client.post(
+        f"/api/groups/{g['short_id']}/invites",
+        json={"mode": "multi"},
+        headers=_auth(member_browser, member_token),
+    )
+    assert minted.status_code == 201, minted.text
+
+
+def test_promote_requires_admin(client, creator_browser, member_browser):
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    member_token, member_uid, _ = _add_member_via_invite(
+        client, g, creator_browser, token, member_browser
+    )
+    # The (non-admin) member tries to promote themselves → 403.
+    resp = client.post(
+        f"/api/groups/{g['short_id']}/admins",
+        json={"user_id": member_uid},
+        headers=_auth(member_browser, member_token),
+    )
+    assert resp.status_code == 403
+
+
+def test_promote_non_member_400(client, creator_browser):
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    # A signed-in account that never joined this group.
+    _, outsider_uid = _sign_in(client, str(uuid.uuid4()))
+    resp = client.post(
+        f"/api/groups/{g['short_id']}/admins",
+        json={"user_id": outsider_uid},
+        headers=_auth(creator_browser, token),
+    )
+    assert resp.status_code == 400
+
+
+# ----------------------------------------------------------------------- boot
+
+
+def test_boot_member_revokes_their_invite(
+    client, creator_browser, member_browser
+):
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    member_token, member_uid, invite_id = _add_member_via_invite(
+        client, g, creator_browser, token, member_browser
+    )
+
+    resp = client.post(
+        f"/api/groups/{g['short_id']}/members/{member_uid}/boot",
+        headers=_auth(creator_browser, token),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["booted"] is True
+
+    # Membership gone: the booted member now 404s on the private group read.
+    read = client.get(
+        f"/api/groups/by-route-id/{g['short_id']}",
+        headers=_auth(member_browser, member_token),
+    )
+    assert read.status_code == 404
+
+    # The invite they joined through is revoked.
+    with psycopg.connect(TEST_DB_URL) as conn:
+        row = conn.execute(
+            "SELECT revoked_at FROM group_invites WHERE id = %s", (invite_id,)
+        ).fetchone()
+    assert row is not None and row[0] is not None
+
+
+def test_boot_rejected_on_public_group(client, creator_browser, member_browser):
+    # Public group (anonymous create) — booting is futile, so 400.
+    resp = client.post("/api/groups", headers=_bid(creator_browser))
+    g = resp.json()
+    assert g["privacy"] == "public"
+    # A second browser visits → auto-joins.
+    client.get(
+        f"/api/groups/by-route-id/{g['short_id']}", headers=_bid(member_browser)
+    )
+    _, member_uid = _sign_in(client, member_browser)
+    boot = client.post(
+        f"/api/groups/{g['short_id']}/members/{member_uid}/boot",
+        headers=_bid(creator_browser),
+    )
+    assert boot.status_code == 400
+
+
+def test_boot_admin_rejected(client, creator_browser, member_browser):
+    token, creator_uid = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    member_token, member_uid, _ = _add_member_via_invite(
+        client, g, creator_browser, token, member_browser
+    )
+    # Promote member, then a co-admin can't boot another admin.
+    client.post(
+        f"/api/groups/{g['short_id']}/admins",
+        json={"user_id": member_uid},
+        headers=_auth(creator_browser, token),
+    )
+    resp = client.post(
+        f"/api/groups/{g['short_id']}/members/{creator_uid}/boot",
+        headers=_auth(member_browser, member_token),
+    )
+    assert resp.status_code == 403
+
+
+def test_boot_self_rejected(client, creator_browser):
+    token, creator_uid = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    resp = client.post(
+        f"/api/groups/{g['short_id']}/members/{creator_uid}/boot",
+        headers=_auth(creator_browser, token),
+    )
+    assert resp.status_code == 400
+
+
+def test_boot_requires_admin(client, creator_browser, member_browser):
+    token, creator_uid = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    member_token, member_uid, _ = _add_member_via_invite(
+        client, g, creator_browser, token, member_browser
+    )
+    # Non-admin member tries to boot the creator → 403.
+    resp = client.post(
+        f"/api/groups/{g['short_id']}/members/{creator_uid}/boot",
+        headers=_auth(member_browser, member_token),
+    )
+    assert resp.status_code == 403
+
+
+# ------------------------------------------------------------- auto-promotion
+
+
+def test_last_admin_leave_promotes_oldest_member(
+    client, creator_browser, member_browser
+):
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    member_token, member_uid, _ = _add_member_via_invite(
+        client, g, creator_browser, token, member_browser
+    )
+    # Creator (the only admin) leaves the group.
+    leave = client.delete(
+        f"/api/groups/{g['short_id']}/membership",
+        headers=_auth(creator_browser, token),
+    )
+    assert leave.status_code == 204
+    # The remaining member was auto-promoted to admin.
+    roster = _members(client, g["short_id"], member_browser, member_token)
+    assert roster["viewer_is_admin"] is True
+    with psycopg.connect(TEST_DB_URL) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM group_admins WHERE group_id = %s AND user_id = %s",
+            (g["id"], member_uid),
+        ).fetchone()
+    assert row is not None
+
+
+# ------------------------------------------------------------- edits admin-gated
+
+
+def test_title_edit_admin_gated(client, creator_browser):
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    # Fresh unlinked browser (no account) → 401.
+    anon = client.post(
+        f"/api/groups/{g['short_id']}/title",
+        json={"group_title": "Hijacked"},
+        headers=_bid(str(uuid.uuid4())),
+    )
+    assert anon.status_code == 401
+    # Admin can edit.
+    ok = client.post(
+        f"/api/groups/{g['short_id']}/title",
+        json={"group_title": "Trip Planning"},
+        headers=_auth(creator_browser, token),
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["title"] == "Trip Planning"
+
+
+def test_image_edit_admin_gated(client, creator_browser, member_browser):
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    # A signed-in non-member can't set the avatar → 403.
+    stranger_token, _ = _sign_in(client, member_browser)
+    forbidden = client.post(
+        f"/api/groups/{g['short_id']}/image",
+        json={"image_base64": PNG_B64, "mime_type": "image/png"},
+        headers=_auth(member_browser, stranger_token),
+    )
+    assert forbidden.status_code == 403
+    # Admin can.
+    ok = client.post(
+        f"/api/groups/{g['short_id']}/image",
+        json={"image_base64": PNG_B64, "mime_type": "image/png"},
+        headers=_auth(creator_browser, token),
+    )
+    assert ok.status_code == 200, ok.text

--- a/server/tests/test_group_privacy.py
+++ b/server/tests/test_group_privacy.py
@@ -125,12 +125,15 @@ def _set_group_privacy_direct(group_id, privacy):
 
 
 class TestCreateGroupPrivacy:
-    def test_anonymous_creates_public_group_no_creator(
+    def test_anonymous_creates_public_group_with_auto_creator(
         self, client, creator_browser
     ):
+        # Migration 142: anonymous create still yields a PUBLIC group, but a
+        # lightweight auto-account is minted and recorded as creator (= admin
+        # #1) so no group is ever admin-less.
         g = _create_empty_group(client, creator_browser)
         assert g["privacy"] == "public"
-        assert g["creator_user_id"] is None
+        assert g["creator_user_id"] is not None
 
     def test_signed_in_creates_private_group_with_creator(
         self, client, creator_browser
@@ -145,7 +148,9 @@ class TestCreateGroupPrivacy:
     ):
         poll = _create_poll(client, creator_browser)
         assert poll["group_privacy"] == "public"
-        assert poll["group_creator_user_id"] is None
+        # Migration 142: the group records the poll's auto-account creator even
+        # for anonymous creates (privacy stays public, decoupled from creator).
+        assert poll["group_creator_user_id"] is not None
 
     def test_signed_in_poll_creates_private_group(
         self, client, creator_browser
@@ -173,9 +178,13 @@ class TestCreateGroupPrivacy:
         )
         assert followup["group_id"] == group_id
         assert followup["group_privacy"] == "public"
-        # creator_user_id was set on the original (anonymous) create as
-        # NULL and isn't touched when adding follow-ups.
-        assert followup["group_creator_user_id"] is None
+        # Migration 142: the original anonymous create recorded an auto-account
+        # creator; adding follow-ups doesn't touch it (or the privacy).
+        assert (
+            followup["group_creator_user_id"]
+            == first["group_creator_user_id"]
+            is not None
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -425,14 +434,19 @@ class TestUpdateGroupPrivacy:
         assert resp.status_code == 200
         assert resp.json()["privacy"] == "private"
 
-    def test_anonymous_caller_401(self, client, creator_browser):
+    def test_no_account_caller_401(
+        self, client, creator_browser, stranger_browser
+    ):
+        # Migration 142: admin-gated. A caller whose browser resolves to NO
+        # account (fresh browser, no bearer) gets 401. NOTE the creator's own
+        # browser would still resolve to its account via the user_browsers
+        # link even without the bearer, so we use a fresh unlinked browser.
         token, _ = _sign_in(client, creator_browser)
         g = _create_empty_group(client, creator_browser, token)
-        # No Authorization header.
         resp = client.post(
             f"/api/groups/{g['short_id']}/privacy",
             json={"privacy": "public"},
-            headers=_bid_headers(creator_browser),
+            headers=_bid_headers(stranger_browser),
         )
         assert resp.status_code == 401
 
@@ -610,19 +624,19 @@ class TestPrivateMemberVisibility:
 
 
 class TestGrandfatheredGroups:
-    def test_existing_groups_are_public(self):
-        """Migration 114 backfilled every pre-Phase-E group to public.
-        Check by-direct-sql on a fresh row created via DEFAULT-only
-        insert (skips application code that sets privacy explicitly)."""
-        with psycopg.connect(TEST_DB_URL) as conn:
-            row = conn.execute(
-                "INSERT INTO groups DEFAULT VALUES RETURNING id, privacy"
-            ).fetchone()
-            conn.commit()
-            assert row[1] == "private"  # default for new INSERTs
-            # Clean up.
-            conn.execute("DELETE FROM groups WHERE id = %s", (row[0],))
-            conn.commit()
+    def test_create_paths_always_record_a_creator(
+        self, client, creator_browser
+    ):
+        """Migration 142: every group-create path records a creator (= admin
+        #1) so no NULL-creator group is ever minted, even anonymously. The
+        invariant lives in app code + `group_admins`, not a NOT NULL on the
+        (still-nullable, vestigial) `creator_user_id` column."""
+        # Empty-group create (anonymous → auto-account creator).
+        g = _create_empty_group(client, creator_browser)
+        assert g["creator_user_id"] is not None
+        # Poll create (anonymous → auto-account creator).
+        poll = _create_poll(client, creator_browser)
+        assert poll["group_creator_user_id"] is not None
 
     def test_legacy_group_remains_accessible_to_strangers(
         self, client, creator_browser, stranger_browser

--- a/server/tests/test_invites.py
+++ b/server/tests/test_invites.py
@@ -111,14 +111,17 @@ def _create_private_group(client, browser_id, token):
 # ----------------------------------------------------------------- create
 
 
-def test_create_invite_anonymous_returns_401(client, creator_browser):
+def test_create_invite_no_account_returns_401(client, creator_browser):
     ctoken, _ = _sign_in(client, creator_browser)
     group = _create_private_group(client, creator_browser, ctoken)
 
+    # Migration 142: admin-gated. A fresh browser resolving to no account → 401
+    # (the creator's own browser would still resolve via its account link even
+    # without a bearer, so use an unlinked one).
     resp = client.post(
         f"/api/groups/{group['id']}/invites",
         json={"mode": "multi"},
-        headers=_bid_headers(creator_browser),  # no bearer
+        headers={"X-Browser-Id": str(uuid.uuid4())},
     )
     assert resp.status_code == 401
 

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -131,13 +131,13 @@ def _create_private_group(client, browser_id, token):
 
 
 def _create_public_anon_group(client, browser_id):
-    """Anonymous create → privacy='public', creator_user_id NULL.
-    Used for the "no recorded creator" 403 cases."""
+    """Anonymous create → privacy='public'. Migration 142: a lightweight
+    auto-account is recorded as creator/admin (no more NULL-creator groups)."""
     resp = client.post("/api/groups", headers=_bid_headers(browser_id))
     assert resp.status_code == 201, resp.text
     group = resp.json()
     assert group["privacy"] == "public"
-    assert group["creator_user_id"] is None
+    assert group["creator_user_id"] is not None
     return group
 
 
@@ -331,13 +331,14 @@ def test_create_join_request_existing_member_short_circuits(
 # ----------------------------------------------------------------------- list
 
 
-def test_list_join_requests_anonymous_returns_401(client, creator_browser):
+def test_list_join_requests_no_account_returns_401(client, creator_browser):
     ctoken, _, _ = _sign_in(client, creator_browser)
     group = _create_private_group(client, creator_browser, ctoken)
 
+    # Migration 142: admin-gated. Fresh unlinked browser → no account → 401.
     resp = client.get(
         f"/api/groups/{group['id']}/join-requests",
-        headers=_bid_headers(creator_browser),  # no token
+        headers={"X-Browser-Id": str(uuid.uuid4())},
     )
     assert resp.status_code == 401
 
@@ -424,11 +425,13 @@ def test_list_join_requests_surfaces_name_and_image_fields(
     assert row["requested_at"]
 
 
-def test_list_join_requests_anon_created_group_returns_403(
+def test_list_join_requests_anon_created_group_creator_is_admin(
     client, creator_browser
 ):
-    """Anonymous-created groups have no recorded creator — no one can
-    list them. Phase I will add a 'claim' upgrade path."""
+    """Migration 142: an anonymous-created group records its creator's
+    auto-account as admin #1. Signing in on the same browser absorbs that
+    auto-account (keeping its admin row), so the original creator CAN now
+    manage join requests — listing returns 200, not the old 403."""
     group = _create_public_anon_group(client, creator_browser)
     ctoken, _, _ = _sign_in(client, creator_browser)
 
@@ -436,21 +439,22 @@ def test_list_join_requests_anon_created_group_returns_403(
         f"/api/groups/{group['id']}/join-requests",
         headers=_bearer_headers(creator_browser, ctoken),
     )
-    assert resp.status_code == 403
+    assert resp.status_code == 200
 
 
 # --------------------------------------------------------------------- decide
 
 
-def test_decide_anonymous_returns_401(client, creator_browser):
+def test_decide_no_account_returns_401(client, creator_browser):
     ctoken, _, _ = _sign_in(client, creator_browser)
     group = _create_private_group(client, creator_browser, ctoken)
 
+    # Migration 142: admin-gated. Fresh unlinked browser → no account → 401.
     bogus_request = str(uuid.uuid4())
     resp = client.post(
         f"/api/groups/{group['id']}/join-requests/{bogus_request}/decide",
         json={"action": "approve"},
-        headers=_bid_headers(creator_browser),
+        headers={"X-Browser-Id": str(uuid.uuid4())},
     )
     assert resp.status_code == 401
 

--- a/server/tests/test_polls_api.py
+++ b/server/tests/test_polls_api.py
@@ -390,6 +390,9 @@ class TestGroupAddition:
     source of truth for the group-name override (no per-poll copies)."""
 
     def _create_root(self, client, creator_secret, **kwargs):
+        # Pin a browser_id so the creator's auto-account (= group admin) is
+        # stable for later admin-gated calls (e.g. the title endpoint).
+        bid = str(uuid.uuid4())
         resp = client.post(
             "/api/polls",
             json={
@@ -397,9 +400,12 @@ class TestGroupAddition:
                 "questions": [_yes_no_question()],
                 **kwargs,
             },
+            headers={"X-Browser-Id": bid},
         )
         assert resp.status_code == 201, resp.text
-        return resp.json()
+        data = resp.json()
+        data["_creator_bid"] = bid
+        return data
 
     def test_poll_added_to_group_inherits_group_id(self, client, creator_secret):
         parent = self._create_root(client, creator_secret)
@@ -504,11 +510,15 @@ class TestGroupAddition:
     def test_update_group_title_endpoint(self, client, creator_secret):
         parent = self._create_root(client, creator_secret)
         group_id = parent["group_id"]
+        # Migration 142: title edits are admin-gated; the creator's browser
+        # resolves to its auto-account admin.
+        admin_hdr = {"X-Browser-Id": parent["_creator_bid"]}
 
         # Set
         resp = client.post(
             f"/api/groups/{group_id}/title",
             json={"group_title": "Renamed"},
+            headers=admin_hdr,
         )
         assert resp.status_code == 200, resp.text
         body = resp.json()
@@ -523,6 +533,7 @@ class TestGroupAddition:
         cleared = client.post(
             f"/api/groups/{group_id}/title",
             json={"group_title": ""},
+            headers=admin_hdr,
         )
         assert cleared.json()["title"] is None
         assert client.get(
@@ -533,11 +544,13 @@ class TestGroupAddition:
         self, client, creator_secret
     ):
         parent = self._create_root(client, creator_secret)
+        admin_hdr = {"X-Browser-Id": parent["_creator_bid"]}
         # groups.short_id is the canonical FE-facing form
         for route_id in (parent["group_id"], parent["group_short_id"]):
             r = client.post(
                 f"/api/groups/{route_id}/title",
                 json={"group_title": f"name-{route_id[:6]}"},
+                headers=admin_hdr,
             )
             assert r.status_code == 200, r.text
 

--- a/server/tests/test_showtimes_cache.py
+++ b/server/tests/test_showtimes_cache.py
@@ -15,6 +15,11 @@ from services.showtimes import cache as cache_mod
 from services.showtimes.alamo import Showtime, _DirectoryCinema
 
 
+# TODO (pre-existing, unrelated to the group-admin work): this fixture is stale —
+# the `Showtime` dataclass gained required `brand` + `group_key` fields (brand-prefix
+# normalization) but this helper wasn't updated, so all 3 tests in this file fail
+# with `TypeError: Showtime.__init__() missing 2 required positional arguments`.
+# Fix: add `brand=None, group_key="dune"` (or the canonical group key) to the call.
 def _showtime(cinema_id: str = "0701") -> Showtime:
     return Showtime(
         session_id="s1", film_id="f1", film_name="Dune", film_year="2026",


### PR DESCRIPTION
## Summary

Generalizes the single `groups.creator_user_id` into a multi-**admin** role. Admins can toggle privacy, edit title/avatar, approve join requests, mint/revoke invite links, add people, **promote** members to admin, and **boot** non-admin members.

Owner-confirmed decisions:
- **No demotion, no owner hierarchy** — once an admin, you stay one until you leave the group (the only event that shrinks the admin set).
- **Boot is private-groups-only** (booting a public-group member is futile — they auto-rejoin) and revokes the specific invite link the booted member joined through.
- **Admins are account-keyed** (`group_members` is browser-keyed, but admin powers need a real account).

## Changes

**Schema (migration 142, destructive):**
- `group_admins(group_id, user_id, granted_at)` + `group_members.joined_via_invite_id`.
- **Wipes legacy NULL-creator groups** (disposable anonymous-era data — ~97% of prod was NULL-creator) and seeds surviving creators as admin #1.
- `creator_user_id` stays nullable (vestigial history; FK is ON DELETE SET NULL). The "every group has an admin" invariant lives in `group_admins` + app code, not a NOT NULL constraint.

**Server:**
- No more NULL-creator groups going forward: both create paths always record a creator (auto-account for anonymous creators), decoupled from privacy. Claim is obsolete (kept as harmless dead code).
- `_require_admin` replaces the single-creator gate on privacy/join-requests/invites, and newly gates title + avatar edits + add-people.
- Promote + boot endpoints; auto-promotion when the last admin leaves or deletes their account; `merge_accounts` repoints admin rows.
- `GET /members` returns `viewer_is_admin` + per-member `is_admin`.

**Frontend:**
- `/info` gates all admin chrome on `viewer_is_admin`; member list shows an Admin badge + (for admins) Make-admin / Remove actions behind a confirmation (Remove only on private groups).
- `GroupPrivacySection` re-gated creator → admin; claim UI removed.

## Test plan
- [x] `test_group_admins.py` (13) + updated group/claim/invite/join/account tests — 110 pass locally.
- [x] FE typecheck + lint clean; 374 vitest pass.
- [x] Verified end-to-end on the branch dev server: create→admin, members join, promote, boot (member 404s + invite revoked), both negatives. Admin vs non-admin /info views screenshot-confirmed.

WARNING: the migration's destructive wipe runs when it deploys: `latest` on merge to main, prod on release.

https://claude.ai/code/session_01YCPxCBYfUQCUbxeRwZFMYb