### PR TITLE
Show "New Group" on the info page for solo groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2572,13 +2572,16 @@ different FE origin, extend the allowlist.
 >     a poll yet was invisible — on an empty group the roster only ever
 >     showed the viewer (the reported "approved Bob, list still says Sam"
 >     symptom). See the dedicated "Group Member Roster" section below for
->     the endpoint + refresh wiring. The HERO AVATAR + TITLE still use
->     `participantNames` (unchanged) — they surface the viewer in the
->     solo-member case so the page doesn't fall through to a gray
->     placeholder circle + "New Group" title; gated on a real localStorage
->     name (we don't invent a group name from "You"). `showViewerInHero`
->     in `app/g/[groupShortId]/info/page.tsx` is the predicate
->     (`participantNames.length === 0 && anonymousRespondentCount === 0 && currentUserName !== null`).
+>     the endpoint + refresh wiring. The HERO AVATAR + TITLE read straight
+>     from the group (`group.participantNames` + `group.title`, the SAME
+>     source the root page + top bar use), so a solo new group reads "New
+>     Group" + the 👥 placeholder avatar everywhere. **The earlier
+>     `showViewerInHero` special-case (which surfaced the creator's own name
+>     as the hero title in the solo case) was REMOVED** — it made the info
+>     page disagree with the rest of the app (reported: a brand-new group
+>     showed "New Group" on the home/top bar but "Sam" on the info page).
+>     Don't reintroduce a viewer-surfacing fallback here; a solo group having
+>     no invented name is the intended consistent state.
 >
 > The legacy `/g/` empty placeholder route still exists as the home
 > new group button's fallback on API failure — kept so a network blip during

--- a/app/g/[groupShortId]/info/page.tsx
+++ b/app/g/[groupShortId]/info/page.tsx
@@ -269,17 +269,13 @@ function Info({ group, groupId }: { group: import("@/lib/groupUtils").Group; gro
     totalCount = membersList.length;
   }
 
-  // Hero + title also surface the viewer in the solo case so the page
-  // doesn't render a gray placeholder + "New Group" fallback for a
-  // single-member group. Gated on a real name — we'd rather not invent a
-  // group name from "You".
-  const showViewerInHero =
-    group.participantNames.length === 0 &&
-    group.anonymousRespondentCount === 0 &&
-    currentUserName !== null;
-  const heroNames = showViewerInHero ? [currentUserName] : group.participantNames;
-  const displayTitle =
-    showViewerInHero && !group.groupTitleOverride ? currentUserName : group.title;
+  // Hero + title read straight from the group (same source the root page and
+  // top bar use) so a solo new group reads "New Group" + the placeholder
+  // avatar everywhere — never the creator's own name. (We used to surface the
+  // viewer in the solo case, which made the info page disagree with the rest
+  // of the app.)
+  const heroNames = group.participantNames;
+  const displayTitle = group.title;
 
   return (
     <>


### PR DESCRIPTION
## Summary
A brand-new group with only the creator showed inconsistent names: the home list and the group top bar read **"New Group"**, but the group **info page** (`/g/<id>/info`) showed the creator's own name (e.g. "Sam") as the hero title.

The info page had a `showViewerInHero` special-case that substituted `currentUserName` for the hero avatar + title in the solo case. The home list and group header instead use `group.title` (which falls back to "New Group") and `group.participantNames` (the viewer filtered out).

## Change
- `app/g/[groupShortId]/info/page.tsx`: drop `showViewerInHero`; read the hero avatar names + title straight from `group.participantNames` / `group.title` — the same source the rest of the app uses. A solo new group now reads "New Group" + the placeholder avatar everywhere.
- The **Members list** is unchanged — it still correctly shows the creator ("Sam · Admin"); only the GROUP NAME stops being invented from the viewer.
- CLAUDE.md note updated to reflect the removed special-case.

## Test plan
- [x] Create a solo group, open `/g/<id>/info` → hero reads "New Group" with the 👥 placeholder, member list shows the creator. ([screenshot](https://claude-group-name-inconsistency-ufyycw.dev.whoeverwants.com/screenshots/info-after.png))

https://claude.ai/code/session_01Cj63coFZLfm78nysSUtPHa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cj63coFZLfm78nysSUtPHa)_