### PR TITLE
groups: keep group membership when forgetting its last poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2538,7 +2538,16 @@ different FE origin, extend the allowlist.
 > the Pydantic model (older bundles still send it) but the server
 > ignores it. (Migration 106 had already collapsed the per-poll-access
 > leg; the bridge was the only remaining non-membership signal, and
-> it's removed too.)
+> it's removed too.) NOTE: the group-page "forget the LAST poll →
+> apiLeaveGroup + route home" special case actually LINGERED until June
+> 2026 despite this bullet — it silently dropped membership, so the
+> whole group vanished from home and private groups 404'd (a real user
+> report). Removed on `claude/group-visibility-poll-deletion-comd3t`:
+> "Forget" is per-poll local browser state on EVERY surface (group-page
+> long-press AND poll info page), never a membership change; only
+> `forgetGroup` / the home bulk-forget leaves a group. Don't
+> reintroduce a last-poll special case — an empty-looking group is a
+> valid state.
 >
 > **Phase C.3 of the group-routing redesign shipped (#267).** (Historical
 > — the legacy bridge described below has since been REMOVED; the

--- a/app/g/[groupShortId]/GroupPage.tsx
+++ b/app/g/[groupShortId]/GroupPage.tsx
@@ -9,7 +9,7 @@ import { buildEmptyGroup, buildGroupFromPollDown, buildGroupSyncFromCache, build
 // POLL_QUERY_PARAM is still used by `GroupPageInner` to redirect legacy
 // `?p=<pollShort>` URLs to the new `/g/<group>/p/<pollShort>` route.
 import { mergePollListPreservingIdentity, mergeQuestionResultsMap } from "@/lib/groupRefresh";
-import { apiGetQuestionResults, apiGetGroupByRouteId, apiGetGroupSummary, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiCutoffPollSuggestions, apiCancelRecurrence, apiGetPollById, apiGetPollByShortId, apiLeaveGroup, apiSetPollFollowState, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
+import { apiGetQuestionResults, apiGetGroupByRouteId, apiGetGroupSummary, apiGetVotes, apiClosePoll, apiReopenPoll, apiCutoffPollAvailability, apiCutoffPollSuggestions, apiCancelRecurrence, apiGetPollById, apiGetPollByShortId, apiSetPollFollowState, ApiError, QUESTION_VOTES_CHANGED_EVENT } from "@/lib/api";
 import RecurrenceCancelSheet from "@/components/RecurrenceCancelSheet";
 import { formatLocalDateISO as formatRecurrenceDateISO } from "@/lib/recurrence";
 import type { Poll } from "@/lib/types";
@@ -2086,16 +2086,14 @@ export function GroupContent({ groupId, overlayCardsOffset, inOverlay }: GroupCo
           setPendingAction(null);
           if (action.kind === 'forget') {
             forgetQuestion(action.question.id);
-            const remaining = group ? group.questions.filter((p) => p.id !== action.question.id) : [];
-            if (group && remaining.length === 0) {
-              // Drop the server-side `group_members` row so the group
-              // doesn't reappear via Phase C.3 membership-based visibility
-              // on the next /api/groups/mine call. Fire-and-forget.
-              void apiLeaveGroup(groupId);
-              router.push('/');
-            } else {
-              setGroup((prev) => (prev ? { ...prev, questions: prev.questions.filter((p) => p.id !== action.question.id) } : prev));
-            }
+            // Forget is per-poll browser state only — it must never touch
+            // group membership. An earlier special case called apiLeaveGroup
+            // when the forgotten poll was the group's last, which silently
+            // removed the user from the whole group (it vanished from home
+            // and private groups 404'd). Groups are first-class now, so an
+            // empty-looking group is a valid state; leaving a group is the
+            // home list's bulk-forget flow, not a side effect of this.
+            setGroup((prev) => (prev ? { ...prev, questions: prev.questions.filter((p) => p.id !== action.question.id) } : prev));
           } else if (action.kind === 'reopen') {
             try {
               // Identity-based authorization server-side (migration 123).


### PR DESCRIPTION
## Summary
- Forgetting the **last** poll in a group no longer drops the user's group membership. The group-page forget-confirm handler had a leftover special case (`remaining.length === 0 → apiLeaveGroup + router.push('/')`) that silently removed the user from the whole group — it vanished from the home list, and private groups 404'd on the direct URL (the reported bug: "when I forget the last poll in a group, I can no longer see the group").
- "Forget" is now uniformly per-poll local browser state on every surface (group-page long-press AND poll info page), matching the confirmation copy ("you can still access it again with the direct link"). Leaving a group remains the explicit home-list bulk-forget flow (`forgetGroup` → `apiLeaveGroup`).
- CLAUDE.md updated: the forget-bridge bullet previously claimed this wiring was already gone; it now records the real removal point.

## Test plan
- [x] End-to-end on the branch dev server (headless Chromium, touch): instant-sign-in → group with one poll → long-press → Forget → confirm → stays on `/g/~1`, reloading the (private) group still renders it, and `/api/groups/mine` still includes the group.
- Demo: https://claude-group-visibility-poll-deletion-comd3t.dev.whoeverwants.com/auth/instant?token=7mjHAIcO-uw2WUTmARLsh416JNqQZJreG3uc15Mpqzc&next=%2Fg%2F~1

https://claude.ai/code/session_01JAsgsBvMszLfYBebBi47wM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAsgsBvMszLfYBebBi47wM)_