### PR TITLE
notifications, groups: admin-wide join-request push, iOS foreground banners, "Pending Join Requests" label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1064,7 +1064,7 @@ If a future feature needs RSVP-style headcount semantics, it should be designed 
 > non-members; creator-only privacy toggle on /info. F = group join
 > requests (migration 115) — signed-in non-members request access
 > via the /info-not-found page, creators approve/deny from a /info
-> "Pending requests" section, push notification fans out to every
+> "Pending Join Requests" section, push notification fans out to every
 > browser the creator's signed in on. G = invite links (migration
 > 116) — creators mint shareable URLs (`/invite/<token>`); raw token
 > + URL surfaced once at create time and persisted as sha256 hash;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1911,14 +1911,30 @@ browser_id) DO NOTHING` pattern as the auto-join paths so an
 existing membership row keeps its original `joined_at` watermark.
 
 Push fan-out: `services/push.py: fan_out_join_request(group_id,
-creator_user_id, payload)`. Walks `user_browsers WHERE user_id =
-creator_user_id` (NOT group_members) — the creator might have
-requested notifications on Device A and be looking at Device B
-when the request lands. Gated on the per-group `notify_new_poll`
-pref so muting a group still mutes join-request noise. Shares
-`_dispatch_pushes` with `fan_out_new_poll` (the send + record-
-outcomes loop is identical) — extracted on this PR so adding a
-third event type doesn't fork the loop.
+admin_user_ids, payload)`. **Targets ALL group admins (June 2026 —
+migration-142 alignment), not just the creator**: the endpoint passes
+`sorted(group_admin_user_ids(conn, group_id))`, so a promoted co-admin
+hears about requests they can act on and a group whose creator deleted
+their account still notifies surviving admins (the old creator-only
+form silently dropped the push when `creator_user_id` was NULL via the
+SET NULL FK). Walks `user_browsers WHERE user_id = ANY(admins)` (NOT
+group_members) — an admin might have requested notifications on Device
+A and be looking at Device B when the request lands. Gated PER-ADMIN
+on the per-group `notify_new_poll` pref (the apref join keys on
+`ub.user_id`, so one admin's account-keyed mute doesn't silence the
+others) — muting a group still mutes join-request noise. Empty admin
+set (admin-less group) → no-op. Shares `_dispatch_pushes` with
+`fan_out_new_poll` (the send + record-outcomes loop is identical).
+Recipient selection pinned by
+`test_join_requests.py::test_join_request_schedules_push_to_all_admins`
+(router level) +
+`test_group_mute_account.py::test_join_request_fan_out_targets_every_admin_account_aware`
+(SQL level). The payload deep-links `/g/<route>/info` — where
+`JoinRequestsSection` (the approve/deny UI) renders for admins — and
+the member-added push on approve/direct-add deep-links `/g/<route>`;
+both carry `tag` + `group_uuid` so the SW/Capacitor bridge listeners
+match on either URL form, and on native iOS the tap routes via
+`pushNotificationActionPerformed` → `navigateFn(detail.url)`.
 
 FE: `apiCreateGroupJoinRequest`, `apiListGroupJoinRequests`,
 `apiDecideGroupJoinRequest` in `lib/api/groups.ts`. The /info page
@@ -3558,6 +3574,7 @@ Per-group "New Poll" notifications via Web Push (browser / PWA / iOS PWA 16.4+) 
 - **`Notification.permission` returns 'denied' in headless Chromium.** Playwright's `permissions: ['notifications']` context grant doesn't override it. To screenshot the active-state card, inject `Object.defineProperty(Notification, 'permission', {get: () => 'granted'})` via `context.addInitScript()` BEFORE the page loads. Real-browser behavior is what users see; the override is screenshot-only.
 - **`ensurePushSubscription()` is idempotent and handles VAPID key rotation.** Before subscribing, it calls `getSubscription()` and compares the existing `applicationServerKey` to the current VAPID public key via `arrayBuffersEqual`. Mismatch → unsubscribe → fresh subscribe. Without this, a dev-DB-nuke (or VAPID key reset) leaves browsers stuck with a stale subscription that the server can no longer sign for.
 - **Capacitor APNS registration is event-based, not promise-returning.** `PushNotifications.register()` returns void; the device token arrives via `addListener('registration', ({value}) => ...)` async. Wrap in a `Promise` that resolves on `registration` and rejects on `registrationError`, with a 60s timeout — first-install on a fresh APNS connection routinely takes 20-40s for iOS to deliver the token (after that the connection is cached and it's near-instant). Bootstrap is fire-and-forget so the long wait costs nothing user-visible. Bundle ID is read from `@capacitor/app: App.getInfo()` (matches the iOS topic for the APNS push); fall back to `com.whoeverwants.app` if the lookup fails. **If `register()` reliably hits the timeout instead of firing `registration` or `registrationError`, the cause is almost certainly the AppDelegate forwarding hooks being missing** — not slow APNS. See the "@capacitor/push-notifications requires AppDelegate forwarding hooks" pitfall below for the symptom + fix.
+- **iOS foreground banners require `plugins.PushNotifications.presentationOptions` in `capacitor.config.ts`** (set June 2026 to `['badge', 'sound', 'alert']`). Without it, iOS suppresses the banner entirely while the app is FOREGROUNDED — only the JS `pushNotificationReceived` event fires, so e.g. a "Join request for ‹group›" / "Added to ‹group›" push arriving while the user was in the app was invisible. The option feeds Capacitor's `userNotificationCenter(_:willPresent:)` so foreground pushes show the banner + sound + badge like backgrounded ones. Config is baked into the native shell at `npx cap sync ios` time → **requires a fresh iOS build + TestFlight update** to take effect (the workflow's path filter triggers on `capacitor.config.ts`), and like all push behavior it can only be verified on a real device.
 - **iOS `App.entitlements` is required AND wired via `CODE_SIGN_ENTITLEMENTS` in both Debug + Release configs in `project.pbxproj`.** Capacitor's default scaffold doesn't add this file. Without `aps-environment` in entitlements, `PushNotifications.register()` fails with `no aps-environment entitlement string found`. The pbxproj edit sits next to the existing `PRODUCT_BUNDLE_IDENTIFIER` line so the workflow's bundle-id sed-patch doesn't interfere.
 - **Each bundle ID needs Push Notifications capability enabled in Apple Developer Portal → Identifiers.** This is per-bundle: `com.whoeverwants.app` AND `com.whoeverwants.app.latest`. Capability mismatch surfaces as `BadDeviceToken` from APNS at send time, not at registration.
 - **Fan-out runs via `BackgroundTasks`, not inline.** `create_poll` schedules `fan_out_new_poll(group_id, creator_browser_id, payload)` to run AFTER the create response is sent. Each subscription's send is wrapped in try/except — a slow or failing push service can't slow the creator's API response, and 410/404 responses delete the dead subscription row inline. `pywebpush` is synchronous (requests under the hood); httpx HTTP/2 is used for APNS. For a typical group with <20 members this fan-out is well under a second; for larger groups, switch to a thread pool inside `fan_out_new_poll`.

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -35,6 +35,20 @@ const config: CapacitorConfig = {
     contentInset: 'never',
     backgroundColor: '#ffffff',
   },
+  plugins: {
+    // Without presentationOptions, iOS suppresses push banners entirely
+    // while the app is FOREGROUNDED — only the JS `pushNotificationReceived`
+    // event fires, so e.g. a "Join request for <group>" or "Added to
+    // <group>" push arriving while the user is in the app was invisible.
+    // Listing alert/sound/badge makes Capacitor's
+    // `userNotificationCenter(_:willPresent:)` show the banner (and play
+    // the sound / stamp the badge) in the foreground too, matching the
+    // backgrounded behavior. Requires a fresh iOS build to take effect
+    // (config is baked into the native shell at `npx cap sync ios` time).
+    PushNotifications: {
+      presentationOptions: ['badge', 'sound', 'alert'],
+    },
+  },
 };
 
 export default config;

--- a/components/JoinRequestsSection.tsx
+++ b/components/JoinRequestsSection.tsx
@@ -200,7 +200,7 @@ export default function JoinRequestsSection({
   return (
     <section className={className}>
       <h2 className="px-1 mb-2 text-sm font-semibold text-gray-500 dark:text-gray-400">
-        Pending requests
+        Pending Join Requests
       </h2>
       {error && (
         <p

--- a/docs/auth-access-model.md
+++ b/docs/auth-access-model.md
@@ -309,7 +309,7 @@ the original session for the rationale.
 | C | OAuth (Apple, Google) | web + Capacitor flows, ID-token verify, account merge on shared email | A |
 | D | Passkey | WebAuthn server + browser; iOS native plugin | A; can ship after E/F if flaky |
 | E | Group privacy | `groups.privacy`, `groups.creator_user_id`, visibility filter, sign-in nudge | A, B |
-| F | Join requests (shipped) | `group_join_requests` table (migration 115), request/approve/deny endpoints, push notification fan-out to creator's `user_browsers`, /info "Pending requests" creator section, "Request to join" CTA on signed-in 404 page | E |
+| F | Join requests (shipped) | `group_join_requests` table (migration 115), request/approve/deny endpoints, push notification fan-out to creator's `user_browsers`, /info "Pending Join Requests" creator section, "Request to join" CTA on signed-in 404 page | E |
 | G | Invite links (shipped) | `group_invites` table (migration 116), creator-side create/list/revoke endpoints, anonymous-allowed `/invite/<token>` landing page that auto-redeems for signed-in viewers, `InviteLinksSection` on /info | E |
 | H | ~~Per-vote anonymity~~ | **NOT PLANNED.** Anonymity flags on votes + read-time filter were originally designed but retired. Anonymous participation is "leave the voter name blank"; no per-vote on/off toggle. | — |
 | I | Polish (partial — **shipped**) | linked-identities display, **add recovery email** (migration 118: `magic_link_tokens.user_id`; `POST /api/auth/recovery-email/{request,verify}`), **delete account** (`DELETE /api/auth/me`), sign out (Phase A). Still deferred: retire `creator_secret`; "claim an anonymous-created group". | A–G |

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -1307,20 +1307,23 @@ def create_group_join_request(
         ).fetchone()
         requester_email = email_row["email"] if email_row else None
 
-        # Read the creator for the push fan-out. Anonymous-created
-        # groups have NULL creator_user_id; skip the push in that case.
-        meta = get_group_metadata(conn, group_id)
-        creator_user_id = meta["creator_user_id"] if meta else None
+        # Read the ADMIN set for the push fan-out. Migration 142: admins —
+        # not the vestigial `creator_user_id` — are who approve/deny join
+        # requests, so every admin (creator + promoted co-admins) gets the
+        # push, and a group whose creator deleted their account still
+        # notifies its surviving admins. An admin-less group has nobody who
+        # could act on the request, so the push is skipped.
+        admin_ids = sorted(group_admin_user_ids(conn, group_id))
         route_for_url, group_phrase, _ = _build_group_push_context(conn, group_id)
 
     # Fire-and-forget push fan-out. Runs only on a brand-new request;
     # a repeat-ping for an already-pending request would just noise the
-    # creator on every "polite re-request" tap.
-    if is_new and creator_user_id:
+    # admins on every "polite re-request" tap.
+    if is_new and admin_ids:
         # Line 1 names the event + group ("Join request for <Group>"); line 2
         # is who's asking. Body stays generic for passkey-only requesters
         # (no email) so they don't surface as a literal "null wants to join".
-        # The /info page has full details once the creator taps in.
+        # The /info page has full details once an admin taps in.
         body_text = (
             f"{requester_email} wants to join"
             if requester_email
@@ -1329,7 +1332,7 @@ def create_group_join_request(
         background_tasks.add_task(
             fan_out_join_request,
             group_id,
-            creator_user_id,
+            admin_ids,
             {
                 "title": f"Join request for {group_phrase}",
                 "body": body_text,

--- a/server/services/push.py
+++ b/server/services/push.py
@@ -604,39 +604,46 @@ def fan_out_new_poll(group_id: str, creator_browser_id: str | None, payload: dic
 
 def fan_out_join_request(
     group_id: str,
-    creator_user_id: str,
+    admin_user_ids: list[str],
     payload: dict,
 ) -> None:
     """Phase F: send a 'someone wants to join your group' push to every
-    browser the creator is signed in on, subject to the per-group
+    browser each group ADMIN is signed in on, subject to the per-group
     notification preference. Same safety contract as `fan_out_new_poll`:
     every error caught, logged, and swallowed so a failing push service
     can't block the request response.
 
-    Recipients are derived from `user_browsers WHERE user_id = creator`
-    (one per linked browser), filtered down to those with active push
-    subscriptions, and gated on the same `notify_new_poll` pref the
-    new-poll path uses — for v1 the per-group pref is the single signal
-    that the creator wants to hear about anything happening on the
-    group. Phase I can add a dedicated `notify_join_request` column if
-    we want to surface join requests separately from new-poll noise.
+    Migration 142 made admins (not the vestigial `creator_user_id`) the
+    people who approve/deny join requests, so they're the recipient set
+    — a promoted co-admin hears about requests they can act on, and a
+    group whose creator deleted their account still notifies its
+    surviving admins. Recipients are derived from `user_browsers WHERE
+    user_id = ANY(admins)` (one per linked browser, per admin), filtered
+    down to those with active push subscriptions, and gated on the same
+    `notify_new_poll` pref the new-poll path uses — for v1 the per-group
+    pref is the single signal that an admin wants to hear about anything
+    happening on the group. Phase I can add a dedicated
+    `notify_join_request` column if we want to surface join requests
+    separately from new-poll noise.
     """
     try:
+        if not admin_user_ids:
+            return
         with get_db() as conn:
             recipients = conn.execute(
                 """
                 SELECT DISTINCT ub.browser_id::text AS browser_id
                   FROM user_browsers ub
                   LEFT JOIN group_notification_preferences apref
-                    ON apref.user_id = %(uid)s::uuid
+                    ON apref.user_id = ub.user_id
                    AND apref.group_id = %(gid)s::uuid
                   LEFT JOIN group_notification_preferences bpref
                     ON bpref.browser_id = ub.browser_id
                    AND bpref.group_id = %(gid)s::uuid
-                 WHERE ub.user_id = %(uid)s::uuid
+                 WHERE ub.user_id = ANY(%(uids)s::uuid[])
                    AND COALESCE(apref.notify_new_poll, bpref.notify_new_poll, TRUE) = TRUE
                 """,
-                {"gid": group_id, "uid": creator_user_id},
+                {"gid": group_id, "uids": list(admin_user_ids)},
             ).fetchall()
             browser_ids = [r["browser_id"] for r in recipients]
             if not browser_ids:

--- a/server/tests/test_group_mute_account.py
+++ b/server/tests/test_group_mute_account.py
@@ -120,3 +120,56 @@ def test_account_less_mute_is_per_browser(client, monkeypatch):
     )
     assert resp.status_code == 200, resp.text
     assert _recipients(monkeypatch, group_id, creator) == [bid_b]
+
+
+def _join_request_recipients(monkeypatch, group_id, admin_user_ids):
+    """Run fan_out_join_request, capturing the browser_ids it would push to."""
+    captured = {}
+
+    def fake_dispatch(subscriptions, payload, vapid):
+        captured["browser_ids"] = sorted(s["browser_id"] for s in subscriptions)
+
+    monkeypatch.setattr(services.push, "_dispatch_pushes", fake_dispatch)
+    services.push.fan_out_join_request(group_id, admin_user_ids, {"title": "x"})
+    return captured.get("browser_ids", [])
+
+
+def test_join_request_fan_out_targets_every_admin_account_aware(
+    client, monkeypatch
+):
+    """`fan_out_join_request` (migration-142 form: a LIST of admin user_ids)
+    must reach every browser of every admin, and an account-keyed mute on one
+    admin must silence ALL of that admin's devices without touching the
+    other admin's."""
+    email_a = f"jr-admin-a-{uuid.uuid4().hex[:8]}@example.com"
+    email_b = f"jr-admin-b-{uuid.uuid4().hex[:8]}@example.com"
+    # Admin A is signed in on two devices; admin B on one.
+    bid_a1, bid_a2, bid_b = (str(uuid.uuid4()) for _ in range(3))
+    token_a, uid_a = _sign_in(client, bid_a1, email_a)
+    _sign_in(client, bid_a2, email_a)
+    _, uid_b = _sign_in(client, bid_b, email_b)
+
+    poll = create_poll(client, browser_id=str(uuid.uuid4()))
+    group_id, route = poll["group_id"], poll["group_short_id"]
+    for bid in (bid_a1, bid_a2, bid_b):
+        _add_member_and_sub(group_id, bid)
+
+    # Both admins, default pref ON → every linked browser is a recipient.
+    assert _join_request_recipients(monkeypatch, group_id, [uid_a, uid_b]) == (
+        sorted([bid_a1, bid_a2, bid_b])
+    )
+
+    # Admin A mutes the group (account-keyed) → both of A's devices drop;
+    # B still gets it.
+    resp = client.put(
+        f"/api/notifications/groups/{route}",
+        json={"notify_new_poll": False},
+        headers=_bearer(bid_a1, token_a),
+    )
+    assert resp.status_code == 200, resp.text
+    assert _join_request_recipients(
+        monkeypatch, group_id, [uid_a, uid_b]
+    ) == [bid_b]
+
+    # Empty admin set (admin-less group) → no-op.
+    assert _join_request_recipients(monkeypatch, group_id, []) == []

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -776,6 +776,99 @@ def test_approve_schedules_member_added_push(
     assert captured == []
 
 
+def test_join_request_schedules_push_to_all_admins(
+    client, creator_browser, requester_browser, monkeypatch
+):
+    """A brand-new join request must schedule ONE `fan_out_join_request`
+    targeting EVERY group admin (migration 142: admins — not the
+    vestigial creator_user_id — approve/deny, so a promoted co-admin
+    must hear about requests they can act on). Payload must carry the
+    `join-request-*` tag + an `/info` deep link (where the pending-
+    requests section lives) + `group_uuid` so the SW/Capacitor bridge
+    listeners can match regardless of the viewer's URL form. A repeat
+    request (already_pending) must NOT re-fire.
+
+    Monkeypatches the helper at its router-side import site — push
+    DELIVERY needs a real subscription; recipient selection is the
+    testable contract.
+    """
+    import routers.groups as groups_router
+
+    captured: list[dict] = []
+
+    def fake_fan_out(group_id, admin_user_ids, payload):
+        captured.append(
+            {
+                "group_id": group_id,
+                "admin_user_ids": list(admin_user_ids),
+                "payload": payload,
+            }
+        )
+
+    monkeypatch.setattr(groups_router, "fan_out_join_request", fake_fan_out)
+
+    ctoken, creator_uid, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    # Add a second member via invite, then promote them to admin so the
+    # group has TWO admins.
+    invite = client.post(
+        f"/api/groups/{group['id']}/invites",
+        json={"mode": "single"},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert invite.status_code == 201, invite.text
+    coadmin_browser = str(uuid.uuid4())
+    atoken, coadmin_uid, _ = _sign_in(client, coadmin_browser)
+    redeemed = client.post(
+        f"/api/auth/invites/{invite.json()['token']}/redeem",
+        headers=_bearer_headers(coadmin_browser, atoken),
+    )
+    assert redeemed.status_code == 200, redeemed.text
+    promoted = client.post(
+        f"/api/groups/{group['id']}/admins",
+        json={"user_id": coadmin_uid},
+        headers=_bearer_headers(creator_browser, ctoken),
+    )
+    assert promoted.status_code == 200, promoted.text
+
+    rtoken, _, requester_email = _sign_in(client, requester_browser)
+    create = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "let me in"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert create.status_code == 200, create.text
+    assert create.json()["status"] == "pending"
+    request_id = create.json()["request"]["id"]
+
+    assert len(captured) == 1, captured
+    call = captured[0]
+    assert call["group_id"] == group["id"]
+    # BOTH admins — the creator and the promoted co-admin — are targeted.
+    assert set(call["admin_user_ids"]) == {creator_uid, coadmin_uid}
+    payload = call["payload"]
+    assert payload["tag"] == f"join-request-{request_id}"
+    # Deep link lands on the group /info page, where JoinRequestsSection
+    # (the approve/deny UI) renders for admins.
+    assert payload["url"].startswith("/g/")
+    assert payload["url"].endswith("/info")
+    assert payload["group_id"]
+    assert payload["group_uuid"] == group["id"]
+    assert requester_email in payload["body"]
+
+    # Repeat request → already_pending → no second push.
+    captured.clear()
+    again = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "still me"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert again.status_code == 200
+    assert again.json()["status"] == "already_pending"
+    assert captured == []
+
+
 def test_deny_does_not_grant_membership_and_allows_re_request(
     client, creator_browser, requester_browser
 ):


### PR DESCRIPTION
## Summary
- Join-request push now fans out to **every group admin** (account-aware, per-admin mute respected) instead of only the recorded creator — `fan_out_join_request(group_id, admin_user_ids, payload)`; survives creator account deletion.
- iOS foreground push banners: `plugins.PushNotifications.presentationOptions = ['badge', 'sound', 'alert']` in `capacitor.config.ts` (needs the fresh iOS build, already uploaded to TestFlight).
- Relabel the /info creator section from "Pending requests" to **"Pending Join Requests"** (`JoinRequestsSection.tsx` + doc references).

## Test plan
- [x] `server/tests/test_join_requests.py::test_join_request_schedules_push_to_all_admins`
- [x] `server/tests/test_group_mute_account.py::test_join_request_fan_out_targets_every_admin_account_aware`
- [x] Full server suite green
- [ ] Foreground banner delivery verified on a real TestFlight device (push delivery can't be demoed headlessly)

https://claude.ai/code/session_01QgWKiuF3tuDvAfRZ56tWRM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgWKiuF3tuDvAfRZ56tWRM)_