### PR TITLE
create-poll: let the title preview grow for multi-line titles

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -2772,7 +2772,7 @@ export function CreateQuestionContent() {
                   bottom edge so the last form field doesn't sit flush with
                   the rounded corner when scrolled to bottom. */}
               <div ref={setSheetScrollerRef} className="flex-1 overflow-y-auto overflow-x-hidden px-3 pb-[4.5rem] space-y-[14.4px]">
-                <div className="text-center px-2 pt-1 break-words h-8 flex items-center justify-center gap-2">
+                <div className="text-center px-2 pt-1 break-words min-h-8 flex items-center justify-center gap-2">
                   {category !== 'yes_no' && (
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- The title-preview row above the new-poll form card had a fixed `h-8` (32px), so any title that wrapped past one line was clipped.
- Changed to `min-h-8`: single-line titles keep the exact same layout; longer titles expand the row and push the cards below down naturally.

## Demo
- [Three-line title, fully visible](``https://claude-poll-title-preview-height-0uum7a.dev.whoeverwants.com/g/?create=1&title=Should%20we%20do%20the%20team%20offsite%20at%20the%20lake%20house%20the%20weekend%20of%20September%2019th%3F)``
- [Screenshot](https://claude-poll-title-preview-height-0uum7a.dev.whoeverwants.com/screenshots/title-preview-multiline.png)

https://claude.ai/code/session_016YVnth7HSrKyKnL1bW9rNn

---
_Generated by [Claude Code](https://claude.ai/code/session_016YVnth7HSrKyKnL1bW9rNn)_