### PR TITLE
groups: member 3-dots action sheet, compact invites, bootable anonymous members

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3204,11 +3204,16 @@ toggle privacy, edit title/avatar, approve join requests, mint/revoke invite
 links, add people directly, **promote** members to admin, and **boot** non-admin
 members. Design decisions (owner-confirmed): **no demotion and no owner
 hierarchy** (Q4 — once an admin, you stay one until you LEAVE the group, which is
-the only event that shrinks the admin set); **boot is PRIVATE-groups-only** (Q3 —
-booting a public-group member is futile, they auto-rejoin on visit) and revokes
-the specific invite link the booted member joined through; **admins are
-account-keyed** (`group_members` is browser-keyed, but admin powers need a real
-account).
+the only event that shrinks the admin set); **boot works on PUBLIC groups too**
+(the original Q3 "private-only" rule was REVISED by the owner — boot revokes the
+member's invite + clears the current roster; on a public group the member can
+still re-visit and auto-rejoin, but the owner wanted the removal action
+available everywhere) and revokes the specific invite link the booted member
+joined through; **admins are account-keyed** (`group_members` is browser-keyed,
+but admin powers need a real account). **Anonymous (no-name) members can be
+booted too** via an opaque per-roster handle (see the boot endpoints + the
+`anonymous_member_handle` bullet below) — we never expose a member's raw
+`browser_id` to the client (it's a cross-group identity token).
 
 - **Schema:** `group_admins(group_id, user_id, granted_at)` PK `(group_id,
   user_id)`, both FKs CASCADE, index on `user_id`. `group_members.joined_via_invite_id`
@@ -3251,23 +3256,45 @@ account).
   silently demotes. No account member to promote ⇒ group stays admin-less (the
   accepted "≥1 account member" condition).
 - **New endpoints:** `POST /{route}/admins {user_id}` (promote a member; target
-  must be a member), `POST /{route}/members/{user_id}/boot` (private-only,
+  must be a member), `POST /{route}/members/{user_id}/boot` (any-privacy now,
   non-admin target, not self → removes membership across linked browsers +
-  revokes their `joined_via_invite_id`). Both admin-only.
+  revokes their `joined_via_invite_id`), `POST /{route}/members/by-handle/{handle}/boot`
+  (boot an ANONYMOUS member by their opaque roster handle — re-derives each
+  anon member's handle server-side, matches, then `boot_member_by_browser`).
+  All admin-only.
+- **`anonymous_member_handle(group_id, person_key)` (`services/groups.py`)** is
+  the opaque-id scheme for booting nameless members without leaking
+  `browser_id`. `person_key` = the member's account user_id (account-no-name)
+  else their browser_id (browser-only); the handle is
+  `sha256(f"{group_id}:{person_key}")` — one-way (doesn't reveal the key),
+  deterministic, group-scoped, and matchable server-side by recomputing it over
+  the group's anonymous members. No secret needed (an attacker who could forge a
+  handle already knows the browser_id; boot is admin-only + scoped to existing
+  members). `load_group_members` now returns `(named, anonymous)` where
+  `anonymous` is a list of `{user_id, browser_id}` (browser_id is a
+  REPRESENTATIVE member row, kept server-side only); the endpoint maps it to
+  `anonymous_members: [{handle}]` and keeps `anonymous_count = len(anonymous)`
+  for older clients.
 - **`GET /{route}/members`** now returns `viewer_is_admin` (top-level) +
-  per-member `is_admin`. Anonymous (nameless) members roll into `anonymous_count`
-  and are never admins (account-keyed); a nameless admin (no display_name) is an
-  admin but rolls up anonymously — FE admins always have a name via the name-gate.
-- **FE:** `apiGetGroupMembers` surfaces `viewer_is_admin` + `is_admin`;
-  `apiPromoteGroupAdmin` / `apiBootGroupMember`. The `/info` page gates ALL admin
-  chrome on `roster.viewer_is_admin` (replacing the old
-  `session.user_id === group.creatorUserId` computation): Privacy toggle (via
-  `GroupPrivacySection`'s new `viewerIsAdmin` prop — its claim flow is removed),
-  JoinRequestsSection/InviteLinksSection `enabled`, Add-people, Edit-title, and
-  per-member Make-admin / Remove buttons (behind a `ConfirmationModal`; Remove
-  only when `group.privacy === 'private'`). The per-POLL info page is UNCHANGED —
-  its close/reopen/cutoff actions gate on POLL authorship (`poll.viewer_is_creator`),
-  a separate concept from group admin.
+  per-member `is_admin`, plus `anonymous_members: [{handle}]` (and the
+  count-only `anonymous_count`). Anonymous (nameless) members are never admins
+  (account-keyed); a nameless admin (no display_name) is an admin but rolls up
+  anonymously — FE admins always have a name via the name-gate.
+- **FE:** `apiGetGroupMembers` surfaces `viewer_is_admin` + `is_admin` +
+  `anonymous_members`; `apiPromoteGroupAdmin` / `apiBootGroupMember` /
+  `apiBootGroupAnonymous`. The `/info` page gates ALL admin chrome on
+  `roster.viewer_is_admin`: Privacy toggle (via `GroupPrivacySection`'s
+  `viewerIsAdmin` prop — its claim flow is removed),
+  JoinRequestsSection/InviteLinksSection `enabled`, Add-people, Edit-title, and a
+  per-member **3-dots action sheet** (`components/MemberActionsSheet.tsx`, haptic
+  on open) offering **Make admin** (named members only) + **Remove from group**
+  (all members, incl. anonymous via handle), each routed through a
+  `ConfirmationModal`. The expandable "N anonymous" roster row reveals individual
+  "Anonymous" rows, each with its own 3-dots → Remove. `InviteLinksSection` is
+  one compact line per invite (mode · usage · age) with a trashcan revoke, and a
+  small `+` mint button in the section header (no separate bottom button). The
+  per-POLL info page is UNCHANGED — its close/reopen/cutoff actions gate on POLL
+  authorship (`poll.viewer_is_creator`), a separate concept from group admin.
 - **Pitfall (the NOT NULL trap):** an early version made `creator_user_id` NOT
   NULL as a guardrail — it broke account deletion (FK SET NULL → NOT NULL
   violation) AND cascaded failures in instant-link / follow-state / account tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3277,7 +3277,10 @@ booted too** via an opaque per-roster handle (see the boot endpoints + the
   for older clients.
 - **`GET /{route}/members`** now returns `viewer_is_admin` (top-level) +
   per-member `is_admin`, plus `anonymous_members: [{handle}]` (and the
-  count-only `anonymous_count`). Anonymous (nameless) members are never admins
+  count-only `anonymous_count`) and `viewer_anonymous_handle` (the viewer's own
+  anon handle, or null — the FE filters exactly this entry out of the displayed
+  anon list so the viewer shows as the "You" row, never with a self-boot
+  3-dots). Anonymous (nameless) members are never admins
   (account-keyed); a nameless admin (no display_name) is an admin but rolls up
   anonymously — FE admins always have a name via the name-gate.
 - **FE:** `apiGetGroupMembers` surfaces `viewer_is_admin` + `is_admin` +

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -27,6 +27,8 @@ import GroupPrivacySection from "@/components/GroupPrivacySection";
 import HeaderPortal from "@/components/HeaderPortal";
 import InitialBubble from "@/components/InitialBubble";
 import RosterRow from "@/components/RosterRow";
+import MemberActionsSheet from "@/components/MemberActionsSheet";
+import { haptic } from "@/lib/haptics";
 import InviteLinksSection from "@/components/InviteLinksSection";
 import JoinRequestsSection from "@/components/JoinRequestsSection";
 import NotificationSettingsCard from "@/components/NotificationSettingsCard";
@@ -69,6 +71,13 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   const [pendingAction, setPendingAction] = useState<
     { kind: "promote" | "boot"; userId: string; name: string } | null
   >(null);
+  // The member whose 3-dots action sheet (Make admin / Remove) is open.
+  const [actionsFor, setActionsFor] = useState<
+    { userId: string; name: string } | null
+  >(null);
+  // Anonymous members are returned only as a count (no per-person data), so
+  // the rolled-up "N anonymous" row expands into N identical "Anonymous" rows.
+  const [anonExpanded, setAnonExpanded] = useState(false);
 
   const goBack = () => {
     // Slide overlay: mount the group root above the current page and slide
@@ -311,50 +320,103 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                   isAdmin={isAdmin}
                   actions={
                     canManage ? (
-                      <>
-                        <button
-                          type="button"
-                          onPointerDown={(e) => e.stopPropagation()}
-                          onClick={() =>
-                            setPendingAction({ kind: "promote", userId: userId!, name })
-                          }
-                          className="shrink-0 text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline active:opacity-70"
+                      <button
+                        type="button"
+                        // stopPropagation so a tap on the 3-dots doesn't also
+                        // fire the row's long-press → profile modal.
+                        onPointerDown={(e) => e.stopPropagation()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          haptic.medium();
+                          setActionsFor({ userId: userId!, name });
+                        }}
+                        className="shrink-0 w-9 h-9 -mr-2 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:opacity-70"
+                        aria-label={`Actions for ${name}`}
+                      >
+                        <svg
+                          className="w-5 h-5"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden
                         >
-                          Make admin
-                        </button>
-                        {isPrivateGroup && (
-                          <button
-                            type="button"
-                            onPointerDown={(e) => e.stopPropagation()}
-                            onClick={() =>
-                              setPendingAction({ kind: "boot", userId: userId!, name })
-                            }
-                            className="shrink-0 text-xs font-medium text-red-600 dark:text-red-400 hover:underline active:opacity-70"
-                          >
-                            Remove
-                          </button>
-                        )}
-                      </>
+                          <circle cx="12" cy="5" r="2" />
+                          <circle cx="12" cy="12" r="2" />
+                          <circle cx="12" cy="19" r="2" />
+                        </svg>
+                      </button>
                     ) : null
                   }
                 />
               );
             })}
             {anonymousExtra > 0 && (
-              <li className="flex items-center gap-3 px-4 py-3 text-gray-500 dark:text-gray-400 italic">
-                <InitialBubble
-                  name={null}
-                  sizeClassName="w-8 h-8"
-                  className="shrink-0"
-                />
-                <span className="min-w-0 break-words">
-                  {anonymousExtra} anonymous
-                </span>
-              </li>
+              <>
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      haptic.light();
+                      setAnonExpanded((v) => !v);
+                    }}
+                    aria-expanded={anonExpanded}
+                    className="w-full flex items-center gap-3 px-4 py-3 text-left text-gray-500 dark:text-gray-400 italic hover:bg-gray-50 dark:hover:bg-gray-800/50 active:opacity-70"
+                  >
+                    <InitialBubble
+                      name={null}
+                      sizeClassName="w-8 h-8"
+                      className="shrink-0"
+                    />
+                    <span className="min-w-0 break-words flex-1">
+                      {anonymousExtra} anonymous
+                    </span>
+                    <svg
+                      className={`shrink-0 w-4 h-4 transition-transform ${anonExpanded ? "rotate-180" : ""}`}
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      viewBox="0 0 24 24"
+                      aria-hidden
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                </li>
+                {anonExpanded &&
+                  Array.from({ length: anonymousExtra }, (_, i) => (
+                    <li
+                      key={`anon-${i}`}
+                      className="flex items-center gap-3 px-4 py-3 text-gray-500 dark:text-gray-400 italic"
+                    >
+                      <InitialBubble
+                        name={null}
+                        sizeClassName="w-8 h-8"
+                        className="shrink-0"
+                      />
+                      <span className="min-w-0 break-words">Anonymous</span>
+                    </li>
+                  ))}
+              </>
             )}
           </ul>
         </div>
       </div>
+
+      {actionsFor && (
+        <MemberActionsSheet
+          isOpen={true}
+          name={actionsFor.name}
+          canRemove={isPrivateGroup}
+          onMakeAdmin={() => {
+            setPendingAction({ kind: "promote", userId: actionsFor.userId, name: actionsFor.name });
+            setActionsFor(null);
+          }}
+          onRemove={() => {
+            setPendingAction({ kind: "boot", userId: actionsFor.userId, name: actionsFor.name });
+            setActionsFor(null);
+          }}
+          onClose={() => setActionsFor(null)}
+        />
+      )}
 
       {pendingAction && (
         <ConfirmationModal

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -14,8 +14,9 @@ import {
   apiGetGroupMembers,
   apiPromoteGroupAdmin,
   apiBootGroupMember,
+  apiBootGroupAnonymous,
 } from "@/lib/api";
-import type { GroupRoster } from "@/lib/api";
+import type { GroupRoster, AnonymousMember } from "@/lib/api";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import {
   GROUP_MEMBERS_CHANGED_EVENT,
@@ -69,11 +70,17 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   // consequential — promote is permanent, boot removes a member + revokes
   // their invite link).
   const [pendingAction, setPendingAction] = useState<
-    { kind: "promote" | "boot"; userId: string; name: string } | null
+    | { kind: "promote" | "boot"; userId: string; name: string }
+    | { kind: "boot-anon"; handle: string; name: string }
+    | null
   >(null);
-  // The member whose 3-dots action sheet (Make admin / Remove) is open.
+  // The member whose 3-dots action sheet is open. Named members carry a
+  // `userId` (promote/boot); anonymous members carry an opaque `handle`
+  // (Remove only — they can't be promoted).
   const [actionsFor, setActionsFor] = useState<
-    { userId: string; name: string } | null
+    | { userId: string; name: string }
+    | { handle: string; name: string }
+    | null
   >(null);
   // Anonymous members are returned only as a count (no per-person data), so
   // the rolled-up "N anonymous" row expands into N identical "Anonymous" rows.
@@ -98,16 +105,17 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   const [roster, setRoster] = useState<GroupRoster | null>(null);
   const [rosterTick, setRosterTick] = useState(0);
   const viewerIsAdmin = roster?.viewer_is_admin ?? false;
-  const isPrivateGroup = group.privacy === "private";
 
   const runPendingAction = () => {
     if (!pendingAction) return;
-    const { kind, userId } = pendingAction;
+    const action = pendingAction;
     setPendingAction(null);
     const call =
-      kind === "promote"
-        ? apiPromoteGroupAdmin(groupId, userId)
-        : apiBootGroupMember(groupId, userId);
+      action.kind === "promote"
+        ? apiPromoteGroupAdmin(groupId, action.userId)
+        : action.kind === "boot"
+          ? apiBootGroupMember(groupId, action.userId)
+          : apiBootGroupAnonymous(groupId, action.handle);
     // Refetch the roster on success so the badge / removal reflects.
     call.then(() => setRosterTick((t) => t + 1)).catch(() => {
       setRosterTick((t) => t + 1);
@@ -154,10 +162,10 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   };
   let membersList: MemberRow[];
   let totalCount: number;
-  let anonymousExtra = 0;
+  let anonymousMembers: AnonymousMember[] = [];
   if (roster) {
     totalCount = roster.members.length + roster.anonymous_count;
-    let anon = roster.anonymous_count;
+    anonymousMembers = [...roster.anonymous_members];
     const rows: MemberRow[] = roster.members.map((m, i) => ({
       name: m.name,
       key: `member-${m.user_id ?? m.name}-${i}`,
@@ -167,8 +175,9 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
     }));
     // The viewer is always a member (visiting auto-joins / the creator is a
     // member). If they aren't a resolved named row, they're one of the
-    // anonymous members — surface them as themselves and pull one out of the
-    // anonymous roll-up so the headcount stays right.
+    // anonymous members — surface them as themselves and drop one anonymous
+    // slot (the viewer's; anonymous members are indistinguishable, and you
+    // can't boot yourself anyway) so the headcount stays right.
     if (!rows.some((r) => isCurrentUserName(r.name))) {
       // Viewer's own row isn't long-pressable (userId null); isAdmin still
       // drives the Admin badge on your own row.
@@ -178,11 +187,10 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         userId: null,
         isAdmin: viewerIsAdmin,
       });
-      if (anon > 0) anon -= 1;
+      if (anonymousMembers.length > 0) anonymousMembers.shift();
     }
     rows.sort((a, b) => a.name.localeCompare(b.name));
     membersList = rows;
-    anonymousExtra = anon;
   } else {
     // First-paint fallback before the roster lands: poll participants + the
     // viewer (the prior behavior). Replaced within a tick by the real roster.
@@ -349,7 +357,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                 />
               );
             })}
-            {anonymousExtra > 0 && (
+            {anonymousMembers.length > 0 && (
               <>
                 <li>
                   <button
@@ -367,7 +375,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                       className="shrink-0"
                     />
                     <span className="min-w-0 break-words flex-1">
-                      {anonymousExtra} anonymous
+                      {anonymousMembers.length} anonymous
                     </span>
                     <svg
                       className={`shrink-0 w-4 h-4 transition-transform ${anonExpanded ? "rotate-180" : ""}`}
@@ -382,9 +390,9 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                   </button>
                 </li>
                 {anonExpanded &&
-                  Array.from({ length: anonymousExtra }, (_, i) => (
+                  anonymousMembers.map((m) => (
                     <li
-                      key={`anon-${i}`}
+                      key={`anon-${m.handle}`}
                       className="flex items-center gap-3 px-4 py-3 text-gray-500 dark:text-gray-400 italic"
                     >
                       <InitialBubble
@@ -392,7 +400,23 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                         sizeClassName="w-8 h-8"
                         className="shrink-0"
                       />
-                      <span className="min-w-0 break-words">Anonymous</span>
+                      <span className="min-w-0 break-words flex-1">Anonymous</span>
+                      {viewerIsAdmin && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setActionsFor({ handle: m.handle, name: "Anonymous" })
+                          }
+                          className="shrink-0 w-9 h-9 -mr-2 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:opacity-70"
+                          aria-label="Actions for anonymous member"
+                        >
+                          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden>
+                            <circle cx="12" cy="5" r="2" />
+                            <circle cx="12" cy="12" r="2" />
+                            <circle cx="12" cy="19" r="2" />
+                          </svg>
+                        </button>
+                      )}
                     </li>
                   ))}
               </>
@@ -405,13 +429,21 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         <MemberActionsSheet
           isOpen={true}
           name={actionsFor.name}
-          canRemove={isPrivateGroup}
+          // Anonymous members (carry a handle) can be removed but not promoted.
+          canMakeAdmin={"userId" in actionsFor}
+          canRemove={true}
           onMakeAdmin={() => {
-            setPendingAction({ kind: "promote", userId: actionsFor.userId, name: actionsFor.name });
+            if ("userId" in actionsFor) {
+              setPendingAction({ kind: "promote", userId: actionsFor.userId, name: actionsFor.name });
+            }
             setActionsFor(null);
           }}
           onRemove={() => {
-            setPendingAction({ kind: "boot", userId: actionsFor.userId, name: actionsFor.name });
+            setPendingAction(
+              "userId" in actionsFor
+                ? { kind: "boot", userId: actionsFor.userId, name: actionsFor.name }
+                : { kind: "boot-anon", handle: actionsFor.handle, name: actionsFor.name },
+            );
             setActionsFor(null);
           }}
           onClose={() => setActionsFor(null)}
@@ -426,7 +458,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
           message={
             pendingAction.kind === "promote"
               ? `Make ${pendingAction.name} an admin? Admins can manage members, invites, and group settings. This can't be undone.`
-              : `Remove ${pendingAction.name} from the group? The invite link they joined with will stop working.`
+              : `Remove ${pendingAction.name} from the group? Any invite link they joined with stops working. On a public group they can rejoin by visiting the link again.`
           }
           confirmText={pendingAction.kind === "promote" ? "Make admin" : "Remove"}
           confirmButtonClass={

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -42,6 +42,37 @@ import {
   type SessionUser,
 } from "@/lib/session";
 
+/** The right-aligned 3-dots button on a member row that opens the action
+ *  sheet. `stopPropagation` on pointerdown so it doesn't fire the row's
+ *  long-press → profile modal. */
+function MemberActionsButton({
+  label,
+  onOpen,
+}: {
+  label: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        haptic.medium();
+        onOpen();
+      }}
+      className="shrink-0 w-9 h-9 -mr-2 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:opacity-70"
+      aria-label={label}
+    >
+      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden>
+        <circle cx="12" cy="5" r="2" />
+        <circle cx="12" cy="12" r="2" />
+        <circle cx="12" cy="19" r="2" />
+      </svg>
+    </button>
+  );
+}
+
 /** Prop-driven inner view. Exposed so the slide overlay can render this
  *  view directly without going through useParams() (the overlay mounts
  *  the component while the URL is still the source page). */
@@ -165,7 +196,11 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   let anonymousMembers: AnonymousMember[] = [];
   if (roster) {
     totalCount = roster.members.length + roster.anonymous_count;
-    anonymousMembers = [...roster.anonymous_members];
+    // Drop the viewer's OWN anonymous entry (the server tells us its handle) —
+    // they surface as the "You" row below, and you can't boot yourself.
+    anonymousMembers = roster.anonymous_members.filter(
+      (m) => m.handle !== roster.viewer_anonymous_handle,
+    );
     const rows: MemberRow[] = roster.members.map((m, i) => ({
       name: m.name,
       key: `member-${m.user_id ?? m.name}-${i}`,
@@ -175,9 +210,7 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
     }));
     // The viewer is always a member (visiting auto-joins / the creator is a
     // member). If they aren't a resolved named row, they're one of the
-    // anonymous members — surface them as themselves and drop one anonymous
-    // slot (the viewer's; anonymous members are indistinguishable, and you
-    // can't boot yourself anyway) so the headcount stays right.
+    // anonymous members — surface them as the "You" row.
     if (!rows.some((r) => isCurrentUserName(r.name))) {
       // Viewer's own row isn't long-pressable (userId null); isAdmin still
       // drives the Admin badge on your own row.
@@ -187,7 +220,6 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
         userId: null,
         isAdmin: viewerIsAdmin,
       });
-      if (anonymousMembers.length > 0) anonymousMembers.shift();
     }
     rows.sort((a, b) => a.name.localeCompare(b.name));
     membersList = rows;
@@ -328,30 +360,10 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                   isAdmin={isAdmin}
                   actions={
                     canManage ? (
-                      <button
-                        type="button"
-                        // stopPropagation so a tap on the 3-dots doesn't also
-                        // fire the row's long-press → profile modal.
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          haptic.medium();
-                          setActionsFor({ userId: userId!, name });
-                        }}
-                        className="shrink-0 w-9 h-9 -mr-2 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:opacity-70"
-                        aria-label={`Actions for ${name}`}
-                      >
-                        <svg
-                          className="w-5 h-5"
-                          fill="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden
-                        >
-                          <circle cx="12" cy="5" r="2" />
-                          <circle cx="12" cy="12" r="2" />
-                          <circle cx="12" cy="19" r="2" />
-                        </svg>
-                      </button>
+                      <MemberActionsButton
+                        label={`Actions for ${name}`}
+                        onOpen={() => setActionsFor({ userId: userId!, name })}
+                      />
                     ) : null
                   }
                 />
@@ -402,20 +414,12 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
                       />
                       <span className="min-w-0 break-words flex-1">Anonymous</span>
                       {viewerIsAdmin && (
-                        <button
-                          type="button"
-                          onClick={() =>
+                        <MemberActionsButton
+                          label="Actions for anonymous member"
+                          onOpen={() =>
                             setActionsFor({ handle: m.handle, name: "Anonymous" })
                           }
-                          className="shrink-0 w-9 h-9 -mr-2 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:opacity-70"
-                          aria-label="Actions for anonymous member"
-                        >
-                          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden>
-                            <circle cx="12" cy="5" r="2" />
-                            <circle cx="12" cy="12" r="2" />
-                            <circle cx="12" cy="19" r="2" />
-                          </svg>
-                        </button>
+                        />
                       )}
                     </li>
                   ))}

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -101,7 +101,8 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
   // consequential — promote is permanent, boot removes a member + revokes
   // their invite link).
   const [pendingAction, setPendingAction] = useState<
-    | { kind: "promote" | "boot"; userId: string; name: string }
+    | { kind: "promote"; userId: string; name: string }
+    | { kind: "boot"; userId: string; name: string }
     | { kind: "boot-anon"; handle: string; name: string }
     | null
   >(null);

--- a/components/InviteLinksSection.tsx
+++ b/components/InviteLinksSection.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/lib/api";
 import type { GroupInvite } from "@/lib/api";
 import { haptic } from "@/lib/haptics";
+import { compactDurationSince } from "@/lib/questionListUtils";
 
 interface Props {
   groupId: string;
@@ -182,9 +183,26 @@ export default function InviteLinksSection({
 
   return (
     <section className={className}>
-      <h2 className="px-1 mb-2 text-sm font-semibold text-gray-500 dark:text-gray-400">
-        Invite links
-      </h2>
+      <div className="px-1 mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400">
+          Invite links
+        </h2>
+        <button
+          type="button"
+          onClick={createInvite}
+          disabled={creating}
+          aria-label="Create invite link"
+          className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full bg-blue-600 hover:bg-blue-700 active:scale-95 text-white disabled:opacity-50 transition-transform"
+        >
+          {creating ? (
+            <span className="text-xs">…</span>
+          ) : (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+            </svg>
+          )}
+        </button>
+      </div>
       {error && (
         <p
           className="px-1 mb-2 text-xs text-red-600 dark:text-red-400"
@@ -205,10 +223,16 @@ export default function InviteLinksSection({
                   : `${invite.use_count} used`;
               const modeLabel =
                 invite.mode === "single" ? "Single use" : "Multi-use";
+              const age = invite.created_at
+                ? compactDurationSince(invite.created_at)
+                : null;
               return (
                 <li key={invite.id} className="px-4 py-2.5 flex items-center gap-2">
                   <span className="min-w-0 flex-1 truncate text-sm text-gray-900 dark:text-white">
                     {modeLabel} · {usageLabel}
+                    {age && (
+                      <span className="text-gray-400 dark:text-gray-500"> · {age}</span>
+                    )}
                   </span>
                   {url && (
                     <button
@@ -237,14 +261,6 @@ export default function InviteLinksSection({
           </ul>
         </div>
       )}
-      <button
-        type="button"
-        onClick={createInvite}
-        disabled={creating}
-        className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 active:scale-95 text-white text-sm font-medium rounded-full disabled:opacity-50 transition-transform"
-      >
-        {creating ? "Creating…" : "Create invite link"}
-      </button>
     </section>
   );
 }

--- a/components/InviteLinksSection.tsx
+++ b/components/InviteLinksSection.tsx
@@ -206,43 +206,31 @@ export default function InviteLinksSection({
               const modeLabel =
                 invite.mode === "single" ? "Single use" : "Multi-use";
               return (
-                <li key={invite.id} className="px-4 py-3 flex flex-col gap-2">
-                  <div className="flex flex-col min-w-0">
-                    <span className="text-gray-900 dark:text-white">
-                      {modeLabel} · {usageLabel}
-                    </span>
-                    {url && (
-                      <span className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 break-all">
-                        {url}
-                      </span>
-                    )}
-                    {!url && (
-                      <span className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-                        Link only shown when first created.
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {url && (
-                      <button
-                        type="button"
-                        onClick={() => copyUrl(invite, url)}
-                        className="flex-1 h-10 rounded-full bg-blue-600 hover:bg-blue-700 active:scale-95 text-white text-sm font-medium transition-transform"
-                        aria-label="Copy invite link"
-                      >
-                        {copiedId === invite.id ? "Copied!" : "Copy link"}
-                      </button>
-                    )}
+                <li key={invite.id} className="px-4 py-2.5 flex items-center gap-2">
+                  <span className="min-w-0 flex-1 truncate text-sm text-gray-900 dark:text-white">
+                    {modeLabel} · {usageLabel}
+                  </span>
+                  {url && (
                     <button
                       type="button"
-                      onClick={() => revokeInvite(invite)}
-                      disabled={revoking}
-                      className="flex-1 h-10 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 active:scale-95 text-gray-800 dark:text-gray-200 text-sm font-medium disabled:opacity-50 transition-transform"
-                      aria-label="Revoke invite"
+                      onClick={() => copyUrl(invite, url)}
+                      className="shrink-0 px-3 h-8 rounded-full bg-blue-600 hover:bg-blue-700 active:scale-95 text-white text-xs font-medium transition-transform"
+                      aria-label="Copy invite link"
                     >
-                      Revoke
+                      {copiedId === invite.id ? "Copied!" : "Copy"}
                     </button>
-                  </div>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => revokeInvite(invite)}
+                    disabled={revoking}
+                    className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-red-600 dark:hover:text-red-400 active:scale-95 disabled:opacity-50 transition"
+                    aria-label="Revoke invite"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
                 </li>
               );
             })}

--- a/components/MemberActionsSheet.tsx
+++ b/components/MemberActionsSheet.tsx
@@ -9,11 +9,12 @@ interface MemberActionsSheetProps {
   isOpen: boolean;
   /** The member's display name (shown in the sheet header). */
   name: string;
-  /** Whether to offer the destructive "Remove from group" action. Boot is
-   *  private-groups-only (booting a public-group member is futile — they
-   *  auto-rejoin on visit), so the /info page passes `false` for public groups. */
+  /** Whether to offer "Make admin". False for anonymous members (admins are
+   *  account-keyed, so a nameless member can't be promoted). */
+  canMakeAdmin?: boolean;
+  /** Whether to offer the destructive "Remove from group" action. */
   canRemove: boolean;
-  onMakeAdmin: () => void;
+  onMakeAdmin?: () => void;
   onRemove: () => void;
   onClose: () => void;
 }
@@ -28,6 +29,7 @@ interface MemberActionsSheetProps {
 export default function MemberActionsSheet({
   isOpen,
   name,
+  canMakeAdmin = true,
   canRemove,
   onMakeAdmin,
   onRemove,
@@ -61,15 +63,17 @@ export default function MemberActionsSheet({
             {name}
           </p>
 
-          <button
-            onClick={() => {
-              haptic.medium();
-              onMakeAdmin();
-            }}
-            className="w-full mb-2 py-3 rounded-2xl bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium border border-blue-200 dark:border-blue-800 active:scale-[0.99]"
-          >
-            Make admin
-          </button>
+          {canMakeAdmin && (
+            <button
+              onClick={() => {
+                haptic.medium();
+                onMakeAdmin?.();
+              }}
+              className="w-full mb-2 py-3 rounded-2xl bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium border border-blue-200 dark:border-blue-800 active:scale-[0.99]"
+            >
+              Make admin
+            </button>
+          )}
           {canRemove && (
             <button
               onClick={() => {

--- a/components/MemberActionsSheet.tsx
+++ b/components/MemberActionsSheet.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect } from 'react';
+import ModalPortal from '@/components/ModalPortal';
+import { useBodyScrollLock } from '@/lib/useBodyScrollLock';
+import { haptic } from '@/lib/haptics';
+
+interface MemberActionsSheetProps {
+  isOpen: boolean;
+  /** The member's display name (shown in the sheet header). */
+  name: string;
+  /** Whether to offer the destructive "Remove from group" action. Boot is
+   *  private-groups-only (booting a public-group member is futile — they
+   *  auto-rejoin on visit), so the /info page passes `false` for public groups. */
+  canRemove: boolean;
+  onMakeAdmin: () => void;
+  onRemove: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Bottom action sheet opened from the 3-dots button on a group member row
+ * (/info). Offers "Make admin" and (private groups only) "Remove from group".
+ * Selecting one closes the sheet; the parent then opens the shared
+ * ConfirmationModal for the consequential confirm step. Haptic feedback fires
+ * on every tap (iOS Core Haptics via @capacitor/haptics).
+ */
+export default function MemberActionsSheet({
+  isOpen,
+  name,
+  canRemove,
+  onMakeAdmin,
+  onRemove,
+  onClose,
+}: MemberActionsSheetProps) {
+  useBodyScrollLock(isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalPortal>
+      <div
+        className="fixed inset-0 z-[80] flex items-end sm:items-center justify-center p-3"
+        onClick={onClose}
+      >
+        <div className="absolute inset-0 bg-black/50" />
+        <div
+          className="relative w-full max-w-sm bg-white dark:bg-gray-800 rounded-3xl shadow-xl p-4"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="px-1 pt-1 pb-3 text-center text-sm text-gray-500 dark:text-gray-400 truncate">
+            {name}
+          </p>
+
+          <button
+            onClick={() => {
+              haptic.medium();
+              onMakeAdmin();
+            }}
+            className="w-full mb-2 py-3 rounded-2xl bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium border border-blue-200 dark:border-blue-800 active:scale-[0.99]"
+          >
+            Make admin
+          </button>
+          {canRemove && (
+            <button
+              onClick={() => {
+                haptic.medium();
+                onRemove();
+              }}
+              className="w-full mb-2 py-3 rounded-2xl bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 font-medium border border-red-200 dark:border-red-800 active:scale-[0.99]"
+            >
+              Remove from group
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="w-full py-3 rounded-2xl bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 font-medium active:scale-[0.99]"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/components/MemberActionsSheet.tsx
+++ b/components/MemberActionsSheet.tsx
@@ -21,7 +21,7 @@ interface MemberActionsSheetProps {
 
 /**
  * Bottom action sheet opened from the 3-dots button on a group member row
- * (/info). Offers "Make admin" and (private groups only) "Remove from group".
+ * (/info). Offers "Make admin" (named members) and "Remove from group".
  * Selecting one closes the sheet; the parent then opens the shared
  * ConfirmationModal for the consequential confirm step. Haptic feedback fires
  * on every tap (iOS Core Haptics via @capacitor/haptics).

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -646,11 +646,19 @@ export interface GroupMember {
   is_admin: boolean;
 }
 
+/** An anonymous (no resolvable name) member. `handle` is an opaque,
+ *  group-scoped id (NOT a browser_id) the boot-by-handle endpoint matches. */
+export interface AnonymousMember {
+  handle: string;
+}
+
 export interface GroupRoster {
   /** Named members, one per distinct person (account-aware de-dup). */
   members: GroupMember[];
   /** Distinct members with no resolvable name (drive-by public-group joins). */
   anonymous_count: number;
+  /** Same set as `anonymous_count`, one entry each with a boot handle. */
+  anonymous_members: AnonymousMember[];
   /** Migration 142: is the viewer an admin of this group? Gates the /info
    *  admin chrome (privacy toggle, invites, join requests, add-people,
    *  promote/boot, title/avatar edits). */
@@ -679,11 +687,16 @@ export async function apiGetGroupMembers(
         : [],
       anonymous_count:
         typeof data?.anonymous_count === 'number' ? data.anonymous_count : 0,
+      anonymous_members: Array.isArray(data?.anonymous_members)
+        ? (data.anonymous_members as any[])
+            .filter((m) => typeof m?.handle === 'string')
+            .map((m) => ({ handle: m.handle as string }))
+        : [],
       viewer_is_admin: !!data?.viewer_is_admin,
     };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
-      return { members: [], anonymous_count: 0, viewer_is_admin: false };
+      return { members: [], anonymous_count: 0, anonymous_members: [], viewer_is_admin: false };
     }
     throw err;
   }
@@ -712,11 +725,16 @@ export async function apiGetGroupPollVoters(
         : [],
       anonymous_count:
         typeof data?.anonymous_count === 'number' ? data.anonymous_count : 0,
+      anonymous_members: Array.isArray(data?.anonymous_members)
+        ? (data.anonymous_members as any[])
+            .filter((m) => typeof m?.handle === 'string')
+            .map((m) => ({ handle: m.handle as string }))
+        : [],
       viewer_is_admin: false,
     };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
-      return { members: [], anonymous_count: 0, viewer_is_admin: false };
+      return { members: [], anonymous_count: 0, anonymous_members: [], viewer_is_admin: false };
     }
     throw err;
   }
@@ -733,14 +751,26 @@ export async function apiPromoteGroupAdmin(
   });
 }
 
-/** Migration 142: remove a non-admin member from a PRIVATE group and revoke
- *  the invite they joined through (admin-only). */
+/** Migration 142: remove a non-admin member from a group and revoke the
+ *  invite they joined through (admin-only; works on public groups too). */
 export async function apiBootGroupMember(
   routeId: string,
   userId: string,
 ): Promise<void> {
   await groupFetch<any>(
     `/${encodeURIComponent(routeId)}/members/${encodeURIComponent(userId)}/boot`,
+    { method: 'POST' },
+  );
+}
+
+/** Remove a specific ANONYMOUS member by their opaque roster handle
+ *  (admin-only). The server never exposes the raw browser_id. */
+export async function apiBootGroupAnonymous(
+  routeId: string,
+  handle: string,
+): Promise<void> {
+  await groupFetch<any>(
+    `/${encodeURIComponent(routeId)}/members/by-handle/${encodeURIComponent(handle)}/boot`,
     { method: 'POST' },
   );
 }

--- a/lib/api/groups.ts
+++ b/lib/api/groups.ts
@@ -652,6 +652,23 @@ export interface AnonymousMember {
   handle: string;
 }
 
+const EMPTY_ROSTER: GroupRoster = {
+  members: [],
+  anonymous_count: 0,
+  anonymous_members: [],
+  viewer_anonymous_handle: null,
+  viewer_is_admin: false,
+};
+
+/** Parse the server's `anonymous_members` array into `AnonymousMember[]`. */
+function parseAnonymousMembers(data: any): AnonymousMember[] {
+  return Array.isArray(data?.anonymous_members)
+    ? (data.anonymous_members as any[])
+        .filter((m) => typeof m?.handle === 'string')
+        .map((m) => ({ handle: m.handle as string }))
+    : [];
+}
+
 export interface GroupRoster {
   /** Named members, one per distinct person (account-aware de-dup). */
   members: GroupMember[];
@@ -659,6 +676,9 @@ export interface GroupRoster {
   anonymous_count: number;
   /** Same set as `anonymous_count`, one entry each with a boot handle. */
   anonymous_members: AnonymousMember[];
+  /** The viewer's own anonymous handle (when they're a nameless member), so the
+   *  FE can drop exactly their entry from the displayed list. Null otherwise. */
+  viewer_anonymous_handle: string | null;
   /** Migration 142: is the viewer an admin of this group? Gates the /info
    *  admin chrome (privacy toggle, invites, join requests, add-people,
    *  promote/boot, title/avatar edits). */
@@ -687,16 +707,16 @@ export async function apiGetGroupMembers(
         : [],
       anonymous_count:
         typeof data?.anonymous_count === 'number' ? data.anonymous_count : 0,
-      anonymous_members: Array.isArray(data?.anonymous_members)
-        ? (data.anonymous_members as any[])
-            .filter((m) => typeof m?.handle === 'string')
-            .map((m) => ({ handle: m.handle as string }))
-        : [],
+      anonymous_members: parseAnonymousMembers(data),
+      viewer_anonymous_handle:
+        typeof data?.viewer_anonymous_handle === 'string'
+          ? data.viewer_anonymous_handle
+          : null,
       viewer_is_admin: !!data?.viewer_is_admin,
     };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
-      return { members: [], anonymous_count: 0, anonymous_members: [], viewer_is_admin: false };
+      return EMPTY_ROSTER;
     }
     throw err;
   }
@@ -725,16 +745,13 @@ export async function apiGetGroupPollVoters(
         : [],
       anonymous_count:
         typeof data?.anonymous_count === 'number' ? data.anonymous_count : 0,
-      anonymous_members: Array.isArray(data?.anonymous_members)
-        ? (data.anonymous_members as any[])
-            .filter((m) => typeof m?.handle === 'string')
-            .map((m) => ({ handle: m.handle as string }))
-        : [],
+      anonymous_members: parseAnonymousMembers(data),
+      viewer_anonymous_handle: null,
       viewer_is_admin: false,
     };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
-      return { members: [], anonymous_count: 0, anonymous_members: [], viewer_is_admin: false };
+      return EMPTY_ROSTER;
     }
     throw err;
   }

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -69,6 +69,7 @@ export {
   apiGetGroupPollVoters,
   apiPromoteGroupAdmin,
   apiBootGroupMember,
+  apiBootGroupAnonymous,
 } from "./groups";
 export type {
   GroupJoinRequest,
@@ -78,6 +79,7 @@ export type {
   GroupPollResult,
   InvitableAccount,
   GroupMember,
+  AnonymousMember,
   GroupRoster,
 } from "./groups";
 

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -1646,6 +1646,11 @@ class GroupMembersResponse(BaseModel):
     members: list[GroupMemberResponse]
     anonymous_count: int
     anonymous_members: list[AnonymousMemberResponse] = []
+    # The viewer's OWN anonymous handle (when they're a nameless member). The FE
+    # drops this exact entry from the displayed anonymous list — they surface as
+    # the "You" row instead, and you can't boot yourself. Null is a harmless
+    # no-op when the viewer is a named member.
+    viewer_anonymous_handle: str | None = None
     viewer_is_admin: bool = False
 
 
@@ -1687,6 +1692,7 @@ def get_group_members(route_id: str, request: Request):
             )
             for m in anon
         ]
+        viewer_key = user_id or browser_id
         return GroupMembersResponse(
             members=[
                 GroupMemberResponse(
@@ -1698,6 +1704,9 @@ def get_group_members(route_id: str, request: Request):
             ],
             anonymous_count=len(anon),
             anonymous_members=anon_handles,
+            viewer_anonymous_handle=(
+                anonymous_member_handle(group_id, viewer_key) if viewer_key else None
+            ),
             viewer_is_admin=viewer_is_admin,
         )
 

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -1802,7 +1802,7 @@ def boot_anonymous_group_member(route_id: str, handle: str, request: Request):
         group_id = resolve_group_id_from_route_id(conn, route_id)
         if not group_id:
             raise HTTPException(status_code=404, detail="Group not found")
-        _require_admin(
+        admin = _require_admin(
             conn, group_id, browser_id=caller_browser, user_id=_user_id(request),
         )
         _, anon = load_group_members(conn, group_id)
@@ -1821,10 +1821,16 @@ def boot_anonymous_group_member(route_id: str, handle: str, request: Request):
             raise HTTPException(
                 status_code=404, detail="Anonymous member not found"
             )
-        if caller_browser and match["browser_id"] == caller_browser:
+        # A nameless admin (auto-account creator) also rolls up anonymously —
+        # don't let the handle path bypass the self/admin guards.
+        if (match["user_id"] and match["user_id"] == admin) or (
+            caller_browser and match["browser_id"] == caller_browser
+        ):
             raise HTTPException(
                 status_code=400, detail="Leave the group instead of booting yourself"
             )
+        if match["user_id"] and is_group_admin(conn, group_id, match["user_id"]):
+            raise HTTPException(status_code=403, detail="Admins can't be booted")
         boot_member_by_browser(conn, group_id, match["browser_id"])
     return BootMemberResponse(booted=True)
 

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -69,7 +69,9 @@ from services.validation import validate_user_name
 from services.groups import (
     _is_uuid_like,
     add_group_admin,
+    anonymous_member_handle,
     boot_member,
+    boot_member_by_browser,
     claim_group as _claim_group_row,
     filter_visible_polls,
     get_group_metadata,
@@ -1622,16 +1624,28 @@ class GroupMemberResponse(BaseModel):
     is_admin: bool = False
 
 
+class AnonymousMemberResponse(BaseModel):
+    """An individual member with no resolvable name. `handle` is an opaque,
+    group-scoped, one-way id (NOT the browser_id — that's a cross-group
+    identity token we never leak) that the boot-by-handle endpoint can match
+    back to the member server-side. Lets an admin remove a specific anonymous
+    drive-by visitor."""
+
+    handle: str
+
+
 class GroupMembersResponse(BaseModel):
     """The group's actual roster. `members` are the named people (one entry
-    per distinct person, account-aware); `anonymous_count` rolls up members
-    with no resolvable name (drive-by URL visitors on public groups).
-    `viewer_is_admin` (migration 142) gates the FE's admin chrome (privacy
-    toggle, invites, join requests, add-people, promote/boot, title/avatar
-    edits)."""
+    per distinct person, account-aware); `anonymous_members` lists members
+    with no resolvable name (drive-by URL visitors on public groups), each
+    carrying an opaque boot handle. `anonymous_count` mirrors its length (kept
+    for older clients). `viewer_is_admin` (migration 142) gates the FE's admin
+    chrome (privacy toggle, invites, join requests, add-people, promote/boot,
+    title/avatar edits)."""
 
     members: list[GroupMemberResponse]
     anonymous_count: int
+    anonymous_members: list[AnonymousMemberResponse] = []
     viewer_is_admin: bool = False
 
 
@@ -1662,6 +1676,17 @@ def get_group_members(route_id: str, request: Request):
         viewer_is_admin = is_caller_admin(
             conn, group_id, browser_id=browser_id, user_id=user_id
         )
+        # Opaque per-person handle keyed on user_id (account-no-name) else
+        # browser_id (browser-only) — same key the boot-by-handle endpoint
+        # re-derives. Never the raw browser_id (cross-group identity token).
+        anon_handles = [
+            AnonymousMemberResponse(
+                handle=anonymous_member_handle(
+                    group_id, m["user_id"] or m["browser_id"]
+                )
+            )
+            for m in anon
+        ]
         return GroupMembersResponse(
             members=[
                 GroupMemberResponse(
@@ -1671,7 +1696,8 @@ def get_group_members(route_id: str, request: Request):
                 )
                 for m in named
             ],
-            anonymous_count=anon,
+            anonymous_count=len(anon),
+            anonymous_members=anon_handles,
             viewer_is_admin=viewer_is_admin,
         )
 
@@ -1727,9 +1753,11 @@ def promote_group_admin(
 )
 def boot_group_member(route_id: str, user_id: str, request: Request):
     """Remove a member from the group and revoke the invite link they joined
-    through. Admin-only, PRIVATE groups only (Q3 — booting a public-group
-    member is futile since they auto-rejoin on the next visit). The target
-    must be a NON-admin member (admins can't be booted — Q4)."""
+    through. Admin-only. Works on public groups too (the owner asked for it —
+    revising the original private-only Q3: on a public group the member can
+    re-visit and auto-rejoin, but the boot still clears the current roster +
+    revokes their specific invite). The target must be a NON-admin member
+    (admins can't be booted — Q4)."""
     target = user_id
     if not _is_uuid_like(target):
         raise HTTPException(status_code=400, detail="Invalid user_id")
@@ -1741,12 +1769,6 @@ def boot_group_member(route_id: str, user_id: str, request: Request):
             conn, group_id,
             browser_id=_browser_id(request), user_id=_user_id(request),
         )
-        meta = get_group_metadata(conn, group_id)
-        if not meta or meta["privacy"] != "private":
-            raise HTTPException(
-                status_code=400,
-                detail="Members can only be booted from private groups",
-            )
         if target == admin:
             raise HTTPException(
                 status_code=400, detail="Leave the group instead of booting yourself"
@@ -1762,6 +1784,48 @@ def boot_group_member(route_id: str, user_id: str, request: Request):
                 status_code=404, detail="User is not a member of this group"
             )
         boot_member(conn, group_id, target)
+    return BootMemberResponse(booted=True)
+
+
+@router.post(
+    "/{route_id}/members/by-handle/{handle}/boot",
+    response_model=BootMemberResponse,
+)
+def boot_anonymous_group_member(route_id: str, handle: str, request: Request):
+    """Remove a specific ANONYMOUS (no resolvable name) member, identified by
+    the opaque handle from the /members roster. Admin-only. We never accept a
+    raw browser_id from the client (cross-group identity token) — instead we
+    re-derive each anonymous member's handle server-side and match. Same
+    public-group semantics as the named boot above."""
+    caller_browser = _browser_id(request)
+    with get_db() as conn:
+        group_id = resolve_group_id_from_route_id(conn, route_id)
+        if not group_id:
+            raise HTTPException(status_code=404, detail="Group not found")
+        _require_admin(
+            conn, group_id, browser_id=caller_browser, user_id=_user_id(request),
+        )
+        _, anon = load_group_members(conn, group_id)
+        match = next(
+            (
+                m
+                for m in anon
+                if anonymous_member_handle(
+                    group_id, m["user_id"] or m["browser_id"]
+                )
+                == handle
+            ),
+            None,
+        )
+        if match is None:
+            raise HTTPException(
+                status_code=404, detail="Anonymous member not found"
+            )
+        if caller_browser and match["browser_id"] == caller_browser:
+            raise HTTPException(
+                status_code=400, detail="Leave the group instead of booting yourself"
+            )
+        boot_member_by_browser(conn, group_id, match["browser_id"])
     return BootMemberResponse(booted=True)
 
 

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -388,12 +388,12 @@ def is_caller_member_of_group(
     return row is not None
 
 
-def load_group_members(conn, group_id: str) -> tuple[list[dict], int]:
+def load_group_members(conn, group_id: str) -> tuple[list[dict], list[dict]]:
     """Resolve a group's ACTUAL roster from `group_members` (NOT poll
     participants — that's what `Group.participantNames` is, and it misses
     members who joined via approve/invite/add-people but haven't voted yet).
 
-    Returns ``(named_members, anonymous_count)``:
+    Returns ``(named_members, anonymous_members)``:
       - ``named_members``: ``[{"name": str, "user_id": str | None}, ...]``,
         one entry per DISTINCT person who has a resolvable display name.
         Account-aware: a person signed in across N browsers collapses to ONE
@@ -401,11 +401,15 @@ def load_group_members(conn, group_id: str) -> tuple[list[dict], int]:
         `user_browsers` union); an anonymous (no-account) browser member is
         its own person keyed on `browser_id`. Name resolution per person:
         account `display_name`, else the most-recent `voter_name` that
-        browser used, else they fall into `anonymous_count`.
-      - ``anonymous_count``: distinct persons with no resolvable name
-        (drive-by URL visitors who auto-joined a public group, nameless
-        browser members). Rolled up so a public group's roster isn't a wall
-        of "anonymous" rows.
+        browser used, else they fall into `anonymous_members`.
+      - ``anonymous_members``: ``[{"user_id": str | None, "browser_id": str},
+        ...]`` — distinct persons with no resolvable name (drive-by URL
+        visitors who auto-joined a public group, nameless browser members).
+        `browser_id` is a REPRESENTATIVE member-row browser for the person;
+        callers must NOT leak it to clients (it's a cross-group identity
+        token) — surface an opaque handle instead (see
+        `anonymous_member_handle`). The list lets admins act on (boot) an
+        individual anonymous member.
 
     Named members are sorted by name (case-insensitive).
     """
@@ -414,6 +418,7 @@ def load_group_members(conn, group_id: str) -> tuple[list[dict], int]:
         SELECT
             COALESCE(ub.user_id::text, gm.browser_id::text) AS person_key,
             ub.user_id::text AS user_id,
+            gm.browser_id::text AS browser_id,
             COALESCE(
                 NULLIF(BTRIM(u.display_name), ''),
                 NULLIF(BTRIM((
@@ -433,13 +438,18 @@ def load_group_members(conn, group_id: str) -> tuple[list[dict], int]:
     ).fetchall()
 
     # Collapse to one entry per person (account de-dup). Keep the first
-    # non-null name we see across the person's browser rows.
+    # non-null name we see across the person's browser rows + a representative
+    # browser_id (any of their member rows — used to target a boot).
     by_person: dict[str, dict] = {}
     for r in rows:
         key = r["person_key"]
         existing = by_person.get(key)
         if existing is None:
-            by_person[key] = {"user_id": r.get("user_id"), "name": r.get("name")}
+            by_person[key] = {
+                "user_id": r.get("user_id"),
+                "name": r.get("name"),
+                "browser_id": r.get("browser_id"),
+            }
         elif not existing["name"] and r.get("name"):
             existing["name"] = r["name"]
 
@@ -448,9 +458,31 @@ def load_group_members(conn, group_id: str) -> tuple[list[dict], int]:
         for p in by_person.values()
         if p["name"]
     ]
-    anonymous_count = sum(1 for p in by_person.values() if not p["name"])
+    anonymous = [
+        {"user_id": p["user_id"], "browser_id": p["browser_id"]}
+        for p in by_person.values()
+        if not p["name"]
+    ]
     named.sort(key=lambda m: m["name"].lower())
-    return named, anonymous_count
+    return named, anonymous
+
+
+def anonymous_member_handle(group_id: str, person_key: str) -> str:
+    """An opaque, deterministic, group-scoped handle for an anonymous member.
+
+    `person_key` is the member's account user_id (account-with-no-name) or
+    their browser_id (browser-only). We NEVER return the raw browser_id to the
+    client (it's a cross-group identity token — an admin could impersonate the
+    member). A SHA-256 over `group_id:person_key` is one-way (doesn't reveal
+    the key), deterministic (stable per response so the FE can act on a row),
+    and matchable server-side: the boot endpoint recomputes the handle over
+    the group's anonymous members and finds the match. No secret needed — an
+    attacker who could forge a handle would already know the browser_id, and
+    boot is admin-only + scoped to existing members of the admin's group.
+    """
+    import hashlib
+
+    return hashlib.sha256(f"{group_id}:{person_key}".encode()).hexdigest()
 
 
 def load_poll_voters(conn, poll_id: str) -> tuple[list[dict], int]:
@@ -634,6 +666,38 @@ def boot_member(conn, group_id: str, target_user_id: str) -> None:
            )
         """,
         {"g": group_id, "u": target_user_id},
+    )
+
+
+def boot_member_by_browser(conn, group_id: str, browser_id: str) -> None:
+    """Boot an anonymous (no resolvable name) member identified by a
+    representative `browser_id`. If that browser is linked to an account,
+    delegate to `boot_member` (removes every linked browser + revokes their
+    invites). Otherwise revoke this row's invite + delete just this
+    (group, browser) membership row. Caller authorizes (admin-only, target is
+    not the caller / not an admin)."""
+    row = conn.execute(
+        "SELECT user_id::text AS uid FROM user_browsers WHERE browser_id = %(b)s::uuid",
+        {"b": browser_id},
+    ).fetchone()
+    if row and row.get("uid"):
+        boot_member(conn, group_id, row["uid"])
+        return
+    conn.execute(
+        """
+        UPDATE group_invites SET revoked_at = NOW()
+         WHERE id = (
+             SELECT joined_via_invite_id FROM group_members
+              WHERE group_id = %(g)s::uuid AND browser_id = %(b)s::uuid
+         )
+           AND revoked_at IS NULL
+        """,
+        {"g": group_id, "b": browser_id},
+    )
+    conn.execute(
+        "DELETE FROM group_members "
+        "WHERE group_id = %(g)s::uuid AND browser_id = %(b)s::uuid",
+        {"g": group_id, "b": browser_id},
     )
 
 

--- a/server/services/groups.py
+++ b/server/services/groups.py
@@ -15,6 +15,7 @@ rest.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 from dataclasses import dataclass, field
@@ -480,8 +481,6 @@ def anonymous_member_handle(group_id: str, person_key: str) -> str:
     attacker who could forge a handle would already know the browser_id, and
     boot is admin-only + scoped to existing members of the admin's group.
     """
-    import hashlib
-
     return hashlib.sha256(f"{group_id}:{person_key}".encode()).hexdigest()
 
 

--- a/server/tests/test_group_admins.py
+++ b/server/tests/test_group_admins.py
@@ -260,15 +260,21 @@ def test_boot_allowed_on_public_group(client, creator_browser, member_browser):
 def test_boot_anonymous_member_by_handle(
     client, creator_browser, member_browser
 ):
-    # Public group; an anonymous (no-name) browser drive-by joins, then the
-    # admin boots them via the opaque handle from /members.
-    resp = client.post("/api/groups", headers=_bid(creator_browser))
-    g = resp.json()
+    # Named admin's public group; an anonymous (no-name) browser drive-by
+    # joins, then the admin boots them via the opaque handle from /members.
+    token, _ = _sign_in(client, creator_browser)
+    g = _create_private_group(client, creator_browser, token)
+    flip = client.post(
+        f"/api/groups/{g['short_id']}/privacy",
+        json={"privacy": "public"},
+        headers=_auth(creator_browser, token),
+    )
+    assert flip.status_code == 200, flip.text
     # Anonymous visitor (no account, no name) auto-joins.
     client.get(
         f"/api/groups/by-route-id/{g['short_id']}", headers=_bid(member_browser)
     )
-    roster = _members(client, g["short_id"], creator_browser)
+    roster = _members(client, g["short_id"], creator_browser, token)
     assert roster["anonymous_count"] >= 1
     assert len(roster["anonymous_members"]) == roster["anonymous_count"]
     handle = roster["anonymous_members"][0]["handle"]

--- a/server/tests/test_group_admins.py
+++ b/server/tests/test_group_admins.py
@@ -5,9 +5,10 @@ Covers:
     auto-account path).
   * GET /members surfaces `viewer_is_admin` + per-member `is_admin`.
   * POST /{route}/admins promotes a member; admin-only; target must be a member.
-  * POST /{route}/members/{user_id}/boot removes a non-admin from a PRIVATE
-    group and revokes the invite they joined through; rejects public groups,
-    admins, and self.
+  * POST /{route}/members/{user_id}/boot removes a non-admin and revokes the
+    invite they joined through (works on public groups too now); rejects
+    admins and self. POST /{route}/members/by-handle/{handle}/boot removes an
+    anonymous member by their opaque roster handle (admin-only).
   * Auto-promotion: when the last admin leaves, the oldest remaining
     account-member is promoted so the group always has an admin.
   * Title/image edits are admin-gated (Q6).
@@ -233,21 +234,70 @@ def test_boot_member_revokes_their_invite(
     assert row is not None and row[0] is not None
 
 
-def test_boot_rejected_on_public_group(client, creator_browser, member_browser):
-    # Public group (anonymous create) — booting is futile, so 400.
+def test_boot_allowed_on_public_group(client, creator_browser, member_browser):
+    # Public group (anonymous create). Booting a named member now works on
+    # public groups too (owner revised the original private-only Q3 rule).
     resp = client.post("/api/groups", headers=_bid(creator_browser))
     g = resp.json()
     assert g["privacy"] == "public"
-    # A second browser visits → auto-joins.
+    # A second browser visits → auto-joins, then signs in (named member).
+    member_token, member_uid = _sign_in(client, member_browser)
     client.get(
-        f"/api/groups/by-route-id/{g['short_id']}", headers=_bid(member_browser)
+        f"/api/groups/by-route-id/{g['short_id']}",
+        headers=_auth(member_browser, member_token),
     )
-    _, member_uid = _sign_in(client, member_browser)
     boot = client.post(
         f"/api/groups/{g['short_id']}/members/{member_uid}/boot",
         headers=_bid(creator_browser),
     )
-    assert boot.status_code == 400
+    assert boot.status_code == 200, boot.text
+    assert boot.json()["booted"] is True
+    # Membership row gone.
+    members = _members(client, g["short_id"], creator_browser)
+    assert all(m["user_id"] != member_uid for m in members["members"])
+
+
+def test_boot_anonymous_member_by_handle(
+    client, creator_browser, member_browser
+):
+    # Public group; an anonymous (no-name) browser drive-by joins, then the
+    # admin boots them via the opaque handle from /members.
+    resp = client.post("/api/groups", headers=_bid(creator_browser))
+    g = resp.json()
+    # Anonymous visitor (no account, no name) auto-joins.
+    client.get(
+        f"/api/groups/by-route-id/{g['short_id']}", headers=_bid(member_browser)
+    )
+    roster = _members(client, g["short_id"], creator_browser)
+    assert roster["anonymous_count"] >= 1
+    assert len(roster["anonymous_members"]) == roster["anonymous_count"]
+    handle = roster["anonymous_members"][0]["handle"]
+    # The raw browser_id must never appear in the response.
+    import json as _json
+
+    assert member_browser not in _json.dumps(roster)
+
+    boot = client.post(
+        f"/api/groups/{g['short_id']}/members/by-handle/{handle}/boot",
+        headers=_bid(creator_browser),
+    )
+    assert boot.status_code == 200, boot.text
+    after = _members(client, g["short_id"], creator_browser)
+    assert after["anonymous_count"] == roster["anonymous_count"] - 1
+
+    # A non-admin can't boot anonymous members.
+    other = str(uuid.uuid4())
+    client.get(
+        f"/api/groups/by-route-id/{g['short_id']}", headers=_bid(other)
+    )
+    roster2 = _members(client, g["short_id"], creator_browser)
+    if roster2["anonymous_members"]:
+        denied = client.post(
+            f"/api/groups/{g['short_id']}/members/by-handle/"
+            f"{roster2['anonymous_members'][0]['handle']}/boot",
+            headers=_bid(other),
+        )
+        assert denied.status_code in (401, 403)
 
 
 def test_boot_admin_rejected(client, creator_browser, member_browser):


### PR DESCRIPTION
## Summary

Group `/info` member-management + invite-link UX refinements (follow-up to the migration-142 admin work).

### Member actions → 3-dots sheet (haptic)
- Each manageable member row's inline "Make admin" / "Remove" buttons are replaced by a **⋮ button** that opens a bottom action sheet (`components/MemberActionsSheet.tsx`) — haptic on open and on each action (iOS Core Haptics via `@capacitor/haptics`). Selecting an action routes through the shared `ConfirmationModal`.
- **Remove now shows for every managed member**, including on public groups. This **revises the original private-only Q3 rule** per the owner: boot revokes the member's invite + clears the current roster (on a public group the member can re-visit and auto-rejoin, but the removal action is now available everywhere). `test_boot_rejected_on_public_group` → `test_boot_allowed_on_public_group`.

### Compact invite links
- One line per invite: `mode · usage · age` (compact age via `compactDurationSince`) + a trashcan revoke.
- The "create invite link" affordance is now a small **`+` button in the section header** (no separate bottom button).

### Bootable anonymous members
- The rolled-up "N anonymous" roster row expands to individual "Anonymous" rows, each with its own ⋮ → **Remove** (anonymous members can't be promoted).
- The roster returns per-anonymous **opaque handles** (`sha256(group_id:person_key)`) — we never expose a member's raw `browser_id` (a cross-group identity token). New `POST /{route}/members/by-handle/{handle}/boot` re-derives + matches the handle server-side, then removes the member (guards self + nameless-admin). `viewer_anonymous_handle` lets the FE drop exactly the viewer's own entry.

## Test plan
- [x] `server/tests/test_group_admins.py` (18) incl. public-group boot + anonymous boot-by-handle + handle never leaks `browser_id`
- [x] `test_group_members_roster.py`, `test_invites.py`, `test_invite_members.py`, `test_profiles.py` (no regression from the roster shape change)
- [x] Visual verification on the dev server (member sheet w/ Make admin + Remove; compact invites; anonymous expand + 3-dots + Remove-only sheet)
- [ ] Haptics need a real iOS device (Simulator/headless can't render them)

https://claude.ai/code/session_01RBhCXSkXB9NTf8ejthb3Ly

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBhCXSkXB9NTf8ejthb3Ly)_