### PR TITLE
ios: iMessage extension — vote from the expanded summary view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3312,7 +3312,24 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
 > the result builder erases the iOS-16-only `ComposeView` type. **Swift-only
 > EXCEPT the one pbxproj change; no server / migration / entitlement / CI-logic
 > change.** Full shape in the plan doc's Phase 4 section; device verification
-> owner-owned (Simulator works for the inner loop). The remaining "Phase 5"
+> owner-owned (Simulator works for the inner loop). **EXPANDED-VIEW BALLOT
+> (deferred Phase 3/4 item) implemented** on `claude/imessage-integration-plan-z5wtsj`
+> — the tapped-bubble summary (`SummaryView`) is now an inline ballot: a vote
+> row per OPEN `yes_no`/`limited_supply` question (per-question via
+> `ExtensionModel.isBallotVotable`, so MULTI-question polls work, unlike the
+> transcript's single-question gate), edit-not-duplicate via the own-vote fetch,
+> live summary refresh on vote — all reusing the batch `POST /api/polls/{id}/votes`
+> + the App-Group identity (NO server/migration/entitlement/CI/pbxproj change).
+> **In-extension name entry** (the keyboard works in `.expanded`): a recipient
+> with a bridged browser id but no name gets a `TextField` → the typed name is
+> the vote's `voter_name` + `BridgedIdentity.rememberName` mirrors it into the
+> App Group (NOT a `POST /api/auth/account/name` mint — that bearer-less path
+> would orphan an existing browser-tied account via `create_name_only_account`;
+> caveat: the app's `NativeIdentitySync` clears the App-Group name on next
+> launch if the app has no name, so a fully-nameless app user may re-type). A
+> never-opened-the-app recipient (no bridged browser id) gets "Open WhoeverWants
+> once to vote here." Shared `VoteChoiceButton` + top-level `VotingTarget`
+> extracted so transcript + expanded can't drift. The remaining "Phase 5"
 > richer-ballot half (expanded ranked/time ballots or a WKWebView) stays gated
 > on earning it.
 > Owner decisions: ship additive (degraded no-app fallback OK); embed a

--- a/docs/imessage-extension-plan.md
+++ b/docs/imessage-extension-plan.md
@@ -16,8 +16,12 @@
 > Phase 4 section for what landed and the on-device verification owed. Phase 4
 > is Swift-only EXCEPT one pbxproj change (the shared `PollTextParser.swift`
 > compiled into the extension target — the documented precedent): no server /
-> migration / entitlement / CI-logic change.** Owner decisions are resolved
-> (see "Resolved decisions" at the bottom).
+> migration / entitlement / CI-logic change. The deferred **expanded-view
+> ballot** (vote on any yes_no/limited_supply question — including
+> multi-question polls — from the tapped-bubble summary, with in-extension name
+> entry) is now implemented (Swift-only, no server/migration change) — see the
+> "Expanded-view ballot" section.** Owner decisions are resolved (see "Resolved
+> decisions" at the bottom).
 >
 > **Verdict up front: feasible, and `MSMessageLiveLayout` is the right API** — but
 > this is the project's first *additional Xcode target* (a Messages extension is a
@@ -387,10 +391,12 @@ atomic batch `POST /api/polls/{id}/votes` + own-vote `GET /api/questions/{id}/vo
   adds chat noise and correctness never depends on it (other viewers' bubbles
   refresh on their own ≤20s SummaryStore TTL / re-render; the server is the
   source of truth).
-- **Deferred (not in this phase):** voting in the EXPANDED summary view (it stays
-  read-only summary + Open/Copy — multi-question + the nameless "set my name here"
-  flow via `POST /api/auth/account/name` route through Open-in-app for now);
-  multi-question inline voting; the name-entry-in-extension account mint.
+- **Deferred (not in this phase) — NOW SHIPPED in the "Expanded-view ballot"
+  section below:** voting in the EXPANDED summary view, multi-question inline
+  voting, and in-extension name entry for nameless recipients. (The one piece
+  still NOT done: a true account *mint* via `POST /api/auth/account/name` — the
+  expanded ballot uses the typed name as `voter_name` + remembers it in the App
+  Group instead; see that section for why.)
 - Exit criteria: (CI) green canary build (compiles the interactive tree). (Owner,
   device — Simulator works for the inner loop) a single-question yes_no/limited_
   supply bubble shows live vote buttons, tapping Yes/No (or Claim/Decline) records
@@ -452,6 +458,67 @@ ONE pbxproj change; **no server / migration / entitlement / CI-logic change**):
   and creates+inserts it, a "should we…" prompt makes a yes/no, a "movie for
   friday" prompt opens the app's create form, and the inserted bubble behaves
   like any other (live results, Phase 3 inline voting).
+
+### Expanded-view ballot (deferred Phase 3/4 item, SHIPPED, pending device verification)
+
+Make the tapped-bubble expanded summary (`SummaryView`) an INTERACTIVE ballot —
+the natural home for the things the transcript can't do, because `.expanded` is
+the one presentation style that takes keyboard input. All Swift in
+`ios/App/MessagesExtension/MessagesViewController.swift`; **no server, migration,
+entitlement, CI, or pbxproj change** (reuses `/summary`, the atomic batch
+`POST /api/polls/{id}/votes`, the own-vote `GET /api/questions/{id}/votes`, and
+the Phase 1 App-Group identity).
+
+What landed:
+- **Per-question vote rows in the summary.** Each open `yes_no` (Yes / No) or
+  `limited_supply` (Claim / No thanks) question renders inline vote buttons
+  (decision C — ranked / time / showtime stay read-only result lines + "Open in
+  app"). Unlike the transcript's single-question gate
+  (`PollSummary.inlineVotableQuestion`), this is **per-question**
+  (`ExtensionModel.isBallotVotable`), so a **multi-question** poll gets a vote
+  row for each tap-votable question, each submitted independently through the
+  batch endpoint (the endpoint already supports per-item subsets — the in-app
+  wrapper stages subsets too).
+- **In-extension name entry.** A recipient who has USED the app (browser id
+  bridged) but never set a name gets a `TextField` (the keyboard works in
+  `.expanded`); the typed name becomes the vote's `voter_name`. A recipient who
+  has NEVER opened the app (no bridged browser id) can't attribute a vote, so the
+  buttons disable under "Open WhoeverWants once to vote here." When a bridged
+  name exists, no field shows and the buttons are live directly.
+- **NO account mint — typed name is `voter_name` + remembered in the App Group.**
+  Deliberately NOT calling `POST /api/auth/account/name`: that endpoint, for a
+  bearer-less caller (the extension never bridges the bearer), ALWAYS routes to
+  `create_name_only_account`, which mints a NEW account and re-points the browser
+  via `link_browser_to_user` — orphaning any existing browser-tied account (no
+  merge on that path). So instead the typed name rides the vote as `voter_name`
+  (exactly how anonymous web voting attributes), and `BridgedIdentity.rememberName`
+  writes `display_name` into the App Group so the next bubble/transcript vote on
+  this device doesn't re-prompt. Caveat: the app's `NativeIdentitySync` clears
+  that key on next launch if the app itself has no name set, so a fully-nameless
+  app user may have to re-type later — accepted for v1. (A clean account-set would
+  need a bearer-less "set name on the browser's existing-or-new account without
+  duplicating" server path, which doesn't exist yet — out of scope.)
+- **Edit-not-duplicate + live refresh, mirroring the transcript.** On load, the
+  ballot fetches the viewer's own vote per votable question (concurrent
+  `withTaskGroup`, only when a browser id is bridged) → highlights current
+  choices + remembers `vote_id` for edits. A vote force-refreshes the summary
+  (`SummaryStore.refresh`) so the read-only result lines + respondent count
+  update at once. `ballotVoting: VotingTarget?` drives the per-button spinner +
+  re-tap gate; a transient failure leaves the prior ballot untouched.
+- **Shared `VoteChoiceButton`.** The tuned pill (selected tint/outline, in-flight
+  spinner, disabled gate) was extracted from the transcript's `VoteButtonRow` so
+  the transcript + expanded ballot can't drift; `VotingTarget` was lifted to a
+  top-level struct shared by both. State lives on `ExtensionModel`
+  (`ballotVotes` / `ballotVoting` / `ballotName`), reset + name-seeded in
+  `showSummary`.
+- **The sender reaches it too** — tapping their own sent bubble opens the same
+  summary, so the composer→share→vote loop closes without leaving Messages.
+- Exit criteria: (CI) green canary build. (Owner, device — Simulator works for
+  the inner loop) tapping a bubble for a multi-question yes_no/limited_supply
+  poll shows a vote row per question; voting updates counts in place; a second
+  tap edits (doesn't duplicate); a nameless-but-app-used recipient can type a
+  name and vote; a never-opened-the-app recipient sees the "open once" guidance;
+  ranked/time questions stay read-only with Open-in-app.
 
 ### Phase 5 — richer surfaces (only if earlier phases earn it)
 

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -2,8 +2,12 @@ import Messages
 import SwiftUI
 import UIKit
 
-// Phases 1 + 2 of docs/imessage-extension-plan.md — share a poll from the
-// Messages drawer (Phase 1) + the live read-only transcript bubble (Phase 2).
+// Phases 1–4 of docs/imessage-extension-plan.md — share a poll from the
+// Messages drawer (Phase 1), the live transcript bubble (Phase 2) with inline
+// voting (Phase 3), compose-in-Messages (Phase 4), plus the expanded-view
+// ballot (the deferred Phase 3/4 item: vote on ANY votable question — including
+// multi-question polls — from the tapped-bubble summary, with name entry, since
+// .expanded takes keyboard input the transcript can't).
 //
 // What this does:
 //   • Compact/expanded drawer view lists the user's recent polls (the same
@@ -56,7 +60,14 @@ import UIKit
 //     with live results + "Open in WhoeverWants" (extensionContext.open is
 //     famously finicky from Messages extensions, so Copy Link is the always-
 //     available fallback and the open failure path copies too). The summary
-//     consumes the same /summary endpoint + SummaryStore as the bubble.
+//     consumes the same /summary endpoint + SummaryStore as the bubble. It is
+//     also an INLINE BALLOT: each open yes_no / limited_supply question (decision
+//     C) — across multi-question polls too — gets vote buttons, edit-not-
+//     duplicate via the viewer's own-vote fetch, just like the transcript. A
+//     nameless recipient (browser id bridged, no name) gets a name field (the
+//     keyboard works in .expanded), so they vote without leaving Messages; a
+//     never-opened-the-app recipient (no browser id) is guided to open it once.
+//     Voting force-refreshes the summary so the read-only result lines update.
 //   • Phase 4 — COMPOSE a poll without leaving Messages. The drawer's "New
 //     poll" entry (and the empty state's CTA) opens an expanded text field
 //     (keyboard needs .expanded); the typed prompt is parsed LOCALLY by the
@@ -142,6 +153,32 @@ private enum BridgedIdentity {
     // Browser-id-only convenience for the picker fetch + invite mint, which
     // don't need the name. Stays gated on a non-empty name via load().
     static func loadBrowserId() -> String? { load()?.browserId }
+
+    // The bridged browser id WITHOUT the name gate. The expanded-view ballot
+    // (reached by tapping a received bubble) lets a recipient who has USED the
+    // app — so a browser id is bridged — but never set a name TYPE one and
+    // vote, since .expanded allows keyboard input (the transcript doesn't).
+    // load()/loadBrowserId() keep the name gate for the picker + invite mint,
+    // which need a usable named account.
+    static func browserIdUnchecked() -> String? {
+        guard let d = UserDefaults(suiteName: suiteName),
+              let browserId = d.string(forKey: browserIdKey), !browserId.isEmpty else {
+            return nil
+        }
+        return browserId
+    }
+
+    // Persist a name typed in the expanded ballot so the next bubble render /
+    // transcript vote on this device doesn't re-prompt. Best-effort LOCAL
+    // mirror only: the app stays the source of truth and re-syncs its own name
+    // on next launch via NativeIdentitySync (which CLEARS this if the app has
+    // no name set — so a fully-nameless app user may have to re-type later;
+    // accepted for v1).
+    static func rememberName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let d = UserDefaults(suiteName: suiteName) else { return }
+        d.set(trimmed, forKey: nameKey)
+    }
 }
 
 // MARK: - Models
@@ -206,6 +243,17 @@ struct PollSummary {
 // the abstain for yes_no, which the bubble doesn't offer but tolerates).
 struct BubbleVote {
     let voteId: String
+    let yesNoChoice: String?
+    let isAbstain: Bool
+}
+
+// The exact choice being submitted — drives the spinner on the SPECIFIC tapped
+// button (not both, which a "differs from current selection" guess would do for
+// a first-time voter) and gates re-taps until it clears. Shared by the
+// transcript bubble (single votable question) AND the expanded-view ballot
+// (per-question across multi-question polls).
+struct VotingTarget: Equatable {
+    let questionId: String
     let yesNoChoice: String?
     let isAbstain: Bool
 }
@@ -589,6 +637,16 @@ final class ExtensionModel: ObservableObject {
     @Published var insertingPollId: String?  // row spinner while minting/inserting
     @Published var toast: String?
 
+    // Expanded-view ballot (vote from the summary without leaving Messages —
+    // the deferred Phase 3/4 item that .expanded uniquely enables, since it
+    // takes keyboard input). Per-question votes drive the selection highlight +
+    // edit-vs-insert; `ballotVoting` is the in-flight choice (spinner + re-tap
+    // gate); `ballotName` is the voter_name (seeded from the bridged name, or
+    // typed by a nameless recipient). Reset + seeded when a summary opens.
+    @Published var ballotVotes: [String: BubbleVote] = [:]
+    @Published var ballotVoting: VotingTarget?
+    @Published var ballotName: String = ""
+
     weak var host: MessagesViewController?
 
     private var lastFetch: Date?
@@ -682,12 +740,18 @@ final class ExtensionModel: ObservableObject {
             return
         }
         summary = .loading(url)
+        // Fresh ballot per poll; seed the name field from the bridged name
+        // (empty → a nameless recipient types one before voting).
+        ballotVotes = [:]
+        ballotVoting = nil
+        ballotName = BridgedIdentity.load()?.name ?? ""
         Task {
             do {
                 let s = try await SummaryStore.shared.summary(shortId: shortId)
                 // The user may have navigated back to the picker mid-fetch.
                 if case .loading(let pending)? = summary, pending == url {
                     summary = .loaded(s, url)
+                    await loadBallotVotes(s)
                 }
             } catch {
                 if case .loading(let pending)? = summary, pending == url {
@@ -700,6 +764,76 @@ final class ExtensionModel: ObservableObject {
     func dismissSummary() {
         summary = nil
         loadPickerIfStale()
+    }
+
+    // MARK: Expanded-view ballot
+
+    // A question the expanded ballot can submit inline: yes_no / limited_supply
+    // on an open poll (decision C — ranked / time / showtime need ranking /
+    // grids / keyboard and stay read-only + "Open in app"). Unlike the
+    // transcript's single-question `inlineVotableQuestion`, this is per-question,
+    // so a multi-question poll gets a vote row for each tap-votable question.
+    static func isBallotVotable(_ q: QuestionSummary, poll: PollSummary) -> Bool {
+        !poll.isClosed && (q.type == "yes_no" || q.type == "limited_supply")
+    }
+
+    // Fetch the viewer's existing vote for each votable question (only when a
+    // browser id is bridged), so the ballot highlights current choices and edits
+    // rather than duplicates. Concurrent; best-effort (a miss → the row inserts).
+    private func loadBallotVotes(_ summary: PollSummary) async {
+        guard let browserId = BridgedIdentity.browserIdUnchecked() else { return }
+        let votable = summary.questions.filter { Self.isBallotVotable($0, poll: summary) }
+        guard !votable.isEmpty else { return }
+        await withTaskGroup(of: (String, BubbleVote?).self) { group in
+            for q in votable {
+                group.addTask { (q.id, await PollAPI.fetchMyVote(questionId: q.id, browserId: browserId)) }
+            }
+            for await (qid, vote) in group {
+                if let vote = vote { ballotVotes[qid] = vote }
+            }
+        }
+    }
+
+    // Submit one question's choice through the atomic batch endpoint (same path
+    // as the transcript + every other surface). Edits when a prior vote exists
+    // (no duplicate row), else inserts. Re-tapping the current choice is a no-op.
+    // On success, force-refreshes the summary so the read-only result lines +
+    // respondent count reflect the new vote, and remembers a freshly-typed name
+    // so the next bubble doesn't re-prompt. A transient failure leaves the prior
+    // state untouched (the buttons re-enable when `ballotVoting` clears).
+    func voteInBallot(question: QuestionSummary, poll: PollSummary, yesNoChoice: String?, isAbstain: Bool) {
+        guard ballotVoting == nil else { return }
+        let name = ballotName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, let browserId = BridgedIdentity.browserIdUnchecked() else { return }
+        if let mine = ballotVotes[question.id],
+           mine.isAbstain == isAbstain, mine.yesNoChoice == yesNoChoice {
+            return
+        }
+        ballotVoting = VotingTarget(questionId: question.id, yesNoChoice: yesNoChoice, isAbstain: isAbstain)
+        BridgedIdentity.rememberName(name)
+        Task {
+            defer { ballotVoting = nil }
+            do {
+                let submitted = try await PollAPI.submitVote(
+                    pollId: poll.pollId,
+                    questionId: question.id,
+                    voteId: ballotVotes[question.id]?.voteId,
+                    voteType: question.type,
+                    yesNoChoice: yesNoChoice,
+                    isAbstain: isAbstain,
+                    name: name,
+                    browserId: browserId
+                )
+                ballotVotes[question.id] = submitted
+                if case .loaded(_, let url)? = summary,
+                   let short = PollAPI.pollShortId(fromMessageURL: url),
+                   let fresh = try? await SummaryStore.shared.refresh(shortId: short) {
+                    summary = .loaded(fresh, url)
+                }
+            } catch {
+                // Keep the prior ballot; re-taps re-enable via the defer.
+            }
+        }
     }
 
     // MARK: Compose (Phase 4 — create a poll without leaving Messages)
@@ -829,15 +963,6 @@ final class TranscriptBubbleModel: ObservableObject {
         case loading
         case loaded(PollSummary)
         case unavailable   // unparseable url / fetch failed → static fallback
-    }
-
-    // The exact choice being submitted — drives the spinner on the SPECIFIC
-    // tapped button (not both, which a "differs from current selection" guess
-    // would do for a first-time voter) and gates re-taps until it clears.
-    struct VotingTarget: Equatable {
-        let questionId: String
-        let yesNoChoice: String?
-        let isAbstain: Bool
     }
 
     @Published var state: State = .loading
@@ -1279,57 +1404,79 @@ private struct SummaryView: View {
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .loaded(let summary, let url):
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(summary.title)
-                                .font(.title3.weight(.semibold))
-                            HStack(spacing: 6) {
-                                if let group = summary.groupName {
-                                    Text(group)
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                }
-                                Text(summary.isClosed ? "Closed" : "Open")
-                                    .font(.caption)
-                                    .padding(.horizontal, 8)
-                                    .padding(.vertical, 2)
-                                    .background(
-                                        (summary.isClosed ? Color(.systemGray5) : Color.green.opacity(0.15)),
-                                        in: Capsule()
-                                    )
-                                    .foregroundColor(summary.isClosed ? .secondary : .green)
-                            }
-                        }
+                loadedBody(summary: summary, url: url)
+            }
+        }
+    }
 
-                        VStack(alignment: .leading, spacing: 8) {
-                            ForEach(summary.questions) { q in
-                                VStack(alignment: .leading, spacing: 2) {
-                                    if let label = q.label {
-                                        Text(label)
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-                                    Text(q.resultText ?? "—")
-                                        .font(.body)
-                                }
-                            }
-                        }
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+    private func loadedBody(summary: PollSummary, url: URL) -> some View {
+        // Inline voting (decision C) is yes_no / limited_supply on an open poll;
+        // the expanded view adds two things the transcript can't: multi-question
+        // polls (a row per votable question) and name entry (the keyboard works
+        // here). A recipient who's never opened the app has no bridged browser
+        // id, so the vote can't attribute to them — guide them to open it once.
+        let hasVotable = summary.questions.contains { ExtensionModel.isBallotVotable($0, poll: summary) }
+        let hasBrowserId = BridgedIdentity.browserIdUnchecked() != nil
+        let bridgedName = BridgedIdentity.load()?.name
+        let nameFilled = !model.ballotName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let canVote = hasVotable && hasBrowserId && nameFilled
 
-                        if summary.respondentCount > 0 {
-                            Text("\(summary.respondentCount) \(summary.respondentCount == 1 ? "person has" : "people have") responded")
-                                .font(.footnote)
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(summary.title)
+                        .font(.title3.weight(.semibold))
+                    HStack(spacing: 6) {
+                        if let group = summary.groupName {
+                            Text(group)
+                                .font(.subheadline)
                                 .foregroundColor(.secondary)
                         }
-
-                        openButtons(url: url)
+                        Text(summary.isClosed ? "Closed" : "Open")
+                            .font(.caption)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(
+                                (summary.isClosed ? Color(.systemGray5) : Color.green.opacity(0.15)),
+                                in: Capsule()
+                            )
+                            .foregroundColor(summary.isClosed ? .secondary : .green)
                     }
-                    .padding()
                 }
+
+                if hasVotable && !hasBrowserId {
+                    Text("Open WhoeverWants once to vote here.")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                } else if hasVotable && bridgedName == nil {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Your name")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        TextField("Name or alias", text: $model.ballotName)
+                            .textFieldStyle(.roundedBorder)
+                            .submitLabel(.done)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(summary.questions) { q in
+                        BallotQuestionRow(model: model, question: q, poll: summary, canVote: canVote)
+                    }
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+
+                if summary.respondentCount > 0 {
+                    Text("\(summary.respondentCount) \(summary.respondentCount == 1 ? "person has" : "people have") responded")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+
+                openButtons(url: url)
             }
+            .padding()
         }
     }
 
@@ -1349,6 +1496,64 @@ private struct SummaryView: View {
             }
             .buttonStyle(.bordered)
         }
+    }
+}
+
+// One question's row in the expanded ballot: label + server-rendered result +
+// (for an open yes_no/limited_supply question) inline vote buttons. Other types
+// and closed polls render the result only. `canVote` folds the poll-level gates
+// (browser id present + name filled) computed once in SummaryView; the buttons
+// stay disabled while another submit is in flight (`model.ballotVoting`).
+private struct BallotQuestionRow: View {
+    @ObservedObject var model: ExtensionModel
+    let question: QuestionSummary
+    let poll: PollSummary
+    let canVote: Bool
+
+    private var mine: BubbleVote? { model.ballotVotes[question.id] }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let label = question.label {
+                Text(label)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Text(question.resultText ?? "—")
+                .font(.body)
+            if ExtensionModel.isBallotVotable(question, poll: poll) {
+                HStack(spacing: 8) {
+                    if question.type == "yes_no" {
+                        choice("Yes", .green,
+                               selected: mine?.isAbstain == false && mine?.yesNoChoice == "yes",
+                               yesNoChoice: "yes", isAbstain: false)
+                        choice("No", .red,
+                               selected: mine?.isAbstain == false && mine?.yesNoChoice == "no",
+                               yesNoChoice: "no", isAbstain: false)
+                    } else {  // limited_supply
+                        choice("Claim a spot", .green,
+                               selected: mine?.isAbstain == false,
+                               yesNoChoice: nil, isAbstain: false)
+                        choice("No thanks", .secondary,
+                               selected: mine?.isAbstain == true,
+                               yesNoChoice: nil, isAbstain: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func choice(_ title: String, _ color: Color, selected: Bool, yesNoChoice: String?, isAbstain: Bool) -> some View {
+        VoteChoiceButton(
+            title: title, color: color, selected: selected,
+            spinning: model.ballotVoting == VotingTarget(
+                questionId: question.id, yesNoChoice: yesNoChoice, isAbstain: isAbstain
+            ),
+            disabled: !canVote || model.ballotVoting != nil,
+            action: {
+                model.voteInBallot(question: question, poll: poll, yesNoChoice: yesNoChoice, isAbstain: isAbstain)
+            }
+        )
     }
 }
 
@@ -1750,12 +1955,33 @@ private struct VoteButtonRow: View {
         yesNoChoice: String?, isAbstain: Bool
     ) -> some View {
         // Spinner only on the button actually being submitted.
-        let spinning = model.voting == TranscriptBubbleModel.VotingTarget(
+        let spinning = model.voting == VotingTarget(
             questionId: question.id, yesNoChoice: yesNoChoice, isAbstain: isAbstain
         )
-        return Button(action: {
-            model.vote(question: question, poll: poll, yesNoChoice: yesNoChoice, isAbstain: isAbstain)
-        }) {
+        return VoteChoiceButton(
+            title: title, color: color, selected: selected, spinning: spinning,
+            disabled: !hasIdentity || busy,
+            action: {
+                model.vote(question: question, poll: poll, yesNoChoice: yesNoChoice, isAbstain: isAbstain)
+            }
+        )
+    }
+}
+
+// Shared presentational vote button — the tuned pill used by BOTH the transcript
+// VoteButtonRow and the expanded BallotQuestionRow. `selected` tints + outlines
+// the current choice; `spinning` shows the in-flight indicator on the one being
+// submitted; `disabled` covers the no-identity / busy gates the callers compute.
+private struct VoteChoiceButton: View {
+    let title: String
+    let color: Color
+    let selected: Bool
+    let spinning: Bool
+    let disabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
             ZStack {
                 if spinning { ProgressView() }
                 Text(title)
@@ -1775,6 +2001,6 @@ private struct VoteButtonRow: View {
             .foregroundColor(selected ? color : .primary)
         }
         .buttonStyle(.plain)
-        .disabled(!hasIdentity || busy)
+        .disabled(disabled)
     }
 }

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -1510,10 +1510,9 @@ private struct BallotQuestionRow: View {
     let poll: PollSummary
     let canVote: Bool
 
-    private var mine: BubbleVote? { model.ballotVotes[question.id] }
-
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        let mine = model.ballotVotes[question.id]
+        return VStack(alignment: .leading, spacing: 6) {
             if let label = question.label {
                 Text(label)
                     .font(.caption)


### PR DESCRIPTION
## Summary

Continues the iMessage extension plan by implementing the deferred Phase 3/4 item: the tapped-bubble **expanded summary is now an interactive ballot**. `.expanded` is the one presentation style that takes keyboard input, so it's the natural home for the things the transcript bubble can't do.

- **Per-question vote rows** for every open `yes_no` / `limited_supply` question — gated per-question (`ExtensionModel.isBallotVotable`), so **multi-question polls** work (the transcript bubble only does single-question). Ranked/time/showtime stay read-only result lines.
- **Edit-not-duplicate + live refresh**: fetches the viewer's own vote per question on load (highlights current choice, remembers `vote_id`), force-refreshes the summary on vote so result lines update — mirroring the transcript.
- **In-extension name entry**: a recipient with a bridged browser id but no name gets a `TextField`; the typed name becomes the vote's `voter_name` and is mirrored into the App Group so they don't re-type. A never-opened-the-app recipient (no browser id) is guided to "Open WhoeverWants once."
- **Deliberately no `POST /api/auth/account/name` mint** — that bearer-less path would orphan an existing browser-tied account via `create_name_only_account`. Typed-name-as-`voter_name` avoids the footgun.
- Extracted a shared `VoteChoiceButton` + lifted `VotingTarget` to top level so the transcript and expanded ballots can't drift.

**Swift-only**: no server / migration / entitlement / CI / pbxproj change — reuses `/summary`, the batch `POST /api/polls/{id}/votes`, the own-vote `GET /api/questions/{id}/votes`, and the existing App-Group identity. Plan doc + CLAUDE.md updated.

## Test plan

- [x] iOS CI build (compiles + archives + uploads the extension target) — green on the pre-rebase commit (run #209)
- [ ] **Device/Simulator (owner-owned — iMessage extension isn't demoable on dev servers):** tap a multi-question yes_no/limited_supply bubble → a vote row per question; voting updates counts in place; a second tap edits (doesn't duplicate); a nameless-but-app-used recipient can type a name and vote; a never-opened-the-app recipient sees the "open once" guidance; ranked/time questions stay read-only.

https://claude.ai/code/session_01BmVUqMb25XS8rwyAcdxGbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmVUqMb25XS8rwyAcdxGbk)_