### PR TITLE
ios: iMessage extension Phase 1 — share a poll from the Messages drawer

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -268,6 +268,14 @@ jobs:
           set -euo pipefail
           plutil -replace CFBundleDisplayName -string "${{ steps.bundle.outputs.display_name }}" ios/App/App/Info.plist
           plutil -extract CFBundleDisplayName raw ios/App/App/Info.plist
+          # The Messages extension's CFBundleDisplayName is the label under the
+          # app's icon in the Messages drawer. Stamp it with the same per-tier
+          # name so a tester with BOTH apps installed can tell the two drawer
+          # entries apart (the committed plist keeps "WhoeverWants" for local
+          # Xcode builds, same convention as the host app's plist).
+          plutil -replace CFBundleDisplayName -string "${{ steps.bundle.outputs.display_name }}" ios/App/MessagesExtension/Info.plist
+          plutil -extract CFBundleDisplayName raw ios/App/MessagesExtension/Info.plist
+          plutil -lint ios/App/MessagesExtension/Info.plist
           # CFBundleSpokenName: set for the canary tier (Siri voice-match fix),
           # ensure ABSENT for prod (so it falls back to "Whoever"). The committed
           # Info.plist carries no spoken name, so prod is clean by default; the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3251,8 +3251,12 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
 
 > **Plan: `docs/imessage-extension-plan.md`.** Goal: interactive poll bubbles in
 > the Messages transcript via a Messages app extension. **Phase 0 (target
-> scaffold + CI wiring) SHIPPED** on `claude/imessage-interactive-polls-vax1x2`;
-> a static SwiftUI placeholder, no live layout / identity / networking yet.
+> scaffold + CI wiring) SHIPPED** via #712. **Phase 1 (share a poll from the
+> drawer) SHIPPED** on `claude/imessage-extension-phase-1-a6esys` — drawer
+> picker (the `PollEntity.fetchAll` fetch via the App-Group identity),
+> `MSMessageTemplateLayout` insert (canonical URL public / poll-scoped invite
+> URL private), bubble-tap native summary with live results; full shape in the
+> plan doc's Phase 1 section; device verification owner-owned.
 > Owner decisions: ship additive (degraded no-app fallback OK); embed a
 > poll-scoped invite token for private-group bubbles (auto-join); v1 inline
 > voting = yes_no + limited_supply only; pursue compose-in-Messages keeping
@@ -3270,16 +3274,64 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
   target/embed-phase/dependency) without a Mac — the single biggest de-risker
   for editing the project from here. Re-run the script to regenerate; it's a
   no-op if the target exists.
-- **Phase 0 has NO entitlements, on purpose.** No App Group / keychain group →
-  automatic signing self-provisions the new bundle ids
+- **Phase 0 had NO entitlements, on purpose; Phase 1 added the App Group.**
+  Phase 0's bare scaffold let automatic signing self-provision the new bundle ids
   (`com.whoeverwants.app[.latest].MessagesExtension`) with ZERO manual Apple
-  Developer portal steps, which is what makes a green canary CI build achievable
-  unattended. The App Group identity bridge (reading `NativeIdentityAppGroup`,
-  the same separate-process channel Siri uses — the extension is its own process,
-  so plain Keychain won't cross to it) is a **Phase 1 prerequisite** that DOES
-  need the one-time manual "App Groups" capability registration on both extension
-  bundle ids (automatic signing does not auto-create App Groups — same caveat the
-  host app's `App.entitlements` documents).
+  Developer portal steps — the unattended green-canary-build trick. Phase 1
+  added `MessagesExtension/MessagesExtension.entitlements` carrying ONLY the
+  App Group (`group.com.whoeverwants.siri` — the same separate-process identity
+  channel Siri uses; the extension is its own process, so plain Keychain won't
+  cross to it), wired via `CODE_SIGN_ENTITLEMENTS` on both ext configs (the gem
+  edit is reflected in `add-messages-extension.rb`). The group is TIER-SHARED,
+  so no per-tier entitlement-scoping step is needed in `ios-build.yml` (unlike
+  the host app's associated-domains). **One-time manual prerequisite: register
+  the "App Groups" capability + assign the group on BOTH extension bundle ids
+  in the Apple Developer portal** (automatic signing does not auto-create App
+  Groups — same caveat the host app's `App.entitlements` documents); without it
+  the archive fails at provisioning for the extension target.
+- **Phase 1 implementation notes (`ios/App/MessagesExtension/MessagesViewController.swift`,
+  self-contained):**
+  - The extension CANNOT import App-target sources without pbxproj surgery, so
+    the tiny tier/identity helpers (`isCanaryBundle`/`feHost`/`apiBase` +
+    the `BridgedIdentity` App Group reader) are DUPLICATED from
+    `AppDelegate.swift` — keep them in lockstep. Canary detection is
+    `bundleIdentifier.hasPrefix("com.whoeverwants.app.latest")` (the ext id is
+    `<host id>.MessagesExtension`, so equality won't match).
+  - Poll picker = the same `POST /api/groups/mine` fetch/title-rule/sort/cap as
+    Siri's `PollEntity.fetchAll`, with X-Browser-Id from the App Group. No
+    identity → "Open WhoeverWants first" state (the name-gate, mirroring Siri).
+  - Private-group shares mint a poll-scoped multi-use no-expiry invite
+    (`POST /api/groups/<route>/invites`, admin-only server-side) and embed
+    `/invite/<token>?wwPoll=<pollShort>` as `message.url`; `wwPoll` exists
+    because the token URL doesn't otherwise name the poll — only the extension
+    reads it (the contract is registered in the `POLL_QUERY_PARAM` docblock in
+    `lib/groupUtils.ts` so web changes don't strip it). The minted token is
+    cached per-poll for the SESSION (re-shares reuse it); cross-session shares
+    mint fresh invites — accepted, each stays revocable from /info (a server
+    get-or-mint would require storing raw tokens, breaking hash-only-storage).
+    Mint failure (non-admin member, network) falls back to the canonical
+    `/g/<g>/p/<p>` URL → recipient hits the normal request-access wall. Public
+    shares use the bare canonical URL (no payload params; the path names it).
+  - The recipient summary uses the deliberately identity-free + visibility-blind
+    `GET /api/polls/{short_id}` + concurrent per-question
+    `GET /api/questions/{id}/results` — acceptable for the on-demand expanded
+    view under decision B (a bubble IS a deliberate capability share), but
+    Phase 2 should add a single identity-free server summary endpoint and
+    migrate this onto it (see the plan doc). Display rules mirror the web:
+    question labels follow `getQuestionSectionTitle` (incl. the yes_no /
+    limited_supply null-label rule; the Swift `categoryLabels` map is the 4th
+    label-mirror site), slot winners render in `_format_slot_label`'s shape,
+    respondent counts honor `voter_name_counts` multiplicity.
+  - `MSMessage` is inserted with `conversation.insert` (NEVER auto-send) +
+    `dismiss()` on success; the template-layout image is RENDERED AT RUNTIME
+    (👋 on black via `UIGraphicsImageRenderer`) because the extension icon is a
+    `.stickersiconset`, which `UIImage(named:)` can't load.
+  - "Open in WhoeverWants" = `extensionContext.open(url)` with a copy-link
+    fallback on failure (the API is known-finicky from Messages extensions);
+    a separate always-visible Copy Link button covers the rest.
+  - The drawer label (ext `CFBundleDisplayName`) is stamped per-tier in the
+    existing display-name workflow step ("Whoever" / "Whoever α") so testers
+    with both apps can tell the two drawer entries apart.
 - **CI wiring (`ios-build.yml`), two load-bearing fixes for a second target:**
   1. The bundle-id sed must patch BOTH targets, **extension-first with anchored
      `;`** (`com\.whoeverwants\.app\.MessagesExtension;` before
@@ -4665,7 +4717,7 @@ Submitting a draft used to navigate to `/p/<newPollShortId>`. The user described
 - **Place detail modal**: Tapping a restaurant/location name opens `PlaceDetailModal` (map embed + metadata). Tapping the address opens an iOS-style action sheet (`AddressActionsModal`) with "Open in Maps" (Apple Maps), "Open in Google Maps", and "Copy Address". Don't use `geo:` URIs on iOS — they're unreliable (may open Google Earth or other random apps). Don't include the business name in maps queries — it triggers a search for multiple branches instead of navigating to the specific address.
 - **`line-clamp-2` breaks flex layouts**: Don't apply `line-clamp-*` to containers with flex children (like `OptionLabel`). The CSS treats flex items as flowing text and truncates unexpectedly. Use `overflow-hidden` instead and let inner components handle their own truncation.
 - **Voting Cutoff field is a shared component**: `components/VotingCutoffField.tsx` renders the inline colored-value dropdown + conditional custom date/time inputs used by every question category in `app/create-question/page.tsx`. Reuse it when adding new categories — don't copy-paste the JSX. The custom date/time inputs inside use ids `customDate` and `customTime`; the component assumes only one instance is rendered at a time (enforced by the mutually exclusive `category === 'time'` vs `category !== 'time'` branches).
-- **Three places to mirror new built-in labels**: `components/TypeFieldInput.tsx: BUILT_IN_TYPES`, `app/create-poll/createPollHelpers.ts: _CATEGORY_LABELS` (used by `labelForCategory`, the canonical FE label resolver), and `server/algorithms/poll_title.py: _CATEGORY_LABELS`. The two label maps must stay in lockstep — the server drives auto-generated wrapper titles; the FE drives draft preview + per-question section headers. `getQuestionSectionTitle` in `lib/questionListUtils.ts` follows this convention (special-cases `time` → `"Time"`, returns null for `yes_no` per the "yes_no is a category, not display text" rule, falls through to `getBuiltInType(category)?.label` for everything else). **yes_no is filtered out of auto-titles on both sides** (see the "'Yes/No' is a CATEGORY, not display text" bullet in the Poll Cards section) — both `draftPollPreview` (FE) and `generate_poll_title` (server) skip yes_no when composing wrapper titles. **`BUILT_IN_TYPES.label` and `_CATEGORY_LABELS` are NOT 1:1** for non-yes_no categories with formatting variants (e.g. the "Yes / No" UI label with spaces vs the historical "Yes/No" auto-title label without spaces) — when you need the auto-title-aligned label string, route through `labelForCategory`, don't read `BUILT_IN_TYPES.label` directly.
+- **Four places to mirror new built-in labels**: `components/TypeFieldInput.tsx: BUILT_IN_TYPES`, `app/create-poll/createPollHelpers.ts: _CATEGORY_LABELS` (used by `labelForCategory`, the canonical FE label resolver), `server/algorithms/poll_title.py: _CATEGORY_LABELS`, and the Swift mirror `categoryLabels` in `ios/App/MessagesExtension/MessagesViewController.swift` (drives the iMessage bubble summary's question labels via its `questionLabel`, which mirrors `getQuestionLabel`'s semantics). The two label maps must stay in lockstep — the server drives auto-generated wrapper titles; the FE drives draft preview + per-question section headers. `getQuestionSectionTitle` in `lib/questionListUtils.ts` follows this convention (special-cases `time` → `"Time"`, returns null for `yes_no` per the "yes_no is a category, not display text" rule, falls through to `getBuiltInType(category)?.label` for everything else). **yes_no is filtered out of auto-titles on both sides** (see the "'Yes/No' is a CATEGORY, not display text" bullet in the Poll Cards section) — both `draftPollPreview` (FE) and `generate_poll_title` (server) skip yes_no when composing wrapper titles. **`BUILT_IN_TYPES.label` and `_CATEGORY_LABELS` are NOT 1:1** for non-yes_no categories with formatting variants (e.g. the "Yes / No" UI label with spaces vs the historical "Yes/No" auto-title label without spaces) — when you need the auto-title-aligned label string, route through `labelForCategory`, don't read `BUILT_IN_TYPES.label` directly.
 - **Time questions need a `question_type === 'time'` short-circuit before reading `category`**, mirroring `_category_for_title` in `server/routers/polls.py`. The Time bubble in `app/create-poll/page.tsx` sets `question_type=time` but leaves `category="custom"` (the form's default). Reading the category alone gives "Custom" everywhere this matters — auto-title generation, section headers, label lookups, AND category-icon lookups (e.g. compact preview pills): `getBuiltInCategoryIcon(sp.category)` returns `undefined` for time questions because "custom" isn't a built-in, so the pill rendered iconless. The `CompactTimePreview` callsite in `app/g/[groupShortId]/GroupCardItem.tsx` hard-codes `getBuiltInCategoryIcon("time")` since it's already inside a `question_type === "time"` branch — same fix idiom. Both `getQuestionSectionTitle` (FE) and `_category_for_title` (server) implement the short-circuit; if you write a third helper that maps a question to its display label, icon, or any other category-driven attribute, it must too.
 
 ### Custom-Category Emoji (per-question icon)

--- a/docs/imessage-extension-plan.md
+++ b/docs/imessage-extension-plan.md
@@ -5,8 +5,10 @@
 > live, tappable poll bubble in the conversation transcript. Written so a future
 > session can pick it up cold.
 >
-> **Status (June 2026): research + plan only — no code yet.** Several owner
-> decisions are needed before Phase 1 (see "Open questions" at the bottom).
+> **Status (June 2026): Phase 0 (target scaffold + CI) shipped via #712;
+> Phase 1 (share-from-drawer) implemented — see the Phase 1 section for what
+> landed and the on-device verification owed.** Owner decisions are resolved
+> (see "Resolved decisions" at the bottom).
 >
 > **Verdict up front: feasible, and `MSMessageLiveLayout` is the right API** — but
 > this is the project's first *additional Xcode target* (a Messages extension is a
@@ -113,9 +115,15 @@ These shape every decision below; re-read before changing the plan.
   visiting the URL). **Private groups: the payload embeds a group invite token**
   (decision B) so the recipient auto-joins on interaction, exactly like clicking
   an `/invite/<token>` link. When sharing a poll whose group is private, the
-  extension mints (or reuses) a multi-use invite scoped to that poll
+  extension mints a multi-use invite scoped to that poll
   (`POST /api/groups/<route>/invites` with `target_poll_id`, the Phase G
-  machinery) and embeds the raw token in the `MSMessage` payload; the bubble's
+  machinery) and embeds the raw token in the `MSMessage` payload. Reuse is
+  SESSION-scoped only (an in-memory poll→token cache in the extension): the raw
+  token is hash-stored server-side and can never be re-listed, so cross-session
+  re-shares mint fresh invites — accepted; they accumulate in the group's /info
+  invites list, where each stays individually revocable (a server-side
+  get-or-mint would require storing raw tokens, breaking hash-only-storage).
+  The bubble's
   "Open in WhoeverWants" deep-link is the canonical `/invite/<token>` URL so the
   fallback path redeems too. **Caveat — redemption needs an account:**
   `POST /api/auth/invites/<token>/redeem` is `user_id`-only (401 anonymous), so a
@@ -196,25 +204,61 @@ App Groups — same caveat the host app already documents in `App.entitlements`)
   sandbox; the device half is owner-owned, consistent with every prior native
   phase (Siri, push, haptics).
 
-### Phase 1 — share a poll from the drawer (template layout, no live layout yet)
+### Phase 1 — share a poll from the drawer (SHIPPED, pending device verification)
 
-- **Prerequisite (manual, one-time):** add the App Group
-  (`group.com.whoeverwants.siri`) entitlement to the extension target + register
-  the "App Groups" capability on `com.whoeverwants.app.MessagesExtension` and
-  `com.whoeverwants.app.latest.MessagesExtension` in the Apple Developer portal.
-  Phase 0 deliberately deferred this so its build self-provisions.
-- Compact/expanded view lists the user's recent polls (the `PollEntity.fetchAll`
-  fetch via the App Group identity; signed-out/nameless → "open the app first"
-  state).
-- Tapping a poll inserts an `MSMessage` with `MSMessageTemplateLayout` (app icon
-  image, poll title as caption, `url` = canonical poll URL for public groups, or
-  a freshly-minted poll-scoped `/invite/<token>` URL for private groups per
-  decision B) into the compose field; user hits send.
-- Tapping the bubble (recipient with app) opens the extension in expanded style:
-  native poll summary + live results + "Open in WhoeverWants"
-  (`extensionContext?.open` — known to be finicky from Messages extensions;
-  budget time, fall back to "copy link" if it won't cooperate).
-- Independently shippable; already useful without any live layout.
+What landed (all in `ios/App/MessagesExtension/MessagesViewController.swift` —
+self-contained; the tier/identity helpers from AppDelegate.swift are duplicated
+there because the extension can't import App-target sources, keep in lockstep):
+- **Entitlements:** `MessagesExtension.entitlements` carries the App Group
+  (`group.com.whoeverwants.siri`), wired via `CODE_SIGN_ENTITLEMENTS` on both
+  configs (and into `add-messages-extension.rb` so the regenerator matches).
+  Same group on both tiers → NO per-tier scoping step in ios-build.yml.
+  **Prerequisite (manual, one-time):** register the "App Groups" capability +
+  assign the group on `com.whoeverwants.app.MessagesExtension` and
+  `com.whoeverwants.app.latest.MessagesExtension` in the Apple Developer portal
+  — automatic signing does NOT auto-create App Groups; without it the archive
+  fails at provisioning for the extension target.
+- **Picker:** drawer lists the user's recent polls — the same
+  `POST /api/groups/mine` fetch / title rule / newest-first sort / cap-50 as
+  Siri's `PollEntity.fetchAll`, authenticated with the App-Group-bridged
+  X-Browser-Id. No bridged identity → "Open WhoeverWants first" state (with a
+  re-check button); distinct empty + network-error states. Private/Closed
+  badges per row.
+- **Share:** tapping a poll inserts an `MSMessage` (`MSMessageTemplateLayout`:
+  runtime-rendered 👋-on-black image, poll title caption, group-name
+  subcaption) into the compose field — never auto-sends. `message.url` =
+  canonical `/g/<group>/p/<poll>` for public groups; for private groups a
+  poll-scoped multi-use invite is minted (`POST /api/groups/<route>/invites`,
+  `target_poll_id` set, no expiry — revocable from /info) and the url is
+  `/invite/<token>?wwPoll=<pollShort>` (decision B). The `wwPoll` param is the
+  extension-side payload (the token URL doesn't otherwise name the poll; the
+  web ignores it). Invite minting is admin-only server-side — a non-admin
+  member sharing a private-group poll falls back to the canonical URL and the
+  recipient hits the normal request-access wall (degraded but coherent).
+- **Bubble tap (recipient with app):** extension opens with
+  `conversation.selectedMessage` set (cold via `willBecomeActive`, warm via
+  `didSelect`) → native summary: title, group, Open/Closed, per-question live
+  results (yes/no counts, claimed counts, winner/leader, time slots in the
+  server's `_format_slot_label` shape; question labels mirror the web's
+  `getQuestionSectionTitle` rules incl. the "Yes/No is a category, not display
+  text" null), respondent count (name-multiplicity-aware, mirroring
+  `namedVoterCount`), "Open in WhoeverWants" (`extensionContext.open`,
+  copy-link fallback on failure) + an always-visible Copy Link button. Fetches
+  the identity-free `GET /api/polls/<short>` + per-question
+  `GET /api/questions/<id>/results` (concurrent) — fine for the on-demand
+  expanded view, but **Phase 2's transcript bubble should get a single tiny
+  identity-free server summary endpoint** (built from
+  `_question_decision_label` / `_format_slot_label` / `_compute_poll_voter_data`)
+  and this view should migrate onto it: multiple live bubbles re-fetching N+1
+  endpoints per render won't fly, and a server endpoint also frees the
+  visibility-blind poll read to be tightened someday without breaking
+  in-flight bubbles.
+- CI: the drawer label (extension `CFBundleDisplayName`) is stamped per-tier
+  ("Whoever" / "Whoever α") in the existing display-name step so testers with
+  both apps can tell the drawer entries apart.
+- Exit criteria: (CI) green canary build. (Owner, device) drawer picker lists
+  polls, send a public + a private poll bubble, recipient tap shows the summary
+  + results, invite-URL bubble redeems on the web fallback path.
 
 ### Phase 2 — live transcript bubble (read-only)
 
@@ -223,6 +267,12 @@ App Groups — same caveat the host app already documents in `App.entitlements`)
 - Transcript instance renders title + live result bars + status (open/closed,
   countdown), fetched on `willBecomeActive`/render with a short in-process cache
   (multiple bubbles, aggressive teardown — keep fetches coalesced + tiny).
+- **Build the identity-free server summary endpoint here** (e.g.
+  `GET /api/polls/{short}/summary` from `_question_decision_label` +
+  `_format_slot_label` + `_compute_poll_voter_data`): one tiny round-trip per
+  bubble instead of Phase 1's poll + per-question results fan-out, and migrate
+  the Phase 1 expanded summary onto it too (frees the visibility-blind
+  `GET /api/polls/{short_id}` to be tightened later without breaking bubbles).
 - `contentSizeThatFits` returns a fixed compact height; no scrolling inside the
   bubble.
 - Private-group bubble (decision B): on first render the recipient isn't a member

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		CA00B0D750BEB2329C980CD9 /* MessagesViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
 		E9ECE4DD63EE9AC4A596887C /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F554A87FA2F92653C6C17A88 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		F657FD539A293585D5A3490F /* MessagesExtension.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MessagesExtension.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +108,7 @@
 				CA00B0D750BEB2329C980CD9 /* MessagesViewController.swift */,
 				E9ECE4DD63EE9AC4A596887C /* Assets.xcassets */,
 				69C10D8BEFF8F39CAF12768D /* Info.plist */,
+				F657FD539A293585D5A3490F /* MessagesExtension.entitlements */,
 			);
 			name = MessagesExtension;
 			path = MessagesExtension;
@@ -464,6 +466,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = MessagesExtension/MessagesExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -490,6 +493,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
 				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = MessagesExtension/MessagesExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = NO;

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -397,6 +397,9 @@ private enum NativeIdentityKeychain {
 // hardened than the Keychain, and name + browser id are enough for an attributed
 // create — X-Browser-Id resolves to the account). MUST match the
 // com.apple.security.application-groups entitlement.
+// MIRRORED (read side) as BridgedIdentity in
+// MessagesExtension/MessagesViewController.swift — keep suite name + keys in
+// lockstep (the extension is a separate target and can't import this file).
 private enum NativeIdentityAppGroup {
     static let suiteName = "group.com.whoeverwants.siri"
     static let nameKey = "display_name"
@@ -510,6 +513,10 @@ public class NativeIdentityPlugin: CAPPlugin, CAPBridgedPlugin {
 // prod build (`com.whoeverwants.app`) the bare hosts. Mirrors CAP_ENV /
 // capacitor.config.ts. Used by both the Phase 1 deep-link host (FE) and the
 // Phase 3 headless API host.
+// MIRRORED (with QuickPollService.apiBase + whoeverwantsFEHost, and the
+// /api/groups/mine parse in PollEntity.fetchAll) in
+// MessagesExtension/MessagesViewController.swift — keep in lockstep when a
+// tier/host changes (the extension is a separate target, can't import this).
 private func whoeverwantsIsCanaryBundle() -> Bool {
     Bundle.main.bundleIdentifier == "com.whoeverwants.app.latest"
 }

--- a/ios/App/MessagesExtension/MessagesExtension.entitlements
+++ b/ios/App/MessagesExtension/MessagesExtension.entitlements
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- App Group: the bridged-identity channel shared with the host app
+	     (NativeIdentityAppGroup in AppDelegate.swift mirrors the display name +
+	     browser id here on every session change; the extension — a SEPARATE
+	     process, like the headless Siri intent — reads them to authenticate its
+	     poll fetches). Same group on BOTH tiers, so no per-tier scoping step in
+	     ios-build.yml is needed (unlike associated-domains on the host app).
+	     PREREQUISITE (one-time, manual — DONE June 2026 for both tiers): the
+	     "App Groups" capability is registered + this group assigned on
+	     com.whoeverwants.app.MessagesExtension
+	     AND com.whoeverwants.app.latest.MessagesExtension in the Apple Developer
+	     portal — automatic signing does NOT auto-create App Groups (same caveat
+	     as the host app's App.entitlements). On a future App ID (a third tier),
+	     repeat that step or the archive fails at provisioning with
+	     "Provisioning profile ... doesn't match the entitlements file's value
+	     for the com.apple.security.application-groups entitlement". -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.whoeverwants.siri</string>
+	</array>
+</dict>
+</plist>

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -2,24 +2,559 @@ import Messages
 import SwiftUI
 import UIKit
 
-// Phase 0 scaffold for the WhoeverWants iMessage extension.
+// Phase 1 of docs/imessage-extension-plan.md — share a poll from the Messages
+// drawer (template layout; the live transcript bubble is Phase 2).
 //
-// This is intentionally a static placeholder: it proves the extension target
-// builds, signs, embeds in the host IPA, and appears in the Messages drawer.
-// No identity bridge, no networking, no MSMessageLiveLayout yet — those land in
-// later phases (see docs/imessage-extension-plan.md). The extension is a
-// SEPARATE process from the host app and cannot see the WebView's localStorage,
-// so future phases read the App-Group-bridged identity (NativeIdentityAppGroup
-// in AppDelegate.swift), gated on the App Groups capability being registered on
-// the per-tier extension bundle ids — a Phase 1 prerequisite, deliberately not
-// required here so automatic signing can self-provision this scaffold.
+// What this does:
+//   • Compact/expanded drawer view lists the user's recent polls (the same
+//     `POST /api/groups/mine` fetch Siri's PollEntity.fetchAll uses), read with
+//     the App-Group-bridged identity. No identity → "open the app first" state.
+//   • Tapping a poll inserts an MSMessage (MSMessageTemplateLayout: icon, poll
+//     title caption, group subcaption) whose url is the canonical
+//     /g/<group>/p/<poll> for public groups, or a freshly-minted poll-scoped
+//     /invite/<token> for private groups (owner decision B — the bubble doubles
+//     as a revocable capability token; recipients auto-join like an invite link).
+//   • Tapping a sent bubble (recipient WITH the app) opens the extension
+//     expanded with `conversation.selectedMessage` set → a native poll summary
+//     with live results + "Open in WhoeverWants" (extensionContext.open is
+//     famously finicky from Messages extensions, so Copy Link is the always-
+//     available fallback and the open failure path copies too).
+//
+// Architectural notes:
+//   • The extension is a SEPARATE target and process. It cannot import
+//     App-target sources without pbxproj surgery, so the small helpers from
+//     AppDelegate.swift are DUPLICATED here and must be kept in lockstep:
+//     the tier constants (isCanaryBundle / feHost / apiBase ↔
+//     whoeverwantsIsCanaryBundle / whoeverwantsFEHost / QuickPollService.apiBase),
+//     the App Group reader (BridgedIdentity ↔ NativeIdentityAppGroup), and the
+//     /api/groups/mine fetch+parse (PollAPI.fetchMyPolls ↔ PollEntity.fetchAll).
+//     If a THIRD copy of the polls fetch ever appears, extract a shared
+//     pure-Foundation file compiled into both targets (the PollTextParser.swift
+//     precedent) instead of duplicating again.
+//   • Identity = name + browser id from the shared App Group
+//     (group.com.whoeverwants.siri), the channel proven to cross process
+//     boundaries in the Siri work (plain Keychain does NOT). The bearer token
+//     is deliberately not bridged; X-Browser-Id resolves to the account
+//     server-side, exactly like the headless Siri create.
+//   • The server stays the source of truth: the message payload carries only
+//     URLs/ids, never poll state, so web voters and bubble viewers can't
+//     diverge (no MSSession update churn needed for correctness).
+
+// MARK: - Tier helpers (mirror AppDelegate.swift — keep in lockstep)
+
+// The extension's bundle id is "<host app id>.MessagesExtension", so the canary
+// build is com.whoeverwants.app.latest.MessagesExtension — prefix-match the
+// host id rather than equality. Process-constant, so plain lazily-initialized
+// globals (not computed vars re-deriving per network call).
+private let isCanaryBundle: Bool =
+    Bundle.main.bundleIdentifier?.hasPrefix("com.whoeverwants.app.latest") == true
+
+// FE host the WebView loads for this tier (deep links + share URLs).
+private let feHost: String =
+    isCanaryBundle ? "latest.whoeverwants.com" : "whoeverwants.com"
+
+// Direct cross-origin API host (NOT the FE host), mirroring lib/api/_internal.ts.
+// FastAPI CORS is allow_origins=["*"] / allow_credentials=False, so a native
+// request with X-Browser-Id as the identity header is exactly the browser shape.
+private let apiBase: String =
+    isCanaryBundle ? "https://api.latest.whoeverwants.com" : "https://api.whoeverwants.com"
+
+// MARK: - Bridged identity (App Group reader; writer is NativeIdentityPlugin)
+
+private enum BridgedIdentity {
+    static let suiteName = "group.com.whoeverwants.siri"
+    static let nameKey = "display_name"
+    static let browserIdKey = "browser_id"
+
+    // Returns the bridged browser id, gated on a non-empty display NAME — the
+    // same "user has actually used the app" signal Siri's
+    // QuickPollService.loadIdentity gates on (name-required model). The name
+    // itself isn't displayed anywhere here, so only the id is returned.
+    static func loadBrowserId() -> String? {
+        guard let d = UserDefaults(suiteName: suiteName),
+              let name = d.string(forKey: nameKey), !name.isEmpty,
+              let browserId = d.string(forKey: browserIdKey), !browserId.isEmpty else {
+            return nil
+        }
+        return browserId
+    }
+}
+
+// MARK: - Models
+
+struct SharablePoll: Identifiable {
+    let id: String            // poll uuid (invite target_poll_id)
+    let shortId: String       // canonical addressable id (/g/<group>/p/<shortId>)
+    let title: String
+    let groupShortId: String?
+    let groupName: String?
+    let groupIsPrivate: Bool
+    let isClosed: Bool
+}
+
+struct QuestionSummary: Identifiable {
+    let id: String            // question uuid
+    let label: String?        // disambiguator in multi-question polls
+    let type: String          // question_type
+    var resultText: String?   // filled by the per-question results fetch
+}
+
+struct PollSummary {
+    let title: String
+    let groupName: String?
+    let isClosed: Bool
+    let respondentCount: Int
+    let questions: [QuestionSummary]
+}
+
+// MARK: - API
+
+private enum PollAPI {
+    // Treat empty strings as absent — the API can return "" for an unset
+    // override, which should never surface as a title / id / group.
+    static func nonEmpty(_ s: String?) -> String? { s.flatMap { $0.isEmpty ? nil : $0 } }
+
+    private static func jsonRequest(url: URL, method: String, browserId: String?, body: [String: Any]? = nil) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let browserId = browserId, !browserId.isEmpty {
+            request.setValue(browserId, forHTTPHeaderField: "X-Browser-Id")
+        }
+        if let body = body {
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        }
+        return request
+    }
+
+    // The user's recent polls — the same POST /api/groups/mine fetch (and the
+    // same questions[0].title-over-display-title rule, newest-first sort, and
+    // cap) as Siri's PollEntity.fetchAll (AppDelegate.swift — keep in
+    // lockstep). Browser-scoped visibility: polls the user created/joined on
+    // THIS device; cross-device-only polls won't surface until opened here
+    // (same accepted limitation as Siri).
+    static func fetchMyPolls(browserId: String) async throws -> [SharablePoll] {
+        guard let url = URL(string: apiBase + "/api/groups/mine") else { throw URLError(.badURL) }
+        let request = jsonRequest(url: url, method: "POST", browserId: browserId,
+                                  body: ["include_results": false])
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw URLError(.badServerResponse)
+        }
+        let polls: [(poll: SharablePoll, createdAt: String)] = arr.compactMap { obj in
+            guard let uuid = nonEmpty(obj["id"] as? String),
+                  let shortId = nonEmpty(obj["short_id"] as? String) else { return nil }
+            let questions = obj["questions"] as? [[String: Any]]
+            let title = nonEmpty(questions?.first?["title"] as? String)
+                ?? nonEmpty(obj["title"] as? String) ?? "Poll"
+            return (
+                poll: SharablePoll(
+                    id: uuid,
+                    shortId: shortId,
+                    title: title,
+                    groupShortId: nonEmpty(obj["group_short_id"] as? String),
+                    groupName: nonEmpty(obj["group_title"] as? String),
+                    groupIsPrivate: (obj["group_privacy"] as? String) == "private",
+                    isClosed: (obj["is_closed"] as? Bool) ?? false
+                ),
+                createdAt: (obj["created_at"] as? String) ?? ""
+            )
+        }
+        // created_at is ISO-8601 → lexicographic descending is chronological.
+        return polls.sorted { $0.createdAt > $1.createdAt }.prefix(50).map { $0.poll }
+    }
+
+    // Mint a poll-scoped multi-use invite for a private group (decision B).
+    // Admin-only server-side (`_require_admin` resolves the actor via the
+    // browser→account link, so X-Browser-Id alone authenticates an admin who
+    // uses the app on this device). Returns the raw token, or nil on ANY
+    // failure — including 403 for a non-admin member, the expected degraded
+    // path: the share falls back to the canonical URL and the recipient hits
+    // the normal "Private Group / request access" wall. No expiry: the invite
+    // stays revocable from the group's /info invites list, mirroring how a
+    // hand-shared invite link already works. The CALLER caches the token per
+    // poll for the session (ExtensionModel.inviteTokens) so re-sharing the
+    // same poll doesn't accumulate invite rows; the raw token is hash-stored
+    // server-side and can never be re-listed, so cross-session shares mint
+    // fresh ones — accepted (see the plan doc).
+    static func mintInviteToken(groupRoute: String, pollUuid: String, browserId: String?) async -> String? {
+        guard let url = URL(string: apiBase + "/api/groups/\(groupRoute)/invites") else { return nil }
+        let request = jsonRequest(url: url, method: "POST", browserId: browserId,
+                                  body: ["mode": "multi", "target_poll_id": pollUuid])
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return nonEmpty(obj["token"] as? String)
+    }
+
+    // Private-group share URL: the invite token path auto-joins the recipient
+    // on the web exactly like a hand-shared invite link; `wwPoll` is the
+    // extension-side payload (the token URL doesn't otherwise name the poll —
+    // only WE read the param; it's registered next to POLL_QUERY_PARAM in
+    // lib/groupUtils.ts so the web side knows it exists).
+    static func inviteURL(token: String, pollShortId: String) -> URL? {
+        URL(string: "https://\(feHost)/invite/\(token)?wwPoll=\(pollShortId)")
+    }
+
+    // Canonical poll URL — mirrors getGroupHrefForPoll (lib/groupUtils.ts) and
+    // the Siri intents' path building. The path itself names the poll, so
+    // public shares need no extra payload params. group_short_id is NOT NULL
+    // post-migration 101; the home fallback is defensive only (never emit the
+    // legacy /p/<short> form — it's redirect-stub-only).
+    static func canonicalURL(for poll: SharablePoll) -> URL {
+        guard let group = poll.groupShortId,
+              let url = URL(string: "https://\(feHost)/g/\(group)/p/\(poll.shortId)") else {
+            return URL(string: "https://\(feHost)/")!
+        }
+        return url
+    }
+
+    // Recover the poll short_id from a received message's url: the explicit
+    // `wwPoll` param (invite-URL form) or the canonical /g/<group>/p/<short>
+    // path. Nil → not one of our poll bubbles (or a malformed payload).
+    static func pollShortId(fromMessageURL url: URL) -> String? {
+        if let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+           let p = nonEmpty(items.first(where: { $0.name == "wwPoll" })?.value) {
+            return p
+        }
+        let parts = url.path.split(separator: "/").map(String.init)
+        if let i = parts.firstIndex(of: "p"), i + 1 < parts.count, parts.first == "g" {
+            return parts[i + 1]
+        }
+        return nil
+    }
+
+    // Poll summary for the recipient's expanded view. GET /api/polls/<short>
+    // and GET /api/questions/<id>/results are identity-free server-side (the
+    // poll read is documented as visibility-blind), which is what lets a
+    // recipient who isn't (yet) a group member see what they were sent —
+    // acceptable under decision B (a bubble IS a deliberate capability share),
+    // but note this aggregates per-question fetches client-side; Phase 2's
+    // transcript bubble wants a single tiny server summary endpoint, and when
+    // that lands this should consume it instead (see the plan doc).
+    static func fetchSummary(shortId: String) async throws -> PollSummary {
+        guard let url = URL(string: apiBase + "/api/polls/\(shortId)") else { throw URLError(.badURL) }
+        let (data, response) = try await URLSession.shared.data(for: jsonRequest(url: url, method: "GET", browserId: nil))
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw URLError(.badServerResponse)
+        }
+        let isClosed = (obj["is_closed"] as? Bool) ?? false
+        let questionObjs = (obj["questions"] as? [[String: Any]]) ?? []
+        let title = nonEmpty(questionObjs.first?["title"] as? String)
+            ?? nonEmpty(obj["title"] as? String) ?? "Poll"
+        // Respondent count honors name multiplicity (two voters who share a
+        // name are two people) — mirrors namedVoterCount in
+        // components/VoterList.tsx.
+        let voterNames = (obj["voter_names"] as? [String]) ?? []
+        let nameCounts = (obj["voter_name_counts"] as? [String: Int]) ?? [:]
+        let namedCount = voterNames.reduce(0) { $0 + max(1, nameCounts[$1] ?? 1) }
+        let anonymous = (obj["anonymous_count"] as? Int) ?? 0
+        let multi = questionObjs.count > 1
+        var questions: [QuestionSummary] = questionObjs.compactMap { q in
+            guard let qid = nonEmpty(q["id"] as? String) else { return nil }
+            let type = (q["question_type"] as? String) ?? "yes_no"
+            // Per-question titles repeat the wrapper title in multi-question
+            // polls, so the disambiguator mirrors the web's
+            // getQuestionSectionTitle: "<Label> for <Context>", either half
+            // optional (label is nil for yes_no/limited_supply per the
+            // "Yes/No is a category, not display text" rule).
+            let label: String? = {
+                guard multi else { return nil }
+                let details = nonEmpty(q["details"] as? String)
+                let typeLabel = questionLabel(type: type, category: q["category"] as? String)
+                if let t = typeLabel, let d = details { return "\(t) for \(d)" }
+                return details ?? typeLabel
+            }()
+            return QuestionSummary(id: qid, label: label, type: type, resultText: nil)
+        }
+        // Live results per question (identity-free), fetched CONCURRENTLY so
+        // the summary's latency is one round-trip, not the sum. Capped — the
+        // summary is a glance, not a ballot.
+        let resultTexts = await withTaskGroup(of: (String, String?).self) { group -> [String: String] in
+            for q in questions.prefix(4) {
+                group.addTask {
+                    (q.id, await fetchResultText(questionId: q.id, type: q.type, pollIsClosed: isClosed))
+                }
+            }
+            var out: [String: String] = [:]
+            for await (qid, text) in group {
+                if let text = text { out[qid] = text }
+            }
+            return out
+        }
+        for i in questions.indices {
+            questions[i].resultText = resultTexts[questions[i].id]
+        }
+        return PollSummary(
+            title: title,
+            groupName: nonEmpty(obj["group_title"] as? String),
+            isClosed: isClosed,
+            respondentCount: namedCount + anonymous,
+            questions: questions
+        )
+    }
+
+    // Built-in category labels — mirror labelForCategory's _CATEGORY_LABELS
+    // (app/create-poll/createPollHelpers.ts) + the server's copy in
+    // server/algorithms/poll_title.py. Keep all three in lockstep when adding
+    // a built-in category.
+    private static let categoryLabels: [String: String] = [
+        "restaurant": "Restaurant",
+        "movie": "Movie",
+        "video_game": "Video Game",
+        "videogame": "Video Game",
+        "location": "Place",
+        "time": "Time",
+        "showtime": "Showtime",
+    ]
+
+    // Mirrors getQuestionLabel (lib/questionListUtils.ts): nil for yes_no (the
+    // documented "Yes/No is a CATEGORY, not display text" rule) and
+    // limited_supply (the title IS the item); "Time"/"Showtime" by type; else
+    // the built-in category label, nil for custom categories.
+    private static func questionLabel(type: String, category: String?) -> String? {
+        switch type {
+        case "yes_no", "limited_supply":
+            return nil
+        case "time":
+            return "Time"
+        case "showtime":
+            return "Showtime"
+        default:
+            return category.flatMap { categoryLabels[$0] }
+        }
+    }
+
+    private static func fetchResultText(questionId: String, type: String, pollIsClosed: Bool) async -> String? {
+        guard let url = URL(string: apiBase + "/api/questions/\(questionId)/results"),
+              let (data, response) = try? await URLSession.shared.data(for: jsonRequest(url: url, method: "GET", browserId: nil)),
+              let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let r = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let totalVotes = (r["total_votes"] as? Int) ?? 0
+        switch type {
+        case "yes_no":
+            guard totalVotes > 0 else { return "No votes yet" }
+            return "Yes \((r["yes_count"] as? Int) ?? 0) · No \((r["no_count"] as? Int) ?? 0)"
+        case "limited_supply":
+            let secured = (r["secured_count"] as? Int) ?? 0
+            if let supply = r["supply_count"] as? Int { return "\(secured)/\(supply) claimed" }
+            return "\(secured) claimed"
+        default:
+            if let winner = nonEmpty(r["winner"] as? String) {
+                let pretty = type == "time" || type == "showtime" ? prettySlot(winner) : winner
+                return pollIsClosed ? "Winner: \(pretty)" : "Leading: \(pretty)"
+            }
+            guard totalVotes > 0 else { return "No votes yet" }
+            return "\(totalVotes) \(totalVotes == 1 ? "response" : "responses")"
+        }
+    }
+
+    // DateFormatter allocation is expensive; both are configured once and only
+    // read afterwards (thread-safe post-iOS-7), so hoist as statics.
+    private static let slotParser: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        return f
+    }()
+    private static let slotDayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "E MMM d"
+        return f
+    }()
+
+    // Time/showtime winners are slot keys ("2026-06-20 19:00-21:00"); render
+    // the start as "Sat Jun 20, 7 PM" — the same shape the server's
+    // _format_slot_label (server/routers/polls.py) uses for push-notification
+    // outcomes, so the bubble summary and the close push agree. Falls through
+    // to the raw key on any parse miss.
+    private static func prettySlot(_ slotKey: String) -> String {
+        guard slotKey.count >= 16, let date = slotParser.date(from: String(slotKey.prefix(16))) else {
+            return slotKey
+        }
+        let comps = Calendar.current.dateComponents([.hour, .minute], from: date)
+        let hour = comps.hour ?? 0
+        let minute = comps.minute ?? 0
+        let period = hour < 12 ? "AM" : "PM"
+        let hour12 = hour % 12 == 0 ? 12 : hour % 12
+        let minuteStr = minute != 0 ? String(format: ":%02d", minute) : ""
+        return "\(slotDayFormatter.string(from: date)), \(hour12)\(minuteStr) \(period)"
+    }
+}
+
+// MARK: - View model
+
+@MainActor
+final class ExtensionModel: ObservableObject {
+    enum PickerState {
+        case loading
+        case needsApp       // no bridged identity — open the app first
+        case empty
+        case error
+        case loaded([SharablePoll])
+    }
+
+    enum SummaryState {
+        case loading(URL)
+        case loaded(PollSummary, URL)
+        case failed(URL)
+    }
+
+    @Published var pickerState: PickerState = .loading
+    @Published var summary: SummaryState?    // non-nil → summary mode (a bubble was tapped)
+    @Published var insertingPollId: String?  // row spinner while minting/inserting
+    @Published var toast: String?
+
+    weak var host: MessagesViewController?
+
+    private var lastFetch: Date?
+    // poll uuid → minted invite token, so re-sharing the same private poll in
+    // one session reuses the invite instead of accumulating rows (the raw
+    // token is one-shot server-side, so this cache is the only reuse possible).
+    private var inviteTokens: [String: String] = [:]
+    private var toastDismissTask: Task<Void, Never>?
+
+    // Called on every willBecomeActive: route to the summary (a bubble was
+    // tapped → selectedMessage is set) or the picker (drawer opened normally).
+    func activate(selectedMessageURL: URL?) {
+        if let url = selectedMessageURL {
+            showSummary(for: url)
+        } else {
+            summary = nil
+            loadPickerIfStale()
+        }
+    }
+
+    func reloadPicker() {
+        lastFetch = nil
+        loadPickerIfStale()
+    }
+
+    // Re-check identity + refetch on activation, but don't refetch on every
+    // compact↔expanded transition — 30s of staleness is fine for a share picker.
+    private func loadPickerIfStale() {
+        if let last = lastFetch, Date().timeIntervalSince(last) < 30,
+           case .loaded = pickerState {
+            return
+        }
+        guard let browserId = BridgedIdentity.loadBrowserId() else {
+            pickerState = .needsApp
+            return
+        }
+        if case .loaded = pickerState {} else { pickerState = .loading }
+        Task {
+            do {
+                let polls = try await PollAPI.fetchMyPolls(browserId: browserId)
+                pickerState = polls.isEmpty ? .empty : .loaded(polls)
+                lastFetch = Date()
+            } catch {
+                pickerState = .error
+            }
+        }
+    }
+
+    // Share = (mint-or-reuse invite for private groups →) build URL → insert.
+    func share(_ poll: SharablePoll) {
+        guard insertingPollId == nil else { return }
+        insertingPollId = poll.id
+        Task {
+            let url = await shareURL(for: poll)
+            host?.insertPollMessage(caption: poll.title, subcaption: poll.groupName, url: url) { [weak self] ok in
+                self?.insertingPollId = nil
+                if !ok { self?.showToast("Couldn't add the poll — try again") }
+            }
+        }
+    }
+
+    private func shareURL(for poll: SharablePoll) async -> URL {
+        guard poll.groupIsPrivate, let groupRoute = poll.groupShortId else {
+            return PollAPI.canonicalURL(for: poll)
+        }
+        var token = inviteTokens[poll.id]
+        if token == nil {
+            token = await PollAPI.mintInviteToken(
+                groupRoute: groupRoute, pollUuid: poll.id,
+                browserId: BridgedIdentity.loadBrowserId()
+            )
+            inviteTokens[poll.id] = token
+        }
+        guard let token = token, let url = PollAPI.inviteURL(token: token, pollShortId: poll.shortId) else {
+            return PollAPI.canonicalURL(for: poll)
+        }
+        return url
+    }
+
+    func showSummary(for url: URL) {
+        guard let shortId = PollAPI.pollShortId(fromMessageURL: url) else {
+            summary = .failed(url)
+            return
+        }
+        summary = .loading(url)
+        Task {
+            do {
+                let s = try await PollAPI.fetchSummary(shortId: shortId)
+                // The user may have navigated back to the picker mid-fetch.
+                if case .loading(let pending)? = summary, pending == url {
+                    summary = .loaded(s, url)
+                }
+            } catch {
+                if case .loading(let pending)? = summary, pending == url {
+                    summary = .failed(url)
+                }
+            }
+        }
+    }
+
+    func dismissSummary() {
+        summary = nil
+        loadPickerIfStale()
+    }
+
+    // "Open in WhoeverWants": extensionContext.open is known-finicky from
+    // Messages extensions (the plan budgets for it) — on failure, fall back to
+    // copying the link so the user can paste it anywhere.
+    func openInApp(_ url: URL) {
+        host?.openURL(url) { [weak self] ok in
+            if !ok {
+                UIPasteboard.general.url = url
+                self?.showToast("Couldn't open the app — link copied instead")
+            }
+        }
+    }
+
+    func copyLink(_ url: URL) {
+        UIPasteboard.general.url = url
+        showToast("Link copied")
+    }
+
+    func showToast(_ text: String) {
+        toast = text
+        toastDismissTask?.cancel()
+        toastDismissTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if !Task.isCancelled { self?.toast = nil }
+        }
+    }
+}
+
+// MARK: - Messages app view controller
+
 class MessagesViewController: MSMessagesAppViewController {
 
-    private var hosting: UIHostingController<PlaceholderView>?
+    private let model = ExtensionModel()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let controller = UIHostingController(rootView: PlaceholderView())
+        model.host = self
+        // Retained via view-controller containment (addChild) — no property needed.
+        let controller = UIHostingController(rootView: RootView(model: model))
         controller.view.backgroundColor = .clear
         addChild(controller)
         controller.view.translatesAutoresizingMaskIntoConstraints = false
@@ -31,21 +566,332 @@ class MessagesViewController: MSMessagesAppViewController {
             controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
         controller.didMove(toParent: self)
-        hosting = controller
+    }
+
+    // Fires on every activation: drawer open (selectedMessage nil → picker) AND
+    // cold bubble tap (selectedMessage set → summary).
+    override func willBecomeActive(with conversation: MSConversation) {
+        super.willBecomeActive(with: conversation)
+        model.activate(selectedMessageURL: conversation.selectedMessage?.url)
+    }
+
+    // Fires when the user taps one of our bubbles while the extension is
+    // already active (the warm path; cold taps arrive via willBecomeActive).
+    override func didSelect(_ message: MSMessage, conversation: MSConversation) {
+        super.didSelect(message, conversation: conversation)
+        if let url = message.url {
+            model.showSummary(for: url)
+        }
+    }
+
+    // Insert the staged message into the compose field (never auto-send — the
+    // user reviews + hits send, per Apple's guidelines). On success, dismiss the
+    // drawer UI so the staged bubble is front and center.
+    func insertPollMessage(caption: String, subcaption: String?, url: URL, completion: @escaping (Bool) -> Void) {
+        guard let conversation = activeConversation else {
+            completion(false)
+            return
+        }
+        let message = MSMessage(session: MSSession())
+        let layout = MSMessageTemplateLayout()
+        layout.image = Self.shareImage
+        layout.caption = caption
+        layout.subcaption = subcaption
+        message.layout = layout
+        message.url = url
+        message.summaryText = caption
+        conversation.insert(message) { [weak self] error in
+            DispatchQueue.main.async {
+                completion(error == nil)
+                if error == nil { self?.dismiss() }
+            }
+        }
+    }
+
+    func openURL(_ url: URL, completion: @escaping (Bool) -> Void) {
+        guard let context = extensionContext else {
+            completion(false)
+            return
+        }
+        context.open(url) { ok in
+            DispatchQueue.main.async { completion(ok) }
+        }
+    }
+
+    // The template layout's image — the app's 👋-on-black mark rendered at
+    // runtime (the extension's icon lives in a .stickersiconset, which isn't
+    // loadable via UIImage(named:), and bundling a second PNG would just be
+    // one more asset to keep in sync). Rendered at scale 1: Messages
+    // re-encodes the layout image anyway, and the default device scale would
+    // pin a ~3 MB 3x bitmap for the extension's lifetime — real money under
+    // an app extension's tight memory budget.
+    static let shareImage: UIImage = {
+        let size = CGSize(width: 300, height: 300)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: size, format: format).image { ctx in
+            UIColor.black.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+            let emoji = "👋" as NSString
+            let attrs: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 170)]
+            let glyph = emoji.size(withAttributes: attrs)
+            emoji.draw(
+                at: CGPoint(x: (size.width - glyph.width) / 2, y: (size.height - glyph.height) / 2),
+                withAttributes: attrs
+            )
+        }
+    }()
+}
+
+// MARK: - SwiftUI views
+
+struct RootView: View {
+    @ObservedObject var model: ExtensionModel
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            if let summary = model.summary {
+                SummaryView(model: model, state: summary)
+            } else {
+                PickerView(model: model)
+            }
+            if let toast = model.toast {
+                Text(toast)
+                    .font(.footnote)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(Color(.systemGray5), in: Capsule())
+                    .padding(.bottom, 12)
+            }
+        }
     }
 }
 
-private struct PlaceholderView: View {
+private struct PickerView: View {
+    @ObservedObject var model: ExtensionModel
+
+    var body: some View {
+        switch model.pickerState {
+        case .loading:
+            VStack(spacing: 10) {
+                ProgressView()
+                Text("Loading your polls…")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .needsApp:
+            CenteredMessage(
+                emoji: "👋",
+                title: "Open WhoeverWants first",
+                detail: "Set your name in the app, then come back here to share your polls.",
+                retryLabel: "Check again"
+            ) { model.reloadPicker() }
+        case .empty:
+            CenteredMessage(
+                emoji: "🗳️",
+                title: "No polls yet",
+                detail: "Create a poll in WhoeverWants and it'll show up here to share.",
+                retryLabel: "Refresh"
+            ) { model.reloadPicker() }
+        case .error:
+            CenteredMessage(
+                emoji: "📡",
+                title: "Couldn't load your polls",
+                detail: "Check your connection and try again.",
+                retryLabel: "Retry"
+            ) { model.reloadPicker() }
+        case .loaded(let polls):
+            List {
+                Section(header: Text("Share a poll")) {
+                    ForEach(polls) { poll in
+                        PollRow(
+                            poll: poll,
+                            inserting: model.insertingPollId == poll.id
+                        ) { model.share(poll) }
+                    }
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+private struct PollRow: View {
+    let poll: SharablePoll
+    let inserting: Bool
+    let action: () -> Void
+
+    private var badges: [String] {
+        [poll.groupIsPrivate ? "Private" : nil, poll.isClosed ? "Closed" : nil]
+            .compactMap { $0 }
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(poll.title)
+                        .font(.body)
+                        .foregroundColor(.primary)
+                        .lineLimit(2)
+                    HStack(spacing: 6) {
+                        if let group = poll.groupName {
+                            Text(group)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                        }
+                        ForEach(badges, id: \.self) { text in
+                            Text(text)
+                                .font(.caption2)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 1)
+                                .background(Color(.systemGray5), in: Capsule())
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                Spacer()
+                if inserting {
+                    ProgressView()
+                } else {
+                    Image(systemName: "plus.bubble")
+                        .foregroundColor(.accentColor)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(inserting)
+    }
+}
+
+private struct SummaryView: View {
+    @ObservedObject var model: ExtensionModel
+    let state: ExtensionModel.SummaryState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { model.dismissSummary() }) {
+                Label("Share a poll", systemImage: "chevron.left")
+                    .font(.subheadline)
+            }
+            .padding(.horizontal)
+            .padding(.top, 12)
+
+            switch state {
+            case .loading:
+                VStack(spacing: 10) {
+                    ProgressView()
+                    Text("Loading poll…")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .failed(let url):
+                VStack(spacing: 12) {
+                    Text("Couldn't load this poll")
+                        .font(.headline)
+                    Text("Open it in WhoeverWants instead.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                    openButtons(url: url)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .loaded(let summary, let url):
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(summary.title)
+                                .font(.title3.weight(.semibold))
+                            HStack(spacing: 6) {
+                                if let group = summary.groupName {
+                                    Text(group)
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                                Text(summary.isClosed ? "Closed" : "Open")
+                                    .font(.caption)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 2)
+                                    .background(
+                                        (summary.isClosed ? Color(.systemGray5) : Color.green.opacity(0.15)),
+                                        in: Capsule()
+                                    )
+                                    .foregroundColor(summary.isClosed ? .secondary : .green)
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(summary.questions) { q in
+                                VStack(alignment: .leading, spacing: 2) {
+                                    if let label = q.label {
+                                        Text(label)
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    Text(q.resultText ?? "—")
+                                        .font(.body)
+                                }
+                            }
+                        }
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+
+                        if summary.respondentCount > 0 {
+                            Text("\(summary.respondentCount) \(summary.respondentCount == 1 ? "person has" : "people have") responded")
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                        }
+
+                        openButtons(url: url)
+                    }
+                    .padding()
+                }
+            }
+        }
+    }
+
+    private func openButtons(url: URL) -> some View {
+        VStack(spacing: 8) {
+            Button(action: { model.openInApp(url) }) {
+                Text("Open in WhoeverWants")
+                    .font(.body.weight(.medium))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
+            .buttonStyle(.borderedProminent)
+            Button(action: { model.copyLink(url) }) {
+                Text("Copy Link")
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}
+
+private struct CenteredMessage: View {
+    let emoji: String
+    let title: String
+    let detail: String
+    let retryLabel: String
+    let retry: () -> Void
+
     var body: some View {
         VStack(spacing: 8) {
-            Text("👋")
-                .font(.system(size: 44))
-            Text("WhoeverWants")
-                .font(.headline)
-            Text("Shareable polls are coming to Messages.")
+            Text(emoji).font(.system(size: 40))
+            Text(title).font(.headline)
+            Text(detail)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
+            Button(retryLabel, action: retry)
+                .buttonStyle(.bordered)
+                .padding(.top, 4)
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/lib/groupUtils.ts
+++ b/lib/groupUtils.ts
@@ -46,7 +46,14 @@ export function filterOutCurrentUser(
 
 /** Query-param key on `/g/<group>` URLs that names a specific poll the page
  *  should expand and scroll to. Absent → no auto-expand, page scrolls to
- *  bottom (the draft form area). */
+ *  bottom (the draft form area).
+ *
+ *  Related reserved param (read by NATIVE code only): the iMessage extension
+ *  embeds `?wwPoll=<pollShortId>` on the `/invite/<token>` URLs it puts in
+ *  message bubbles, because the token path doesn't otherwise name the target
+ *  poll (ios/App/MessagesExtension/MessagesViewController.swift). The web
+ *  deliberately ignores it — don't add invite-page query-param validation or
+ *  forwarding that would strip/reject it, or in-flight bubbles break. */
 export const POLL_QUERY_PARAM = 'p';
 
 /** How many distinct people voted under `name`, per a `voter_name_counts` /

--- a/scripts/ios/add-messages-extension.rb
+++ b/scripts/ios/add-messages-extension.rb
@@ -15,10 +15,11 @@
 #   gem install xcodeproj
 #   ruby scripts/ios/add-messages-extension.rb
 #
-# Phase 0 deliberately gives the extension NO custom entitlements (no App Group,
-# no keychain group) so automatic signing can self-provision the new bundle ids
-# (com.whoeverwants.app[.latest].MessagesExtension) with zero manual Apple
-# Developer portal steps. The App Group identity bridge is a Phase 1 concern.
+# Phase 0 deliberately gave the extension NO custom entitlements so automatic
+# signing could self-provision the new bundle ids with zero manual portal steps.
+# Phase 1 added MessagesExtension.entitlements (the App Group identity bridge),
+# which requires the one-time manual "App Groups" capability registration on
+# com.whoeverwants.app[.latest].MessagesExtension in the Apple Developer portal.
 
 require "xcodeproj"
 
@@ -45,6 +46,7 @@ group = project.main_group.new_group(EXT_NAME, EXT_NAME)
 swift_ref = group.new_reference("MessagesViewController.swift")
 assets_ref = group.new_reference("Assets.xcassets")
 group.new_reference("Info.plist") # referenced for the project navigator; not in a build phase
+group.new_reference("MessagesExtension.entitlements") # navigator only; wired via CODE_SIGN_ENTITLEMENTS
 
 ext.add_file_references([swift_ref])
 ext.resources_build_phase.add_file_reference(assets_ref)
@@ -57,6 +59,7 @@ settings = {
   "SWIFT_VERSION" => "5.0",
   "TARGETED_DEVICE_FAMILY" => "1,2",
   "CODE_SIGN_STYLE" => "Automatic",
+  "CODE_SIGN_ENTITLEMENTS" => "#{EXT_NAME}/#{EXT_NAME}.entitlements",
   "GENERATE_INFOPLIST_FILE" => "NO",
   "ASSETCATALOG_COMPILER_APPICON_NAME" => "iMessage App Icon",
   "MARKETING_VERSION" => "1.0",


### PR DESCRIPTION
## Summary
- **App Group entitlement on the MessagesExtension target** (`group.com.whoeverwants.siri`, the Siri identity bridge) via `MessagesExtension.entitlements` + `CODE_SIGN_ENTITLEMENTS` on both configs; `add-messages-extension.rb` regenerator updated to match. The one-time Apple Developer portal App Groups registration on both extension bundle ids is DONE (canary build green with the entitlement).
- **Drawer picker**: lists the user's recent polls — same `POST /api/groups/mine` fetch/title-rule/sort/cap as Siri's `PollEntity.fetchAll`, authenticated with the App-Group-bridged X-Browser-Id. No bridged identity → "Open WhoeverWants first" state; distinct empty/error states; Private/Closed badges.
- **Share**: tapping a poll inserts an `MSMessage` (template layout: runtime-rendered 👋-on-black image, title caption, group subcaption; never auto-sends). `message.url` = canonical `/g/<group>/p/<poll>` for public groups; private groups mint a poll-scoped multi-use invite (session-cached per poll) and embed `/invite/<token>?wwPoll=<short>` — decision B; mint failure falls back to the canonical URL.
- **Bubble tap (recipient with app)**: native summary — title, group, open/closed, per-question live results (concurrent fetches; labels mirror `getQuestionSectionTitle`, slot winners in `_format_slot_label`'s shape, respondent count honors `voter_name_counts` multiplicity), "Open in WhoeverWants" with copy-link fallback + always-visible Copy Link.
- **CI**: extension `CFBundleDisplayName` stamped per tier ("Whoever" / "Whoever α") so both drawer entries are distinguishable.
- Docs: plan doc Phase 1 marked shipped (+ Phase 2 server-summary-endpoint TODO), CLAUDE.md updated, `wwPoll` payload contract registered next to `POLL_QUERY_PARAM`.

## Test plan
- [x] Canary iOS CI build green with the new entitlement (archive + embed .appex + TestFlight upload): run 27443912915
- [x] pbxproj structure validated via the xcodeproj gem (CODE_SIGN_ENTITLEMENTS both configs, embed phase + dependency intact, bundle-id sed contract app×2/ext×2)
- [x] Entitlements/Info.plist lint + regenerator idempotency check
- [ ] On-device (owner): drawer picker lists polls; send a public + a private poll bubble; recipient tap shows summary + live results; invite-URL bubble redeems on the web fallback

https://claude.ai/code/session_01QVnNXHxe3TnbiAPa7BN11S