### PR TITLE
ios, polls: rank a poll from the iMessage expanded ballot (Phase 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3329,9 +3329,25 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
 > launch if the app has no name, so a fully-nameless app user may re-type). A
 > never-opened-the-app recipient (no bridged browser id) gets "Open WhoeverWants
 > once to vote here." Shared `VoteChoiceButton` + top-level `VotingTarget`
-> extracted so transcript + expanded can't drift. The remaining "Phase 5"
-> richer-ballot half (expanded ranked/time ballots or a WKWebView) stays gated
-> on earning it.
+> extracted so transcript + expanded can't drift.
+> **Phase 5 FIRST INCREMENT — native RANKED-CHOICE expanded ballot** implemented
+> on `claude/imessage-integration-plan-hgt316`: the tapped-bubble summary now
+> lets a recipient RANK a ranked_choice question inline (per-question, so a
+> multi-question poll mixes yes/no + ranked rows). ONE additive server field
+> (`PollSummaryQuestionResponse.options`, surfaced by `_summarize_question` ONLY
+> for ranked_choice with finalized options — null for other types / a ranked
+> poll still in its suggestion phase, which stays read-only; options text only,
+> no metadata) + Swift only (`QuestionSummary.options`, `BubbleVote.rankedChoices`
+> for edit-restore, `submitVote(rankedChoices:)` → `vote_type:"ranked_choice"` +
+> `ranked_choices` through the SAME atomic batch endpoint, STRICT ranking no
+> tiers; `ExtensionModel.ballotRankOrder` working-order + `toggleRank` /
+> `submitRanking`; `BallotQuestionRow.rankedSection` tap-to-rank-with-badges +
+> explicit Submit/Update). NO migration / entitlement / CI / pbxproj change.
+> Transcript inline voting stays yes_no/limited_supply only (a scrolling
+> transcript is the wrong place to build an order). Tests:
+> `server/tests/test_poll_summary.py`. The remaining "Phase 5" halves (expanded
+> TIME/showtime ballots or a WKWebView for every-type-at-once) stay gated on
+> earning it.
 > Owner decisions: ship additive (degraded no-app fallback OK); embed a
 > poll-scoped invite token for private-group bubbles (auto-join); v1 inline
 > voting = yes_no + limited_supply only; pursue compose-in-Messages keeping

--- a/docs/imessage-extension-plan.md
+++ b/docs/imessage-extension-plan.md
@@ -20,8 +20,11 @@
 > ballot** (vote on any yes_no/limited_supply question — including
 > multi-question polls — from the tapped-bubble summary, with in-extension name
 > entry) is now implemented (Swift-only, no server/migration change) — see the
-> "Expanded-view ballot" section.** Owner decisions are resolved (see "Resolved
-> decisions" at the bottom).
+> "Expanded-view ballot" section. Phase 5's FIRST increment — a native
+> RANKED-CHOICE ballot in the expanded view (one additive server field +
+> Swift tap-to-rank UI) — is implemented; the time/showtime + WKWebView halves
+> stay gated. See the Phase 5 section.** Owner decisions are resolved (see
+> "Resolved decisions" at the bottom).
 >
 > **Verdict up front: feasible, and `MSMessageLiveLayout` is the right API** — but
 > this is the project's first *additional Xcode target* (a Messages extension is a
@@ -522,12 +525,52 @@ What landed:
 
 ### Phase 5 — richer surfaces (only if earlier phases earn it)
 
-- Expanded-presentation ballots for ranked/time polls (native), OR a WKWebView in
-  expanded style loading the poll detail page with the session injected via
-  `WKUserScript` (localStorage seed from the App Group identity) — prototype
-  before committing; memory + auth-injection complexity are both real. (This is
-  the remaining half of the original "Phase 4" — the compose half shipped above;
-  this richer-ballot half is still gated on earning it.)
+**Native ranked-choice expanded ballot — SHIPPED, pending device verification.**
+The first Phase 5 increment (owner-greenlit). The expanded summary view's ballot
+(`SummaryView` → `BallotQuestionRow`) now lets a recipient RANK a ranked_choice
+question inline, alongside the existing yes_no/limited_supply rows. Per-question,
+so a multi-question poll can mix a yes/no row and a ranked row. What landed:
+- **Server (one additive field, no migration):** `PollSummaryQuestionResponse`
+  gains `options: list[str] | None`, populated by `_summarize_question`
+  (`routers/polls.py`) ONLY for `ranked_choice` questions with finalized
+  `options` (null for every other type AND for a ranked poll still in its
+  suggestion phase — which therefore stays read-only in the bubble). Options
+  text only, no `options_metadata` (the bubble renders plain labels). Tests:
+  `test_poll_summary.py` (`test_options_only_surfaced_for_ranked_choice` +
+  the ranked-winner test now asserts `options`).
+- **Swift (all in `MessagesViewController.swift`, no entitlement/CI/pbxproj
+  change):** `QuestionSummary.options` parsed from `/summary`; `BubbleVote`
+  gains `rankedChoices` (parsed from the own-vote GET + the POST response) so an
+  edit restores the viewer's prior order; `submitVote` gains a defaulted
+  `rankedChoices:` param sending `vote_type:"ranked_choice"` + `ranked_choices`
+  through the SAME atomic batch endpoint (strict ranking, NO tiers — the bubble
+  is a "simple taps" surface, and the server treats a missing
+  `ranked_choice_tiers` as singleton tiers). `ExtensionModel.isBallotVotable`
+  extends to ranked (open + ≥2 options); `ballotRankOrder` (per-question working
+  order, seeded from the existing vote in `loadBallotVotes`, reset in
+  `showSummary`) drives a tap-to-rank UI (`rankedSection` in `BallotQuestionRow`:
+  tap an option to append it in preference order with its rank badge, tap again
+  to remove) + an explicit Submit/Update button (`submitRanking` — ranking isn't
+  a single tap; edit-not-duplicate + live `SummaryStore.refresh`, mirroring
+  `voteInBallot`). `VotingTarget(questionId, nil, false)` drives the submit
+  spinner + re-tap gate (no collision — a question is ranked XOR
+  limited_supply). Transcript inline voting stays yes_no/limited_supply only
+  (decision C — a scrolling transcript is the wrong place to build up an order).
+- Exit criteria: (CI) green canary build (compiles the ranked ballot). (Owner,
+  device — Simulator works for the inner loop) tapping a bubble for a
+  ranked_choice poll shows the candidate list; tapping options builds a numbered
+  ranking; Submit records the vote + updates the result line; a second pass
+  Updates (doesn't duplicate); a closed or suggestion-phase ranked poll stays
+  read-only; multi-question polls mixing yes/no + ranked show both row types.
+
+**Still gated (not yet earned):**
+- Expanded-presentation ballots for **time/showtime** polls (native) — the
+  availability/preference grid is heavy even in-app; deferred until the bubble
+  proves worth it on device.
+- A **WKWebView** in expanded style loading the poll detail page with the
+  session injected via `WKUserScript` (localStorage seed from the App Group
+  identity) — would unlock every type at once, but prototype before committing;
+  memory + auth-injection complexity are both real.
 
 ## Resolved decisions (owner, June 2026)
 

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -203,6 +203,10 @@ struct QuestionSummary: Identifiable {
     let resultText: String?   // server-rendered one-line result
     let yesCount: Int?
     let noCount: Int?
+    // Candidate list for the expanded ranked ballot (Phase 5) — server
+    // surfaces it only for ranked_choice with finalized options; nil for
+    // every other type and for a ranked poll still in its suggestion phase.
+    let options: [String]?
 }
 
 struct PollSummary {
@@ -245,6 +249,9 @@ struct BubbleVote {
     let voteId: String
     let yesNoChoice: String?
     let isAbstain: Bool
+    // The viewer's existing ranking, so the expanded ranked ballot (Phase 5)
+    // restores their order on edit. nil for non-ranked votes.
+    let rankedChoices: [String]?
 }
 
 // The exact choice being submitted — drives the spinner on the SPECIFIC tapped
@@ -264,6 +271,9 @@ private enum PollAPI {
     // Treat empty strings as absent — the API can return "" for an unset
     // override, which should never surface as a title / id / group.
     static func nonEmpty(_ s: String?) -> String? { s.flatMap { $0.isEmpty ? nil : $0 } }
+    // Array sibling — an empty array (e.g. options on a non-ranked question) is
+    // "absent" the same way an empty string is.
+    static func nonEmpty(_ a: [String]?) -> [String]? { a.flatMap { $0.isEmpty ? nil : $0 } }
 
     private static func jsonRequest(url: URL, method: String, browserId: String?, body: [String: Any]? = nil) -> URLRequest {
         var request = URLRequest(url: url)
@@ -400,7 +410,8 @@ private enum PollAPI {
                 type: (q["question_type"] as? String) ?? "yes_no",
                 resultText: nonEmpty(q["result_text"] as? String),
                 yesCount: q["yes_count"] as? Int,
-                noCount: q["no_count"] as? Int
+                noCount: q["no_count"] as? Int,
+                options: nonEmpty(q["options"] as? [String])
             )
         }
         return PollSummary(
@@ -423,7 +434,8 @@ private enum PollAPI {
     // row so the bubble can update its selection without a separate re-fetch.
     static func submitVote(
         pollId: String, questionId: String, voteId: String?, voteType: String,
-        yesNoChoice: String?, isAbstain: Bool, name: String, browserId: String
+        yesNoChoice: String?, isAbstain: Bool, rankedChoices: [String]? = nil,
+        name: String, browserId: String
     ) async throws -> BubbleVote {
         guard let url = URL(string: apiBase + "/api/polls/\(pollId)/votes") else { throw URLError(.badURL) }
         var item: [String: Any] = ["question_id": questionId, "is_abstain": isAbstain]
@@ -433,6 +445,10 @@ private enum PollAPI {
             item["vote_type"] = voteType   // insert
         }
         if let choice = yesNoChoice { item["yes_no_choice"] = choice }
+        // Strict ranking only (no tiers/equal rankings — the transcript can't
+        // express them); the server treats a missing ranked_choice_tiers as
+        // singleton tiers from this flat list.
+        if let ranked = rankedChoices { item["ranked_choices"] = ranked }
         let body: [String: Any] = ["voter_name": name, "items": [item]]
         let request = jsonRequest(url: url, method: "POST", browserId: browserId, body: body)
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -445,7 +461,8 @@ private enum PollAPI {
         return BubbleVote(
             voteId: vid,
             yesNoChoice: nonEmpty(row["yes_no_choice"] as? String),
-            isAbstain: (row["is_abstain"] as? Bool) ?? false
+            isAbstain: (row["is_abstain"] as? Bool) ?? false,
+            rankedChoices: nonEmpty(row["ranked_choices"] as? [String])
         )
     }
 
@@ -466,7 +483,8 @@ private enum PollAPI {
         return BubbleVote(
             voteId: vid,
             yesNoChoice: nonEmpty(row["yes_no_choice"] as? String),
-            isAbstain: (row["is_abstain"] as? Bool) ?? false
+            isAbstain: (row["is_abstain"] as? Bool) ?? false,
+            rankedChoices: nonEmpty(row["ranked_choices"] as? [String])
         )
     }
 
@@ -646,6 +664,12 @@ final class ExtensionModel: ObservableObject {
     @Published var ballotVotes: [String: BubbleVote] = [:]
     @Published var ballotVoting: VotingTarget?
     @Published var ballotName: String = ""
+    // Per-question working ranking for the expanded ranked ballot (Phase 5).
+    // questionId → ordered option texts (best first). Built up by tapping
+    // options in order; seeded from the viewer's existing vote on load, so an
+    // edit starts from their prior order. Submitted explicitly (ranking isn't a
+    // single tap), unlike yes_no/limited_supply which submit on tap.
+    @Published var ballotRankOrder: [String: [String]] = [:]
 
     weak var host: MessagesViewController?
 
@@ -744,6 +768,7 @@ final class ExtensionModel: ObservableObject {
         // (empty → a nameless recipient types one before voting).
         ballotVotes = [:]
         ballotVoting = nil
+        ballotRankOrder = [:]
         ballotName = BridgedIdentity.load()?.name ?? ""
         Task {
             do {
@@ -769,12 +794,22 @@ final class ExtensionModel: ObservableObject {
     // MARK: Expanded-view ballot
 
     // A question the expanded ballot can submit inline: yes_no / limited_supply
-    // on an open poll (decision C — ranked / time / showtime need ranking /
-    // grids / keyboard and stay read-only + "Open in app"). Unlike the
-    // transcript's single-question `inlineVotableQuestion`, this is per-question,
-    // so a multi-question poll gets a vote row for each tap-votable question.
+    // (tap → submit) OR ranked_choice with ≥2 finalized options (tap-to-rank →
+    // explicit submit — Phase 5). The expanded view uniquely allows ranking
+    // because it isn't a scrolling transcript; the transcript bubble stays
+    // yes_no/limited_supply only (decision C). Time / showtime still need
+    // grids and stay read-only + "Open in app". A ranked poll in its suggestion
+    // phase has no finalized options (options nil) → not yet rankable here.
+    // Unlike the transcript's single-question `inlineVotableQuestion`, this is
+    // per-question, so a multi-question poll gets a vote row for each votable
+    // question.
     static func isBallotVotable(_ q: QuestionSummary, poll: PollSummary) -> Bool {
-        !poll.isClosed && (q.type == "yes_no" || q.type == "limited_supply")
+        guard !poll.isClosed else { return false }
+        switch q.type {
+        case "yes_no", "limited_supply": return true
+        case "ranked_choice": return (q.options?.count ?? 0) >= 2
+        default: return false
+        }
     }
 
     // Fetch the viewer's existing vote for each votable question (only when a
@@ -789,7 +824,17 @@ final class ExtensionModel: ObservableObject {
                 group.addTask { (q.id, await PollAPI.fetchMyVote(questionId: q.id, browserId: browserId)) }
             }
             for await (qid, vote) in group {
-                if let vote = vote { ballotVotes[qid] = vote }
+                if let vote = vote {
+                    ballotVotes[qid] = vote
+                    // Seed the ranked ballot's working order from the existing
+                    // vote (filtered to options still on the ballot) so an edit
+                    // starts from the viewer's prior ranking.
+                    if let ranked = vote.rankedChoices,
+                       let opts = summary.questions.first(where: { $0.id == qid })?.options {
+                        let valid = Set(opts)
+                        ballotRankOrder[qid] = ranked.filter { valid.contains($0) }
+                    }
+                }
             }
         }
     }
@@ -832,6 +877,61 @@ final class ExtensionModel: ObservableObject {
                 }
             } catch {
                 // Keep the prior ballot; re-taps re-enable via the defer.
+            }
+        }
+    }
+
+    // Toggle an option in the working ranking (Phase 5): tap an unranked option
+    // to append it (it becomes the next preference), tap a ranked one to remove
+    // it (the rest renumber implicitly). No-op while a submit is in flight.
+    func toggleRank(questionId: String, option: String) {
+        guard ballotVoting == nil else { return }
+        var order = ballotRankOrder[questionId] ?? []
+        if let idx = order.firstIndex(of: option) {
+            order.remove(at: idx)
+        } else {
+            order.append(option)
+        }
+        ballotRankOrder[questionId] = order
+    }
+
+    // Submit the working ranking through the same atomic batch endpoint
+    // (vote_type "ranked_choice"; ranked_choices = the ordered list). Edits when
+    // a prior vote exists (no duplicate); no-op when the order is empty or
+    // unchanged. Mirrors voteInBallot's gating + live refresh; `ballotVoting`
+    // (yesNoChoice nil) drives the submit-button spinner + re-tap gate.
+    func submitRanking(question: QuestionSummary, poll: PollSummary) {
+        guard ballotVoting == nil else { return }
+        let name = ballotName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let order = ballotRankOrder[question.id] ?? []
+        guard !name.isEmpty, !order.isEmpty,
+              let browserId = BridgedIdentity.browserIdUnchecked() else { return }
+        if let mine = ballotVotes[question.id], mine.rankedChoices == order { return }
+        ballotVoting = VotingTarget(questionId: question.id, yesNoChoice: nil, isAbstain: false)
+        BridgedIdentity.rememberName(name)
+        Task {
+            defer { ballotVoting = nil }
+            do {
+                let submitted = try await PollAPI.submitVote(
+                    pollId: poll.pollId,
+                    questionId: question.id,
+                    voteId: ballotVotes[question.id]?.voteId,
+                    voteType: "ranked_choice",
+                    yesNoChoice: nil,
+                    isAbstain: false,
+                    rankedChoices: order,
+                    name: name,
+                    browserId: browserId
+                )
+                ballotVotes[question.id] = submitted
+                ballotRankOrder[question.id] = submitted.rankedChoices ?? order
+                if case .loaded(_, let url)? = summary,
+                   let short = PollAPI.pollShortId(fromMessageURL: url),
+                   let fresh = try? await SummaryStore.shared.refresh(shortId: short) {
+                    summary = .loaded(fresh, url)
+                }
+            } catch {
+                // Keep the prior ranking; re-submit re-enables via the defer.
             }
         }
     }
@@ -1521,24 +1621,84 @@ private struct BallotQuestionRow: View {
             Text(question.resultText ?? "—")
                 .font(.body)
             if ExtensionModel.isBallotVotable(question, poll: poll) {
-                HStack(spacing: 8) {
-                    if question.type == "yes_no" {
-                        choice("Yes", .green,
-                               selected: mine?.isAbstain == false && mine?.yesNoChoice == "yes",
-                               yesNoChoice: "yes", isAbstain: false)
-                        choice("No", .red,
-                               selected: mine?.isAbstain == false && mine?.yesNoChoice == "no",
-                               yesNoChoice: "no", isAbstain: false)
-                    } else {  // limited_supply
-                        choice("Claim a spot", .green,
-                               selected: mine?.isAbstain == false,
-                               yesNoChoice: nil, isAbstain: false)
-                        choice("No thanks", .secondary,
-                               selected: mine?.isAbstain == true,
-                               yesNoChoice: nil, isAbstain: true)
+                if question.type == "ranked_choice" {
+                    rankedSection
+                } else {
+                    HStack(spacing: 8) {
+                        if question.type == "yes_no" {
+                            choice("Yes", .green,
+                                   selected: mine?.isAbstain == false && mine?.yesNoChoice == "yes",
+                                   yesNoChoice: "yes", isAbstain: false)
+                            choice("No", .red,
+                                   selected: mine?.isAbstain == false && mine?.yesNoChoice == "no",
+                                   yesNoChoice: "no", isAbstain: false)
+                        } else {  // limited_supply
+                            choice("Claim a spot", .green,
+                                   selected: mine?.isAbstain == false,
+                                   yesNoChoice: nil, isAbstain: false)
+                            choice("No thanks", .secondary,
+                                   selected: mine?.isAbstain == true,
+                                   yesNoChoice: nil, isAbstain: true)
+                        }
                     }
                 }
             }
+        }
+    }
+
+    // Tap-to-rank ballot: tap options in preference order (each shows its rank
+    // number), tap again to remove. An explicit Submit applies the order (ranking
+    // isn't a single tap, unlike yes_no/limited_supply). Strict ranking only — no
+    // tiers (the bubble is a "simple taps" surface per Apple's live-layout rules).
+    @ViewBuilder private var rankedSection: some View {
+        let order = model.ballotRankOrder[question.id] ?? []
+        let spinning = model.ballotVoting == VotingTarget(
+            questionId: question.id, yesNoChoice: nil, isAbstain: false
+        )
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Tap to rank in order")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            ForEach(question.options ?? [], id: \.self) { opt in
+                let rank = order.firstIndex(of: opt).map { $0 + 1 }
+                Button(action: {
+                    model.toggleRank(questionId: question.id, option: opt)
+                }) {
+                    HStack(spacing: 8) {
+                        ZStack {
+                            Circle()
+                                .strokeBorder(rank != nil ? Color.accentColor : Color(.systemGray3), lineWidth: 1.5)
+                                .background(Circle().fill(rank != nil ? Color.accentColor : Color.clear))
+                                .frame(width: 22, height: 22)
+                            if let rank = rank {
+                                Text("\(rank)")
+                                    .font(.caption.weight(.bold))
+                                    .foregroundColor(.white)
+                            }
+                        }
+                        Text(opt)
+                            .font(.body)
+                            .foregroundColor(.primary)
+                            .multilineTextAlignment(.leading)
+                        Spacer(minLength: 0)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!canVote || model.ballotVoting != nil)
+            }
+            Button(action: { model.submitRanking(question: question, poll: poll) }) {
+                HStack(spacing: 6) {
+                    if spinning { ProgressView().controlSize(.small) }
+                    Text(model.ballotVotes[question.id] == nil ? "Submit ranking" : "Update ranking")
+                        .font(.subheadline.weight(.medium))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!canVote || model.ballotVoting != nil || order.isEmpty)
+            .padding(.top, 2)
         }
     }
 

--- a/server/models.py
+++ b/server/models.py
@@ -614,6 +614,12 @@ class PollSummaryQuestionResponse(BaseModel):
     no_count: int | None = None
     secured_count: int | None = None
     supply_count: int | None = None
+    # The candidate list to rank, surfaced ONLY for ranked_choice questions
+    # whose options are finalized (null otherwise, and null for a ranked poll
+    # still in its suggestion phase). Drives the iMessage expanded-view ranked
+    # ballot (docs/imessage-extension-plan.md Phase 5); other surfaces ignore
+    # it. Options text only — no metadata (the bubble renders plain labels).
+    options: list[str] | None = None
 
 
 class PollSummaryResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -1488,6 +1488,12 @@ def _summarize_question(
         text = f"{n} response{'' if n == 1 else 's'}"
     else:
         text = "No votes yet"
+    # Surface the candidate list ONLY for ranked_choice with finalized options
+    # — the iMessage expanded ballot ranks them (Phase 5). A ranked poll still
+    # in its suggestion phase has options=None, which the bubble reads as
+    # not-yet-rankable (read-only). Plain text, no metadata.
+    opts = question_row.get("options")
+    options = list(opts) if qtype == "ranked_choice" and opts else None
     return PollSummaryQuestionResponse(
         id=str(question_row["id"]),
         label=_summary_question_label(question_row, multi),
@@ -1498,6 +1504,7 @@ def _summarize_question(
         no_count=results.no_count,
         secured_count=results.secured_count,
         supply_count=results.supply_count,
+        options=options,
     )
 
 

--- a/server/tests/test_poll_summary.py
+++ b/server/tests/test_poll_summary.py
@@ -124,10 +124,33 @@ class TestPollSummary:
         assert resp.status_code == 201, resp.text
         s_open = _summary(client, poll)
         assert s_open["questions"][0]["result_text"] == "Leading: Thai"
+        # The expanded ranked ballot (Phase 5) needs the candidate list.
+        assert s_open["questions"][0]["options"] == ["Thai", "Sushi"]
         assert close_poll(client, poll).status_code == 200
         s_closed = _summary(client, poll)
         assert s_closed["is_closed"] is True
         assert s_closed["questions"][0]["result_text"] == "Winner: Thai"
+
+    def test_options_only_surfaced_for_ranked_choice(self, client):
+        """`options` rides only ranked_choice questions (the ballot ranks
+        them); yes_no / limited_supply leave it null so the bubble never tries
+        to rank a two-button question."""
+        poll = create_poll(
+            client,
+            questions=[
+                yes_no_question(context="Up for it?"),
+                {
+                    "question_type": "ranked_choice",
+                    "category": "custom",
+                    "context": "Dinner",
+                    "options": ["Thai", "Sushi", "Pizza"],
+                },
+            ],
+        )
+        s = _summary(client, poll)
+        by_type = {q["question_type"]: q for q in s["questions"]}
+        assert by_type["yes_no"]["options"] is None
+        assert by_type["ranked_choice"]["options"] == ["Thai", "Sushi", "Pizza"]
 
     def test_limited_supply_claimed_line(self, client):
         poll = create_poll(


### PR DESCRIPTION
## Summary

Phase 5's first increment of the iMessage extension (`docs/imessage-extension-plan.md`): the tapped-bubble **expanded summary** now lets a recipient **rank a ranked_choice question inline**, alongside the existing yes_no / limited_supply rows. Per-question, so a multi-question poll mixes a yes/no row and a ranked row.

The owner chose the native ranked-choice ballot as the first Phase 5 step (over the time/showtime grid and the WKWebView route, both still gated).

### Server (one additive field, no migration)
- `PollSummaryQuestionResponse.options`, surfaced by `_summarize_question` **only** for `ranked_choice` questions with finalized options — null for every other type and for a ranked poll still in its suggestion phase (so those stay read-only in the bubble). Options text only, no metadata. (Deliberately NOT reused from `_compute_results.options`, which leaks tentative suggestion-phase options.)

### Swift (`MessagesViewController.swift` — no entitlement / CI / pbxproj change)
- `QuestionSummary.options` parsed from `/summary`; `BubbleVote.rankedChoices` so an edit restores the viewer's prior order.
- `submitVote(rankedChoices:)` sends `vote_type:"ranked_choice"` + `ranked_choices` through the **same atomic batch endpoint** every surface uses (strict ranking, no tiers — the bubble is a "simple taps" surface; the server treats a missing `ranked_choice_tiers` as singleton tiers).
- `isBallotVotable` extends to ranked (open + ≥2 options); `ballotRankOrder` working order (seeded from the existing vote, reset on open) + `toggleRank`/`submitRanking` drive a tap-to-rank-with-numbered-badges UI (`rankedSection`) with an explicit Submit/Update button — edit-not-duplicate + live `SummaryStore.refresh`, mirroring `voteInBallot`.
- Transcript inline voting stays yes_no/limited_supply only.

## Test plan
- [x] `server/tests/test_poll_summary.py` — 10/10 (2 new ranked-options assertions: surfaced for ranked, null for yes_no)
- [x] `test_polls_api.py` + `test_ballot_privacy.py` green (72 total)
- [x] Live API demo on the branch dev server: `GET /api/polls/<short>/summary` returns the candidate list for a ranked poll
- [ ] **Owner / device**: rank a poll from a Messages bubble on a real iPhone (native-iOS-only, like every prior iMessage phase)

🤖 native ballot UI needs on-device verification; the server contract is web-demoable.

https://claude.ai/code/session_011TWcKaZ7jjYg5YiqvC6hdR
