### PR TITLE
groups: optional message on join requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1949,6 +1949,26 @@ viewers on the same page get a "Sign in to request access" CTA
 that opens `SignInModal`; signing in fires
 `SESSION_CHANGED_EVENT` and the button surfaces without remount.
 
+**Requester messages (June 2026).** The wall's request flow includes an
+optional note textarea ("Add a note so they know who you are") sent as
+the request's `message` — previously the API/`/info` display supported
+messages but the only UI callsite hardcoded `null`, so no user could
+ever attach one. Cap: `MESSAGE_MAX_CHARS = 500` in
+`services/join_requests.py` (SILENT truncation for raw-API callers,
+mirroring the `_sanitize_plus_one_names` trim-and-bound convention —
+not a 400; the column is unbounded TEXT so this is the only guard);
+the FE `JOIN_REQUEST_MESSAGE_MAX` maxLength in `GroupLoadState.tsx`
+must stay in lockstep. The admins' join-request push body appends a
+120-char snippet of the note (`<email> wants to join: "<note…>"`,
+same cap convention as `_poll_decision_summary` — 2 sites, inline per
+the extract-at-the-3rd-site rule). Re-requests still keep the FIRST
+pending message (no overwrite). The textarea needs `text-left` (the
+wall wrapper is text-center and text-align cascades into form fields).
+The Go Home button sits at the BOTTOM of the wall — the request flow
+is the primary action, Go Home is the escape hatch. Tests:
+`test_create_join_request_message_truncated_to_cap` +
+`test_join_request_push_body_includes_message`.
+
 **Account name is required to request access (server backstop + FE
 gate).** `POST /api/groups/<route_id>/join-requests` runs
 `validate_user_name(users.display_name)` AFTER the member-or-creator

--- a/components/GroupLoadState.tsx
+++ b/components/GroupLoadState.tsx
@@ -67,9 +67,16 @@ export function GroupLoading({ label = "Loading group..." }: { label?: string })
  *     will be notified."; on 404 show "Group not found."; on 401
  *     (token expired mid-tap) show a re-sign-in nudge.
  */
+/** Mirrors `MESSAGE_MAX_CHARS` in `server/services/join_requests.py` —
+ *  the server truncates anything longer, so the FE caps input at the
+ *  same length to keep what the user typed and what the admins see
+ *  identical. */
+const JOIN_REQUEST_MESSAGE_MAX = 500;
+
 export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
   const router = useRouter();
   const [session, setSession] = useState<SessionUser | null>(null);
+  const [message, setMessage] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [status, setStatus] = useState<
     | { kind: "idle" }
@@ -153,7 +160,7 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
     if (!routeId || submitting) return;
     setSubmitting(true);
     setStatus({ kind: "idle" });
-    apiCreateGroupJoinRequest(routeId, null)
+    apiCreateGroupJoinRequest(routeId, message.trim() || null)
       .then((result) => {
         if (result.status === "already_member") {
           setStatus({
@@ -229,6 +236,26 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
           </button>
           {canRequest && !requestSent && (
             <div className="mt-4">
+              {/* Optional note shown to the group's admins next to the
+                  pending request on /info ("hi, it's Alice from work").
+                  `text-left` is load-bearing: the page wrapper is
+                  text-center and text-align cascades into form fields.
+                  Height via CSS (no `rows` attr) per the textarea-sizing
+                  pitfalls; `block` kills the inline-block descender gap. */}
+              <textarea
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                onBlur={() => {
+                  const trimmed = message.trim();
+                  if (trimmed !== message) setMessage(trimmed);
+                }}
+                disabled={submitting}
+                maxLength={JOIN_REQUEST_MESSAGE_MAX}
+                placeholder="Add a note so they know who you are (optional)"
+                aria-label="Optional message to send with your request"
+                className="block w-full mb-3 px-3 py-2 text-sm text-left bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none disabled:opacity-50"
+                style={{ height: "76px" }}
+              />
               <button
                 type="button"
                 onClick={requestAccess}

--- a/components/GroupLoadState.tsx
+++ b/components/GroupLoadState.tsx
@@ -228,12 +228,6 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
               ? "Request access to view this group."
               : "This group may not exist or you don’t have access."}
           </p>
-          <button
-            onClick={() => router.push("/")}
-            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
-          >
-            Go Home
-          </button>
           {canRequest && !requestSent && (
             <div className="mt-4">
               {/* Optional note shown to the group's admins next to the
@@ -294,6 +288,14 @@ export function GroupNotFound({ routeId }: { routeId?: string } = {}) {
               {status.message}
             </p>
           )}
+          <div className="mt-6">
+            <button
+              onClick={() => router.push("/")}
+              className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+            >
+              Go Home
+            </button>
+          </div>
         </div>
       </div>
       <SignInModal isOpen={signInOpen} onClose={() => setSignInOpen(false)} />

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -1329,6 +1329,19 @@ def create_group_join_request(
             if requester_email
             else "Someone wants to join"
         )
+        # Surface the requester's optional note on line 2 so the admin has
+        # context before tapping in. Capped at 120 chars, mirroring
+        # `_poll_decision_summary`'s push-body convention; the full text
+        # lives on /info. `summary.message` is the freshly-inserted row's
+        # message here — the fan-out is gated on `is_new`, so it can't be
+        # a stale already-pending message.
+        if summary.message:
+            snippet = (
+                summary.message
+                if len(summary.message) <= 120
+                else summary.message[:119].rstrip() + "…"
+            )
+            body_text = f'{body_text}: "{snippet}"'
         background_tasks.add_task(
             fan_out_join_request,
             group_id,

--- a/server/services/join_requests.py
+++ b/server/services/join_requests.py
@@ -32,6 +32,14 @@ from services.groups import backdate_membership_for_user
 
 logger = logging.getLogger(__name__)
 
+# Cap on the requester's optional message. The FE textarea enforces the
+# same limit (`JOIN_REQUEST_MESSAGE_MAX` in components/GroupLoadState.tsx
+# — keep in lockstep); raw-API callers get silently truncated rather
+# than 400'd, matching the `_sanitize_plus_one_names` trim-and-bound
+# convention. The column is unbounded TEXT, so this is the only guard
+# against megabyte messages rendered verbatim on the admins' /info page.
+MESSAGE_MAX_CHARS = 500
+
 
 @dataclass
 class JoinRequestSummary:
@@ -72,7 +80,7 @@ def create_join_request(
     don't want a re-fire on every "polite re-request" tap. Phase I can
     add an explicit "edit my message" action if anyone asks.
     """
-    msg = (message or "").strip() or None
+    msg = (message or "").strip()[:MESSAGE_MAX_CHARS].rstrip() or None
     # Attempt INSERT; on conflict, SELECT the existing row. Two-step is
     # the cleanest way to express "first writer wins, everyone else
     # reads" in postgres without a RAISE-and-recover dance.

--- a/server/tests/test_join_requests.py
+++ b/server/tests/test_join_requests.py
@@ -255,6 +255,81 @@ def test_create_join_request_new_returns_pending(
     assert body["request"]["requester_email"] == remail
 
 
+def test_create_join_request_message_truncated_to_cap(
+    client, creator_browser, requester_browser
+):
+    """The optional message is capped at MESSAGE_MAX_CHARS server-side
+    (the FE textarea enforces the same limit; raw-API callers get
+    silently truncated, not 400'd). The column is unbounded TEXT, so
+    this is the only guard against megabyte messages rendered verbatim
+    on the admins' /info page."""
+    from services.join_requests import MESSAGE_MAX_CHARS
+
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    rtoken, _, _ = _sign_in(client, requester_browser)
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "x" * (MESSAGE_MAX_CHARS + 100)},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["request"]["message"] == "x" * MESSAGE_MAX_CHARS
+
+
+def test_join_request_push_body_includes_message(
+    client, creator_browser, requester_browser, monkeypatch
+):
+    """When the requester includes a message, the admins' push body
+    carries it on line 2 ('<email> wants to join: "<note>"') so they
+    have context before tapping into /info. A message longer than 120
+    chars is snipped with an ellipsis — push bodies stay short.
+    Monkeypatches the fan-out at its router-side import site (delivery
+    needs a real subscription; the payload is the testable contract)."""
+    import routers.groups as groups_router
+
+    captured: list[dict] = []
+
+    def fake_fan_out(group_id, admin_user_ids, payload):
+        captured.append(payload)
+
+    monkeypatch.setattr(groups_router, "fan_out_join_request", fake_fan_out)
+
+    ctoken, _, _ = _sign_in(client, creator_browser)
+    group = _create_private_group(client, creator_browser, ctoken)
+
+    rtoken, _, remail = _sign_in(client, requester_browser)
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "Hi, it's Alice from the climbing gym"},
+        headers=_bearer_headers(requester_browser, rtoken),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "pending"
+
+    assert len(captured) == 1
+    assert (
+        captured[0]["body"]
+        == f'{remail} wants to join: "Hi, it\'s Alice from the climbing gym"'
+    )
+
+    # Long message → 119 chars kept + ellipsis in the push body (the
+    # full text still lands on /info via the stored row).
+    long_browser = str(uuid.uuid4())
+    ltoken, _, lemail = _sign_in(client, long_browser)
+    resp = client.post(
+        f"/api/groups/{group['id']}/join-requests",
+        json={"message": "y" * 300},
+        headers=_bearer_headers(long_browser, ltoken),
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(captured) == 2
+    assert captured[1]["body"] == f'{lemail} wants to join: "{"y" * 119}…"'
+
+
 def test_create_join_request_repeat_returns_already_pending(
     client, creator_browser, requester_browser
 ):


### PR DESCRIPTION
## Summary
- The join-request API + admin `/info` display already supported an optional `message`, but the only UI entry point (the "Request to join" button on the private-group wall) hardcoded `null` — no user could ever attach one. Adds an optional "Add a note so they know who you are" textarea to `GroupNotFound`'s request flow.
- Caps the message server-side at 500 chars (`MESSAGE_MAX_CHARS` in `services/join_requests.py`; silent truncation for raw-API callers, FE `maxLength` kept in lockstep — the column is unbounded TEXT, so this is the only guard).
- Surfaces the note in the admins' join-request push body (`alice@x.com wants to join: "Hi, it's Alice…"`, 120-char snippet matching the poll-decision push convention).
- Moves the Go Home button to the bottom of the private-group wall — the request flow is the primary action, Go Home is the escape hatch.

## Test plan
- [x] `server/tests/test_join_requests.py` 26/26 (2 new: truncation cap + push-body contract incl. ellipsis snip)
- [x] Adjacent suites `test_group_mute_account.py` + `test_group_admins.py` 17/17
- [x] Browser-verified on the branch dev server: requester types a note → request sent → note renders in the admin's Pending Join Requests on `/info`; Go Home renders below the request flow

https://claude.ai/code/session_01EmxTcWEJ6aCb1pJoPi42eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmxTcWEJ6aCb1pJoPi42eM)_