### PR TITLE
ios: tap on the iMessage live bubble opens the expanded summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3359,11 +3359,17 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
     indents its first line by `iconBadgeClearance = 44` and the rows below
     keep the full width. Any future live-bubble layout must keep that corner
     clear.
-  - **The bubble is read-only and hit-testing-disabled** (`allowsHitTesting(false)`
-    + `isUserInteractionEnabled = false` on the hosting view) so a tap falls
-    through to Messages → the extension opens EXPANDED with `selectedMessage`
-    set → the Phase 1 summary view. Phase 3 replaces this with inline vote
-    buttons for yes_no/limited_supply.
+  - **The bubble is read-only; the transcript VC handles its own tap.** Live
+    bubbles get NO template-style tap-to-open from Messages (device-verified:
+    an unhandled tap does nothing — an earlier assumption that it "falls
+    through" was wrong). The SwiftUI tree is hit-testing-disabled
+    (`allowsHitTesting(false)` + `isUserInteractionEnabled = false` on the
+    hosting view) so a `UITapGestureRecognizer` on the VC's root view gets the
+    tap and calls `requestPresentationStyle(.expanded)` — per the docs, a
+    transcript-style controller may request ONLY `.expanded`, and the system
+    then displays a NEW instance in that style, which activates with the
+    bubble's message selected → the Phase 1 summary view. Phase 3 replaces
+    the read-only surface with inline vote buttons for yes_no/limited_supply.
   - **`GET /api/polls/{short_id}/summary` (`get_poll_summary` in
     `routers/polls.py`, model `PollSummaryResponse`)** is identity-free like
     `/preview` (decision B: a bubble is a deliberate capability share) and

--- a/docs/imessage-extension-plan.md
+++ b/docs/imessage-extension-plan.md
@@ -38,9 +38,12 @@ These shape every decision below; re-read before changing the plan.
   extension's `MSMessagesAppViewController` with the `.transcript` presentation
   style and shows its view as the message bubble. Interactivity IS allowed in the
   transcript, with hard limits (per Apple's WWDC17 guidance, still current):
-  - **No keyboard input** in transcript style — text entry requires requesting
-    `.expanded` (and `requestPresentationStyle` is itself not callable from a
-    transcript instance; the user taps through instead).
+  - **No keyboard input** in transcript style — text entry requires `.expanded`.
+    A transcript instance MAY call `requestPresentationStyle(.expanded)` (the
+    only legal style from transcript); the system then displays a NEW instance
+    in that style. It must, in fact: unhandled taps on a live bubble do NOT
+    open the extension the way template bubbles do (device-verified in
+    Phase 2).
   - **Simple taps only** — Apple explicitly says stick to button taps; anything
     complex is disorienting inside a scrolling transcript.
   - **Aggressive teardown** — transcript instances are created per-render and
@@ -301,9 +304,13 @@ changes — the bubble is pure code in the existing extension target):
   (which migrated onto the `/summary` endpoint, retiring its
   poll + N-results fan-out). Stale-on-error: a bubble re-render that fails
   serves the last summary rather than an error state.
-- **Read-only by design**: the bubble's SwiftUI tree is hit-testing-disabled
-  (+ `isUserInteractionEnabled = false` on the hosting view), so a tap falls
-  through to Messages → extension opens expanded → the Phase 1 summary view.
+- **Read-only by design; the transcript VC owns the tap.** Live bubbles get
+  no template-style tap-to-open from Messages (device-verified: an unhandled
+  tap did nothing), so the bubble's SwiftUI tree is hit-testing-disabled
+  (+ `isUserInteractionEnabled = false` on the hosting view) and a
+  `UITapGestureRecognizer` on the VC's root view calls
+  `requestPresentationStyle(.expanded)` — the system opens a new expanded
+  instance with the bubble's message selected → the Phase 1 summary view.
   Phase 3 adds the inline vote buttons.
 - **Private-group bubbles render WITHOUT redeeming the invite** — supersedes
   this phase's original "redeem before fetching" sketch, which assumed the

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -25,9 +25,12 @@ import UIKit
 //     GET /api/polls/<short>/summary through a process-level cache
 //     (SummaryStore) so several bubbles re-rendering in one conversation
 //     coalesce into one round-trip. Read-only by design (Phase 3 adds
-//     voting): the SwiftUI tree is hit-testing-disabled, so a tap falls
-//     through to Messages, which opens the extension expanded → the summary
-//     view below. Rendering NEVER redeems the embedded invite token — the
+//     voting): the SwiftUI tree is hit-testing-disabled and the transcript
+//     VC handles the tap itself via requestPresentationStyle(.expanded) —
+//     live bubbles get NO template-style tap-to-open from Messages
+//     (device-verified) — which makes the system open a new expanded
+//     instance with this bubble's message selected → the summary view
+//     below. Rendering NEVER redeems the embedded invite token — the
 //     summary endpoint is identity-free, and joining a group because you
 //     scrolled past a bubble would surprise; redemption stays on the explicit
 //     open-in-app / web paths.
@@ -551,11 +554,21 @@ class MessagesViewController: MSMessagesAppViewController {
         let controller: UIViewController
         if presentationStyle == .transcript {
             let hosting = UIHostingController(rootView: TranscriptBubbleView(model: bubbleModel))
-            // Read-only in Phase 2: with hit-testing off, a tap on the bubble
-            // falls through to Messages, which opens the extension expanded
-            // (the summary view) — the same flow as tapping a template bubble.
+            // Read-only in Phase 2: the SwiftUI tree takes no touches, so the
+            // tap recognizer below (on self.view) receives bubble taps.
             hosting.view.isUserInteractionEnabled = false
             controller = hosting
+            // Live-layout bubbles get NO template-style tap-to-open from
+            // Messages (device-verified: an unhandled tap does nothing). The
+            // transcript instance must handle the tap itself: per the docs,
+            // requesting a presentation style from a transcript-style
+            // controller makes the system display a NEW instance in that
+            // style — which activates with this bubble's message selected →
+            // the expanded summary. `.expanded` is the only legal request
+            // from transcript.
+            view.addGestureRecognizer(
+                UITapGestureRecognizer(target: self, action: #selector(transcriptBubbleTapped))
+            )
         } else {
             model.host = self
             controller = UIHostingController(rootView: RootView(model: model))
@@ -572,6 +585,10 @@ class MessagesViewController: MSMessagesAppViewController {
             controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
         controller.didMove(toParent: self)
+    }
+
+    @objc private func transcriptBubbleTapped() {
+        requestPresentationStyle(.expanded)
     }
 
     // Fires on every activation: transcript bubble render (presentationStyle
@@ -945,8 +962,8 @@ struct TranscriptBubbleView: View {
             .padding(12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .background(Color(.systemBackground))
-            // Belt-and-braces with the hosting view's isUserInteractionEnabled
-            // = false: taps fall through to Messages → the expanded summary.
+            // Read-only: the VC's tap recognizer (not the SwiftUI tree) owns
+            // the tap → requestPresentationStyle(.expanded) → the summary.
             .allowsHitTesting(false)
     }
 


### PR DESCRIPTION
## Summary
- Device verification found tapping the live bubble did nothing. The Phase 2 assumption that an unhandled tap "falls through" to Messages and opens the extension (the template-bubble behavior) is **wrong for live layouts** — Messages gives live bubbles no tap-to-open of their own.
- Per the `requestPresentationStyle(_:)` docs, a transcript-style controller may request `.expanded` (the only legal style from transcript), and "the system creates a new instance of the view controller and displays it using the provided presentation style" — which activates with the bubble's message selected and routes into the existing expanded summary.
- The transcript VC now carries a `UITapGestureRecognizer` on its root view doing exactly that; the SwiftUI tree stays hit-testing-disabled so the recognizer owns the tap.
- Plan doc + CLAUDE.md corrected (the "taps fall through" claim was recorded as a platform fact and is now fixed at both altitudes).

## Test plan
- [x] iOS canary build (Swift compile gate)
- [ ] Owner, device: tapping the live bubble opens the expanded poll summary

https://claude.ai/code/session_01XkEBkEe1G5wC9oKn1cyjXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkEBkEe1G5wC9oKn1cyjXa)_