### PR TITLE
ios: iMessage extension Phase 4 — compose a poll without leaving Messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3289,13 +3289,32 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
 > AND the Phase 1 expanded summary through a process-level `SummaryStore`
 > (20s TTL + in-flight coalescing); full shape + the no-redeem-on-render
 > decision in the plan doc's Phase 2 section; device verification owner-owned.
-> **Phase 3 (INLINE VOTING in the transcript) implemented** on
-> `claude/imessage-extension-phase-2-px2mrm` — **Swift-only, NO server /
+> **Phase 3 (INLINE VOTING in the transcript) SHIPPED** via #718 —
+> **Swift-only, NO server /
 > migration / entitlement / CI / pbxproj change** (`/summary` already returns
 > `poll_id` + per-question counts; voting reuses the atomic batch
 > `POST /api/polls/{id}/votes` + own-vote `GET /api/questions/{id}/votes` + the
 > Phase 1 App-Group identity). Full shape in the plan doc's Phase 3 section;
-> device verification owner-owned.
+> device verification owner-owned. **Phase 4 COMPOSE-A-POLL-IN-MESSAGES
+> (decision D) implemented** on `claude/imessage-integration-plan-b52mln` —
+> a "New poll" drawer entry opens an expanded text field; the typed prompt is
+> parsed LOCALLY by the **shared `PollTextParser` (now compiled into the
+> extension target — the documented pure-Foundation-shared-file precedent, one
+> minimal pbxproj change adding a PBXBuildFile that reuses the App-target file
+> ref; bundle-id sed count unaffected, parser parity harness untouched)** with
+> a live preview; **options/yes-no → headless create** (`PollAPI.createPoll`
+> mirrors `QuickPollService.createPoll`: POST `/api/polls`, App-Group identity,
+> no bearer → PUBLIC group) then inserts the fresh poll's bubble; **category →
+> "Open WhoeverWants to finish"** via the SAME `?create=1&category=…&for=…`
+> deep link Siri uses (the composer can't collect time windows / suggestions /
+> reference location). iOS 16+ (the parser is gated there); all New-poll entry
+> points behind `#available`, with `#available` as the SOLE branch condition so
+> the result builder erases the iOS-16-only `ComposeView` type. **Swift-only
+> EXCEPT the one pbxproj change; no server / migration / entitlement / CI-logic
+> change.** Full shape in the plan doc's Phase 4 section; device verification
+> owner-owned (Simulator works for the inner loop). The remaining "Phase 5"
+> richer-ballot half (expanded ranked/time ballots or a WKWebView) stays gated
+> on earning it.
 > Owner decisions: ship additive (degraded no-app fallback OK); embed a
 > poll-scoped invite token for private-group bubbles (auto-join); v1 inline
 > voting = yes_no + limited_supply only; pursue compose-in-Messages keeping
@@ -3488,6 +3507,66 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
     bridged bearer to union accounts) won't have their prior vote found by
     `fetchMyVote` → a fresh insert → double-count across devices. Rare; accepted
     for v1, matching the app's own anonymous-browser limitation.
+- **Phase 4 implementation notes (compose-a-poll-in-Messages — Swift + ONE pbxproj change):**
+  - **NO server / migration / entitlement / CI-logic change.** Reuses POST
+    `/api/polls` (the same create the FE + Siri use) + the Phase 1 App-Group
+    identity. The ONLY non-Swift change: `PollTextParser.swift` is compiled into
+    the extension target (one PBXBuildFile in `project.pbxproj` reusing the
+    existing App-target file ref). No new file + no new target → the `ios-build.yml`
+    bundle-id sed count is unaffected (still app×2 + ext×2, asserted by the step),
+    and the parity harness (`scripts/ios/test-parser.sh`, compiles the file
+    standalone) is untouched.
+  - **`scripts/ios/add-messages-extension.rb` is now idempotent end-to-end** — it
+    finds-or-creates the target (was an early `exit 0` when it existed), THEN
+    idempotently ensures the shared parser ref is in the extension's Sources
+    phase. Re-running it on the committed project adds only the parser build file.
+    Run on Linux (`gem install xcodeproj`); the result is committed (CI never runs
+    the gem).
+  - **The shared parser, NOT a duplicate.** This is the documented precedent the
+    extension's own header comment calls out ("If a THIRD copy of the polls fetch
+    ever appears, extract a shared pure-Foundation file compiled into both targets
+    — the PollTextParser.swift precedent"). The parser carries the JS↔Swift parity
+    contract (`tests/fixtures/poll-parse-cases.json`), so a copy would rot — share
+    it. (The tier/identity/fetch helpers stay duplicated; only the parser is
+    shared.)
+  - **`PollAPI.createPoll(parsed:name:browserId:)` mirrors
+    `QuickPollService.createPoll`** (AppDelegate.swift — keep in lockstep): builds
+    the single question from the parsed decision (`.options` → fixed-options
+    ranked_choice, `winner_method:"consensus"`, the "for X" tail as `context`;
+    `.yesNo` → yes/no whose prompt is both title + context), POSTs with
+    `creator_name` + X-Browser-Id (no bearer bridged), and parses the
+    `PollResponse` into a `SharablePoll` (questions[0].title over the display
+    title). **No bearer → the new group is PUBLIC** (`_resolve_or_create_group`
+    keys privacy on the SIGNED-IN user only, None here), so the inserted bubble
+    uses the canonical URL with no invite mint — exactly the Siri headless-create
+    behavior. `createPoll` + `optionsTitle`/`yesNoTitle` are iOS 16 (the parser).
+  - **`.category` → open the app, not headless.** A category poll needs the create
+    form (time windows / suggestions / reference location), so `createFromCompose`
+    routes it to `PollAPI.createCategoryURL` (mirrors `whoeverwantsCreatePollURL`:
+    `/g/?create=1&category=…&for=…`, no literal title so the web auto-titles
+    "<Category> for <context>") via `extensionContext.open` (copy-link fallback).
+    Same fork as Siri Phase 3's `.category` deep link. The button label flips to
+    "Open WhoeverWants to finish" so it's announced up front.
+  - **iOS 16 gating, result-builder-safe.** The parser is `@available(iOS 16.0, *)`,
+    so `ComposeView`/`ComposePreview`/`createFromCompose`/`PollAPI.createPoll` are
+    too; every "New poll" entry point is behind `#available(iOS 16.0, *)`, and the
+    `RootView` routing puts `#available` as the SOLE condition of its branch
+    (`if model.composing { if #available { ComposeView } else { Picker } }`) — a
+    MIXED boolean+availability condition (`if composing, #available`) is NOT
+    guaranteed to trigger the builder's `buildLimitedAvailability` type erasure for
+    the iOS-16-only `ComposeView` type. iOS 15 keeps the prior empty-state guidance,
+    no composer (additive).
+  - **Compose state lives on `ExtensionModel`** (`composing` bool + `ComposeState`
+    enum, Equatable for the `.creating` spinner compare); `activate` preserves an
+    in-progress compose session across a Messages background/foreground (the no-URL
+    branch returns early while `composing`) and a bubble tap (selectedMessage)
+    supersedes it (`composing = false`). On successful insert, `composing` resets so
+    a reopen lands on the picker; on insert failure (poll already created) it
+    reloads the picker so the new poll is re-shareable from the list.
+  - **Device-only-verifiable** like every native phase (Simulator works for the
+    inner loop): keyboard focus timing in an extension + `extensionContext.open`
+    from Messages are the on-device unknowns. Not unit-testable in the JS suite, not
+    demoable on the dev server.
 - **CI wiring (`ios-build.yml`), two load-bearing fixes for a second target:**
   1. The bundle-id sed must patch BOTH targets, **extension-first with anchored
      `;`** (`com\.whoeverwants\.app\.MessagesExtension;` before

--- a/docs/imessage-extension-plan.md
+++ b/docs/imessage-extension-plan.md
@@ -9,10 +9,15 @@
 > Phase 1 (share-from-drawer) shipped via #713; Phase 2 (live read-only
 > transcript bubble + the identity-free `/summary` endpoint) shipped via #715;
 > Phase 3 (INLINE VOTING in the transcript — yes_no Yes/No + limited_supply
-> Claim/Decline, identity-gated, edit-not-duplicate) implemented — see the
-> Phase 3 section for what landed and the on-device verification owed. Phase 3
-> is Swift-only: no server / migration / entitlement / CI change.** Owner
-> decisions are resolved (see "Resolved decisions" at the bottom).
+> Claim/Decline, identity-gated, edit-not-duplicate) shipped via #718;
+> Phase 4 COMPOSE-A-POLL-IN-MESSAGES (decision D — a "New poll" composer in the
+> drawer: typed prompt → shared `PollTextParser` → headless create for
+> options/yes-no, "open the app to finish" for category) implemented — see the
+> Phase 4 section for what landed and the on-device verification owed. Phase 4
+> is Swift-only EXCEPT one pbxproj change (the shared `PollTextParser.swift`
+> compiled into the extension target — the documented precedent): no server /
+> migration / entitlement / CI-logic change.** Owner decisions are resolved
+> (see "Resolved decisions" at the bottom).
 >
 > **Verdict up front: feasible, and `MSMessageLiveLayout` is the right API** — but
 > this is the project's first *additional Xcode target* (a Messages extension is a
@@ -394,21 +399,68 @@ atomic batch `POST /api/polls/{id}/votes` + own-vote `GET /api/questions/{id}/vo
   summary, a nameless viewer sees disabled buttons + the hint, and a private-group
   bubble vote joins the voter (poll appears in their app afterward).
 
-### Phase 4 — richer surfaces (only if earlier phases earn it)
+### Phase 4 — compose-a-poll-in-Messages (decision D, SHIPPED, pending device verification)
+
+What landed (Swift in `ios/App/MessagesExtension/MessagesViewController.swift` +
+ONE pbxproj change; **no server / migration / entitlement / CI-logic change**):
+- **The shared `PollTextParser.swift` is now compiled into the extension target**
+  (the documented "pure-Foundation file shared with the App target" precedent —
+  it carries the JS↔Swift parity contract, so a duplicate would rot). Added to
+  the extension's Sources phase idempotently by `scripts/ios/add-messages-extension.rb`
+  (which now finds-or-creates the target, then ensures the parser ref); the
+  committed `project.pbxproj` gains exactly one PBXBuildFile reusing the existing
+  App-target file ref. No new file + no new target → the bundle-id sed count in
+  `ios-build.yml` is unaffected (still app×2 + ext×2), and the parser parity
+  harness (`scripts/ios/test-parser.sh`, compiles the file standalone) is
+  untouched.
+- **"New poll" entry in the drawer** (a row above "Share a poll" in the loaded
+  list AND the primary CTA in the empty state). Tapping it requests `.expanded`
+  (a text field needs the keyboard, only allowed in expanded — never
+  compact/transcript) and shows `ComposeView`: a text field + a LIVE preview of
+  the poll the prompt would make (the same `PollTextParser.decide` the in-app
+  search box's top suggestion uses) + a create button.
+- **options / yes-no → headless create.** `PollAPI.createPoll` mirrors
+  `QuickPollService.createPoll` (POST `/api/polls`, App-Group identity, no bearer
+  bridged → the new poll lands in a PUBLIC group) and returns a `SharablePoll`,
+  whose bubble is inserted into the conversation immediately — the killer demo:
+  make + share a poll without leaving the chat. The created poll's bubble is the
+  same `MSMessageLiveLayout` insert as Phase 1/2 (canonical URL, no invite mint
+  since the group is public).
+- **category → "Open WhoeverWants to finish."** A `.category` poll (restaurant /
+  time / movie / …) can't be finished in a transcript — it needs the form's time
+  windows / suggestion entry / reference location — so the button label changes
+  to "Open WhoeverWants to finish" (announced up front, not a surprise tap) and
+  opens the in-app create form prefilled via the SAME `?create=1&category=…&for=…`
+  deep link Siri's `.category` fallback uses (`PollAPI.createCategoryURL` mirrors
+  `whoeverwantsCreatePollURL`). The in-app create path stays exposed (owner
+  constraint: the composer is additive, never the only way).
+- **iOS 16+ (the parser is gated there).** All New-poll entry points + the
+  `ComposeView`/`ComposePreview` + the create method are behind
+  `#available(iOS 16.0, *)`; iOS 15 users keep the prior empty-state guidance and
+  no composer (additive). The RootView routing puts `#available` as the SOLE
+  condition of its branch so the result builder applies `buildLimitedAvailability`
+  to the iOS-16-only `ComposeView` type.
+- **Identity:** re-checked at create time (name + browserId from the App Group);
+  the New-poll entry only appears once a bridged identity exists (the picker's
+  `.needsApp` state precedes it), so the create's name-gate is defensive. A
+  compose session is preserved across a Messages background/foreground (the
+  `activate` no-URL branch returns early while `composing`), and a bubble tap
+  (selectedMessage) supersedes it.
+- Exit criteria: (CI) green canary build (compiles the parser into the ext +
+  the compose tree). (Owner, device — Simulator works for the inner loop) the
+  drawer shows "New poll", typing "pizza, tacos, or sushi" previews a pick-one
+  and creates+inserts it, a "should we…" prompt makes a yes/no, a "movie for
+  friday" prompt opens the app's create form, and the inserted bubble behaves
+  like any other (live results, Phase 3 inline voting).
+
+### Phase 5 — richer surfaces (only if earlier phases earn it)
 
 - Expanded-presentation ballots for ranked/time polls (native), OR a WKWebView in
   expanded style loading the poll detail page with the session injected via
   `WKUserScript` (localStorage seed from the App Group identity) — prototype
-  before committing; memory + auth-injection complexity are both real.
-- **Compose-a-new-poll inside Messages (decision D — pursue it).** Expanded view
-  text field → `PollTextParser.decide` → headless create (the `QuickPollService`
-  flow) → insert the bubble for the fresh poll. "Create and share a poll without
-  leaving the conversation" is the killer demo. **Constraint (owner): the
-  in-app create path must stay exposed** — the Messages composer is purely
-  additive, never the only way to make a poll. In practice the extension's text
-  field only handles the parser-headless-creatable types (yes_no, options,
-  category-deep-link); anything richer ("Open in WhoeverWants to finish") routes
-  to the in-app create flow, same fork as Siri Phase 3's `.category` deep link.
+  before committing; memory + auth-injection complexity are both real. (This is
+  the remaining half of the original "Phase 4" — the compose half shipped above;
+  this richer-ballot half is still gated on earning it.)
 
 ## Resolved decisions (owner, June 2026)
 

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 		7A0117EA2F1D000000000002 /* PollTextParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0117EA2F1D000000000001 /* PollTextParser.swift */; };
+		AA0CCC64EE32101B84C84830 /* PollTextParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0117EA2F1D000000000001 /* PollTextParser.swift */; };
 		AD37D19D2A5E9E1DB47AB76E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E9ECE4DD63EE9AC4A596887C /* Assets.xcassets */; };
 		AF9FAA69C2F1844B6E71C409 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F554A87FA2F92653C6C17A88 /* Foundation.framework */; };
 		E64315A804417C57E01F45BE /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00B0D750BEB2329C980CD9 /* MessagesViewController.swift */; };
@@ -272,6 +273,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E64315A804417C57E01F45BE /* MessagesViewController.swift in Sources */,
+				AA0CCC64EE32101B84C84830 /* PollTextParser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -57,6 +57,22 @@ import UIKit
 //     famously finicky from Messages extensions, so Copy Link is the always-
 //     available fallback and the open failure path copies too). The summary
 //     consumes the same /summary endpoint + SummaryStore as the bubble.
+//   • Phase 4 — COMPOSE a poll without leaving Messages. The drawer's "New
+//     poll" entry (and the empty state's CTA) opens an expanded text field
+//     (keyboard needs .expanded); the typed prompt is parsed LOCALLY by the
+//     shared PollTextParser (now compiled into this target — the precedent for
+//     a pure-Foundation file shared with the App target) into the same poll
+//     shape the in-app search box's top suggestion would make, with a live
+//     preview. options / yes-no polls are created HEADLESSLY (POST /api/polls
+//     with the App-Group identity, mirroring QuickPollService — so the new
+//     poll lands in a PUBLIC group, no bearer bridged) and the fresh poll's
+//     bubble is inserted into the conversation immediately. category polls
+//     (restaurant / time / …) can't be finished in a transcript (they need
+//     time windows / suggestions / a reference location), so they route to the
+//     in-app create form via the same `?create=1&category=…&for=…` deep link
+//     Siri uses — the in-app create path stays exposed (owner constraint:
+//     the composer is additive, never the only way). iOS 16+ (the parser is
+//     gated there); the New-poll entry points are all behind #available.
 //
 // Architectural notes:
 //   • The extension is a SEPARATE target and process. It cannot import
@@ -406,6 +422,78 @@ private enum PollAPI {
         )
     }
 
+    // Phase 4 — headless create from the in-Messages composer. Mirrors
+    // QuickPollService.createPoll (AppDelegate.swift — keep in lockstep): POST
+    // /api/polls with creator_name + an explicit title + the single question the
+    // parser decided, identified by X-Browser-Id (no bearer is bridged, exactly
+    // like the Siri headless create — so the new poll lands in a PUBLIC group,
+    // shareable by canonical URL with no invite mint). Returns a SharablePoll
+    // built from the PollResponse so the composer can immediately insert its
+    // bubble. `.category` never reaches here — the composer routes it to the
+    // create-form deep link (those polls need time windows / suggestions /
+    // reference location the transcript can't collect).
+    @available(iOS 16.0, *)
+    static func createPoll(parsed: PollTextParser.Parsed, name: String, browserId: String?) async throws -> SharablePoll {
+        guard let url = URL(string: apiBase + "/api/polls") else { throw URLError(.badURL) }
+        var question: [String: Any]
+        let title: String
+        switch parsed.kind {
+        case .options:
+            question = [
+                "question_type": "ranked_choice",
+                "options": parsed.options,
+                "winner_method": "consensus",
+            ]
+            if !parsed.context.isEmpty { question["context"] = parsed.context }
+            title = PollTextParser.optionsTitle(parsed.options, context: parsed.context)
+        case .yesNo, .category:
+            question = ["question_type": "yes_no", "context": parsed.prompt]
+            title = PollTextParser.yesNoTitle(parsed.prompt)
+        }
+        let body: [String: Any] = ["creator_name": name, "title": title, "questions": [question]]
+        let request = jsonRequest(url: url, method: "POST", browserId: browserId, body: body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let uuid = nonEmpty(obj["id"] as? String),
+              let shortId = nonEmpty(obj["short_id"] as? String) else {
+            throw URLError(.badServerResponse)
+        }
+        // Same parse as fetchMyPolls (questions[0].title over the display title,
+        // which may carry the group-name override).
+        let questions = obj["questions"] as? [[String: Any]]
+        let pollTitle = nonEmpty(questions?.first?["title"] as? String)
+            ?? nonEmpty(obj["title"] as? String) ?? title
+        return SharablePoll(
+            id: uuid,
+            shortId: shortId,
+            title: pollTitle,
+            groupShortId: nonEmpty(obj["group_short_id"] as? String),
+            groupName: nonEmpty(obj["group_title"] as? String),
+            groupIsPrivate: (obj["group_privacy"] as? String) == "private",
+            isClosed: (obj["is_closed"] as? Bool) ?? false
+        )
+    }
+
+    // Deep link to the in-app create form for a `.category` poll (the composer
+    // can't finish these — they need the form). Mirrors
+    // whoeverwantsCreatePollURL(path:category:context:) (AppDelegate.swift): no
+    // literal title, so the web auto-titles "<Category> for <context>".
+    static func createCategoryURL(category: String, context: String) -> URL? {
+        var c = URLComponents()
+        c.scheme = "https"
+        c.host = feHost
+        c.path = "/g/"
+        var items = [
+            URLQueryItem(name: "create", value: "1"),
+            URLQueryItem(name: "category", value: category),
+        ]
+        let ctx = context.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !ctx.isEmpty { items.append(URLQueryItem(name: "for", value: ctx)) }
+        c.queryItems = items
+        return c.url
+    }
+
     // The endpoint strips microseconds server-side specifically so the strict
     // ISO8601DateFormatter parses it ("2026-06-20T19:00:00+00:00").
     // Configured once and only read afterwards → safe as a static.
@@ -485,8 +573,19 @@ final class ExtensionModel: ObservableObject {
         case failed(URL)
     }
 
+    // Phase 4 compose flow (expanded view; keyboard needs .expanded). Editing →
+    // (creating → editing-on-error) → inserted+dismissed. Equatable so the view
+    // can compare against `.creating` for the in-flight button spinner.
+    enum ComposeState: Equatable {
+        case editing
+        case creating
+        case error(String)
+    }
+
     @Published var pickerState: PickerState = .loading
     @Published var summary: SummaryState?    // non-nil → summary mode (a bubble was tapped)
+    @Published var composing = false         // true → compose mode (supersedes picker)
+    @Published var composeState: ComposeState = .editing
     @Published var insertingPollId: String?  // row spinner while minting/inserting
     @Published var toast: String?
 
@@ -500,10 +599,18 @@ final class ExtensionModel: ObservableObject {
     private var toastDismissTask: Task<Void, Never>?
 
     // Called on every willBecomeActive: route to the summary (a bubble was
-    // tapped → selectedMessage is set) or the picker (drawer opened normally).
+    // tapped → selectedMessage is set), preserve an in-progress compose session
+    // across a background/foreground round-trip, or load the picker.
     func activate(selectedMessageURL: URL?) {
         if let url = selectedMessageURL {
+            // A bubble tap supersedes any compose session.
+            composing = false
             showSummary(for: url)
+        } else if composing {
+            // Stay in compose — don't wipe the user's typed prompt. (Presentation
+            // transitions don't fire willBecomeActive; this only guards an actual
+            // Messages background/foreground while composing.)
+            return
         } else {
             summary = nil
             loadPickerIfStale()
@@ -593,6 +700,95 @@ final class ExtensionModel: ObservableObject {
     func dismissSummary() {
         summary = nil
         loadPickerIfStale()
+    }
+
+    // MARK: Compose (Phase 4 — create a poll without leaving Messages)
+
+    // Enter compose mode. A text field needs keyboard input, which is only
+    // allowed in .expanded (never compact/transcript), so request it.
+    func startCompose() {
+        summary = nil
+        composeState = .editing
+        composing = true
+        host?.requestPresentationStyle(.expanded)
+    }
+
+    func exitCompose() {
+        composing = false
+        composeState = .editing
+        loadPickerIfStale()
+    }
+
+    // Parse the typed prompt LOCALLY (the shared PollTextParser — same decision
+    // the in-app search box's top suggestion makes), then:
+    //   • .category → can't headlessly create (needs the form's time windows /
+    //     suggestions / reference location) → open the prefilled create form in
+    //     the app, same fork as Siri's `.category` deep link. The user finishes
+    //     there and shares from the drawer.
+    //   • .options / .yesNo → create HEADLESSLY (POST /api/polls with the
+    //     App-Group identity) and insert the fresh poll's bubble into the
+    //     conversation. The "killer demo": make + share a poll without leaving
+    //     the chat.
+    // Identity is re-checked here (the picker's New-poll entry is only shown once
+    // there's a bridged identity, but a defensive guard costs nothing).
+    @available(iOS 16.0, *)
+    func createFromCompose(text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, composeState != .creating else { return }
+        guard let identity = BridgedIdentity.load() else {
+            composeState = .error("Open WhoeverWants and set your name to create a poll.")
+            return
+        }
+        let parsed = PollTextParser.decide(trimmed)
+        if parsed.kind == .category, let category = parsed.category {
+            openCategoryForm(category: category, context: parsed.context)
+            return
+        }
+        composeState = .creating
+        Task {
+            do {
+                let poll = try await PollAPI.createPoll(
+                    parsed: parsed, name: identity.name, browserId: identity.browserId
+                )
+                // Public group (no bearer bridged) → canonical URL; shareURL
+                // handles the private case defensively (a fresh headless create
+                // is always public, so it falls straight through).
+                let url = await shareURL(for: poll)
+                host?.insertPollMessage(caption: poll.title, subcaption: poll.groupName, url: url) { [weak self] ok in
+                    if ok {
+                        // insertPollMessage dismissed the drawer; reset so a
+                        // reopen lands on the picker, not a stale compose.
+                        self?.composing = false
+                        self?.composeState = .editing
+                    } else {
+                        // The poll exists — let the user re-share it from the list.
+                        self?.composeState = .error("Created the poll, but couldn't add it to the message. Share it from the list below.")
+                        self?.composing = false
+                        self?.reloadPicker()
+                    }
+                }
+            } catch {
+                composeState = .error("Couldn't create the poll. Check your connection and try again.")
+            }
+        }
+    }
+
+    // Open the in-app create form prefilled to the detected category + context
+    // (`.category` polls finish in the WebView). extensionContext.open is
+    // known-finicky from Messages extensions, so fall back to copying the link.
+    private func openCategoryForm(category: String, context: String) {
+        guard let url = PollAPI.createCategoryURL(category: category, context: context) else {
+            composeState = .error("Couldn't build the create link. Try making this poll in the app.")
+            return
+        }
+        host?.openURL(url) { [weak self] ok in
+            if ok {
+                self?.exitCompose()
+            } else {
+                UIPasteboard.general.url = url
+                self?.composeState = .error("Couldn't open the app — link copied. Paste it in Safari to finish.")
+            }
+        }
     }
 
     // "Open in WhoeverWants": extensionContext.open is known-finicky from
@@ -878,11 +1074,7 @@ struct RootView: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            if let summary = model.summary {
-                SummaryView(model: model, state: summary)
-            } else {
-                PickerView(model: model)
-            }
+            content
             if let toast = model.toast {
                 Text(toast)
                     .font(.footnote)
@@ -893,10 +1085,39 @@ struct RootView: View {
             }
         }
     }
+
+    @ViewBuilder
+    private var content: some View {
+        if model.composing {
+            // #available is the SOLE condition of its branch so the result
+            // builder applies buildLimitedAvailability to the iOS-16-only
+            // ComposeView type (a mixed boolean+availability condition isn't
+            // guaranteed to). The else is unreachable — the New-poll entry
+            // points are themselves iOS-16-gated — but the builder needs it.
+            if #available(iOS 16.0, *) {
+                ComposeView(model: model)
+            } else {
+                PickerView(model: model)
+            }
+        } else if let summary = model.summary {
+            SummaryView(model: model, state: summary)
+        } else {
+            PickerView(model: model)
+        }
+    }
 }
 
 private struct PickerView: View {
     @ObservedObject var model: ExtensionModel
+
+    // Shared "New poll" label (empty-state CTA + loaded-list row). Only the
+    // button chrome differs between the two sites (borderedProminent vs plain +
+    // accent tint), so just the label — the bit that would drift on a rename /
+    // icon swap — is factored out.
+    private var newPollLabel: some View {
+        Label("New poll", systemImage: "square.and.pencil")
+            .font(.body.weight(.medium))
+    }
 
     var body: some View {
         switch model.pickerState {
@@ -916,12 +1137,33 @@ private struct PickerView: View {
                 retryLabel: "Check again"
             ) { model.reloadPicker() }
         case .empty:
-            CenteredMessage(
-                emoji: "🗳️",
-                title: "No polls yet",
-                detail: "Create a poll in WhoeverWants and it'll show up here to share.",
-                retryLabel: "Refresh"
-            ) { model.reloadPicker() }
+            // With the composer (iOS 16+) the empty state is a create CTA, not a
+            // dead end — make a poll right here. Older iOS falls back to the
+            // "create in the app" guidance.
+            if #available(iOS 16.0, *) {
+                VStack(spacing: 8) {
+                    Text("🗳️").font(.system(size: 40))
+                    Text("No polls yet").font(.headline)
+                    Text("Make your first poll and share it without leaving Messages.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                    Button(action: { model.startCompose() }) { newPollLabel }
+                        .buttonStyle(.borderedProminent)
+                        .padding(.top, 4)
+                    Button("Refresh") { model.reloadPicker() }
+                        .buttonStyle(.bordered)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                CenteredMessage(
+                    emoji: "🗳️",
+                    title: "No polls yet",
+                    detail: "Create a poll in WhoeverWants and it'll show up here to share.",
+                    retryLabel: "Refresh"
+                ) { model.reloadPicker() }
+            }
         case .error:
             CenteredMessage(
                 emoji: "📡",
@@ -931,6 +1173,14 @@ private struct PickerView: View {
             ) { model.reloadPicker() }
         case .loaded(let polls):
             List {
+                if #available(iOS 16.0, *) {
+                    Section {
+                        Button(action: { model.startCompose() }) {
+                            newPollLabel.foregroundColor(.accentColor)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
                 Section(header: Text("Share a poll")) {
                     ForEach(polls) { poll in
                         PollRow(
@@ -1123,6 +1373,134 @@ private struct CenteredMessage: View {
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Compose a poll (Phase 4 — create without leaving Messages)
+
+// Expanded-presentation text field → PollTextParser.decide → headless create
+// (options / yes-no) or "open the app to finish" (category). The live preview
+// teaches the box's grammar the same way the in-app search box does: "A, B, or
+// C" → pick-one; "should we…" → yes/no; "movie for friday" → a category poll
+// that opens the app. iOS 16+ (the shared parser is gated there); the New-poll
+// entry points are all behind `#available(iOS 16.0, *)`, so this never mounts
+// on iOS 15.
+@available(iOS 16.0, *)
+private struct ComposeView: View {
+    @ObservedObject var model: ExtensionModel
+    @State private var text = ""
+    @FocusState private var focused: Bool
+
+    private var parsed: PollTextParser.Parsed? {
+        let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? nil : PollTextParser.decide(t)
+    }
+
+    private var creating: Bool { model.composeState == .creating }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { model.exitCompose() }) {
+                Label("Share a poll", systemImage: "chevron.left")
+                    .font(.subheadline)
+            }
+            .padding(.horizontal)
+            .padding(.top, 12)
+            .disabled(creating)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("Ask a question")
+                        .font(.title3.weight(.semibold))
+
+                    TextField("Pizza, tacos, or sushi?", text: $text, axis: .vertical)
+                        .lineLimit(1...4)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($focused)
+                        .disabled(creating)
+
+                    if let parsed {
+                        ComposePreview(parsed: parsed)
+                    }
+
+                    actionButton
+
+                    if case .error(let message) = model.composeState {
+                        Text(message)
+                            .font(.footnote)
+                            .foregroundColor(.red)
+                    }
+
+                    Text("Tip: list choices like “A, B, or C” for a pick-one poll, or ask a yes/no question.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+            }
+        }
+        .onAppear { focused = true }
+    }
+
+    private var actionButton: some View {
+        // `.category` polls can't be finished headlessly — the button opens the
+        // app instead, and the label says so up front (not a surprise tap).
+        let isCategory = parsed?.kind == .category
+        let label = isCategory ? "Open WhoeverWants to finish" : "Create & add to message"
+        return Button(action: { model.createFromCompose(text: text) }) {
+            ZStack {
+                if creating { ProgressView() }
+                Text(label)
+                    .font(.body.weight(.medium))
+                    .opacity(creating ? 0 : 1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(parsed == nil || creating)
+    }
+}
+
+// Live "what poll will this make" preview, mirroring the web search box's top
+// suggestion. The category-label map matches the parser's CategoryDef labels
+// (location → "Place", not "Location").
+@available(iOS 16.0, *)
+private struct ComposePreview: View {
+    let parsed: PollTextParser.Parsed
+
+    private static let categoryLabels: [String: String] = [
+        "restaurant": "Restaurant", "movie": "Movie", "video_game": "Video Game",
+        "time": "Time", "location": "Place", "showtime": "Showtime",
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            switch parsed.kind {
+            case .options:
+                row("Pick one", systemImage: "list.bullet")
+                Text(PollTextParser.optionsTitle(parsed.options, context: parsed.context))
+                    .font(.subheadline)
+            case .yesNo:
+                row("Yes / No", systemImage: "checkmark.circle")
+                Text(PollTextParser.yesNoTitle(parsed.prompt))
+                    .font(.subheadline)
+            case .category:
+                let name = parsed.category.flatMap { Self.categoryLabels[$0] } ?? "Custom"
+                row("\(name) poll", systemImage: "arrow.up.forward.app")
+                Text("Opens WhoeverWants to add details, then share it from the list.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func row(_ title: String, systemImage: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.caption.weight(.medium))
+            .foregroundColor(.secondary)
     }
 }
 

--- a/scripts/ios/add-messages-extension.rb
+++ b/scripts/ios/add-messages-extension.rb
@@ -30,63 +30,78 @@ DEPLOYMENT_TARGET = "15.0"
 
 project = Xcodeproj::Project.open(PROJECT_PATH)
 
-if project.targets.any? { |t| t.name == EXT_NAME }
-  puts "#{EXT_NAME} target already exists — nothing to do."
-  exit 0
+ext = project.targets.find { |t| t.name == EXT_NAME }
+
+if ext.nil?
+  app_target = project.targets.find { |t| t.name == "App" }
+  raise "App target not found" unless app_target
+
+  ext = project.new_target(:messages_extension, EXT_NAME, :ios, DEPLOYMENT_TARGET, nil, :swift)
+
+  # Group holding the extension's sources (path-based so files resolve relative
+  # to ios/App/MessagesExtension).
+  group = project.main_group.new_group(EXT_NAME, EXT_NAME)
+  swift_ref = group.new_reference("MessagesViewController.swift")
+  assets_ref = group.new_reference("Assets.xcassets")
+  group.new_reference("Info.plist") # referenced for the project navigator; not in a build phase
+  group.new_reference("MessagesExtension.entitlements") # navigator only; wired via CODE_SIGN_ENTITLEMENTS
+
+  ext.add_file_references([swift_ref])
+  ext.resources_build_phase.add_file_reference(assets_ref)
+
+  settings = {
+    "PRODUCT_NAME" => "$(TARGET_NAME)",
+    "PRODUCT_BUNDLE_IDENTIFIER" => EXT_BUNDLE_ID,
+    "INFOPLIST_FILE" => "#{EXT_NAME}/Info.plist",
+    "IPHONEOS_DEPLOYMENT_TARGET" => DEPLOYMENT_TARGET,
+    "SWIFT_VERSION" => "5.0",
+    "TARGETED_DEVICE_FAMILY" => "1,2",
+    "CODE_SIGN_STYLE" => "Automatic",
+    "CODE_SIGN_ENTITLEMENTS" => "#{EXT_NAME}/#{EXT_NAME}.entitlements",
+    "GENERATE_INFOPLIST_FILE" => "NO",
+    "ASSETCATALOG_COMPILER_APPICON_NAME" => "iMessage App Icon",
+    "MARKETING_VERSION" => "1.0",
+    "CURRENT_PROJECT_VERSION" => "1",
+    "SKIP_INSTALL" => "NO",
+    "LD_RUNPATH_SEARCH_PATHS" => [
+      "$(inherited)",
+      "@executable_path/Frameworks",
+      "@executable_path/../../Frameworks",
+    ],
+  }
+
+  ext.build_configurations.each do |config|
+    config.build_settings.merge!(settings)
+  end
+
+  # Embed the .appex into the host app + make the app depend on it.
+  app_target.add_dependency(ext)
+  embed_phase = app_target.new_copy_files_build_phase("Embed Foundation Extensions")
+  embed_phase.symbol_dst_subfolder_spec = :plug_ins
+  embed_phase.dst_path = ""
+  build_file = embed_phase.add_file_reference(ext.product_reference)
+  build_file.settings = { "ATTRIBUTES" => ["RemoveHeadersOnCopy"] }
+
+  # Automatic provisioning for the new target.
+  attrs = project.root_object.attributes["TargetAttributes"] ||= {}
+  attrs[ext.uuid] = { "ProvisioningStyle" => "Automatic" }
+
+  puts "Added #{EXT_NAME} target (#{EXT_BUNDLE_ID}) and embedded it in App."
+else
+  puts "#{EXT_NAME} target already exists — ensuring shared sources."
 end
 
-app_target = project.targets.find { |t| t.name == "App" }
-raise "App target not found" unless app_target
-
-ext = project.new_target(:messages_extension, EXT_NAME, :ios, DEPLOYMENT_TARGET, nil, :swift)
-
-# Group holding the extension's sources (path-based so files resolve relative
-# to ios/App/MessagesExtension).
-group = project.main_group.new_group(EXT_NAME, EXT_NAME)
-swift_ref = group.new_reference("MessagesViewController.swift")
-assets_ref = group.new_reference("Assets.xcassets")
-group.new_reference("Info.plist") # referenced for the project navigator; not in a build phase
-group.new_reference("MessagesExtension.entitlements") # navigator only; wired via CODE_SIGN_ENTITLEMENTS
-
-ext.add_file_references([swift_ref])
-ext.resources_build_phase.add_file_reference(assets_ref)
-
-settings = {
-  "PRODUCT_NAME" => "$(TARGET_NAME)",
-  "PRODUCT_BUNDLE_IDENTIFIER" => EXT_BUNDLE_ID,
-  "INFOPLIST_FILE" => "#{EXT_NAME}/Info.plist",
-  "IPHONEOS_DEPLOYMENT_TARGET" => DEPLOYMENT_TARGET,
-  "SWIFT_VERSION" => "5.0",
-  "TARGETED_DEVICE_FAMILY" => "1,2",
-  "CODE_SIGN_STYLE" => "Automatic",
-  "CODE_SIGN_ENTITLEMENTS" => "#{EXT_NAME}/#{EXT_NAME}.entitlements",
-  "GENERATE_INFOPLIST_FILE" => "NO",
-  "ASSETCATALOG_COMPILER_APPICON_NAME" => "iMessage App Icon",
-  "MARKETING_VERSION" => "1.0",
-  "CURRENT_PROJECT_VERSION" => "1",
-  "SKIP_INSTALL" => "NO",
-  "LD_RUNPATH_SEARCH_PATHS" => [
-    "$(inherited)",
-    "@executable_path/Frameworks",
-    "@executable_path/../../Frameworks",
-  ],
-}
-
-ext.build_configurations.each do |config|
-  config.build_settings.merge!(settings)
+# Phase 4 (compose-a-poll-in-Messages) reuses the natural-language parser. Like
+# every other "compile a pure-Foundation file into both targets" case, the
+# extension shares App/PollTextParser.swift rather than duplicating it (it's the
+# documented precedent + carries the JS↔Swift parity contract, so a copy would
+# rot). Idempotent: the existing App-target PBXFileReference is added to the
+# extension's Sources phase only if not already present.
+parser_ref = project.files.find { |f| f.display_name == "PollTextParser.swift" }
+raise "PollTextParser.swift file reference not found in project" unless parser_ref
+unless ext.source_build_phase.files_references.include?(parser_ref)
+  ext.add_file_references([parser_ref])
+  puts "Added PollTextParser.swift to #{EXT_NAME} sources (shared with App)."
 end
-
-# Embed the .appex into the host app + make the app depend on it.
-app_target.add_dependency(ext)
-embed_phase = app_target.new_copy_files_build_phase("Embed Foundation Extensions")
-embed_phase.symbol_dst_subfolder_spec = :plug_ins
-embed_phase.dst_path = ""
-build_file = embed_phase.add_file_reference(ext.product_reference)
-build_file.settings = { "ATTRIBUTES" => ["RemoveHeadersOnCopy"] }
-
-# Automatic provisioning for the new target.
-attrs = project.root_object.attributes["TargetAttributes"] ||= {}
-attrs[ext.uuid] = { "ProvisioningStyle" => "Automatic" }
 
 project.save
-puts "Added #{EXT_NAME} target (#{EXT_BUNDLE_ID}) and embedded it in App."


### PR DESCRIPTION
Decision D from `docs/imessage-extension-plan.md`. Phases 0–3 (share-from-drawer, live transcript bubble, inline voting) already shipped; this adds **compose-and-share a poll without leaving the Messages conversation** — the plan's "killer demo".

## What landed

- A **"New poll"** entry in the drawer (a row above "Share a poll" + the empty-state CTA) opens an expanded text field (keyboard needs `.expanded`) with a **live preview** of the poll the prompt would make.
- The typed prompt is parsed locally by the **shared `PollTextParser`** — the same decision the in-app search box's top suggestion makes:
  - `"pizza, tacos, or sushi"` → a pick-one poll, **created headlessly** (`POST /api/polls` with the App-Group identity, no bearer bridged → a **public** group) and its bubble inserted into the chat immediately.
  - `"should we meet friday"` → a yes/no, same headless create + insert.
  - `"movie for friday"` → a category poll that can't be finished in a transcript (needs time windows / suggestions / reference location), so the button reads **"Open WhoeverWants to finish"** and routes to the in-app create form via the same `?create=1&category=…&for=…` deep link Siri uses. The in-app create path stays exposed (owner constraint: the composer is additive, never the only way).

## Scope / risk

- **Swift-only except one minimal pbxproj change**: `PollTextParser.swift` (a pure-Foundation file already in the App target) is now **compiled into the extension target** rather than duplicated — the documented "shared file compiled into both targets" precedent. `scripts/ios/add-messages-extension.rb` is now idempotent (find-or-create the target, then ensure the parser ref is in its Sources phase). The pbxproj diff is one `PBXBuildFile` reusing the existing file ref — **no new file, no new target**, so the `ios-build.yml` bundle-id sed count is unaffected (still app×2 + ext×2) and the parser parity harness is untouched.
- **No server / migration / entitlement / CI-logic change** — reuses `POST /api/polls` + the existing deep link + the Phase 1 App-Group identity.
- iOS 16+ (the parser is gated there); all New-poll entry points behind `#available`, with `#available` as the *sole* branch condition so the SwiftUI result builder erases the iOS-16-only `ComposeView` type. iOS 15 keeps the prior empty-state guidance (additive).

## Test plan

- [x] CI: green canary build (compiles the parser into the extension + the compose tree, runs the parser parity harness, archives + uploads to TestFlight — verified on run #205 of the pre-rebase SHA; re-running on the rebased SHA).
- [ ] Device/Simulator (owner-owned, like every prior iMessage/Siri phase): drawer shows "New poll"; "pizza, tacos, or sushi" previews a pick-one and creates+inserts it; a "should we…" prompt makes a yes/no; "movie for friday" opens the app's create form; the inserted bubble behaves like any other (live results + inline voting).
- Not demoable on a dev server — native-iOS-only, no web-visible surface (the only web-touching pieces already exist).

Docs: `docs/imessage-extension-plan.md` (Phase 4 marked shipped; the remaining richer-ballot/WKWebView work renumbered to Phase 5) and the CLAUDE.md iMessage section updated.

https://claude.ai/code/session_0198cXa1GWpYqeqySkTX9Muf

---
_Generated by [Claude Code](https://claude.ai/code/session_0198cXa1GWpYqeqySkTX9Muf)_