### PR TITLE
groups: extract require_group_read_access for members-only reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3173,16 +3173,23 @@ Bob → list still says only Sam). Shipped on
   the in-tree child through the global event would be a downgrade (it'd
   pretend a parent/child relationship is cross-route). `/info` also refetches
   on tab `visibilitychange → visible`.
-- **TODO (pre-existing, out of scope of the roster PR): extract a shared
-  `require_group_read_access(conn, route_id, *, browser_id, user_id) → group_id`
-  helper.** The "resolve route → 404 on miss → `get_group_metadata` → 404
-  non-members of a private group" block is now copy-pasted byte-for-byte
-  across ≥3 read endpoints (`get_group_summary`, the by-route-id read, and the
-  new `get_group_members`); `get_group_metadata` is fetched at ~7 call sites.
-  The new endpoint faithfully follows the existing pattern; collapsing all
-  members-only reads onto one helper (so the privacy contract is a single
-  auditable point) is a separate refactor that touches untouched endpoints —
-  do it as its own change, not bolted onto a feature PR.
+- **`require_group_read_access(conn, route_id, *, browser_id, user_id) → group_id`
+  (`routers/groups.py`, SHIPPED) is the single members-only-read privacy gate.**
+  Collapses the "resolve route → 404 on miss → `get_group_metadata` → 404
+  non-members of a private group" block that was copy-pasted byte-for-byte in
+  `get_group_summary` + `get_group_members`. Public groups stay openly readable
+  (NO auto-join — these endpoints only READ metadata/roster), private groups 404
+  non-members; raises HTTPException(404, "Group not found") internally. It's the
+  read-side sibling of `services/groups.py: resolve_group_for_visit` (the
+  `/by-route-id` AUTO-JOIN variant — that one writes a membership row for public
+  visitors, so the two can't be merged). Route any NEW members-only read through
+  this helper so the privacy contract stays a single auditable point. NOTE the
+  deliberately-stricter outliers that do NOT use it: `get_poll_voters`
+  (`/poll/{ref}/voter-identities`) member-gates EVEN public groups, and `claim_group`
+  gates on membership with a 403/custom detail — different contracts. `get_group_metadata`
+  is still fetched directly at the non-read sites (push creator lookup in the
+  join-request endpoint, the boot-private-only check) where the read-access gate
+  doesn't apply.
 - Tests: `server/tests/test_group_members_roster.py` (named members incl.
   not-yet-voted, account de-dup across browsers, anonymous roll-up, private
   members-only).

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -235,6 +235,39 @@ class GroupTitleResponse(BaseModel):
 router = APIRouter(prefix="/api/groups", tags=["groups"])
 
 
+def require_group_read_access(
+    conn, route_id: str, *, browser_id: str | None, user_id: str | None
+) -> str:
+    """Resolve `route_id` → group_id for a members-only READ endpoint,
+    enforcing Phase E privacy. Returns the group_id; raises HTTPException(404)
+    when the route doesn't resolve OR the group is private and the caller
+    isn't a member.
+
+    This is the read-side sibling of `resolve_group_for_visit` (used by the
+    `/by-route-id` endpoints), with ONE deliberate difference: it does NOT
+    auto-join public-group visitors — these endpoints (/summary, /members)
+    only READ metadata + roster, so they leave membership untouched. Public
+    groups stay openly readable (consistent with /summary + /preview being
+    public); private groups 404 non-members. Collapsing the members-only
+    reads onto this helper makes "who can read a private group's
+    chrome/roster" a single auditable point, so a new members-only read
+    can't drift from the existing ones.
+    """
+    group_id = resolve_group_id_from_route_id(conn, route_id)
+    if not group_id:
+        raise HTTPException(status_code=404, detail="Group not found")
+    meta = get_group_metadata(conn, group_id)
+    if (
+        meta
+        and meta["privacy"] == "private"
+        and not is_caller_member_of_group(
+            conn, group_id, browser_id=browser_id, user_id=user_id
+        )
+    ):
+        raise HTTPException(status_code=404, detail="Group not found")
+    return group_id
+
+
 class MyGroupsRequest(BaseModel):
     """Request body for `POST /api/groups/mine`.
 
@@ -452,15 +485,9 @@ def get_group_summary(route_id: str, request: Request):
     browser_id = _browser_id(request)
     user_id = _user_id(request)
     with get_db() as conn:
-        group_id = resolve_group_id_from_route_id(conn, route_id)
-        if not group_id:
-            raise HTTPException(status_code=404, detail="Group not found")
-        meta = get_group_metadata(conn, group_id)
-        if meta and meta["privacy"] == "private":
-            if not is_caller_member_of_group(
-                conn, group_id, browser_id=browser_id, user_id=user_id
-            ):
-                raise HTTPException(status_code=404, detail="Group not found")
+        group_id = require_group_read_access(
+            conn, route_id, browser_id=browser_id, user_id=user_id
+        )
         # `has_polls` (visibility-blind) lets the FE tell "all my history is
         # hidden pre-join" apart from "brand-new empty group" — folded into
         # the one SELECT so the summary stays a single round-trip. See
@@ -1627,15 +1654,9 @@ def get_group_members(route_id: str, request: Request):
     browser_id = _browser_id(request)
     user_id = _user_id(request)
     with get_db() as conn:
-        group_id = resolve_group_id_from_route_id(conn, route_id)
-        if not group_id:
-            raise HTTPException(status_code=404, detail="Group not found")
-        meta = get_group_metadata(conn, group_id)
-        if meta and meta["privacy"] == "private":
-            if not is_caller_member_of_group(
-                conn, group_id, browser_id=browser_id, user_id=user_id
-            ):
-                raise HTTPException(status_code=404, detail="Group not found")
+        group_id = require_group_read_access(
+            conn, route_id, browser_id=browser_id, user_id=user_id
+        )
         named, anon = load_group_members(conn, group_id)
         admin_ids = group_admin_user_ids(conn, group_id)
         viewer_is_admin = is_caller_admin(


### PR DESCRIPTION
## Summary

Handles the parked TODO in CLAUDE.md's Group Member Roster section: extract a shared `require_group_read_access` helper so the members-only-read privacy contract is a single auditable point.

The "resolve route → 404 on miss → `get_group_metadata` → 404 private non-members" gate was copy-pasted byte-for-byte in `get_group_summary` and `get_group_members`. Both now call one helper.

- **Public groups stay openly readable** (no auto-join — these endpoints only read metadata/roster), **private groups 404 non-members** — behavior identical to before.
- It's the read-side sibling of `services/groups.py: resolve_group_for_visit` (the `/by-route-id` auto-join variant that writes a membership row for public visitors), so the two can't be merged.
- Deliberately-stricter sites are left as-is: `get_poll_voters` member-gates even public groups, and `claim_group` gates on membership with a 403/custom detail — different contracts.
- CLAUDE.md TODO converted to a SHIPPED note describing the canonical gate.

Pure internal refactor — the API responses are byte-identical, so there's no user-visible surface to demo.

## Test plan
- [x] `server/tests/test_group_privacy.py` — green
- [x] `server/tests/test_group_members_roster.py` — green
- [x] `server/tests/test_empty_groups.py` — green
- [x] `server/tests/test_group_admins.py` — green
- [x] `server/tests/test_groups_visibility.py` — green

https://claude.ai/code/session_01FiBo8Y7ZyUu8ciByp6FcS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiBo8Y7ZyUu8ciByp6FcS9)_