### PR TITLE
groups: resolve account from browser id for bearer-less /mine + /empty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1151,6 +1151,28 @@ linked browser when user_id is set — otherwise tapping "leave" on
 one device just leaves on that device, and the group reappears on
 the next visit from another linked browser.
 
+**The `user_id` fed to `load_user_visibility` MUST be the
+account-aware id (`resolve_actor_user_id(conn, user_id=<bearer>,
+browser_id=<X-Browser-Id>)`), NOT the bearer-only id.** A
+bearer-LESS caller that carries only `X-Browser-Id` — the iMessage
+extension AND Siri, which deliberately don't bridge the bearer (only
+the browser id) — still needs the account expansion, because the
+browser→account link (`user_browsers`) is what makes the surface
+"follow the user." Passing the raw bearer `user_id` (None for these
+callers) keys visibility on the LITERAL browser's direct
+`group_members` rows only, so a fresh browser id (minted on every
+app reinstall) shows an EMPTY group list in the extension/Siri even
+though that browser is linked to the user's account — surfaced as
+"No polls yet" in the Messages drawer (`claude/ios-imessage-polls-missing`,
+June 2026). `/api/groups/mine` already computed the account-aware
+`viewer_user_id` for poll-authorship a few lines later; the fix was
+to compute it FIRST and feed it to `load_user_visibility` (same in
+`/empty`). The create/vote paths were already correct (they route
+through `resolve_actor_user_id`). Regression:
+`test_groups_visibility.py::test_linked_browser_without_bearer_sees_account_groups`.
+Don't "simplify" the reorder back to `user_id=user_id` — it
+re-breaks the extension after any reinstall.
+
 **The `accessible_question_ids` "forget bridge" has been REMOVED.**
 `group_members` is the single source of truth for visibility on
 every tier (anonymous and signed-in alike). "Forget a group" is

--- a/server/routers/groups.py
+++ b/server/routers/groups.py
@@ -307,7 +307,22 @@ def get_my_groups(
     user_id = _user_id(request)
 
     with get_db() as conn:
-        visibility = load_user_visibility(conn, browser_id, user_id=user_id)
+        # Resolve the account from the bearer OR the browser→account link, and
+        # build visibility against THAT — so a caller carrying only X-Browser-Id
+        # (the iMessage extension + Siri deliberately don't bridge the bearer)
+        # sees every group their account belongs to, not just groups this exact
+        # browser joined directly. Without it, a fresh browser id (e.g. after an
+        # app reinstall, which mints a new one) shows an empty poll list in
+        # those surfaces even though the browser is linked to the user's
+        # account. This is the same account-aware id used below for poll
+        # authorship; feeding it into load_user_visibility mirrors what the
+        # create/vote paths already do via resolve_actor_user_id.
+        viewer_user_id = resolve_actor_user_id(
+            conn, user_id=user_id, browser_id=browser_id
+        )
+        visibility = load_user_visibility(
+            conn, browser_id, user_id=viewer_user_id
+        )
 
         member_group_ids = list(visibility.joined_by_group.keys())
         candidate_pids = poll_ids_for_group_ids(conn, member_group_ids)
@@ -315,9 +330,6 @@ def get_my_groups(
             return []
 
         visible_pids = filter_visible_polls(conn, candidate_pids, visibility)
-        viewer_user_id = resolve_actor_user_id(
-            conn, user_id=user_id, browser_id=browser_id
-        )
         # Keep the caller's contact list ("people you've encountered") fresh
         # off the home-load path: a decoupled upsert of everyone they
         # currently share a group with, bumping each contact's last_seen_at.
@@ -361,7 +373,14 @@ def get_my_empty_groups(request: Request):
     if not browser_id and not user_id:
         return []
     with get_db() as conn:
-        visibility = load_user_visibility(conn, browser_id, user_id=user_id)
+        # Account-aware via bearer OR browser→account link (see /mine), so a
+        # bearer-less caller (extension / Siri) gets the account's empty groups.
+        viewer_user_id = resolve_actor_user_id(
+            conn, user_id=user_id, browser_id=browser_id
+        )
+        visibility = load_user_visibility(
+            conn, browser_id, user_id=viewer_user_id
+        )
         member_gids = list(visibility.joined_by_group.keys())
         if not member_gids:
             return []

--- a/server/tests/test_groups_visibility.py
+++ b/server/tests/test_groups_visibility.py
@@ -414,6 +414,35 @@ class TestMultiBrowserUserVisibility:
         ids = {p["id"] for p in resp.json()}
         assert poll["id"] not in ids
 
+    def test_linked_browser_without_bearer_sees_account_groups(
+        self, client, creator_secret, creator_browser, stranger_browser
+    ):
+        """The iMessage extension + Siri carry ONLY X-Browser-Id, never the
+        bearer — so /mine must resolve the account from the browser→account
+        link, not just the bearer. A browser linked to the account (e.g. a
+        fresh browser id after an app reinstall, re-linked on sign-in) must
+        see the account's groups even with no Authorization header. Pre-fix,
+        load_user_visibility keyed only on the literal browser_id when no
+        bearer was present, so this surfaced an empty list (the reported
+        'no polls yet' in the Messages drawer)."""
+        user_id = _new_user_id()
+        _link_browser_to_user(creator_browser, user_id)
+        _link_browser_to_user(stranger_browser, user_id)
+
+        # Group created + joined on browser A.
+        poll = create_poll(client, creator_secret, browser_id=creator_browser)
+
+        # Browser B is linked to the same account but sends NO bearer — the
+        # extension/Siri shape. It has no group_members row of its own.
+        resp = client.post(
+            "/api/groups/mine",
+            json={"accessible_question_ids": []},
+            headers={"X-Browser-Id": stranger_browser},
+        )
+        assert resp.status_code == 200, resp.text
+        ids = {p["id"] for p in resp.json()}
+        assert poll["id"] in ids
+
     def test_empty_groups_listed_across_linked_browsers(
         self, client, creator_browser, stranger_browser
     ):


### PR DESCRIPTION
## Summary

Fixes the iMessage extension showing **"No polls yet"** after an app reinstall (also affects Siri).

The extension/Siri call `POST /api/groups/mine` with **only `X-Browser-Id`** — they deliberately don't bridge the session bearer. But `get_my_groups` built visibility from the bearer-only `user_id`, so `load_user_visibility` keyed on the **literal browser's** direct `group_members` rows and never expanded across the account's other browsers.

After a reinstall the WebView mints a fresh browser id with no direct memberships, so the Messages-drawer picker returned `[]` even though that browser is linked to the user's account (and the app itself, which sends the bearer, still showed the groups). The decisive tell: users saw `.empty` ("No polls yet"), not `.needsApp` ("Open WhoeverWants first") — so the App-Group identity bridge was working; the server just returned nothing. The picker code is byte-identical across extension Phase 1→3, so this was never a code regression — the reinstall exposed the gap.

## Fix

Feed the **account-aware** id (`resolve_actor_user_id`, which resolves the account from the bearer OR the browser→account `user_browsers` link) into `load_user_visibility` — the exact value `get_my_groups` already computed a few lines later for poll authorship, and what the create/vote paths already use. Applied to `/empty` too. Pure reorder + reuse in `/mine`; one indexed `user_browsers` lookup added to `/empty` (a home-load endpoint, not a hot path).

Scoped intentionally to `/mine` + `/empty` (what the extension/Siri call). `/by-route-id` reads auto-join the browser so they don't exhibit this; centralizing account-resolution into `load_user_visibility` itself would change privacy-gated reads and is left as a separate follow-up.

No FE / iOS change — the fix goes live for the **Latest** app the moment this lands on `main` (canary auto-deploys) and for **prod** on the next release; no new TestFlight build needed.

## Test plan
- [x] New regression `test_groups_visibility.py::test_linked_browser_without_bearer_sees_account_groups` — verified it **fails without** the fix (empty set) and **passes with** it.
- [x] 128 tests across `test_groups_visibility / test_empty_groups / test_groups_api / test_group_privacy / test_leave_group / test_follow_state / test_viewer_responded / test_invite_members` all pass.
- [x] Live reproduction on the branch dev server of the extension's exact request shape (account-linked browser, no bearer) → poll now returned; an unlinked browser → empty (account-scoped, no leak).

https://claude.ai/code/session_01Qxcv5G4qZ5gVk6zb4Bhc9T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qxcv5G4qZ5gVk6zb4Bhc9T)_