### PR TITLE
groups: keep all-hidden-polls groups on the home list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2404,10 +2404,11 @@ different FE origin, extend the allowlist.
 >     `GroupSummary {id, short_id, title, created_at}`. Requires a
 >     `browser_id` (400 if missing) so the new group has a member.
 >   * `POST /api/groups/empty` — every group the caller is a member of
->     that has zero polls **visible to them** (June 2026: the anti-join
->     is visibility-aware, mirroring `filter_visible_polls`'s
->     `is_closed = false OR updated_at >= MIN(joined_at)` predicate
->     with the same account-union joined_at semantics). Two shapes:
+>     that has zero polls **visible to them** (June 2026: composes the
+>     same `load_user_visibility` + `filter_visible_polls` pair as
+>     `/mine`, so the closed-before-join rule has a single source of
+>     truth — an "empty" group is a member group none of whose polls
+>     survive the filter). Two shapes:
 >     brand-new poll-less groups (`has_polls: false`) AND groups whose
 >     every poll is hidden by the closed-before-join filter
 >     (`has_polls: true` → FE `Group.hasHiddenPolls`; the home row

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2404,11 +2404,24 @@ different FE origin, extend the allowlist.
 >     `GroupSummary {id, short_id, title, created_at}`. Requires a
 >     `browser_id` (400 if missing) so the new group has a member.
 >   * `POST /api/groups/empty` — every group the caller is a member of
->     that has zero polls. The membership lookup is `group_members` ∩
->     anti-join `polls`. Sorted newest-first. Pure membership — empty
->     groups always show for their members. (Same as everywhere now:
->     the legacy `accessible_question_ids` forget bridge has been
->     removed; `group_members` is the single source of truth.)
+>     that has zero polls **visible to them** (June 2026: the anti-join
+>     is visibility-aware, mirroring `filter_visible_polls`'s
+>     `is_closed = false OR updated_at >= MIN(joined_at)` predicate
+>     with the same account-union joined_at semantics). Two shapes:
+>     brand-new poll-less groups (`has_polls: false`) AND groups whose
+>     every poll is hidden by the closed-before-join filter
+>     (`has_polls: true` → FE `Group.hasHiddenPolls`; the home row
+>     shows "No open polls" instead of "New group — tap to add a
+>     poll"). The second shape closes a home-list gap from a real prod
+>     report: an invitee to a group whose only poll had closed before
+>     the invite was minted had NO home entry at all — `/mine` filtered
+>     the poll out and the old all-polls anti-join excluded the group
+>     here too, so the group "disappeared" after redeem (misattributed
+>     by the reporter to a username change made in between — the rename
+>     was a red herring; they just hadn't visited home before it).
+>     Sorted newest-first. Pure membership otherwise (the legacy
+>     `accessible_question_ids` forget bridge is gone; `group_members`
+>     is the single source of truth).
 >   * `GET /api/groups/by-route-id/{id}/summary` — identity-free read
 >     returning just `GroupSummary`. No membership write. Used by
 >     `useGroup` (and `GroupPageInner`'s fallback chain) when
@@ -2466,6 +2479,12 @@ different FE origin, extend the allowlist.
 > into the creator's account) joins "now", so account-aware visibility
 > doesn't union the creator's old membership — signing in surfaces the
 > full history. The blank-page fix is independent of that.
+> **The HOME-LIST counterpart shipped June 2026**: `/api/groups/empty`
+> now ALSO returns member groups whose every poll is hidden pre-join
+> (with `has_polls: true`), so such a group keeps a home row ("No open
+> polls" badge via `Group.hasHiddenPolls` in `GroupList.tsx`) instead
+> of vanishing from home entirely — see the `POST /api/groups/empty`
+> bullet above for the prod report that surfaced the gap.
 >
 > **`Group.groupTitleOverride` carries the raw `groups.title`** (or
 > null) so the edit-title page input can pre-fill with the raw value

--- a/components/GroupList.tsx
+++ b/components/GroupList.tsx
@@ -378,7 +378,17 @@ export default function GroupList({ polls, emptyGroups = [], onGroupsForgotten }
             participantNameCounts={group.participantNameCounts}
             imageUrl={group.imageUrl}
             createdAt={latestQuestion?.created_at ?? null}
-            statusBadge={group.isEmpty ? 'New group — tap to add a poll' : undefined}
+            statusBadge={
+              group.isEmpty
+                ? group.hasHiddenPolls
+                  // Every poll closed before this viewer joined (the
+                  // closed-before-join filter hides them), so "new
+                  // group" would mislead — there's history, just none
+                  // they can see yet.
+                  ? 'No open polls'
+                  : 'New group — tap to add a poll'
+                : undefined
+            }
             soonestUnvotedDeadline={group.soonestUnvotedDeadline}
             unvotedDeadlineKind={group.unvotedDeadlineKind}
             hasUnread={hasUnread}

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -9,9 +9,10 @@ home / group page bootstrap (discoverRelatedQuestions + getAccessiblePolls
 `POST /api/groups` creates an empty group and joins the caller — used by
 the home "+" FAB so a group materializes in the DB BEFORE any polls
 exist. That way the user can name the group, see info, and share the
-URL immediately. Empty groups (member with 0 visible polls) are
-surfaced on `POST /api/groups/mine` via the `empty_groups` array, and
-on `GET /api/groups/by-route-id/{id}/summary` for the group page's
+URL immediately. Groups with 0 polls visible to the member (brand-new
+empty groups AND groups whose every poll is hidden by the
+closed-before-join filter) are surfaced by `POST /api/groups/empty`,
+and on `GET /api/groups/by-route-id/{id}/summary` for the group page's
 direct-URL load path.
 
 A third endpoint — `DELETE /api/groups/{route_id}/membership` — is the
@@ -126,9 +127,10 @@ class GroupSummary(BaseModel):
     # late joiner, so `/by-route-id` returns [] while the group is not
     # actually empty). Lets the FE distinguish a brand-new empty group
     # (show the create-first-poll flow) from a group whose history is all
-    # hidden pre-join (show the To Do/New/Old tabs with empty messages).
-    # Only `get_group_summary` computes a real value; the /empty + create
-    # paths are genuinely poll-less so they keep the False default.
+    # hidden pre-join (show the To Do/New/Old tabs with empty messages;
+    # home list shows a "No open polls" row). `get_group_summary` and
+    # `get_my_empty_groups` compute real values; the create path is
+    # genuinely poll-less so it keeps the False default.
     has_polls: bool = False
 
 
@@ -333,14 +335,26 @@ def get_my_groups(
 @router.post("/empty", response_model=list[GroupSummary])
 def get_my_empty_groups(request: Request):
     """Return every group the caller is a `group_members` row for that
-    has zero polls. Sorted newest-first. Called by the home page in
-    parallel with `/mine`.
+    has zero polls VISIBLE to them. Sorted newest-first. Called by the
+    home page in parallel with `/mine`.
 
-    The visibility rule is intentionally NOT applied — a group whose
-    every poll was closed before the caller's joined_at watermark
-    still appears here (the "are there any polls at all?" question
-    has no time dimension). The /mine endpoint owns visibility
-    filtering for groups that do have polls.
+    Two shapes land here:
+      * brand-new groups with no polls at all (`has_polls: false`) —
+        the home list shows the "tap to add a poll" row;
+      * groups whose every poll is hidden by the closed-before-join
+        filter (`has_polls: true`, surfaced FE-side as
+        `Group.hasHiddenPolls`). Without this shape, a member invited
+        to a group whose polls had ALL closed before they joined had
+        NO home entry at all: `/mine` filtered every poll out and the
+        old all-polls anti-join here excluded the group too, so the
+        only way back in was re-opening the invite URL (real prod
+        report, June 2026 — the disappearance was misattributed to an
+        unrelated settings change).
+
+    The per-poll visibility predicate mirrors `filter_visible_polls`
+    (`is_closed = false OR updated_at >= joined_at`), with the MIN
+    joined_at across the caller's linked browsers — same
+    most-permissive account-union semantics as `load_user_visibility`.
     """
     browser_id = _browser_id(request)
     user_id = _user_id(request)
@@ -349,30 +363,42 @@ def get_my_empty_groups(request: Request):
     with get_db() as conn:
         # Membership predicate matches `load_user_visibility`'s logic:
         # current browser OR any browser linked to the caller's
-        # user_id. DISTINCT collapses duplicates when multiple linked
-        # browsers all have a row for the same group.
+        # user_id, grouped to one row per group with the earliest
+        # joined_at watermark.
         rows = conn.execute(
-            """SELECT DISTINCT g.id, g.short_id, g.title, g.created_at,
-                       g.image_updated_at, g.privacy, g.creator_user_id
-                 FROM groups g
-                 JOIN group_members m ON m.group_id = g.id
-                WHERE (
-                    m.browser_id = %(bid)s::uuid
-                    OR (
-                        %(uid)s::uuid IS NOT NULL
-                        AND m.browser_id IN (
-                            SELECT browser_id FROM user_browsers
-                             WHERE user_id = %(uid)s::uuid
+            """WITH my_groups AS (
+                    SELECT m.group_id, MIN(m.joined_at) AS joined_at
+                      FROM group_members m
+                     WHERE m.browser_id = %(bid)s::uuid
+                        OR (
+                            %(uid)s::uuid IS NOT NULL
+                            AND m.browser_id IN (
+                                SELECT browser_id FROM user_browsers
+                                 WHERE user_id = %(uid)s::uuid
+                            )
                         )
-                    )
-                )
-                  AND NOT EXISTS (
-                      SELECT 1 FROM polls p WHERE p.group_id = g.id
+                     GROUP BY m.group_id
+               )
+               SELECT g.id, g.short_id, g.title, g.created_at,
+                      g.image_updated_at, g.privacy, g.creator_user_id,
+                      EXISTS (
+                          SELECT 1 FROM polls p WHERE p.group_id = g.id
+                      ) AS has_polls
+                 FROM groups g
+                 JOIN my_groups mg ON mg.group_id = g.id
+                WHERE NOT EXISTS (
+                      SELECT 1 FROM polls p
+                       WHERE p.group_id = g.id
+                         AND (p.is_closed = false
+                              OR p.updated_at >= mg.joined_at)
                   )
                 ORDER BY g.created_at DESC""",
             {"bid": browser_id, "uid": user_id},
         ).fetchall()
-        return [_row_to_group_summary(r) for r in rows]
+        return [
+            _row_to_group_summary(r, has_polls=bool(r.get("has_polls")))
+            for r in rows
+        ]
 
 
 def _row_to_group_summary(row, has_polls: bool = False) -> GroupSummary:

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -351,52 +351,47 @@ def get_my_empty_groups(request: Request):
         report, June 2026 — the disappearance was misattributed to an
         unrelated settings change).
 
-    The per-poll visibility predicate mirrors `filter_visible_polls`
-    (`is_closed = false OR updated_at >= joined_at`), with the MIN
-    joined_at across the caller's linked browsers — same
-    most-permissive account-union semantics as `load_user_visibility`.
+    Composes the same `load_user_visibility` + `filter_visible_polls`
+    pair as `/mine` so the closed-before-join rule keeps a single
+    source of truth: an "empty" group is simply a member group none
+    of whose polls survive the filter.
     """
     browser_id = _browser_id(request)
     user_id = _user_id(request)
     if not browser_id and not user_id:
         return []
     with get_db() as conn:
-        # Membership predicate matches `load_user_visibility`'s logic:
-        # current browser OR any browser linked to the caller's
-        # user_id, grouped to one row per group with the earliest
-        # joined_at watermark.
+        visibility = load_user_visibility(conn, browser_id, user_id=user_id)
+        member_gids = list(visibility.joined_by_group.keys())
+        if not member_gids:
+            return []
+
+        poll_rows = conn.execute(
+            "SELECT id, group_id FROM polls"
+            " WHERE group_id = ANY(%(gids)s::uuid[])",
+            {"gids": member_gids},
+        ).fetchall()
+        visible_pids = set(filter_visible_polls(
+            conn, [str(r["id"]) for r in poll_rows], visibility,
+        ))
+        groups_with_polls = {str(r["group_id"]) for r in poll_rows}
+        groups_with_visible = {
+            str(r["group_id"]) for r in poll_rows
+            if str(r["id"]) in visible_pids
+        }
+
+        empty_gids = [g for g in member_gids if g not in groups_with_visible]
+        if not empty_gids:
+            return []
         rows = conn.execute(
-            """WITH my_groups AS (
-                    SELECT m.group_id, MIN(m.joined_at) AS joined_at
-                      FROM group_members m
-                     WHERE m.browser_id = %(bid)s::uuid
-                        OR (
-                            %(uid)s::uuid IS NOT NULL
-                            AND m.browser_id IN (
-                                SELECT browser_id FROM user_browsers
-                                 WHERE user_id = %(uid)s::uuid
-                            )
-                        )
-                     GROUP BY m.group_id
-               )
-               SELECT g.id, g.short_id, g.title, g.created_at,
-                      g.image_updated_at, g.privacy, g.creator_user_id,
-                      EXISTS (
-                          SELECT 1 FROM polls p WHERE p.group_id = g.id
-                      ) AS has_polls
-                 FROM groups g
-                 JOIN my_groups mg ON mg.group_id = g.id
-                WHERE NOT EXISTS (
-                      SELECT 1 FROM polls p
-                       WHERE p.group_id = g.id
-                         AND (p.is_closed = false
-                              OR p.updated_at >= mg.joined_at)
-                  )
-                ORDER BY g.created_at DESC""",
-            {"bid": browser_id, "uid": user_id},
+            f"""SELECT {_GROUP_SUMMARY_COLUMNS}
+                 FROM groups
+                WHERE id = ANY(%(gids)s::uuid[])
+                ORDER BY created_at DESC""",
+            {"gids": empty_gids},
         ).fetchall()
         return [
-            _row_to_group_summary(r, has_polls=bool(r.get("has_polls")))
+            _row_to_group_summary(r, has_polls=str(r["id"]) in groups_with_polls)
             for r in rows
         ]
 

--- a/server/tests/test_empty_groups.py
+++ b/server/tests/test_empty_groups.py
@@ -13,7 +13,7 @@ Shared fixtures (`client`, `creator_secret`, `browser_id`) and helpers
 import re
 import uuid
 
-from tests.conftest import bid_headers, create_poll
+from tests.conftest import bid_headers, close_poll, create_poll
 
 
 UUID_RE = re.compile(
@@ -136,6 +136,80 @@ class TestGetMyEmptyGroups:
         # Either no groups for the empty header, or no groups for the
         # freshly minted id — both produce an empty list.
         assert resp.json() == []
+
+    def test_group_with_all_polls_hidden_pre_join_appears(
+        self, client, creator_secret, browser_id,
+    ):
+        """The home-list gap from the June 2026 prod report: a member
+        whose group's every poll closed BEFORE they joined gets nothing
+        from `/mine` (closed-before-join filter) — so `/empty` must
+        surface the group (with `has_polls: true`) or it has no home
+        entry at all and the only way back is the invite URL."""
+        poll = create_poll(client, creator_secret, browser_id=browser_id)
+        resp = close_poll(client, poll)
+        assert resp.status_code == 200, resp.text
+
+        # A late joiner: visiting the (public) group URL auto-joins with
+        # joined_at = now, which is AFTER the poll closed.
+        joiner = str(uuid.uuid4())
+        read = client.get(
+            f"/api/groups/by-route-id/{poll['group_short_id']}",
+            headers=bid_headers(joiner),
+        )
+        assert read.status_code == 200, read.text
+        # The closed-pre-join poll is filtered from the group read…
+        assert read.json() == []
+
+        # …and /mine is equally empty…
+        mine = client.post(
+            "/api/groups/mine",
+            json={"include_results": False},
+            headers=bid_headers(joiner),
+        )
+        assert mine.status_code == 200
+        assert mine.json() == []
+
+        # …so /empty must carry the group, flagged as having (hidden)
+        # polls so the FE renders the hidden-history row, not the
+        # "new group — tap to add a poll" copy.
+        empty = client.post("/api/groups/empty", headers=bid_headers(joiner))
+        assert empty.status_code == 200, empty.text
+        by_id = {g["id"]: g for g in empty.json()}
+        assert poll["group_id"] in by_id
+        assert by_id[poll["group_id"]]["has_polls"] is True
+
+    def test_closed_poll_group_stays_off_empty_for_pre_close_member(
+        self, client, creator_secret, browser_id,
+    ):
+        """The creator joined before the close, so the closed poll is
+        still visible to them — the group belongs to their `/mine`
+        response and must NOT also appear on `/empty`."""
+        poll = create_poll(client, creator_secret, browser_id=browser_id)
+        resp = close_poll(client, poll)
+        assert resp.status_code == 200, resp.text
+
+        empty = client.post(
+            "/api/groups/empty", headers=bid_headers(browser_id),
+        )
+        assert empty.status_code == 200
+        assert poll["group_id"] not in {g["id"] for g in empty.json()}
+
+    def test_open_poll_group_stays_off_empty_for_late_joiner(
+        self, client, creator_secret, browser_id,
+    ):
+        """An open poll is visible to any member regardless of join
+        time, so its group is `/mine` territory — never `/empty`."""
+        poll = create_poll(client, creator_secret, browser_id=browser_id)
+        joiner = str(uuid.uuid4())
+        read = client.get(
+            f"/api/groups/by-route-id/{poll['group_short_id']}",
+            headers=bid_headers(joiner),
+        )
+        assert read.status_code == 200, read.text
+
+        empty = client.post("/api/groups/empty", headers=bid_headers(joiner))
+        assert empty.status_code == 200
+        assert poll["group_id"] not in {g["id"] for g in empty.json()}
 
 
 class TestGroupSummary:


### PR DESCRIPTION
## Summary
- Root cause of the prod report "redeemed an invite, saw the group, then it disappeared from home": the group's only poll had been manually closed **before** the invite was minted, so the closed-before-join filter hid it from the invitee. `/api/groups/mine` filtered the poll out and `/api/groups/empty` only returned groups with zero polls at all — so a member group whose every poll is hidden pre-join had **no home entry whatsoever**. (The username change in the report was a red herring — the reporter just hadn't visited home between redeeming and renaming; verified against the prod DB.)
- `POST /api/groups/empty` is now visibility-aware: it composes the same `load_user_visibility` + `filter_visible_polls` pair as `/mine` and returns member groups none of whose polls survive the filter, with a real per-group `has_polls` so the existing `GroupSummary.has_polls → Group.hasHiddenPolls` plumbing carries it to the FE.
- Home row for such groups shows **"No open polls"** instead of the misleading "New group — tap to add a poll".
- CLAUDE.md updated (the `/empty` bullet + the `has_polls`/`hasHiddenPolls` section).

## Test plan
- [x] 3 new server tests in `test_empty_groups.py`: late joiner to an all-closed group gets the group from `/empty` with `has_polls: true`; pre-close member does NOT (it's `/mine` territory); open-poll group never lands on `/empty`
- [x] Full server suite passes (834/834)
- [x] Live demo on the branch dev server replicating the prod timeline (create → close → invitee joins after close → home shows the "No open polls" row)
- [x] Verified against prod data that the invited browser currently gets `[]` from both endpoints (the bug) while its membership row is intact

https://claude.ai/code/session_01VbdKQXY2SFKRzSvamVUFQ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbdKQXY2SFKRzSvamVUFQ2)_