### PR TITLE
ios: iMessage extension Phase 3 — inline voting in the transcript bubble

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3266,6 +3266,13 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
 > AND the Phase 1 expanded summary through a process-level `SummaryStore`
 > (20s TTL + in-flight coalescing); full shape + the no-redeem-on-render
 > decision in the plan doc's Phase 2 section; device verification owner-owned.
+> **Phase 3 (INLINE VOTING in the transcript) implemented** on
+> `claude/imessage-extension-phase-2-px2mrm` — **Swift-only, NO server /
+> migration / entitlement / CI / pbxproj change** (`/summary` already returns
+> `poll_id` + per-question counts; voting reuses the atomic batch
+> `POST /api/polls/{id}/votes` + own-vote `GET /api/questions/{id}/votes` + the
+> Phase 1 App-Group identity). Full shape in the plan doc's Phase 3 section;
+> device verification owner-owned.
 > Owner decisions: ship additive (degraded no-app fallback OK); embed a
 > poll-scoped invite token for private-group bubbles (auto-join); v1 inline
 > voting = yes_no + limited_supply only; pursue compose-in-Messages keeping
@@ -3349,7 +3356,8 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
     `willBecomeActive` keyed on presentationStyle (NOT in viewDidLoad — the
     style isn't reliably set there), with the drawer/transcript models `lazy`
     so each instance only allocates its own role's model.
-    `contentSizeThatFits` returns a fixed 148pt (`TranscriptBubbleView.bubbleHeight`);
+    `contentSizeThatFits` returns a fixed `TranscriptBubbleView.bubbleHeight`
+    (148pt in Phase 2; bumped to 168pt in Phase 3 to fit a vote-button row);
     >2 questions collapse into "+N more" so the fixed height never clips.
   - **Messages overlays the extension's APP ICON on the live bubble's
     top-left corner** — the OS draws it, the extension can't remove or move
@@ -3359,17 +3367,18 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
     indents its first line by `iconBadgeClearance = 44` and the rows below
     keep the full width. Any future live-bubble layout must keep that corner
     clear.
-  - **The bubble is read-only; the transcript VC handles its own tap.** Live
-    bubbles get NO template-style tap-to-open from Messages (device-verified:
-    an unhandled tap does nothing — an earlier assumption that it "falls
-    through" was wrong). The SwiftUI tree is hit-testing-disabled
-    (`allowsHitTesting(false)` + `isUserInteractionEnabled = false` on the
-    hosting view) so a `UITapGestureRecognizer` on the VC's root view gets the
-    tap and calls `requestPresentationStyle(.expanded)` — per the docs, a
-    transcript-style controller may request ONLY `.expanded`, and the system
-    then displays a NEW instance in that style, which activates with the
-    bubble's message selected → the Phase 1 summary view. Phase 3 replaces
-    the read-only surface with inline vote buttons for yes_no/limited_supply.
+  - **(Phase 2, SUPERSEDED by Phase 3) The bubble WAS read-only; the
+    transcript VC handled its own tap.** Live bubbles get NO template-style
+    tap-to-open from Messages (device-verified: an unhandled tap does nothing —
+    an earlier assumption that it "falls through" was wrong). Phase 2 made the
+    SwiftUI tree hit-testing-disabled (`allowsHitTesting(false)` +
+    `isUserInteractionEnabled = false` on the hosting view) so a
+    `UITapGestureRecognizer` on the VC's root view got the tap and called
+    `requestPresentationStyle(.expanded)`. **Phase 3 reverses this** (the tree
+    is interactive, the recognizer is gone — see the Phase 3 notes below). The
+    DEVICE FINDING still stands: a transcript-style controller may request ONLY
+    `.expanded`, and the system displays a NEW instance in that style activated
+    with the bubble's message selected → the summary view.
   - **`GET /api/polls/{short_id}/summary` (`get_poll_summary` in
     `routers/polls.py`, model `PollSummaryResponse`)** is identity-free like
     `/preview` (decision B: a bubble is a deliberate capability share) and
@@ -3395,6 +3404,67 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
     would join the viewer to a group because they scrolled past a bubble.
     Redemption stays on the explicit paths (web `/invite/<token>` fallback,
     Open in WhoeverWants, Phase 3 vote-time join).
+- **Phase 3 implementation notes (inline voting — Swift-only, same file):**
+  - **NO server / migration / entitlement / CI / pbxproj change.** `/summary`
+    already returns `poll_id` + per-question `yes_count`/`no_count`/
+    `secured_count`/`supply_count`; voting reuses the atomic batch
+    `POST /api/polls/{id}/votes` + own-vote `GET /api/questions/{id}/votes` + the
+    Phase 1 App-Group identity. The ONLY new summary parse is `PollSummary.pollId`
+    (the POST target); limited_supply uses the server-rendered `result_text`, so
+    no structured-count parse was added.
+  - **The transcript SwiftUI tree is now INTERACTIVE** — Phase 2's
+    `allowsHitTesting(false)` + `isUserInteractionEnabled = false` + the VC's
+    `UITapGestureRecognizer` are all GONE. Vote buttons are SwiftUI `Button`s;
+    the title / result rows / footer are EACH wrapped in a plain
+    `Button { model.requestExpand() }` (→ `host?.requestPresentationStyle(.expanded)`),
+    so every tappable region is explicit — NOT a UIKit fall-through (an
+    interactive hosting view consumes taps, so the old recognizer wouldn't fire
+    anymore). The vote buttons are SIBLINGS of the content Button in the VStack,
+    never nested (SwiftUI forbids Button-in-Button), so a button tap votes while
+    a tap elsewhere expands. **This interaction model is device-only-verifiable**
+    (Simulator works for the inner loop) — if SwiftUI gestures somehow don't fire
+    in a live transcript, that's the finding to address.
+  - **Inline voting is gated to a SINGLE-question poll whose one question is
+    `yes_no` (Yes/No) or `limited_supply` (Claim a spot / No thanks)** —
+    `PollSummary.inlineVotableQuestion` (also requires open + a non-empty pollId).
+    Closed / multi-question / other types (ranked / time / showtime) stay
+    read-only; tapping opens the expanded summary. The expanded summary view
+    itself stays read-only this phase (multi-question + the nameless
+    set-name-here flow route through Open-in-app) — deferred.
+  - **Identity-gated** on the App-Group name+browserId: `BridgedIdentity.load()`
+    now returns BOTH (`name` = the batch endpoint's required `voter_name`,
+    `browserId` = `X-Browser-Id`); `loadBrowserId()` delegates. With identity the
+    buttons are live; without it they render disabled under "Set your name in the
+    app to vote" (a transcript can't take keyboard input — the nameless user taps
+    through to expanded → Open in WhoeverWants → set name in app).
+  - **Edit, don't duplicate.** On load (votable + identity) the bubble fetches the
+    viewer's OWN vote (`PollAPI.fetchMyVote` → `GET /api/questions/{id}/votes`,
+    ballot-privacy-scoped to their browser) into `myVotes[questionId]` → highlights
+    the current choice + remembers the `vote_id`. A vote sends the batch POST with
+    `vote_id` set (EDIT — server uses the row's existing vote_type + enforces
+    browser-ownership) or null (INSERT, `vote_type` required). The bubble votes
+    with the SAME browser_id that cast the original vote, so the edit-path
+    ownership check passes. Re-tapping the current choice is a no-op.
+  - **`TranscriptBubbleModel.voting: VotingTarget?`** (the exact `{questionId,
+    yesNoChoice, isAbstain}` being submitted) drives the spinner on the SPECIFIC
+    tapped button + gates re-taps. NOT a "differs from current selection" guess —
+    that spins BOTH buttons for a first-time voter (neither matches the nil prior
+    selection). On success, `myVotes` is updated straight from the POST response +
+    `SummaryStore.refresh(shortId:)` force-re-fetches (bypassing the 20s TTL) so
+    the aggregate counts update at once. A transient POST failure leaves the prior
+    bubble untouched (buttons re-enable when `voting` clears via `defer`).
+  - **Vote-time join for free** — the batch endpoint `join_group_for_poll`s the
+    voter, so voting on a private-group bubble auto-joins them (the plan's
+    vote-time join); voting doesn't gate on visibility server-side (the privacy
+    gate is read-only), so no separate invite redeem is needed.
+  - **No post-vote `MSSession` "bump"** (the plan's optional cosmetic) — skipped:
+    adds chat noise, correctness never depends on it (the server is the source of
+    truth; other viewers' bubbles refresh on their own ≤20s `SummaryStore` TTL).
+  - **Browser-scoped identity caveat** (same as Siri / Phase 1): the bridged
+    browser_id is per-device, so a user who voted on a DIFFERENT device (no
+    bridged bearer to union accounts) won't have their prior vote found by
+    `fetchMyVote` → a fresh insert → double-count across devices. Rare; accepted
+    for v1, matching the app's own anonymous-browser limitation.
 - **CI wiring (`ios-build.yml`), two load-bearing fixes for a second target:**
   1. The bundle-id sed must patch BOTH targets, **extension-first with anchored
      `;`** (`com\.whoeverwants\.app\.MessagesExtension;` before

--- a/docs/imessage-extension-plan.md
+++ b/docs/imessage-extension-plan.md
@@ -7,10 +7,12 @@
 >
 > **Status (June 2026): Phase 0 (target scaffold + CI) shipped via #712;
 > Phase 1 (share-from-drawer) shipped via #713; Phase 2 (live read-only
-> transcript bubble + the identity-free `/summary` endpoint) implemented —
-> see the Phase 2 section for what landed and the on-device verification
-> owed.** Owner decisions are resolved (see "Resolved decisions" at the
-> bottom).
+> transcript bubble + the identity-free `/summary` endpoint) shipped via #715;
+> Phase 3 (INLINE VOTING in the transcript — yes_no Yes/No + limited_supply
+> Claim/Decline, identity-gated, edit-not-duplicate) implemented — see the
+> Phase 3 section for what landed and the on-device verification owed. Phase 3
+> is Swift-only: no server / migration / entitlement / CI change.** Owner
+> decisions are resolved (see "Resolved decisions" at the bottom).
 >
 > **Verdict up front: feasible, and `MSMessageLiveLayout` is the right API** — but
 > this is the project's first *additional Xcode target* (a Messages extension is a
@@ -328,18 +330,69 @@ changes — the bubble is pure code in the existing extension target):
   right for 1-question and 3-question polls, tap still opens the expanded
   summary, and a no-app recipient still sees the Phase 1 template fallback.
 
-### Phase 3 — inline voting in the transcript
+### Phase 3 — inline voting in the transcript (SHIPPED, pending device verification)
 
-- yes_no: Yes / No tap → name-gate check (App Group identity) → POST batch vote →
-  optimistic re-render with fresh results. limited_supply: Claim / Decline, same
-  shape.
-- Nameless/signed-out users: transcript can't take keyboard input — render the
-  buttons disabled with "Set your name in the app to vote" (or tap-through to
-  expanded, which CAN host text entry, and reuse the name-only account mint
-  `POST /api/auth/account/name`).
-- Optional cosmetic: after voting, `conversation.send` a session-keyed update so
-  the bubble bumps in the transcript for others. Skip if it adds chat noise —
-  correctness never depends on it.
+What landed (Swift only in `ios/App/MessagesExtension/MessagesViewController.swift`
+— **NO server, migration, entitlement, CI, or pbxproj change**: `/summary`
+already returns `poll_id` + per-question counts, voting reuses the existing
+atomic batch `POST /api/polls/{id}/votes` + own-vote `GET /api/questions/{id}/votes`
++ the App-Group identity wired in Phase 1):
+- **The transcript SwiftUI tree is now INTERACTIVE.** Phase 2's read-only design
+  (`allowsHitTesting(false)` on the tree + a UIKit `UITapGestureRecognizer` on
+  the VC view to drive `requestPresentationStyle(.expanded)`) is replaced: the
+  recognizer is gone, the hosting view is interactive, and the bubble drives the
+  expand itself — the title / result rows / footer are each wrapped in a plain
+  SwiftUI `Button` calling `model.requestExpand()` (→ `host?.requestPresentationStyle(.expanded)`),
+  while the vote buttons are sibling `Button`s that consume their own taps. Live
+  bubbles still get NO template-style tap-to-open from Messages (device-verified),
+  so an explicit tappable region everywhere is the design — not a fall-through.
+- **Inline voting is gated to a SINGLE-question poll whose one question is
+  `yes_no` (Yes / No) or `limited_supply` (Claim a spot / No thanks).** Closed,
+  multi-question, and other types (ranked / time / showtime — they need
+  ranking / grids / keyboard) stay read-only; tapping opens the expanded summary.
+  `PollSummary.inlineVotableQuestion` is the gate.
+- **Identity-gated on the App-Group name+browserId** (`BridgedIdentity.load()` now
+  returns both — `name` = the batch endpoint's required `voter_name`, `browserId`
+  = `X-Browser-Id`). With identity, buttons are live; without it they render
+  disabled under "Set your name in the app to vote" (a transcript can't take
+  keyboard input — the nameless user taps through to the expanded summary →
+  Open in WhoeverWants → set their name in the app, then come back).
+- **Edit, don't duplicate.** On load (votable + identity) the bubble fetches the
+  viewer's OWN vote via `GET /api/questions/{id}/votes` (ballot-privacy-scoped to
+  their browser) → highlights the current choice + remembers the `vote_id`. A
+  vote sends the batch POST with `vote_id` set (EDIT — the server uses the row's
+  existing vote_type + enforces browser-ownership) or null (INSERT). Re-tapping
+  the current choice is a no-op. On success the bubble force-refreshes the
+  summary (`SummaryStore.refresh`, bypassing the 20s TTL) so the aggregate counts
+  update at once; `myVotes` is updated straight from the POST response.
+- **Vote-time join for free.** The batch endpoint `join_group_for_poll`s the
+  voter, so voting on a private-group bubble auto-joins them (the plan's vote-time
+  join) with no separate invite redeem — voting doesn't gate on visibility
+  server-side (the privacy gate is read-only).
+- **`TranscriptBubbleModel.voting: VotingTarget?`** (the exact `{questionId,
+  yesNoChoice, isAbstain}` being submitted) drives the spinner on the SPECIFIC
+  tapped button + gates re-taps — NOT a "differs from current selection" guess,
+  which would spin both buttons for a first-time voter. A transient POST failure
+  leaves the prior bubble untouched; the buttons re-enable when `voting` clears.
+- **`bubbleHeight` bumped 148 → 168** to fit a vote-button row above the footer
+  (one fixed height serves every shape since votable-ness isn't known
+  synchronously at `contentSizeThatFits` time; read-only bubbles absorb the slack
+  via the Spacer — the owner may tune on device).
+- **No post-vote `MSSession` "bump"** (the plan's optional cosmetic) — skipped: it
+  adds chat noise and correctness never depends on it (other viewers' bubbles
+  refresh on their own ≤20s SummaryStore TTL / re-render; the server is the
+  source of truth).
+- **Deferred (not in this phase):** voting in the EXPANDED summary view (it stays
+  read-only summary + Open/Copy — multi-question + the nameless "set my name here"
+  flow via `POST /api/auth/account/name` route through Open-in-app for now);
+  multi-question inline voting; the name-entry-in-extension account mint.
+- Exit criteria: (CI) green canary build (compiles the interactive tree). (Owner,
+  device — Simulator works for the inner loop) a single-question yes_no/limited_
+  supply bubble shows live vote buttons, tapping Yes/No (or Claim/Decline) records
+  the vote + updates the counts without leaving Messages, a second tap CHANGES
+  (doesn't duplicate) the vote, tapping the title/footer still opens the expanded
+  summary, a nameless viewer sees disabled buttons + the hint, and a private-group
+  bubble vote joins the voter (poll appears in their app afterward).
 
 ### Phase 4 — richer surfaces (only if earlier phases earn it)
 

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -24,16 +24,33 @@ import UIKit
 //     respondent count, fetched from the identity-free
 //     GET /api/polls/<short>/summary through a process-level cache
 //     (SummaryStore) so several bubbles re-rendering in one conversation
-//     coalesce into one round-trip. Read-only by design (Phase 3 adds
-//     voting): the SwiftUI tree is hit-testing-disabled and the transcript
-//     VC handles the tap itself via requestPresentationStyle(.expanded) —
-//     live bubbles get NO template-style tap-to-open from Messages
-//     (device-verified) — which makes the system open a new expanded
-//     instance with this bubble's message selected → the summary view
-//     below. Rendering NEVER redeems the embedded invite token — the
-//     summary endpoint is identity-free, and joining a group because you
-//     scrolled past a bubble would surprise; redemption stays on the explicit
-//     open-in-app / web paths.
+//     coalesce into one round-trip. Rendering NEVER redeems the embedded
+//     invite token — the summary endpoint is identity-free, and joining a
+//     group because you scrolled past a bubble would surprise; redemption
+//     stays on the explicit open-in-app / web / vote paths.
+//   • Phase 3 — INLINE VOTING in the transcript. A SINGLE-question poll whose
+//     one question is yes_no (Yes / No) or limited_supply (Claim / No thanks)
+//     gets tap-to-vote buttons in the bubble; everything else (closed,
+//     multi-question, ranked/time) stays read-only. The SwiftUI tree is now
+//     INTERACTIVE (no allowsHitTesting(false); the old UIKit tap recognizer
+//     is gone): the vote buttons are SwiftUI Buttons, and the title / results
+//     / footer are wrapped in plain Buttons that requestPresentationStyle(
+//     .expanded) — live bubbles get NO template-style tap-to-open from
+//     Messages (device-verified), so the bubble drives the expand itself.
+//     Voting is identity-gated on the App-Group name+browserId (the
+//     name-required model — a transcript can't take keyboard input, so a
+//     nameless viewer sees disabled buttons + "Set your name in the app to
+//     vote" and taps through to the expanded summary). The bubble fetches the
+//     viewer's OWN vote (GET /api/questions/<id>/votes, ballot-privacy-scoped
+//     to their browser) so it highlights the current choice and EDITS rather
+//     than duplicates on a change; votes go through the atomic batch
+//     POST /api/polls/<id>/votes (which join_group_for_poll's the voter, so a
+//     private-group bubble auto-joins them on vote — the plan's vote-time
+//     join — no separate invite redeem needed). On success the bubble force-
+//     refreshes the summary so the aggregate counts update immediately. No
+//     post-vote MSSession "bump" (skipped per the plan — it adds chat noise
+//     and correctness never depends on it; other viewers' bubbles refresh on
+//     their own ≤20s SummaryStore TTL / re-render).
 //   • Tapping a sent bubble (recipient WITH the app) opens the extension
 //     expanded with `conversation.selectedMessage` set → a native poll summary
 //     with live results + "Open in WhoeverWants" (extensionContext.open is
@@ -87,18 +104,28 @@ private enum BridgedIdentity {
     static let nameKey = "display_name"
     static let browserIdKey = "browser_id"
 
-    // Returns the bridged browser id, gated on a non-empty display NAME — the
-    // same "user has actually used the app" signal Siri's
-    // QuickPollService.loadIdentity gates on (name-required model). The name
-    // itself isn't displayed anywhere here, so only the id is returned.
-    static func loadBrowserId() -> String? {
+    // The bridged name + browser id, present together iff the user has
+    // actually used the app (the name-required model Siri's
+    // QuickPollService.loadIdentity gates on). The name is the `voter_name`
+    // the batch endpoint requires (non-blank), the browser id the
+    // X-Browser-Id that attributes the vote to their account.
+    struct Value {
+        let name: String
+        let browserId: String
+    }
+
+    static func load() -> Value? {
         guard let d = UserDefaults(suiteName: suiteName),
               let name = d.string(forKey: nameKey), !name.isEmpty,
               let browserId = d.string(forKey: browserIdKey), !browserId.isEmpty else {
             return nil
         }
-        return browserId
+        return Value(name: name, browserId: browserId)
     }
+
+    // Browser-id-only convenience for the picker fetch + invite mint, which
+    // don't need the name. Stays gated on a non-empty name via load().
+    static func loadBrowserId() -> String? { load()?.browserId }
 }
 
 // MARK: - Models
@@ -126,6 +153,7 @@ struct QuestionSummary: Identifiable {
 }
 
 struct PollSummary {
+    let pollId: String        // POST target for inline votes (Phase 3)
     let title: String
     let groupName: String?
     let isClosedFlag: Bool    // server is_closed; display closed-ness via isClosed
@@ -142,6 +170,28 @@ struct PollSummary {
         if let deadline = responseDeadline { return deadline <= Date() }
         return false
     }
+
+    // The single question eligible for INLINE transcript voting (Phase 3):
+    // exactly one question, of a tap-votable type (yes_no / limited_supply),
+    // poll still open, poll id present. Multi-question polls and other types
+    // (ranked / time / showtime — they need ranking / grids / keyboard) stay
+    // read-only in the bubble; tapping opens the expanded summary instead.
+    var inlineVotableQuestion: QuestionSummary? {
+        guard !isClosed, !pollId.isEmpty, questions.count == 1,
+              let q = questions.first,
+              q.type == "yes_no" || q.type == "limited_supply" else { return nil }
+        return q
+    }
+}
+
+// The viewer's own vote on a question — fetched (GET /votes) for the
+// selection highlight, returned by the vote POST. `yes_no_choice` is
+// "yes"/"no" for yes_no; `isAbstain` is the decline for limited_supply (and
+// the abstain for yes_no, which the bubble doesn't offer but tolerates).
+struct BubbleVote {
+    let voteId: String
+    let yesNoChoice: String?
+    let isAbstain: Bool
 }
 
 // MARK: - API
@@ -290,12 +340,69 @@ private enum PollAPI {
             )
         }
         return PollSummary(
+            pollId: nonEmpty(obj["poll_id"] as? String) ?? "",
             title: nonEmpty(obj["title"] as? String) ?? "Poll",
             groupName: nonEmpty(obj["group_name"] as? String),
             isClosedFlag: (obj["is_closed"] as? Bool) ?? false,
             responseDeadline: parseISODate(nonEmpty(obj["response_deadline"] as? String)),
             respondentCount: (obj["respondent_count"] as? Int) ?? 0,
             questions: questions
+        )
+    }
+
+    // Inline vote (Phase 3): one item through the atomic batch endpoint, the
+    // same POST /api/polls/{id}/votes every surface uses. EDITS when voteId is
+    // set (no duplicate row; the server uses the existing row's vote_type and
+    // enforces browser-ownership), else INSERTS (vote_type required). The
+    // endpoint join_group_for_poll's the voter, so a private-group bubble
+    // auto-joins them here (the plan's vote-time join). Returns the resulting
+    // row so the bubble can update its selection without a separate re-fetch.
+    static func submitVote(
+        pollId: String, questionId: String, voteId: String?, voteType: String,
+        yesNoChoice: String?, isAbstain: Bool, name: String, browserId: String
+    ) async throws -> BubbleVote {
+        guard let url = URL(string: apiBase + "/api/polls/\(pollId)/votes") else { throw URLError(.badURL) }
+        var item: [String: Any] = ["question_id": questionId, "is_abstain": isAbstain]
+        if let voteId = voteId {
+            item["vote_id"] = voteId       // edit
+        } else {
+            item["vote_type"] = voteType   // insert
+        }
+        if let choice = yesNoChoice { item["yes_no_choice"] = choice }
+        let body: [String: Any] = ["voter_name": name, "items": [item]]
+        let request = jsonRequest(url: url, method: "POST", browserId: browserId, body: body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let row = arr.first(where: { ($0["question_id"] as? String) == questionId }) ?? arr.first,
+              let vid = nonEmpty(row["id"] as? String) else {
+            throw URLError(.badServerResponse)
+        }
+        return BubbleVote(
+            voteId: vid,
+            yesNoChoice: nonEmpty(row["yes_no_choice"] as? String),
+            isAbstain: (row["is_abstain"] as? Bool) ?? false
+        )
+    }
+
+    // The caller's OWN vote on a question (GET /api/questions/{id}/votes is
+    // ballot-privacy-scoped to their browser set), so the bubble highlights
+    // the current choice and edits rather than duplicates. Returns nil on any
+    // failure / no prior vote → the bubble just inserts. `.last` = most recent
+    // in the rare legacy multi-row case.
+    static func fetchMyVote(questionId: String, browserId: String) async -> BubbleVote? {
+        guard let url = URL(string: apiBase + "/api/questions/\(questionId)/votes") else { return nil }
+        guard let (data, response) = try? await URLSession.shared.data(
+                for: jsonRequest(url: url, method: "GET", browserId: browserId)),
+              let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let row = arr.last, let vid = nonEmpty(row["id"] as? String) else {
+            return nil
+        }
+        return BubbleVote(
+            voteId: vid,
+            yesNoChoice: nonEmpty(row["yes_no_choice"] as? String),
+            isAbstain: (row["is_abstain"] as? Bool) ?? false
         )
     }
 
@@ -344,6 +451,19 @@ final class SummaryStore {
             if let hit = cache[shortId] { return hit.summary }
             throw error
         }
+    }
+
+    // Force a fresh fetch (bypassing the TTL) and update the cache — used
+    // right after the viewer votes so THIS bubble shows the new aggregate
+    // counts immediately. Other bubbles for the same poll pick it up on their
+    // own next render (≤ maxAge TTL).
+    func refresh(shortId: String) async throws -> PollSummary {
+        let task = Task { try await PollAPI.fetchSummary(shortId: shortId) }
+        inFlight[shortId] = task
+        defer { inFlight[shortId] = nil }
+        let summary = try await task.value
+        cache[shortId] = (summary, Date())
+        return summary
     }
 }
 
@@ -515,19 +635,98 @@ final class TranscriptBubbleModel: ObservableObject {
         case unavailable   // unparseable url / fetch failed → static fallback
     }
 
+    // The exact choice being submitted — drives the spinner on the SPECIFIC
+    // tapped button (not both, which a "differs from current selection" guess
+    // would do for a first-time voter) and gates re-taps until it clears.
+    struct VotingTarget: Equatable {
+        let questionId: String
+        let yesNoChoice: String?
+        let isAbstain: Bool
+    }
+
     @Published var state: State = .loading
+    // questionId → the viewer's own vote: drives the selection highlight and
+    // edit-vs-insert. Populated from the own-vote fetch on load + the vote
+    // POST response.
+    @Published var myVotes: [String: BubbleVote] = [:]
+    @Published var voting: VotingTarget?
+
+    // Set by the VC at mount so a bubble tap can requestPresentationStyle.
+    weak var host: MessagesViewController?
+
+    private var shortId: String?
 
     func load(messageURL: URL?) {
         guard let url = messageURL,
-              let shortId = PollAPI.pollShortId(fromMessageURL: url) else {
+              let short = PollAPI.pollShortId(fromMessageURL: url) else {
             state = .unavailable
             return
         }
+        shortId = short
         Task {
             do {
-                state = .loaded(try await SummaryStore.shared.summary(shortId: shortId))
+                let summary = try await SummaryStore.shared.summary(shortId: short)
+                state = .loaded(summary)
+                await loadMyVoteIfVotable(summary)
             } catch {
                 state = .unavailable
+            }
+        }
+    }
+
+    // Fetch the viewer's own vote for the single inline-votable question (only
+    // when there's a bridged identity), so the bubble highlights the current
+    // choice and edits rather than duplicates. No-op for read-only bubbles.
+    private func loadMyVoteIfVotable(_ summary: PollSummary) async {
+        guard let q = summary.inlineVotableQuestion,
+              let id = BridgedIdentity.load() else { return }
+        if let mine = await PollAPI.fetchMyVote(questionId: q.id, browserId: id.browserId) {
+            myVotes[q.id] = mine
+        }
+    }
+
+    // Tap-anywhere-but-a-button → open the expanded summary. Live bubbles get
+    // no template-style tap-to-open from Messages (device-verified), so the
+    // bubble drives the expand itself; .expanded is the only style a
+    // transcript instance may request.
+    func requestExpand() {
+        host?.requestPresentationStyle(.expanded)
+    }
+
+    // yes_no Yes/No (yesNoChoice set, isAbstain false) or limited_supply
+    // Claim (isAbstain false) / Decline (isAbstain true). Edits the viewer's
+    // existing vote when present (no duplicate row), else inserts. Re-tapping
+    // the current choice is a no-op. Force-refreshes the summary on success so
+    // the counts reflect the new vote at once. A transient failure leaves the
+    // prior state untouched (the buttons re-enable when `voting`
+    // clears).
+    func vote(question: QuestionSummary, poll: PollSummary, yesNoChoice: String?, isAbstain: Bool) {
+        guard voting == nil, let id = BridgedIdentity.load() else { return }
+        if let mine = myVotes[question.id],
+           mine.isAbstain == isAbstain, mine.yesNoChoice == yesNoChoice {
+            return
+        }
+        voting = VotingTarget(questionId: question.id, yesNoChoice: yesNoChoice, isAbstain: isAbstain)
+        Task {
+            defer { voting = nil }
+            do {
+                let submitted = try await PollAPI.submitVote(
+                    pollId: poll.pollId,
+                    questionId: question.id,
+                    voteId: myVotes[question.id]?.voteId,
+                    voteType: question.type,
+                    yesNoChoice: yesNoChoice,
+                    isAbstain: isAbstain,
+                    name: id.name,
+                    browserId: id.browserId
+                )
+                myVotes[question.id] = submitted
+                if let short = shortId,
+                   let fresh = try? await SummaryStore.shared.refresh(shortId: short) {
+                    state = .loaded(fresh)
+                }
+            } catch {
+                // Keep the prior bubble; re-taps re-enable via the defer.
             }
         }
     }
@@ -553,22 +752,15 @@ class MessagesViewController: MSMessagesAppViewController {
         hasMountedUI = true
         let controller: UIViewController
         if presentationStyle == .transcript {
-            let hosting = UIHostingController(rootView: TranscriptBubbleView(model: bubbleModel))
-            // Read-only in Phase 2: the SwiftUI tree takes no touches, so the
-            // tap recognizer below (on self.view) receives bubble taps.
-            hosting.view.isUserInteractionEnabled = false
-            controller = hosting
-            // Live-layout bubbles get NO template-style tap-to-open from
-            // Messages (device-verified: an unhandled tap does nothing). The
-            // transcript instance must handle the tap itself: per the docs,
-            // requesting a presentation style from a transcript-style
-            // controller makes the system display a NEW instance in that
-            // style — which activates with this bubble's message selected →
-            // the expanded summary. `.expanded` is the only legal request
-            // from transcript.
-            view.addGestureRecognizer(
-                UITapGestureRecognizer(target: self, action: #selector(transcriptBubbleTapped))
-            )
+            // Phase 3: the SwiftUI tree is now INTERACTIVE (vote buttons must
+            // take taps). The bubble's own plain Buttons drive the
+            // tap-to-expand (requestPresentationStyle(.expanded) via
+            // bubbleModel.host) — live bubbles get NO template-style tap-to-open
+            // from Messages (device-verified), so there's nothing to fall back
+            // to a UIKit recognizer for, and an interactive hosting view would
+            // consume those taps anyway.
+            bubbleModel.host = self
+            controller = UIHostingController(rootView: TranscriptBubbleView(model: bubbleModel))
         } else {
             model.host = self
             controller = UIHostingController(rootView: RootView(model: model))
@@ -585,10 +777,6 @@ class MessagesViewController: MSMessagesAppViewController {
             controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
         controller.didMove(toParent: self)
-    }
-
-    @objc private func transcriptBubbleTapped() {
-        requestPresentationStyle(.expanded)
     }
 
     // Fires on every activation: transcript bubble render (presentationStyle
@@ -938,14 +1126,16 @@ private struct CenteredMessage: View {
     }
 }
 
-// MARK: - Transcript bubble (Phase 2, read-only)
+// MARK: - Transcript bubble (Phase 3 — inline voting)
 
 struct TranscriptBubbleView: View {
     // contentSizeThatFits returns this fixed compact height (per the plan: no
-    // scrolling inside a bubble; the question count isn't knowable at sizing
-    // time). The layout below is budgeted to fit the worst case: a 2-line
-    // title + two question rows + the status footer.
-    static let bubbleHeight: CGFloat = 148
+    // scrolling inside a bubble; the votable-ness isn't knowable synchronously
+    // at sizing time, so one height serves every shape). Budgeted to fit the
+    // worst case: a 2-line title + result row + a vote-button row + the status
+    // footer. Read-only bubbles absorb the slack via the Spacer. The owner may
+    // tune this on device.
+    static let bubbleHeight: CGFloat = 168
 
     // Messages overlays the extension's APP ICON on the live bubble's
     // top-left corner (the OS draws it — we don't render it and can't move
@@ -962,9 +1152,20 @@ struct TranscriptBubbleView: View {
             .padding(12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .background(Color(.systemBackground))
-            // Read-only: the VC's tap recognizer (not the SwiftUI tree) owns
-            // the tap → requestPresentationStyle(.expanded) → the summary.
-            .allowsHitTesting(false)
+        // Phase 3: the tree is INTERACTIVE — vote buttons take taps; the
+        // title / results / footer are plain Buttons that requestExpand().
+    }
+
+    // Wraps a content region so tapping it opens the expanded summary — the
+    // three non-vote-button regions (unavailable fallback, title+results,
+    // footer) all share this. Live bubbles get no template-style tap-to-open
+    // from Messages (device-verified), so each region carries its own
+    // affordance; the vote buttons are SIBLINGS that consume their own taps.
+    private func expandButton<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        Button(action: { model.requestExpand() }) {
+            content().contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
     @ViewBuilder
@@ -974,17 +1175,19 @@ struct TranscriptBubbleView: View {
             ProgressView()
                 .padding(.leading, Self.iconBadgeClearance)
         case .unavailable:
-            // Static fallback — the tap-through to the expanded summary still
-            // works (it has its own retry + Open/Copy affordances). No 👋
-            // glyph of our own: the OS already badges the bubble with the
-            // app icon.
-            VStack(alignment: .leading, spacing: 4) {
-                Text("WhoeverWants poll")
-                    .font(.subheadline.weight(.semibold))
-                    .padding(.leading, Self.iconBadgeClearance)
-                Text("Tap to view")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            // Static fallback — tapping opens the expanded summary (its own
+            // retry + Open/Copy affordances). No 👋 glyph of our own: the OS
+            // already badges the bubble with the app icon.
+            expandButton {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("WhoeverWants poll")
+                        .font(.subheadline.weight(.semibold))
+                        .padding(.leading, Self.iconBadgeClearance)
+                    Text("Tap to view")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         case .loaded(let summary):
             loaded(summary)
@@ -992,44 +1195,60 @@ struct TranscriptBubbleView: View {
     }
 
     private func loaded(_ summary: PollSummary) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(summary.title)
-                .font(.subheadline.weight(.semibold))
-                .lineLimit(2)
-                .multilineTextAlignment(.leading)
-                .padding(.leading, Self.iconBadgeClearance)
+        let votable = summary.inlineVotableQuestion
+        return VStack(alignment: .leading, spacing: 6) {
+            // Title + result rows — tap opens the expanded summary. (The vote
+            // buttons below are SIBLINGS, not nested, so a button tap votes
+            // while a tap here expands.)
+            expandButton {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(summary.title)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                        .padding(.leading, Self.iconBadgeClearance)
 
-            // Up to 2 question rows; extras collapse into "+N more" so the
-            // fixed-height bubble never clips mid-row.
-            ForEach(summary.questions.prefix(2)) { q in
-                VStack(alignment: .leading, spacing: 2) {
-                    if let label = q.label {
-                        Text(label)
+                    // Up to 2 question rows; extras collapse into "+N more" so
+                    // the fixed-height bubble never clips mid-row.
+                    ForEach(summary.questions.prefix(2)) { q in
+                        VStack(alignment: .leading, spacing: 2) {
+                            if let label = q.label {
+                                Text(label)
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(1)
+                            }
+                            if q.type == "yes_no", let yes = q.yesCount, let no = q.noCount, yes + no > 0 {
+                                YesNoBar(yes: yes, no: no)
+                            } else if let text = q.resultText {
+                                Text(text)
+                                    .font(.footnote)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                    if summary.questions.count > 2 {
+                        Text("+\(summary.questions.count - 2) more")
                             .font(.caption2)
                             .foregroundColor(.secondary)
-                            .lineLimit(1)
-                    }
-                    if q.type == "yes_no", let yes = q.yesCount, let no = q.noCount, yes + no > 0 {
-                        YesNoBar(yes: yes, no: no)
-                    } else if let text = q.resultText {
-                        Text(text)
-                            .font(.footnote)
-                            .lineLimit(1)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            if summary.questions.count > 2 {
-                Text("+\(summary.questions.count - 2) more")
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
+
+            if let q = votable {
+                VoteButtonRow(question: q, poll: summary, model: model)
             }
 
             Spacer(minLength: 0)
 
-            Text(footerText(summary))
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .lineLimit(1)
+            expandButton {
+                Text(footerText(summary))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
     }
 
@@ -1088,5 +1307,96 @@ private struct YesNoBar: View {
                 .foregroundColor(.secondary)
                 .fixedSize()
         }
+    }
+}
+
+// Phase 3 inline-vote buttons for a single yes_no / limited_supply question.
+// Identity-gated: with a bridged name+browserId, the buttons are live (the
+// current choice highlighted, a spinner on the in-flight one); without it,
+// they're disabled under a "Set your name in the app to vote" hint (a
+// transcript can't take keyboard input — the user taps through to the
+// expanded summary → Open in WhoeverWants → set their name there).
+private struct VoteButtonRow: View {
+    let question: QuestionSummary
+    let poll: PollSummary
+    @ObservedObject var model: TranscriptBubbleModel
+
+    // Read at render: the user may have set their name in the app between
+    // bubble renders (each transcript instance is short-lived). A UserDefaults
+    // peek is cheap.
+    private var hasIdentity: Bool { BridgedIdentity.load() != nil }
+
+    private var mine: BubbleVote? { model.myVotes[question.id] }
+    private var busy: Bool { model.voting?.questionId == question.id }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                if question.type == "yes_no" {
+                    button(
+                        "Yes", color: .green,
+                        selected: mine?.isAbstain == false && mine?.yesNoChoice == "yes",
+                        yesNoChoice: "yes", isAbstain: false
+                    )
+                    button(
+                        "No", color: .red,
+                        selected: mine?.isAbstain == false && mine?.yesNoChoice == "no",
+                        yesNoChoice: "no", isAbstain: false
+                    )
+                } else {  // limited_supply
+                    button(
+                        // `mine?.isAbstain == false` is false when mine is nil,
+                        // so it already implies a claim exists (parallels the
+                        // `== true` decline check below).
+                        "Claim a spot", color: .green,
+                        selected: mine?.isAbstain == false,
+                        yesNoChoice: nil, isAbstain: false
+                    )
+                    button(
+                        "No thanks", color: .secondary,
+                        selected: mine?.isAbstain == true,
+                        yesNoChoice: nil, isAbstain: true
+                    )
+                }
+            }
+            if !hasIdentity {
+                Text("Set your name in the app to vote")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private func button(
+        _ title: String, color: Color, selected: Bool,
+        yesNoChoice: String?, isAbstain: Bool
+    ) -> some View {
+        // Spinner only on the button actually being submitted.
+        let spinning = model.voting == TranscriptBubbleModel.VotingTarget(
+            questionId: question.id, yesNoChoice: yesNoChoice, isAbstain: isAbstain
+        )
+        return Button(action: {
+            model.vote(question: question, poll: poll, yesNoChoice: yesNoChoice, isAbstain: isAbstain)
+        }) {
+            ZStack {
+                if spinning { ProgressView() }
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                    .opacity(spinning ? 0 : 1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 7)
+            .background(
+                selected ? color.opacity(0.18) : Color(.systemGray6),
+                in: RoundedRectangle(cornerRadius: 9)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 9)
+                    .stroke(selected ? color.opacity(0.7) : Color.clear, lineWidth: 1.5)
+            )
+            .foregroundColor(selected ? color : .primary)
+        }
+        .buttonStyle(.plain)
+        .disabled(!hasIdentity || busy)
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 of `docs/imessage-extension-plan.md`: a **single-question yes_no (Yes / No) or limited_supply (Claim a spot / No thanks)** poll now gets tap-to-vote buttons inside the live `MSMessageLiveLayout` transcript bubble — both sender and recipient vote inline without leaving Messages. Everything else (closed, multi-question, ranked/time/showtime) stays read-only and taps through to the expanded summary.

**Swift-only — no server, migration, entitlement, CI, or Xcode-project change.** The Phase 2 `/summary` endpoint already returns `poll_id` + per-question counts; voting reuses the existing atomic batch `POST /api/polls/{id}/votes`, the own-vote `GET /api/questions/{id}/votes`, and the Phase 1 App-Group identity bridge. The only changed code is `ios/App/MessagesExtension/MessagesViewController.swift` (+ plan doc + CLAUDE.md).

### Design
- **Interactive tree.** Phase 2's `allowsHitTesting(false)` + UIKit tap recognizer are gone. Vote buttons are SwiftUI Buttons; the title/results/footer are plain Buttons (shared `expandButton` helper) that call `requestPresentationStyle(.expanded)` — every tappable region is explicit, since an interactive hosting view would consume the old recognizer's taps.
- **Identity-gated** on the bridged name + browser id. Nameless viewers see disabled buttons + "Set your name in the app to vote" and tap through to expanded.
- **Edit, don't duplicate.** The bubble fetches the viewer's own vote on load (ballot-privacy-scoped) to highlight the current choice and send `vote_id` on a change; the per-button spinner is driven by the exact `VotingTarget` (not a "differs from selection" guess, which would spin both buttons for a first-time vote).
- **Vote-time join for free** — the batch endpoint already joins the voter, so a private-group bubble vote auto-joins them with no separate invite redeem.
- `bubbleHeight` 148 → 168 for the button row; no post-vote `MSSession` bump.
- Deferred: voting in the expanded view, and multi-question inline voting.

## Test plan
- [ ] CI green (vitest + lint + Vercel — unaffected, no JS/TS changed).
- [ ] iOS build (`ios-build.yml`, Mac runner) compiles the interactive extension + uploads to the `Whoever α` TestFlight.
- [ ] Device/Simulator: single-question yes_no & limited_supply bubble shows live vote buttons; tap records the vote and updates counts inline; a second tap **changes** (doesn't duplicate); tapping the title/footer opens the expanded summary; nameless viewer sees disabled buttons + hint; private-group bubble vote joins the voter (poll appears in their app).

🤖 Native-iOS-only — not demoable on the dev server; device verification owner-owned.

https://claude.ai/code/session_014P8asvAfnnUt3qks3wm11K

---
_Generated by [Claude Code](https://claude.ai/code/session_014P8asvAfnnUt3qks3wm11K)_