### PR TITLE
Align new-poll Notes field with other form fields

### DIFF
--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -92,9 +92,10 @@ import {
 } from "./createPollHelpers";
 export const dynamic = 'force-dynamic';
 
-// Matches the rendered height of a single-line <input> with py-2 padding.
-// Used for the Details textarea initial height and auto-grow reset.
-const SINGLE_LINE_INPUT_HEIGHT = 42;
+// Matches the rendered height of a single-line field row (h-12 = 48px:
+// a 24px text-base line + py-3's 24px). Used for the Details textarea
+// auto-grow reset so one line of Notes lines up with the other field rows.
+const SINGLE_LINE_INPUT_HEIGHT = 48;
 
 // How long the new-poll sheet body's open-at-top scroll pin stays armed
 // (see setSheetScrollerRef). Sized to outlast the iOS soft-keyboard collapse
@@ -3223,7 +3224,7 @@ export function CreateQuestionContent() {
                         setDetails(e.target.value);
                         const el = e.target;
                         el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
-                        const maxH = 5 * 20 + 16;
+                        const maxH = 5 * 24 + 24;
                         el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
                         el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
                       }}
@@ -3233,7 +3234,7 @@ export function CreateQuestionContent() {
                       }}
                       disabled={isLoading}
                       rows={3}
-                      className="block w-full bg-transparent text-sm focus:outline-none dark:text-white disabled:opacity-50 disabled:cursor-not-allowed resize-none"
+                      className="block w-full bg-transparent text-base py-3 text-gray-500 dark:text-gray-500 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed resize-none"
                     />
                   </section>
                 </div>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -97,6 +97,16 @@ export const dynamic = 'force-dynamic';
 // auto-grow reset so one line of Notes lines up with the other field rows.
 const SINGLE_LINE_INPUT_HEIGHT = 48;
 
+// Sizes the Notes textarea to its content: starts at one line and grows up
+// to ~5 lines, then scrolls. Called on every change AND when the textarea
+// first attaches (callback ref) so it opens at one line instead of rows={N}.
+function autoSizeDetailsTextarea(el: HTMLTextAreaElement) {
+  el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
+  const maxH = 5 * 24 + 24;
+  el.style.height = Math.min(el.scrollHeight, maxH) + "px";
+  el.style.overflowY = el.scrollHeight > maxH ? "auto" : "hidden";
+}
+
 // How long the new-poll sheet body's open-at-top scroll pin stays armed
 // (see setSheetScrollerRef). Sized to outlast the iOS soft-keyboard collapse
 // (~250-400ms) + the sheet's 300ms slide-up with margin; the user's first
@@ -529,6 +539,13 @@ export function CreateQuestionContent() {
   const [recurrenceStart] = useState(() => formatRecurrenceDateISO(new Date()));
   const [details, setDetails] = useState("");
   const detailsRef = useRef<HTMLTextAreaElement>(null);
+  // Callback ref: size the Notes textarea to its content the moment it
+  // attaches (ModalPortal mounts it after open), so it opens at one line for
+  // an empty draft yet grows to fit restored/duplicated multi-line content.
+  const setDetailsEl = useCallback((el: HTMLTextAreaElement | null) => {
+    detailsRef.current = el;
+    if (el) autoSizeDetailsTextarea(el);
+  }, []);
   const [category, setCategory] = useState<string>('custom');
   // Emoji for the poll category (empty = use the default fallback glyph,
   // rendered faded in front of the title preview).
@@ -3217,23 +3234,19 @@ export function CreateQuestionContent() {
                   </label>
                   <section className="rounded-3xl bg-white dark:bg-gray-800 px-4">
                     <textarea
-                      ref={detailsRef}
+                      ref={setDetailsEl}
                       id="details"
                       value={details}
                       onChange={(e) => {
                         setDetails(e.target.value);
-                        const el = e.target;
-                        el.style.height = `${SINGLE_LINE_INPUT_HEIGHT}px`;
-                        const maxH = 5 * 24 + 24;
-                        el.style.height = Math.min(el.scrollHeight, maxH) + 'px';
-                        el.style.overflowY = el.scrollHeight > maxH ? 'auto' : 'hidden';
+                        autoSizeDetailsTextarea(e.target);
                       }}
                       onBlur={() => {
                         const trimmed = details.trim();
                         if (trimmed !== details) setDetails(trimmed);
                       }}
                       disabled={isLoading}
-                      rows={3}
+                      rows={1}
                       className="block w-full bg-transparent text-base py-3 text-gray-500 dark:text-gray-500 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed resize-none"
                     />
                   </section>

--- a/app/create-poll/page.tsx
+++ b/app/create-poll/page.tsx
@@ -538,12 +538,10 @@ export function CreateQuestionContent() {
   const [recurrence, setRecurrence] = useState<RecurrenceRule>(DEFAULT_RECURRENCE);
   const [recurrenceStart] = useState(() => formatRecurrenceDateISO(new Date()));
   const [details, setDetails] = useState("");
-  const detailsRef = useRef<HTMLTextAreaElement>(null);
   // Callback ref: size the Notes textarea to its content the moment it
   // attaches (ModalPortal mounts it after open), so it opens at one line for
   // an empty draft yet grows to fit restored/duplicated multi-line content.
   const setDetailsEl = useCallback((el: HTMLTextAreaElement | null) => {
-    detailsRef.current = el;
     if (el) autoSizeDetailsTextarea(el);
   }, []);
   const [category, setCategory] = useState<string>('custom');


### PR DESCRIPTION
## Summary
The new-poll **Notes** textarea looked and behaved differently from the other settings rows:

- It used `text-sm` with a `dark:text-white` value color and no vertical padding, so it read smaller and tighter than the field values around it.
- It started at `rows={3}` but the first keystroke's auto-grow reset it to one line, so it visibly **collapsed on typing**.

This brings it in line with the rest of the form:

- **Value text style** → `text-base` + the faded `text-gray-500 dark:text-gray-500` color the other field inputs use (Context, Voting Cutoff, Scoring Algorithm, …).
- **Internal vertical padding** → `py-3` (≈12px), so a line of notes has the same breathing room as the `h-12` settings rows.
- **Sizing** → starts at one line and grows with content. The textarea is sized on attach via a callback ref (it mounts after the modal's `ModalPortal` commits), so an empty draft opens at one line while restored/duplicated multi-line content still grows to fit. The shared `autoSizeDetailsTextarea` helper is used by both the attach-time sizing and `onChange`; `SINGLE_LINE_INPUT_HEIGHT`/max-height were updated to `text-base` line metrics.

## Test plan
- [x] Empty form: Notes opens at one line (verified on dev server screenshot).
- [x] Typing grows the field and the value renders in the same size/grey as the other field values.
- [ ] On-device: confirm soft-keyboard/visual-viewport behavior of the sheet is unaffected (styling-only change).

https://claude.ai/code/session_019uKChUZrDFUGb2MsyeiY1V

---
_Generated by [Claude Code](https://claude.ai/code/session_019uKChUZrDFUGb2MsyeiY1V)_