### PR TITLE
ios, polls: native time/showtime ballot in the iMessage expanded view (Phase 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3345,9 +3345,35 @@ Full phased plan: `docs/siri-integration-plan.md` (working order 1 → 2 → 3 �
 > explicit Submit/Update). NO migration / entitlement / CI / pbxproj change.
 > Transcript inline voting stays yes_no/limited_supply only (a scrolling
 > transcript is the wrong place to build an order). Tests:
-> `server/tests/test_poll_summary.py`. The remaining "Phase 5" halves (expanded
-> TIME/showtime ballots or a WKWebView for every-type-at-once) stay gated on
-> earning it.
+> `server/tests/test_poll_summary.py`.
+> **Phase 5 SECOND INCREMENT — native TIME/SHOWTIME expanded ballot** implemented
+> on `claude/imessage-integration-plan-u347uv`: the tapped-bubble summary now lets
+> a recipient mark **want / neutral / can't** on a finalized `time` / `showtime`
+> question (per-question, so a multi-question poll mixes any row types) — so the
+> expanded view covers native voting for every type except a still-collecting-
+> availability time poll (read-only by design). ONE additive server field
+> (`PollSummaryQuestionResponse.slots: list[PollSummarySlot]` = `{key,label}`,
+> surfaced by `_summarize_question` ONLY for finalized time/showtime — null for
+> other types, an availability-phase time poll (`options=None`), and a cancelled
+> event; `label` = `_format_slot_label(key)` server-rendered since the Swift
+> slot-label mirror was deleted in Phase 2; a NEW field, not reusing `options`,
+> because a slot's display label ≠ its vote-payload key) + Swift only
+> (`QuestionSummary.slots`; `BubbleVote` gains `likedSlots`/`dislikedSlots` for
+> edit-restore PLUS opaque `voterDayTimeWindows`/`voterDuration`/
+> `voterMinParticipants` passthrough — the server DIRECT-WRITES these on a time
+> edit, NOT COALESCE, so a preference edit must re-send the voter's stored
+> availability or it clobbers it + the winner headcount; a shared
+> `BubbleVote.parse(row)` now backs both the own-vote GET + the POST response;
+> `submitVote` gains defaulted slot/availability params → `vote_type:"time"`/
+> `"showtime"` through the SAME atomic batch endpoint; `isBallotVotable` extends
+> to time/showtime (open + ≥1 slot); `ballotSlots` (questionId→slotKey→
+> `.like`/`.dislike`, absent = neutral) + `cycleSlot`/`submitSlots`;
+> `BallotQuestionRow.slotSection` tap-to-cycle 👍/👎 + explicit Submit/Update).
+> NO migration / entitlement / CI / pbxproj change. Transcript inline voting
+> stays yes_no/limited_supply only (a scrolling transcript is the wrong place for
+> a slot grid). Tests: `server/tests/test_poll_summary.py::TestSummarySlots`.
+> The remaining "Phase 5" half (a WKWebView for every-type-at-once) stays gated
+> on earning it.
 > Owner decisions: ship additive (degraded no-app fallback OK); embed a
 > poll-scoped invite token for private-group bubbles (auto-join); v1 inline
 > voting = yes_no + limited_supply only; pursue compose-in-Messages keeping

--- a/docs/imessage-extension-plan.md
+++ b/docs/imessage-extension-plan.md
@@ -22,8 +22,12 @@
 > entry) is now implemented (Swift-only, no server/migration change) — see the
 > "Expanded-view ballot" section. Phase 5's FIRST increment — a native
 > RANKED-CHOICE ballot in the expanded view (one additive server field +
-> Swift tap-to-rank UI) — is implemented; the time/showtime + WKWebView halves
-> stay gated. See the Phase 5 section.** Owner decisions are resolved (see
+> Swift tap-to-rank UI) — is implemented; the SECOND increment — a native
+> TIME/SHOWTIME want/neutral/can't ballot in the expanded view (one more
+> additive `slots` field + Swift tap-to-cycle UI) — is now implemented too, so
+> the expanded view covers native voting for every type except a
+> still-collecting-availability time poll. Only the WKWebView half stays gated.
+> See the Phase 5 section.** Owner decisions are resolved (see
 > "Resolved decisions" at the bottom).
 >
 > **Verdict up front: feasible, and `MSMessageLiveLayout` is the right API** — but
@@ -563,10 +567,53 @@ so a multi-question poll can mix a yes/no row and a ranked row. What landed:
   Updates (doesn't duplicate); a closed or suggestion-phase ranked poll stays
   read-only; multi-question polls mixing yes/no + ranked show both row types.
 
+**Native time/showtime expanded ballot — SHIPPED, pending device verification.**
+The second Phase 5 increment (owner-greenlit). The expanded summary's ballot now
+lets a recipient mark **want / neutral / can't** on a finalized `time` or
+`showtime` question, alongside the yes_no/limited_supply/ranked rows — so the
+expanded view now covers native voting for EVERY question type except a
+still-collecting-availability time poll (read-only by design). Per-question, so a
+multi-question poll mixes any of the row types. What landed:
+- **Server (one additive field, no migration):** `PollSummaryQuestionResponse`
+  gains `slots: list[PollSummarySlot] | None` (`PollSummarySlot = {key, label}`),
+  populated by `_summarize_question` (`routers/polls.py`) ONLY for finalized
+  `time` / `showtime` questions — null for every other type, for a time poll
+  still collecting availability (`options=None` → read-only), and for a cancelled
+  "event's off" poll. `key` is the `liked_slots`/`disliked_slots` payload value;
+  `label` is `_format_slot_label(key)` server-rendered (the Swift slot-label
+  mirror was deleted in Phase 2, so the label MUST come from the server). A new
+  `slots` field — NOT reusing `options` — because a slot's display label differs
+  from its vote-payload key (ranked options are both). Tests:
+  `test_poll_summary.py::TestSummarySlots`.
+- **Swift (all in `MessagesViewController.swift`, no entitlement/CI/pbxproj
+  change):** `QuestionSummary.slots` (parsed from `/summary` into a `SlotSummary
+  {key,label}`); `BubbleVote` gains `likedSlots`/`dislikedSlots` (restore the
+  viewer's marks on edit) PLUS opaque `voterDayTimeWindows`/`voterDuration`/
+  `voterMinParticipants` (a `[[String:Any]]`/`[String:Any]`/`Int` passthrough —
+  the server DIRECT-WRITES these on a time edit, NOT COALESCE, so a preference
+  edit MUST re-send the voter's stored availability or it clobbers it + the
+  winner's slot-availability headcount). `submitVote` gains defaulted
+  `likedSlots`/`dislikedSlots`/availability params sending `vote_type:"time"`/
+  `"showtime"` through the SAME atomic batch endpoint. A shared
+  `BubbleVote.parse(row)` factory now backs both the own-vote GET and the POST
+  response (they share the VoteResponse shape) so the parse can't drift.
+  `ExtensionModel.isBallotVotable` extends to `time`/`showtime` (open + ≥1 slot);
+  `ballotSlots` (questionId → slotKey → `.like`/`.dislike`, absent = neutral;
+  seeded from the existing vote in `loadBallotVotes`, reset in `showSummary`)
+  drives a tap-to-cycle UI (`slotSection` in `BallotQuestionRow`: tap a slot to
+  cycle neutral → want → can't, 👍/👎 indicator) + an explicit Submit/Update
+  (`submitSlots` — preferences aren't a single tap; edit-not-duplicate + live
+  `SummaryStore.refresh`). Transcript inline voting stays yes_no/limited_supply
+  only (decision C — a scrolling transcript is the wrong place for a slot grid).
+- Exit criteria: (CI) green canary build (compiles the slot ballot). (Owner,
+  device — Simulator works for the inner loop) tapping a bubble for a finalized
+  time / showtime poll shows the candidate slots; tapping cycles want/can't/skip;
+  Submit records the vote + updates the "Leading:" line; a second pass Updates
+  (doesn't duplicate) AND preserves any in-app-submitted availability; a time
+  poll still collecting availability stays read-only; multi-question polls mixing
+  types show each row.
+
 **Still gated (not yet earned):**
-- Expanded-presentation ballots for **time/showtime** polls (native) — the
-  availability/preference grid is heavy even in-app; deferred until the bubble
-  proves worth it on device.
 - A **WKWebView** in expanded style loading the poll detail page with the
   session injected via `WKUserScript` (localStorage seed from the App Group
   identity) — would unlock every type at once, but prototype before committing;

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -1752,6 +1752,13 @@ private struct BallotQuestionRow: View {
     let poll: PollSummary
     let canVote: Bool
 
+    // The in-flight sentinel for an explicit-Submit ballot (ranked / time /
+    // showtime — a question is exactly one of these, so yesNoChoice nil +
+    // isAbstain false never collides with a yes_no/limited_supply target).
+    private var submitTarget: VotingTarget {
+        VotingTarget(questionId: question.id, yesNoChoice: nil, isAbstain: false)
+    }
+
     var body: some View {
         let mine = model.ballotVotes[question.id]
         return VStack(alignment: .leading, spacing: 6) {
@@ -1796,9 +1803,7 @@ private struct BallotQuestionRow: View {
     // tiers (the bubble is a "simple taps" surface per Apple's live-layout rules).
     @ViewBuilder private var rankedSection: some View {
         let order = model.ballotRankOrder[question.id] ?? []
-        let spinning = model.ballotVoting == VotingTarget(
-            questionId: question.id, yesNoChoice: nil, isAbstain: false
-        )
+        let spinning = model.ballotVoting == submitTarget
         VStack(alignment: .leading, spacing: 6) {
             Text("Tap to rank in order")
                 .font(.caption)
@@ -1854,9 +1859,7 @@ private struct BallotQuestionRow: View {
     @ViewBuilder private var slotSection: some View {
         let marks = model.ballotSlots[question.id] ?? [:]
         let hasMark = !marks.isEmpty
-        let spinning = model.ballotVoting == VotingTarget(
-            questionId: question.id, yesNoChoice: nil, isAbstain: false
-        )
+        let spinning = model.ballotVoting == submitTarget
         VStack(alignment: .leading, spacing: 6) {
             Text("Tap to mark 👍 want · 👎 can't")
                 .font(.caption)

--- a/ios/App/MessagesExtension/MessagesViewController.swift
+++ b/ios/App/MessagesExtension/MessagesViewController.swift
@@ -207,7 +207,26 @@ struct QuestionSummary: Identifiable {
     // surfaces it only for ranked_choice with finalized options; nil for
     // every other type and for a ranked poll still in its suggestion phase.
     let options: [String]?
+    // Candidate slots for the expanded time/showtime want/neutral/can't ballot
+    // (Phase 5) — server surfaces them (key + friendly label) only for finalized
+    // time / showtime questions; nil for every other type, for a time poll still
+    // collecting availability, and for a cancelled event.
+    let slots: [SlotSummary]?
 }
+
+// A time/showtime candidate slot: `key` is the liked_slots/disliked_slots
+// payload value, `label` is the server-rendered friendly form the bubble shows.
+struct SlotSummary: Identifiable {
+    let key: String
+    let label: String
+    var id: String { key }
+}
+
+// A slot's want/can't mark in the expanded ballot. Absent = neutral; tapping a
+// slot cycles neutral → want → can't → neutral (mirrors the web TimeSlotBubbles
+// / ShowtimeBubbles tri-state). like → liked_slots ("want"), dislike →
+// disliked_slots ("can't attend").
+enum SlotChoice: Equatable { case like, dislike }
 
 struct PollSummary {
     let pollId: String        // POST target for inline votes (Phase 3)
@@ -252,6 +271,38 @@ struct BubbleVote {
     // The viewer's existing ranking, so the expanded ranked ballot (Phase 5)
     // restores their order on edit. nil for non-ranked votes.
     let rankedChoices: [String]?
+    // The viewer's existing time/showtime marks, so the want/can't ballot
+    // restores them on edit. Raw arrays (NOT nonEmpty'd) — an empty array is a
+    // meaningful "marked nothing" state, distinct from nil = no slot vote.
+    let likedSlots: [String]?
+    let dislikedSlots: [String]?
+    // The voter's in-app time availability, captured opaquely so a preference
+    // EDIT from the bubble re-sends it verbatim — the server direct-writes these
+    // columns on a time edit (NOT COALESCE), so omitting them clobbers the
+    // voter's availability and the winner's slot-availability headcount. nil for
+    // showtime and for a bubble-only voter who never submitted availability.
+    let voterDayTimeWindows: [[String: Any]]?
+    let voterDuration: [String: Any]?
+    let voterMinParticipants: Int?
+}
+
+extension BubbleVote {
+    // Single parser for a VoteResponse-shaped row (own-vote GET + batch POST
+    // both return this shape) so the two callsites can't drift.
+    static func parse(_ row: [String: Any]) -> BubbleVote? {
+        guard let vid = PollAPI.nonEmpty(row["id"] as? String) else { return nil }
+        return BubbleVote(
+            voteId: vid,
+            yesNoChoice: PollAPI.nonEmpty(row["yes_no_choice"] as? String),
+            isAbstain: (row["is_abstain"] as? Bool) ?? false,
+            rankedChoices: PollAPI.nonEmpty(row["ranked_choices"] as? [String]),
+            likedSlots: row["liked_slots"] as? [String],
+            dislikedSlots: row["disliked_slots"] as? [String],
+            voterDayTimeWindows: row["voter_day_time_windows"] as? [[String: Any]],
+            voterDuration: row["voter_duration"] as? [String: Any],
+            voterMinParticipants: row["voter_min_participants"] as? Int
+        )
+    }
 }
 
 // The exact choice being submitted — drives the spinner on the SPECIFIC tapped
@@ -404,6 +455,10 @@ private enum PollAPI {
         }
         let questions: [QuestionSummary] = ((obj["questions"] as? [[String: Any]]) ?? []).compactMap { q in
             guard let qid = nonEmpty(q["id"] as? String) else { return nil }
+            let slots = (q["slots"] as? [[String: Any]])?.compactMap { s -> SlotSummary? in
+                guard let key = nonEmpty(s["key"] as? String) else { return nil }
+                return SlotSummary(key: key, label: nonEmpty(s["label"] as? String) ?? key)
+            }
             return QuestionSummary(
                 id: qid,
                 label: nonEmpty(q["label"] as? String),
@@ -411,7 +466,8 @@ private enum PollAPI {
                 resultText: nonEmpty(q["result_text"] as? String),
                 yesCount: q["yes_count"] as? Int,
                 noCount: q["no_count"] as? Int,
-                options: nonEmpty(q["options"] as? [String])
+                options: nonEmpty(q["options"] as? [String]),
+                slots: (slots?.isEmpty ?? true) ? nil : slots
             )
         }
         return PollSummary(
@@ -435,6 +491,9 @@ private enum PollAPI {
     static func submitVote(
         pollId: String, questionId: String, voteId: String?, voteType: String,
         yesNoChoice: String?, isAbstain: Bool, rankedChoices: [String]? = nil,
+        likedSlots: [String]? = nil, dislikedSlots: [String]? = nil,
+        voterDayTimeWindows: [[String: Any]]? = nil, voterDuration: [String: Any]? = nil,
+        voterMinParticipants: Int? = nil,
         name: String, browserId: String
     ) async throws -> BubbleVote {
         guard let url = URL(string: apiBase + "/api/polls/\(pollId)/votes") else { throw URLError(.badURL) }
@@ -449,21 +508,23 @@ private enum PollAPI {
         // express them); the server treats a missing ranked_choice_tiers as
         // singleton tiers from this flat list.
         if let ranked = rankedChoices { item["ranked_choices"] = ranked }
+        // Time/showtime want/can't. Re-send the captured availability on a time
+        // edit so the server's direct-write doesn't NULL it (see BubbleVote).
+        if let liked = likedSlots { item["liked_slots"] = liked }
+        if let disliked = dislikedSlots { item["disliked_slots"] = disliked }
+        if let w = voterDayTimeWindows { item["voter_day_time_windows"] = w }
+        if let d = voterDuration { item["voter_duration"] = d }
+        if let m = voterMinParticipants { item["voter_min_participants"] = m }
         let body: [String: Any] = ["voter_name": name, "items": [item]]
         let request = jsonRequest(url: url, method: "POST", browserId: browserId, body: body)
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
               let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
               let row = arr.first(where: { ($0["question_id"] as? String) == questionId }) ?? arr.first,
-              let vid = nonEmpty(row["id"] as? String) else {
+              let vote = BubbleVote.parse(row) else {
             throw URLError(.badServerResponse)
         }
-        return BubbleVote(
-            voteId: vid,
-            yesNoChoice: nonEmpty(row["yes_no_choice"] as? String),
-            isAbstain: (row["is_abstain"] as? Bool) ?? false,
-            rankedChoices: nonEmpty(row["ranked_choices"] as? [String])
-        )
+        return vote
     }
 
     // The caller's OWN vote on a question (GET /api/questions/{id}/votes is
@@ -477,15 +538,10 @@ private enum PollAPI {
                 for: jsonRequest(url: url, method: "GET", browserId: browserId)),
               let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
               let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
-              let row = arr.last, let vid = nonEmpty(row["id"] as? String) else {
+              let row = arr.last else {
             return nil
         }
-        return BubbleVote(
-            voteId: vid,
-            yesNoChoice: nonEmpty(row["yes_no_choice"] as? String),
-            isAbstain: (row["is_abstain"] as? Bool) ?? false,
-            rankedChoices: nonEmpty(row["ranked_choices"] as? [String])
-        )
+        return BubbleVote.parse(row)
     }
 
     // Phase 4 — headless create from the in-Messages composer. Mirrors
@@ -670,6 +726,11 @@ final class ExtensionModel: ObservableObject {
     // edit starts from their prior order. Submitted explicitly (ranking isn't a
     // single tap), unlike yes_no/limited_supply which submit on tap.
     @Published var ballotRankOrder: [String: [String]] = [:]
+    // Per-question want/can't marks for the expanded time/showtime ballot
+    // (Phase 5). questionId → slotKey → choice (absent = neutral). Seeded from
+    // the viewer's existing liked/disliked on load; submitted explicitly
+    // (preferences aren't a single tap), like the ranked ballot.
+    @Published var ballotSlots: [String: [String: SlotChoice]] = [:]
 
     weak var host: MessagesViewController?
 
@@ -769,6 +830,7 @@ final class ExtensionModel: ObservableObject {
         ballotVotes = [:]
         ballotVoting = nil
         ballotRankOrder = [:]
+        ballotSlots = [:]
         ballotName = BridgedIdentity.load()?.name ?? ""
         Task {
             do {
@@ -808,6 +870,9 @@ final class ExtensionModel: ObservableObject {
         switch q.type {
         case "yes_no", "limited_supply": return true
         case "ranked_choice": return (q.options?.count ?? 0) >= 2
+        // Finalized time/showtime → tri-state want/can't over the slots. A time
+        // poll still collecting availability has no slots (nil) → read-only.
+        case "time", "showtime": return (q.slots?.count ?? 0) >= 1
         default: return false
         }
     }
@@ -826,13 +891,23 @@ final class ExtensionModel: ObservableObject {
             for await (qid, vote) in group {
                 if let vote = vote {
                     ballotVotes[qid] = vote
+                    let q = summary.questions.first(where: { $0.id == qid })
                     // Seed the ranked ballot's working order from the existing
                     // vote (filtered to options still on the ballot) so an edit
                     // starts from the viewer's prior ranking.
-                    if let ranked = vote.rankedChoices,
-                       let opts = summary.questions.first(where: { $0.id == qid })?.options {
+                    if let ranked = vote.rankedChoices, let opts = q?.options {
                         let valid = Set(opts)
                         ballotRankOrder[qid] = ranked.filter { valid.contains($0) }
+                    }
+                    // Seed the time/showtime marks from the existing liked/disliked
+                    // (filtered to slots still on the ballot), restoring the
+                    // viewer's want/can't on edit.
+                    if let slots = q?.slots {
+                        let valid = Set(slots.map { $0.key })
+                        var marks: [String: SlotChoice] = [:]
+                        for k in (vote.likedSlots ?? []) where valid.contains(k) { marks[k] = .like }
+                        for k in (vote.dislikedSlots ?? []) where valid.contains(k) { marks[k] = .dislike }
+                        if !marks.isEmpty { ballotSlots[qid] = marks }
                     }
                 }
             }
@@ -932,6 +1007,73 @@ final class ExtensionModel: ObservableObject {
                 }
             } catch {
                 // Keep the prior ranking; re-submit re-enables via the defer.
+            }
+        }
+    }
+
+    // Cycle a slot's mark in the working time/showtime ballot (Phase 5):
+    // neutral → want → can't → neutral (mirrors the web tri-state). No-op while
+    // a submit is in flight.
+    func cycleSlot(questionId: String, slotKey: String) {
+        guard ballotVoting == nil else { return }
+        var marks = ballotSlots[questionId] ?? [:]
+        switch marks[slotKey] {
+        case nil: marks[slotKey] = .like
+        case .like: marks[slotKey] = .dislike
+        case .dislike: marks[slotKey] = nil
+        }
+        ballotSlots[questionId] = marks
+    }
+
+    // Submit the working want/can't marks through the same atomic batch endpoint
+    // (vote_type "time"/"showtime"; liked_slots = want, disliked_slots = can't).
+    // Edits when a prior vote exists (no duplicate); no-op when nothing is marked
+    // or the marks are unchanged. On a TIME edit, re-sends the captured
+    // availability so the server's direct-write doesn't NULL it (see BubbleVote).
+    // Mirrors submitRanking's gating + live refresh.
+    func submitSlots(question: QuestionSummary, poll: PollSummary) {
+        guard ballotVoting == nil else { return }
+        let name = ballotName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let marks = ballotSlots[question.id] ?? [:]
+        let liked = marks.filter { $0.value == .like }.map { $0.key }.sorted()
+        let disliked = marks.filter { $0.value == .dislike }.map { $0.key }.sorted()
+        guard !name.isEmpty, !(liked.isEmpty && disliked.isEmpty),
+              let browserId = BridgedIdentity.browserIdUnchecked() else { return }
+        if let mine = ballotVotes[question.id],
+           Set(mine.likedSlots ?? []) == Set(liked),
+           Set(mine.dislikedSlots ?? []) == Set(disliked) {
+            return
+        }
+        ballotVoting = VotingTarget(questionId: question.id, yesNoChoice: nil, isAbstain: false)
+        BridgedIdentity.rememberName(name)
+        Task {
+            defer { ballotVoting = nil }
+            do {
+                let existing = ballotVotes[question.id]
+                let isTime = question.type == "time"
+                let submitted = try await PollAPI.submitVote(
+                    pollId: poll.pollId,
+                    questionId: question.id,
+                    voteId: existing?.voteId,
+                    voteType: question.type,
+                    yesNoChoice: nil,
+                    isAbstain: false,
+                    likedSlots: liked,
+                    dislikedSlots: disliked,
+                    voterDayTimeWindows: isTime ? existing?.voterDayTimeWindows : nil,
+                    voterDuration: isTime ? existing?.voterDuration : nil,
+                    voterMinParticipants: isTime ? existing?.voterMinParticipants : nil,
+                    name: name,
+                    browserId: browserId
+                )
+                ballotVotes[question.id] = submitted
+                if case .loaded(_, let url)? = summary,
+                   let short = PollAPI.pollShortId(fromMessageURL: url),
+                   let fresh = try? await SummaryStore.shared.refresh(shortId: short) {
+                    summary = .loaded(fresh, url)
+                }
+            } catch {
+                // Keep the prior marks; re-submit re-enables via the defer.
             }
         }
     }
@@ -1623,6 +1765,8 @@ private struct BallotQuestionRow: View {
             if ExtensionModel.isBallotVotable(question, poll: poll) {
                 if question.type == "ranked_choice" {
                     rankedSection
+                } else if question.type == "time" || question.type == "showtime" {
+                    slotSection
                 } else {
                     HStack(spacing: 8) {
                         if question.type == "yes_no" {
@@ -1700,6 +1844,67 @@ private struct BallotQuestionRow: View {
             .disabled(!canVote || model.ballotVoting != nil || order.isEmpty)
             .padding(.top, 2)
         }
+    }
+
+    // Tap-to-mark ballot for time/showtime: tap a slot to cycle want → can't →
+    // skip (👍 / 👎 / blank); an explicit Submit applies the set (preferences
+    // aren't a single tap, like ranking). want → liked_slots, can't →
+    // disliked_slots; on a time edit the stored availability rides along
+    // unchanged (model.submitSlots).
+    @ViewBuilder private var slotSection: some View {
+        let marks = model.ballotSlots[question.id] ?? [:]
+        let hasMark = !marks.isEmpty
+        let spinning = model.ballotVoting == VotingTarget(
+            questionId: question.id, yesNoChoice: nil, isAbstain: false
+        )
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Tap to mark 👍 want · 👎 can't")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            ForEach(question.slots ?? []) { slot in
+                Button(action: {
+                    model.cycleSlot(questionId: question.id, slotKey: slot.key)
+                }) {
+                    HStack(spacing: 8) {
+                        slotIndicator(marks[slot.key])
+                        Text(slot.label)
+                            .font(.body)
+                            .foregroundColor(.primary)
+                            .multilineTextAlignment(.leading)
+                        Spacer(minLength: 0)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!canVote || model.ballotVoting != nil)
+            }
+            Button(action: { model.submitSlots(question: question, poll: poll) }) {
+                HStack(spacing: 6) {
+                    if spinning { ProgressView().controlSize(.small) }
+                    Text(model.ballotVotes[question.id] == nil ? "Submit" : "Update")
+                        .font(.subheadline.weight(.medium))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!canVote || model.ballotVoting != nil || !hasMark)
+            .padding(.top, 2)
+        }
+    }
+
+    private func slotIndicator(_ choice: SlotChoice?) -> some View {
+        let symbol: String
+        let color: Color
+        switch choice {
+        case .like: symbol = "hand.thumbsup.fill"; color = .green
+        case .dislike: symbol = "hand.thumbsdown.fill"; color = .red
+        case nil: symbol = "circle"; color = Color(.systemGray3)
+        }
+        return Image(systemName: symbol)
+            .font(.system(size: 20))
+            .foregroundColor(color)
+            .frame(width: 24, height: 24)
     }
 
     private func choice(_ title: String, _ color: Color, selected: Bool, yesNoChoice: String?, isAbstain: Bool) -> some View {

--- a/server/models.py
+++ b/server/models.py
@@ -592,6 +592,15 @@ class PollResponse(BaseModel):
     initial_suggestion_vote_ids: dict[str, str] | None = None
 
 
+class PollSummarySlot(BaseModel):
+    """One time/showtime candidate slot for the iMessage expanded ballot:
+    `key` is what the vote payload references (liked_slots / disliked_slots),
+    `label` is the friendly _format_slot_label form the bubble renders."""
+
+    key: str
+    label: str
+
+
 class PollSummaryQuestionResponse(BaseModel):
     """One question's compact result line for the iMessage bubble summary
     (GET /api/polls/{short_id}/summary). `result_text` is server-rendered so
@@ -620,6 +629,15 @@ class PollSummaryQuestionResponse(BaseModel):
     # ballot (docs/imessage-extension-plan.md Phase 5); other surfaces ignore
     # it. Options text only — no metadata (the bubble renders plain labels).
     options: list[str] | None = None
+    # Time/showtime candidate slots, surfaced ONLY for finalized time / showtime
+    # questions (null for every other type, for a time poll still collecting
+    # availability — options=None → read-only — and for a cancelled "event's
+    # off" poll). Each carries the slot KEY (the liked_slots/disliked_slots
+    # value the vote payload references) plus the server-rendered LABEL the
+    # bubble displays (key formatting lives server-side; the Swift slot-label
+    # mirror was deleted in Phase 2). Drives the iMessage expanded-view
+    # want/neutral/can't ballot (docs/imessage-extension-plan.md Phase 5).
+    slots: list[PollSummarySlot] | None = None
 
 
 class PollSummaryResponse(BaseModel):

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -365,6 +365,12 @@ def _insert_poll(
             response_dt = datetime.fromisoformat(
                 req.response_deadline.replace("Z", "+00:00")
             )
+            # TODO (pre-existing, surfaced June 2026): a tz-NAIVE
+            # response_deadline (no offset/Z) parses to a naive response_dt and
+            # the comparison below raises "can't compare offset-naive and
+            # offset-aware datetimes" → 500. The FE always sends tz-aware, so
+            # this is latent (only a raw/malformed API caller hits it). If
+            # hardening: coerce response_dt to UTC when tzinfo is None.
             if prephase_deadline >= response_dt:
                 prephase_deadline = response_dt - timedelta(minutes=1)
     # "Plus one/more": default ON for polls with a time question (the common

--- a/server/routers/polls.py
+++ b/server/routers/polls.py
@@ -30,6 +30,7 @@ from models import (
     PollResponse,
     PollSummaryQuestionResponse,
     PollSummaryResponse,
+    PollSummarySlot,
     SetFollowStateRequest,
     PollVoteItem,
     PlusOneCandidateResponse,
@@ -1494,6 +1495,16 @@ def _summarize_question(
     # not-yet-rankable (read-only). Plain text, no metadata.
     opts = question_row.get("options")
     options = list(opts) if qtype == "ranked_choice" and opts else None
+    # Time/showtime: surface the finalized slots (key + friendly label) for the
+    # expanded want/neutral/can't ballot (Phase 5). A time poll still collecting
+    # availability has options=None (read-only); a cancelled event surfaces none
+    # (the bubble shows "Event's off"). Showtime slots are pre-finalized at
+    # create. Both slot-key shapes format through _format_slot_label.
+    slots = (
+        [PollSummarySlot(key=k, label=_format_slot_label(k)) for k in opts]
+        if qtype in ("time", "showtime") and opts and not results.time_event_cancelled
+        else None
+    )
     return PollSummaryQuestionResponse(
         id=str(question_row["id"]),
         label=_summary_question_label(question_row, multi),
@@ -1505,6 +1516,7 @@ def _summarize_question(
         secured_count=results.secured_count,
         supply_count=results.supply_count,
         options=options,
+        slots=slots,
     )
 
 

--- a/server/tests/test_poll_summary.py
+++ b/server/tests/test_poll_summary.py
@@ -3,6 +3,7 @@ summary powering the iMessage live transcript bubble (Phase 2 of
 docs/imessage-extension-plan.md)."""
 
 import uuid
+from datetime import datetime, timedelta, timezone
 
 from tests.conftest import (
     close_poll,
@@ -10,6 +11,14 @@ from tests.conftest import (
     group_members_for,
     yes_no_question,
 )
+
+
+def _future_date(days: int = 3) -> str:
+    return (datetime.now(timezone.utc) + timedelta(days=days)).strftime("%Y-%m-%d")
+
+
+def _future_iso(hours: int = 72) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).isoformat()
 
 
 def _vote_yes_no(client, poll, voter_name, choice, *, question_id=None, browser_id=None):
@@ -194,3 +203,120 @@ class TestPollSummary:
         s = _summary(client, poll)
         assert s["response_deadline"] is not None
         assert "." not in s["response_deadline"]
+
+
+class TestSummarySlots:
+    """`slots` (key + friendly label) rides finalized time / showtime questions
+    so the iMessage expanded want/neutral/can't ballot can render + submit
+    (Phase 5). The Swift slot-label mirror was deleted in Phase 2, so the label
+    MUST come from the server."""
+
+    def test_finalized_time_surfaces_slots_only_for_time(self, client):
+        d1, d2 = _future_date(3), _future_date(4)
+        # A no-availability time question finalizes its slots at create, so the
+        # poll opens straight into the preference ballot — exactly the bubble's
+        # votable state. Paired with a yes_no question to prove slots ride only
+        # the time question.
+        body = {
+            "creator_name": "Host",
+            "response_deadline": _future_iso(),
+            "questions": [
+                {"question_type": "yes_no", "context": "Bring snacks?"},
+                {
+                    "question_type": "time",
+                    "category": "time",
+                    "day_time_windows": [
+                        {"day": d1, "windows": [{"min": "18:00", "max": "20:00"}]},
+                        {"day": d2, "windows": [{"min": "18:00", "max": "20:00"}]},
+                    ],
+                    "duration_window": {
+                        "minValue": 2, "maxValue": 2,
+                        "minEnabled": True, "maxEnabled": True,
+                    },
+                },
+            ],
+        }
+        resp = client.post("/api/polls", json=body)
+        assert resp.status_code == 201, resp.text
+        s = _summary(client, resp.json())
+        by_type = {q["question_type"]: q for q in s["questions"]}
+        assert by_type["yes_no"]["slots"] is None
+        time_slots = by_type["time"]["slots"]
+        assert [x["key"] for x in time_slots] == [
+            f"{d1} 18:00-20:00",
+            f"{d2} 18:00-20:00",
+        ]
+        # Server renders a friendly label distinct from the raw key.
+        assert all(x["label"] and x["label"] != x["key"] for x in time_slots)
+
+    def test_time_in_availability_phase_has_no_slots(self, client):
+        d = _future_date(3)
+        body = {
+            "creator_name": "Host",
+            "response_deadline": _future_iso(),
+            "prephase_deadline_minutes": 120,
+            "questions": [
+                {
+                    "question_type": "time",
+                    "category": "time",
+                    "suggestion_deadline_minutes": 120,
+                    "day_time_windows": [
+                        {"day": d, "windows": [{"min": "18:00", "max": "20:00"}]}
+                    ],
+                    "duration_window": {
+                        "minValue": 2, "maxValue": 2,
+                        "minEnabled": True, "maxEnabled": True,
+                    },
+                }
+            ],
+        }
+        resp = client.post("/api/polls", json=body)
+        assert resp.status_code == 201, resp.text
+        s = _summary(client, resp.json())
+        # Still collecting availability (options unfinalized) → read-only bubble.
+        assert s["questions"][0]["slots"] is None
+
+    def test_showtime_surfaces_slots_and_vote_updates_result(self, client):
+        keys = ["2026-06-20 19:10-21:56", "2026-06-20 21:30-23:56"]
+        body = {
+            "creator_name": "Host",
+            "response_deadline": _future_iso(),
+            "questions": [
+                {
+                    "question_type": "showtime",
+                    "category": "showtime",
+                    "context": "Dune: Part Two",
+                    "is_auto_title": True,
+                    "options": keys,
+                    "options_metadata": {
+                        keys[0]: {"cinema_name": "Alamo", "format": "70mm"},
+                        keys[1]: {"cinema_name": "Alamo", "format": "Digital"},
+                    },
+                }
+            ],
+        }
+        resp = client.post("/api/polls", json=body)
+        assert resp.status_code == 201, resp.text
+        poll = resp.json()
+        qid = poll["questions"][0]["id"]
+        s = _summary(client, poll)
+        slots = s["questions"][0]["slots"]
+        assert [x["key"] for x in slots] == keys
+        assert all(x["label"] and x["label"] != x["key"] for x in slots)
+        # A want vote moves the "Leading:" line (same path the bubble vote uses).
+        vote = client.post(
+            f"/api/polls/{poll['id']}/votes",
+            json={
+                "voter_name": "Voter",
+                "items": [{
+                    "question_id": qid,
+                    "vote_type": "showtime",
+                    "liked_slots": [keys[1]],
+                    "disliked_slots": [keys[0]],
+                }],
+            },
+            headers={"X-Browser-Id": str(uuid.uuid4())},
+        )
+        assert vote.status_code == 201, vote.text
+        s2 = _summary(client, poll)
+        assert s2["questions"][0]["result_text"].startswith("Leading:")


### PR DESCRIPTION
## Summary

The second Phase 5 increment of the iMessage extension (`docs/imessage-extension-plan.md`), owner-greenlit. The tapped-bubble **expanded** summary now lets a recipient mark **want / neutral / can't** on a finalized `time` or `showtime` question — completing native voting for every question type except a time poll still collecting availability (read-only by design). Per-question, so a multi-question poll mixes any row types. Follows the exact shape of the just-shipped ranked-choice ballot.

**No migration / entitlement / CI / pbxproj change.**

## Server (one additive field)
- `PollSummaryQuestionResponse.slots: list[PollSummarySlot]` (`{key, label}`), surfaced by `_summarize_question` **only** for finalized time/showtime — null for other types, an availability-phase time poll (`options=None`), and a cancelled event. `label` = `_format_slot_label(key)` server-rendered (the Swift slot-label mirror was deleted in Phase 2). A *new* field, not reusing `options`, because a slot's display label ≠ its vote-payload key (ranked options are both).

## Swift (`MessagesExtension/MessagesViewController.swift`)
- `QuestionSummary.slots`; `BubbleVote` gains `likedSlots`/`dislikedSlots` for edit-restore **plus** opaque `voterDayTimeWindows`/`voterDuration`/`voterMinParticipants` passthrough — the server direct-writes those on a *time* edit (not COALESCE), so a preference edit must re-send the voter's stored availability or it clobbers it + the winner headcount.
- Shared `BubbleVote.parse(row)` now backs both the own-vote GET and the POST response (same VoteResponse shape) so the parse can't drift.
- `submitVote` gains defaulted slot/availability params → `vote_type:"time"`/`"showtime"` through the same atomic batch endpoint; `isBallotVotable` extends to time/showtime (open + ≥1 slot); `ballotSlots` + `cycleSlot`/`submitSlots`; `BallotQuestionRow.slotSection` tap-to-cycle (neutral → want → can't, 👍/👎) + explicit Submit/Update.
- Transcript inline voting stays yes_no/limited_supply only (decision C — a scrolling transcript is the wrong place for a slot grid).

## Also
- Inline TODO in `_insert_poll` for a pre-existing latent 500 (a tz-naive `response_deadline` + a prephase deadline trips an aware/naive datetime compare; the FE always sends tz-aware, so it's latent — not touched).

## Test plan
- [x] `server/tests/test_poll_summary.py::TestSummarySlots` (3 new): finalized time surfaces slots only for time, availability-phase time → null, showtime surfaces slots + a vote flips the "Leading:" line.
- [x] Full server suite green locally (`test_poll_summary`, `test_showtime_poll`, `test_time_poll`, `test_time_availability_toggle`, `test_polls_api`, `test_notification_events`, `test_options_metadata`).
- [x] Verified on the dev server: time poll → `slots` (key + label); showtime → a want/can't vote through the batch endpoint flips "Leading: 7:10 PM" → "9:30 PM"; availability-phase time → `slots: null`.
- [ ] **Native ballot UI** — owner-verified on the iOS Simulator / TestFlight (Messages extensions can't be exercised from CI/sandbox), consistent with every prior iMessage phase.

https://claude.ai/code/session_01QVnNXHxe3TnbiAPa7BN11S

---
_Generated by [Claude Code](https://claude.ai/code/session_01MT2zWDpMsoYGYN9jZpwqDU)_